### PR TITLE
120615 net worth flip

### DIFF
--- a/src/applications/dependents/686c-674/components/PicklistRemoveDependents.jsx
+++ b/src/applications/dependents/686c-674/components/PicklistRemoveDependents.jsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  VaCheckboxGroup,
+  VaCheckbox,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import { scrollToTop } from 'platform/utilities/scroll';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import { scrollToFirstError } from '~/platform/utilities/ui';
+import { slugifyText } from 'platform/forms-system/src/js/patterns/array-builder';
+
+import { getFullName, calculateAge } from '../../shared/utils';
+
+const RemoveDependentsPicklist = ({
+  data = {},
+  goBack,
+  goForward,
+  setFormData,
+  contentBeforeButtons,
+  contentAfterButtons,
+}) => {
+  const [formSubmitted, setFormSubmitted] = useState(false);
+  const [showCheckboxError, setShowCheckboxError] = useState(false);
+  useEffect(() => {
+    scrollToTop();
+  }, []);
+
+  // Get current spouse from dependents list from API (added via prefill)
+  const dependents =
+    (data?.dependents?.hasDependents && data.dependents?.awarded) || [];
+  const slugifyKey = dependent =>
+    slugifyText(`${dependent.fullName.first}-${dependent.ssn.slice(-4)}`);
+  const keys = dependents.map(slugifyKey);
+
+  // picklistChoices is an array so we can use the followup page pattern (using
+  // arrayPath, showPagePerItem & itemFilter)
+  const picklistChoices = dependents.reduce((acc, dependent, index) => {
+    const key = keys[index];
+    // Set initial value to false if not set
+    // This ensures the checkbox is unchecked on initial render
+    acc[index] = {
+      ...dependent,
+      key,
+      selected: acc[index]?.selected || false,
+    };
+    return acc;
+  }, data['view:removeDependentPickList'] || []);
+  const atLeastOneChecked = (list = picklistChoices) =>
+    list.some(v => v.selected);
+
+  const handlers = {
+    onChange: event => {
+      const isChecked = event.detail.checked;
+      const key = event.target.getAttribute('data-key');
+      const newList = picklistChoices.map(
+        item => (item.key === key ? { ...item, selected: isChecked } : item),
+      );
+
+      setFormData({
+        ...data,
+        'view:removeDependentPickList': newList,
+      });
+      setShowCheckboxError(formSubmitted && !atLeastOneChecked(newList));
+    },
+    onSubmit: event => {
+      event.preventDefault();
+      setFormSubmitted(true);
+      if (atLeastOneChecked()) {
+        goForward(data);
+      } else {
+        setShowCheckboxError(true);
+        setTimeout(scrollToFirstError);
+      }
+    },
+  };
+
+  return (
+    <form onSubmit={handlers.onSubmit}>
+      <VaCheckboxGroup
+        class="vads-u-margin-bottom--2"
+        error={showCheckboxError ? 'Select at least one option' : null}
+        label-header-level="3"
+        label="Which dependents would you like to remove?"
+        hint="Select all dependents you would like to remove"
+        onVaChange={handlers.onChange}
+        required
+      >
+        {picklistChoices.map(item => {
+          const dependentFullName = getFullName(item.fullName);
+          const age = calculateAge(item.dateOfBirth, {
+            dateInFormat: 'yyyy-MM-dd',
+          }).labeledAge;
+          return (
+            <VaCheckbox
+              key={item.key}
+              data-key={item.key}
+              name="view:removeDependentPickList"
+              label={dependentFullName}
+              checked={item.selected || false}
+              tile
+            >
+              <div slot="internal-description" className="vads-u-margin-y--1">
+                {`${item.relationshipToVeteran}, ${age}`}
+              </div>
+              {item.relationshipToVeteran === 'Parent' ? (
+                <div slot="internal-description">
+                  <p className="vads-u-margin-bottom--0">
+                    <strong>Note:</strong> A parent dependent can only be
+                    removed if they have died
+                  </p>
+                </div>
+              ) : null}
+            </VaCheckbox>
+          );
+        })}
+      </VaCheckboxGroup>
+
+      <va-additional-info
+        class="vads-u-margin-bottom--4"
+        trigger="Why can I only remove a parent dependent if they have died?"
+      >
+        The only removal option for a parent allowed in this form is due to
+        death. If your parent is still living and you need to make changes to
+        your benefits, call us at <va-telephone contact="8008271000" /> (
+        <va-telephone contact="711" tty />
+        ).
+      </va-additional-info>
+
+      {contentBeforeButtons}
+      <FormNavButtons goBack={goBack} submitToContinue />
+      {contentAfterButtons}
+    </form>
+  );
+};
+
+RemoveDependentsPicklist.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goForward: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  schema: PropTypes.object.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  uiSchema: PropTypes.object.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+  updatePage: PropTypes.func,
+  onReviewPage: PropTypes.bool,
+};
+
+export default RemoveDependentsPicklist;

--- a/src/applications/dependents/686c-674/config/chapters/formConfig674.js
+++ b/src/applications/dependents/686c-674/config/chapters/formConfig674.js
@@ -1,0 +1,257 @@
+import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
+
+import {
+  addStudentsOptions,
+  addStudentsIntroPage,
+  addStudentsSummaryPage,
+  studentInformationPage,
+  studentIDInformationPage,
+  studentIncomePage,
+  studentAddressPage,
+  studentMaritalStatusPage,
+  studentEducationBenefitsPage,
+  studentProgramInfoPage,
+  studentEducationBenefitsStartDatePage,
+  studentStoppedAttendingDatePage,
+  studentAttendancePage,
+  schoolAccreditationPage,
+  studentTermDatesPage,
+  previousTermQuestionPage,
+  previousTermDatesPage,
+  claimsOrReceivesPensionPage,
+  studentEarningsPage,
+  studentFutureEarningsPage,
+  studentAssetsPage,
+  remarksPage,
+  studentMarriageDatePage,
+} from './674/addStudentsArrayPages';
+
+import { TASK_KEYS } from '../constants';
+import { isChapterFieldRequired } from '../helpers';
+import {
+  shouldShowStudentIncomeQuestions,
+  isAddingDependents,
+} from '../utilities';
+
+export default {
+  title: 'Add one or more students between ages 18 and 23',
+  pages: {
+    ...arrayBuilderPages(addStudentsOptions, pageBuilder => ({
+      addStudentsIntro: pageBuilder.introPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674',
+        uiSchema: addStudentsIntroPage.uiSchema,
+        schema: addStudentsIntroPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsSummary: pageBuilder.summaryPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students',
+        uiSchema: addStudentsSummaryPage.uiSchema,
+        schema: addStudentsSummaryPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartOne: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-information',
+        uiSchema: studentInformationPage.uiSchema,
+        schema: studentInformationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartTwo: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-identification',
+        uiSchema: studentIDInformationPage.uiSchema,
+        schema: studentIDInformationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartThree: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-income',
+        uiSchema: studentIncomePage.uiSchema,
+        schema: studentIncomePage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          !formData?.vaDependentsNetWorthAndPension,
+      }),
+      addStudentsPartFour: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-address',
+        uiSchema: studentAddressPage.uiSchema,
+        schema: studentAddressPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartFive: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-marital-status',
+        uiSchema: studentMaritalStatusPage.uiSchema,
+        schema: studentMaritalStatusPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartSix: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-marriage-date',
+        uiSchema: studentMarriageDatePage.uiSchema,
+        schema: studentMarriageDatePage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          formData?.studentInformation?.[index]?.wasMarried,
+      }),
+      addStudentsPartSeven: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-education-benefits',
+        uiSchema: studentEducationBenefitsPage.uiSchema,
+        schema: studentEducationBenefitsPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartEight: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path:
+          'report-674/add-students/:index/student-education-benefits/start-date',
+        uiSchema: studentEducationBenefitsStartDatePage.uiSchema,
+        schema: studentEducationBenefitsStartDatePage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          ['ch35', 'fry', 'feca'].some(
+            key =>
+              formData?.studentInformation?.[index]?.typeOfProgramOrBenefit?.[
+                key
+              ] === true,
+          ),
+      }),
+      addStudentsPartNine: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-program-information',
+        uiSchema: studentProgramInfoPage.uiSchema,
+        schema: studentProgramInfoPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartTen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-attendance-information',
+        uiSchema: studentAttendancePage.uiSchema,
+        schema: studentAttendancePage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartEleven: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/date-student-stopped-attending',
+        uiSchema: studentStoppedAttendingDatePage.uiSchema,
+        schema: studentStoppedAttendingDatePage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          !formData?.studentInformation?.[index]?.schoolInformation
+            ?.studentIsEnrolledFullTime,
+      }),
+      addStudentsPartTwelve: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/school-or-program-accreditation',
+        uiSchema: schoolAccreditationPage.uiSchema,
+        schema: schoolAccreditationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartThirteen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/term-dates',
+        uiSchema: studentTermDatesPage.uiSchema,
+        schema: studentTermDatesPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartFourteen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-previously-attended',
+        uiSchema: previousTermQuestionPage.uiSchema,
+        schema: previousTermQuestionPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+      addStudentsPartFifteen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/previous-term-dates',
+        uiSchema: previousTermDatesPage.uiSchema,
+        schema: previousTermDatesPage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          formData?.studentInformation?.[index]?.schoolInformation
+            ?.studentDidAttendSchoolLastTerm,
+      }),
+      addStudentsPartSixteen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/additional-student-income',
+        uiSchema: claimsOrReceivesPensionPage.uiSchema,
+        schema: claimsOrReceivesPensionPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          !formData?.vaDependentsNetWorthAndPension,
+      }),
+      addStudentsPartSeventeen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/all-student-income',
+        uiSchema: studentEarningsPage.uiSchema,
+        schema: studentEarningsPage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          shouldShowStudentIncomeQuestions({ formData, index }),
+      }),
+      addStudentsPartEighteen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/expected-student-income',
+        uiSchema: studentFutureEarningsPage.uiSchema,
+        schema: studentFutureEarningsPage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          shouldShowStudentIncomeQuestions({ formData, index }),
+      }),
+      addStudentsPartNineteen: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/student-assets',
+        uiSchema: studentAssetsPage.uiSchema,
+        schema: studentAssetsPage.schema,
+        depends: (formData, index) =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData) &&
+          shouldShowStudentIncomeQuestions({ formData, index }),
+      }),
+      addStudentsPartTwenty: pageBuilder.itemPage({
+        title: 'Add one or more students between ages 18 and 23',
+        path: 'report-674/add-students/:index/additional-remarks',
+        uiSchema: remarksPage.uiSchema,
+        schema: remarksPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.report674) &&
+          isAddingDependents(formData),
+      }),
+    })),
+  },
+};

--- a/src/applications/dependents/686c-674/config/chapters/formConfigAdd.js
+++ b/src/applications/dependents/686c-674/config/chapters/formConfigAdd.js
@@ -1,0 +1,287 @@
+import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
+
+import CurrentSpouse from '../../components/CurrentSpouse';
+
+import {
+  currentMarriageInformation,
+  currentMarriageInformationPartTwo,
+  currentMarriageInformationPartThree,
+  currentMarriageInformationPartFour,
+  currentMarriageInformationPartFive,
+  doesLiveWithSpouse,
+  spouseInformation,
+  spouseInformationPartTwo,
+  spouseInformationPartThree,
+} from './report-add-a-spouse';
+import {
+  spouseMarriageHistoryOptions,
+  spouseMarriageHistorySummaryPage,
+  formerMarriagePersonalInfoPage,
+  formerMarriageEndReasonPage,
+  formerMarriageStartDatePage,
+  formerMarriageEndDatePage,
+  formerMarriageStartLocationPage,
+  formerMarriageEndLocationPage,
+} from './report-add-a-spouse/spouseMarriageHistoryArrayPages';
+import {
+  veteranMarriageHistoryOptions,
+  veteranMarriageHistorySummaryPage,
+  vetFormerMarriagePersonalInfoPage,
+  vetFormerMarriageEndReasonPage,
+  vetFormerMarriageStartDatePage,
+  vetFormerMarriageEndDatePage,
+  vetFormerMarriageStartLocationPage,
+  vetFormerMarriageEndLocationPage,
+} from './report-add-a-spouse/veteranMarriageHistoryArrayPages';
+
+import { TASK_KEYS } from '../constants';
+import { isChapterFieldRequired } from '../helpers';
+import {
+  showPensionRelatedQuestions,
+  isAddingDependents,
+  noV3Picklist,
+} from '../utilities';
+
+export const addSpouse = {
+  title: 'Add your spouse',
+  pages: {
+    spouseNameInformation: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData),
+      title: 'Your spouse’s personal information',
+      path: 'add-spouse/current-legal-name',
+      CustomPage: CurrentSpouse,
+      CustomPageReview: null,
+      uiSchema: spouseInformation.uiSchema,
+      schema: spouseInformation.schema,
+    },
+    spouseNameInformationPartTwo: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData),
+      title: 'Spouse’s identification information',
+      path: 'add-spouse/personal-information',
+      uiSchema: spouseInformationPartTwo.uiSchema,
+      schema: spouseInformationPartTwo.schema,
+    },
+    spouseNameInformationPartThree: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData) &&
+        formData?.spouseInformation?.isVeteran,
+      title: 'Your spouse’s military service information',
+      path: 'add-spouse/military-service-information',
+      uiSchema: spouseInformationPartThree.uiSchema,
+      schema: spouseInformationPartThree.schema,
+    },
+    doesLiveWithSpouse: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData),
+      title: 'Information about your marriage',
+      path: 'current-marriage-information/living-together',
+      uiSchema: doesLiveWithSpouse.uiSchema,
+      schema: doesLiveWithSpouse.schema,
+    },
+    currentMarriageInformation: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData) &&
+        !formData?.doesLiveWithSpouse?.spouseDoesLiveWithVeteran,
+      title: 'Spouse’s address',
+      path: 'current-marriage-information/spouse-address',
+      uiSchema: currentMarriageInformation.uiSchema,
+      schema: currentMarriageInformation.schema,
+    },
+    // TODO: Rename all of these files to be more dynamic in case we need to move pages around
+    currentMarriageInformationPartFive: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData) &&
+        !formData?.doesLiveWithSpouse?.spouseDoesLiveWithVeteran,
+      title: 'Reason you live separately from your spouse',
+      path: 'current-marriage-information/reason-for-living-separately',
+      uiSchema: currentMarriageInformationPartFive.uiSchema,
+      schema: currentMarriageInformationPartFive.schema,
+    },
+    currentMarriageInformationPartTwo: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData) &&
+        showPensionRelatedQuestions(formData),
+      title: 'Spouse’s income',
+      path: 'current-marriage-information/spouse-income',
+      uiSchema: currentMarriageInformationPartTwo.uiSchema,
+      schema: currentMarriageInformationPartTwo.schema,
+    },
+    currentMarriageInformationPartThree: {
+      depends: formData =>
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData),
+      title: 'Where did you get married?',
+      path: 'current-marriage-information/location-of-marriage',
+      uiSchema: currentMarriageInformationPartThree.uiSchema,
+      schema: currentMarriageInformationPartThree.schema,
+    },
+    currentMarriageInformationPartFour: {
+      depends: formData =>
+        noV3Picklist(formData) &&
+        isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+        isAddingDependents(formData),
+      title: 'How did you get married?',
+      path: 'current-marriage-information/type-of-marriage',
+      uiSchema: currentMarriageInformationPartFour.uiSchema,
+      schema: currentMarriageInformationPartFour.schema,
+    },
+
+    ...arrayBuilderPages(spouseMarriageHistoryOptions, pageBuilder => ({
+      spouseMarriageHistorySummary: pageBuilder.summaryPage({
+        title: 'Spouse’s marital history',
+        path: 'current-spouse-marriage-history',
+        uiSchema: spouseMarriageHistorySummaryPage.uiSchema,
+        schema: spouseMarriageHistorySummaryPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      spouseMarriageHistoryPartOne: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Former spouse information',
+        path:
+          'current-spouse-marriage-history/:index/former-spouse-information',
+        uiSchema: formerMarriagePersonalInfoPage.uiSchema,
+        schema: formerMarriagePersonalInfoPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      spouseMarriageHistoryPartTwo: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Reason former marriage ended',
+        path:
+          'current-spouse-marriage-history/:index/reason-former-marriage-ended',
+        uiSchema: formerMarriageEndReasonPage.uiSchema,
+        schema: formerMarriageEndReasonPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      spouseMarriageHistoryPartThree: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Date former marriage started',
+        path: 'current-spouse-marriage-history/:index/date-marriage-started',
+        uiSchema: formerMarriageStartDatePage.uiSchema,
+        schema: formerMarriageStartDatePage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      spouseMarriageHistoryPartFour: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Date former marriage ended',
+        path: 'current-spouse-marriage-history/:index/date-marriage-ended',
+        uiSchema: formerMarriageEndDatePage.uiSchema,
+        schema: formerMarriageEndDatePage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      spouseMarriageHistoryPartFive: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Location where former marriage started',
+        path:
+          'current-spouse-marriage-history/:index/location-where-marriage-started',
+        uiSchema: formerMarriageStartLocationPage.uiSchema,
+        schema: formerMarriageStartLocationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      spouseMarriageHistoryPartSix: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Location where former marriage ended',
+        path:
+          'current-spouse-marriage-history/:index/location-where-marriage-ended',
+        uiSchema: formerMarriageEndLocationPage.uiSchema,
+        schema: formerMarriageEndLocationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+    })),
+
+    ...arrayBuilderPages(veteranMarriageHistoryOptions, pageBuilder => ({
+      veteranMarriageHistorySummary: pageBuilder.summaryPage({
+        title:
+          'Information needed to add your spouse: Former spouse information',
+        path: 'veteran-marriage-history',
+        uiSchema: veteranMarriageHistorySummaryPage.uiSchema,
+        schema: veteranMarriageHistorySummaryPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      veteranMarriageHistoryPartOne: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Former spouse information',
+        path: 'veteran-marriage-history/:index/former-spouse-information',
+        uiSchema: vetFormerMarriagePersonalInfoPage.uiSchema,
+        schema: vetFormerMarriagePersonalInfoPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      veteranMarriageHistoryPartTwo: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Reason former marriage ended',
+        path: 'veteran-marriage-history/:index/reason-former-marriage-ended',
+        uiSchema: vetFormerMarriageEndReasonPage.uiSchema,
+        schema: vetFormerMarriageEndReasonPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      veteranMarriageHistoryPartThree: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Date former marriage started',
+        path: 'veteran-marriage-history/:index/date-marriage-started',
+        uiSchema: vetFormerMarriageStartDatePage.uiSchema,
+        schema: vetFormerMarriageStartDatePage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      veteranMarriageHistoryPartFour: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Date former marriage ended',
+        path: 'veteran-marriage-history/:index/date-marriage-ended',
+        uiSchema: vetFormerMarriageEndDatePage.uiSchema,
+        schema: vetFormerMarriageEndDatePage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      veteranMarriageHistoryPartFive: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Location where former marriage started',
+        path: 'veteran-marriage-history/:index/location-where-marriage-started',
+        uiSchema: vetFormerMarriageStartLocationPage.uiSchema,
+        schema: vetFormerMarriageStartLocationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+      veteranMarriageHistoryPartSix: pageBuilder.itemPage({
+        title:
+          'Information needed to add your spouse: Location where former marriage ended',
+        path: 'veteran-marriage-history/:index/location-where-marriage-ended',
+        uiSchema: vetFormerMarriageEndLocationPage.uiSchema,
+        schema: vetFormerMarriageEndLocationPage.schema,
+        depends: formData =>
+          isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
+          isAddingDependents(formData),
+      }),
+    })),
+  },
+};

--- a/src/applications/dependents/686c-674/config/chapters/formConfigRemovePicklist.js
+++ b/src/applications/dependents/686c-674/config/chapters/formConfigRemovePicklist.js
@@ -1,0 +1,30 @@
+import {
+  showV3Picklist,
+  hasAwardedDependents,
+  isRemovingDependents,
+} from '../utilities';
+
+import PicklistRemoveDependents from '../../components/PicklistRemoveDependents';
+
+import removeDependentPicklist from './picklist/removeDependentPicklist';
+
+export const removeDependentsPicklistOptions = {
+  title: 'Manage dependents',
+  path: 'options-selection/remove-active-dependents',
+  uiSchema: removeDependentPicklist.uiSchema,
+  schema: removeDependentPicklist.schema,
+  CustomPage: PicklistRemoveDependents,
+  CustomPageReview: null,
+  depends: formData =>
+    showV3Picklist(formData) &&
+    hasAwardedDependents(formData) &&
+    isRemovingDependents(formData),
+};
+
+export const removeDependentsPicklistPages = {
+  title: 'Remove dependents',
+  pages: {
+    removeSpouseFollowup: {},
+    removeChildFollowup: {},
+  },
+};

--- a/src/applications/dependents/686c-674/config/chapters/formConfigRemoveV2.js
+++ b/src/applications/dependents/686c-674/config/chapters/formConfigRemoveV2.js
@@ -1,0 +1,463 @@
+import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
+
+import {
+  formerSpouseInformation,
+  formerSpouseInformationPartThree,
+  formerSpouseInformationPartTwo,
+} from './report-divorce';
+
+import {
+  childAddressPage,
+  householdChildInfoPage,
+  parentOrGuardianPage,
+  removeChildHouseholdIntroPage,
+  removeChildHouseholdOptions,
+  removeChildHouseholdSummaryPage,
+  stepchildLeftHouseholdDatePage,
+  supportAmountPage,
+  veteranSupportsChildPage,
+} from './stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages';
+
+import {
+  deceasedDependentOptions,
+  deceasedDependentIntroPage,
+  deceasedDependentSummaryPage,
+  deceasedDependentPersonalInfoPage,
+  deceasedDependentTypePage,
+  deceasedDependentChildTypePage,
+  deceasedDependentDateOfDeathPage,
+  deceasedDependentLocationOfDeathPage,
+  deceasedDependentIncomePage,
+} from './report-dependent-death/deceasedDependentArrayPages';
+
+import {
+  removeChildStoppedAttendingSchoolOptions,
+  removeChildStoppedAttendingSchoolIntroPage,
+  removeChildStoppedAttendingSchoolSummaryPage,
+  childInformationPage,
+  dateChildLeftSchoolPage,
+  childIncomeQuestionPage,
+} from './report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages';
+import {
+  removeMarriedChildIntroPage,
+  removeMarriedChildOptions,
+  removeMarriedChildSummaryPage,
+  marriedChildInformationPage,
+  marriedChildIncomeQuestionPage,
+  dateChildMarriedPage,
+} from './report-marriage-of-child/removeMarriedChildArrayPages';
+
+import { TASK_KEYS } from '../constants';
+import { isChapterFieldRequired } from '../helpers';
+import { isRemovingDependents, noV3Picklist } from '../utilities';
+
+export const reportDivorce = {
+  title: 'Remove a divorced spouse',
+  pages: {
+    formerSpouseInformation: {
+      depends: formData =>
+        noV3Picklist(formData) &&
+        isChapterFieldRequired(formData, TASK_KEYS.reportDivorce) &&
+        isRemovingDependents(formData),
+      title: 'Divorced spouse’s information',
+      path: 'report-a-divorce/former-spouse-information',
+      uiSchema: formerSpouseInformation.uiSchema,
+      schema: formerSpouseInformation.schema,
+    },
+    formerSpouseInformationPartTwo: {
+      depends: formData =>
+        noV3Picklist(formData) &&
+        isChapterFieldRequired(formData, TASK_KEYS.reportDivorce) &&
+        isRemovingDependents(formData),
+      title: 'When, where, and why did this marriage end?',
+      path: 'report-a-divorce/divorce-information',
+      uiSchema: formerSpouseInformationPartTwo.uiSchema,
+      schema: formerSpouseInformationPartTwo.schema,
+    },
+    formerSpouseInformationPartThree: {
+      depends: formData =>
+        noV3Picklist(formData) &&
+        isChapterFieldRequired(formData, TASK_KEYS.reportDivorce) &&
+        isRemovingDependents(formData) &&
+        !formData?.vaDependentsNetWorthAndPension,
+      title: 'Divorced spouse’s income',
+      path: 'report-a-divorce/former-spouse-income',
+      uiSchema: formerSpouseInformationPartThree.uiSchema,
+      schema: formerSpouseInformationPartThree.schema,
+    },
+  },
+};
+
+export const reportStepchildNotInHousehold = {
+  title: 'Remove one or more stepchildren who have left your household',
+  pages: {
+    ...arrayBuilderPages(removeChildHouseholdOptions, pageBuilder => ({
+      removeChildHouseholdIntro: pageBuilder.introPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path: '686-stepchild-no-longer-part-of-household',
+        uiSchema: removeChildHouseholdIntroPage.uiSchema,
+        schema: removeChildHouseholdIntroPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeChildHouseholdSummary: pageBuilder.summaryPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path: '686-stepchild-no-longer-part-of-household/summary',
+        uiSchema: removeChildHouseholdSummaryPage.uiSchema,
+        schema: removeChildHouseholdSummaryPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeChildHouseholdPartOne: pageBuilder.itemPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path:
+          '686-stepchild-no-longer-part-of-household/:index/child-information',
+        uiSchema: householdChildInfoPage.uiSchema,
+        schema: householdChildInfoPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      stepchildLeftHouseholdDate: pageBuilder.itemPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path:
+          '686-stepchild-no-longer-part-of-household/:index/date-child-left-household',
+        uiSchema: stepchildLeftHouseholdDatePage.uiSchema,
+        schema: stepchildLeftHouseholdDatePage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeChildHouseholdPartTwo: pageBuilder.itemPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path:
+          '686-stepchild-no-longer-part-of-household/:index/veteran-supports-child',
+        uiSchema: veteranSupportsChildPage.uiSchema,
+        schema: veteranSupportsChildPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeChildHouseholdPartThree: pageBuilder.itemPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path:
+          '686-stepchild-no-longer-part-of-household/:index/child-support-amount',
+        uiSchema: supportAmountPage.uiSchema,
+        schema: supportAmountPage.schema,
+        depends: (formData, index) =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData) &&
+          formData?.stepChildren?.[index]?.supportingStepchild,
+      }),
+      removeChildHouseholdPartFour: pageBuilder.itemPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path: '686-stepchild-no-longer-part-of-household/:index/child-address',
+        uiSchema: childAddressPage.uiSchema,
+        schema: childAddressPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeChildHouseholdPartFive: pageBuilder.itemPage({
+        title:
+          'Information needed to report a stepchild is no longer part of your household',
+        path:
+          '686-stepchild-no-longer-part-of-household/:index/parent-or-guardian',
+        uiSchema: parentOrGuardianPage.uiSchema,
+        schema: parentOrGuardianPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportStepchildNotInHousehold,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+    })),
+  },
+};
+
+export const deceasedDependents = {
+  title: 'Remove one or more dependents who have died',
+  pages: {
+    ...arrayBuilderPages(deceasedDependentOptions, pageBuilder => ({
+      dependentAdditionalInformationIntro: pageBuilder.introPage({
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData),
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death',
+        uiSchema: deceasedDependentIntroPage.uiSchema,
+        schema: deceasedDependentIntroPage.schema,
+      }),
+      dependentAdditionalInformationSummary: pageBuilder.summaryPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/dependent-summary',
+        uiSchema: deceasedDependentSummaryPage.uiSchema,
+        schema: deceasedDependentSummaryPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData),
+      }),
+      dependentAdditionalInformationPartOne: pageBuilder.itemPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/:index/dependent-information',
+        uiSchema: deceasedDependentPersonalInfoPage.uiSchema,
+        schema: deceasedDependentPersonalInfoPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData),
+      }),
+      dependentAdditionalInformationPartTwo: pageBuilder.itemPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/:index/dependent-type',
+        uiSchema: deceasedDependentTypePage.uiSchema,
+        schema: deceasedDependentTypePage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData),
+      }),
+      dependentAdditionalInformationPartThree: pageBuilder.itemPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/:index/child-type',
+        uiSchema: deceasedDependentChildTypePage.uiSchema,
+        schema: deceasedDependentChildTypePage.schema,
+        depends: (formData, index) =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData) &&
+          formData?.deaths?.[index]?.dependentType === 'CHILD',
+      }),
+      dependentAdditionalInformationPartFour: pageBuilder.itemPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/:index/date-of-death',
+        uiSchema: deceasedDependentDateOfDeathPage.uiSchema,
+        schema: deceasedDependentDateOfDeathPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData),
+      }),
+      dependentAdditionalInformationPartFive: pageBuilder.itemPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/:index/location-of-death',
+        uiSchema: deceasedDependentLocationOfDeathPage.uiSchema,
+        schema: deceasedDependentLocationOfDeathPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData),
+      }),
+      dependentAdditionalInformationPartSix: pageBuilder.itemPage({
+        title: 'Information needed to remove a dependent who has died',
+        path: '686-report-dependent-death/:index/dependent-income',
+        uiSchema: deceasedDependentIncomePage.uiSchema,
+        schema: deceasedDependentIncomePage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
+          isRemovingDependents(formData) &&
+          !formData?.vaDependentsNetWorthAndPension,
+      }),
+    })),
+  },
+};
+
+export const reportChildMarriage = {
+  title: 'Remove one or more children who got married',
+  pages: {
+    ...arrayBuilderPages(removeMarriedChildOptions, pageBuilder => ({
+      removeMarriedChildIntro: pageBuilder.introPage({
+        title: 'Information needed to report the marriage of a child under 18',
+        path: '686-report-marriage-of-child',
+        uiSchema: removeMarriedChildIntroPage.uiSchema,
+        schema: removeMarriedChildIntroPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportMarriageOfChildUnder18,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeMarriedChildSummary: pageBuilder.summaryPage({
+        title: 'Information needed to report the marriage of a child under 18',
+        path: '686-report-marriage-of-child/summary',
+        uiSchema: removeMarriedChildSummaryPage.uiSchema,
+        schema: removeMarriedChildSummaryPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportMarriageOfChildUnder18,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeMarriedChildPartOne: pageBuilder.itemPage({
+        title: 'Information needed to report the marriage of a child under 18',
+        path: '686-report-marriage-of-child/:index/child-information',
+        uiSchema: marriedChildInformationPage.uiSchema,
+        schema: marriedChildInformationPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportMarriageOfChildUnder18,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeMarriedChildPartTwo: pageBuilder.itemPage({
+        title: 'Information needed to report the marriage of a child under 18',
+        path: '686-report-marriage-of-child/:index/date-child-married',
+        uiSchema: dateChildMarriedPage.uiSchema,
+        schema: dateChildMarriedPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportMarriageOfChildUnder18,
+          ) &&
+          isRemovingDependents(formData),
+      }),
+      removeMarriedChildPartThree: pageBuilder.itemPage({
+        title: 'Information needed to report the marriage of a child under 18',
+        path: '686-report-marriage-of-child/:index/child-income',
+        uiSchema: marriedChildIncomeQuestionPage.uiSchema,
+        schema: marriedChildIncomeQuestionPage.schema,
+        depends: formData =>
+          noV3Picklist(formData) &&
+          isChapterFieldRequired(
+            formData,
+            TASK_KEYS.reportMarriageOfChildUnder18,
+          ) &&
+          isRemovingDependents(formData) &&
+          !formData?.vaDependentsNetWorthAndPension,
+      }),
+    })),
+  },
+};
+
+export const reportChildStoppedAttendingSchool = {
+  title: 'Remove one or more children between ages 18 and 23 who left school',
+  pages: {
+    ...arrayBuilderPages(
+      removeChildStoppedAttendingSchoolOptions,
+      pageBuilder => ({
+        childNoLongerInSchoolIntro: pageBuilder.introPage({
+          title:
+            'Information needed to report a child 18-23 years old stopped attending school',
+          path: 'report-child-stopped-attending-school',
+          uiSchema: removeChildStoppedAttendingSchoolIntroPage.uiSchema,
+          schema: removeChildStoppedAttendingSchoolIntroPage.schema,
+          depends: formData =>
+            noV3Picklist(formData) &&
+            isChapterFieldRequired(
+              formData,
+              TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
+            ) &&
+            isRemovingDependents(formData),
+        }),
+        childNoLongerInSchoolSummary: pageBuilder.summaryPage({
+          title:
+            'Information needed to report a child 18-23 years old stopped attending school',
+          path: 'report-child-stopped-attending-school/summary',
+          uiSchema: removeChildStoppedAttendingSchoolSummaryPage.uiSchema,
+          schema: removeChildStoppedAttendingSchoolSummaryPage.schema,
+          depends: formData =>
+            noV3Picklist(formData) &&
+            isChapterFieldRequired(
+              formData,
+              TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
+            ) &&
+            isRemovingDependents(formData),
+        }),
+        childNoLongerInSchoolPartOne: pageBuilder.itemPage({
+          title:
+            'Information needed to report a child 18-23 years old stopped attending school',
+          path:
+            'report-child-stopped-attending-school/:index/child-information',
+          uiSchema: childInformationPage.uiSchema,
+          schema: childInformationPage.schema,
+          depends: formData =>
+            noV3Picklist(formData) &&
+            isChapterFieldRequired(
+              formData,
+              TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
+            ) &&
+            isRemovingDependents(formData),
+        }),
+        childNoLongerInSchoolPartTwo: pageBuilder.itemPage({
+          title:
+            'Information needed to report a child 18-23 years old stopped attending school',
+          path:
+            'report-child-stopped-attending-school/:index/date-child-left-school',
+          uiSchema: dateChildLeftSchoolPage.uiSchema,
+          schema: dateChildLeftSchoolPage.schema,
+          depends: formData =>
+            noV3Picklist(formData) &&
+            isChapterFieldRequired(
+              formData,
+              TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
+            ) &&
+            isRemovingDependents(formData),
+        }),
+        childNoLongerInSchoolPartThree: pageBuilder.itemPage({
+          title:
+            'Information needed to report a child 18-23 years old stopped attending school',
+          path: 'report-child-stopped-attending-school/:index/child-income',
+          uiSchema: childIncomeQuestionPage.uiSchema,
+          schema: childIncomeQuestionPage.schema,
+          depends: formData =>
+            noV3Picklist(formData) &&
+            isChapterFieldRequired(
+              formData,
+              TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
+            ) &&
+            isRemovingDependents(formData) &&
+            !formData?.vaDependentsNetWorthAndPension,
+        }),
+      }),
+    ),
+  },
+};

--- a/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
@@ -40,7 +40,7 @@ export const whatAreAssets = (
 
 export const netWorthTitle = ({ netWorthLimit, featureFlag } = {}) => {
   if (!featureFlag) {
-    return `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`;
+    return `Did your household have a net worth less than $${NETWORTH_VALUE} in the last tax year?`;
   }
 
   const number = netWorthLimit || NETWORTH_VALUE;
@@ -48,5 +48,5 @@ export const netWorthTitle = ({ netWorthLimit, featureFlag } = {}) => {
     `${number}`.replace(/,/g, ''),
     10,
   ).toLocaleString('en-US');
-  return `Did the household have a net worth greater than $${formattedNumber} in the last tax year?`;
+  return `Did your household have a net worth less than $${formattedNumber} in the last tax year?`;
 };

--- a/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
@@ -8,7 +8,7 @@ import { whatAreAssets, netWorthTitle } from './helpers';
 export const schema = {
   type: 'object',
   properties: {
-    householdIncome: yesNoSchema,
+    'view:householdIncome': yesNoSchema,
   },
 };
 
@@ -18,7 +18,20 @@ export const uiSchema = {
     'If you currently receive VA pension benefits, we need to know your net worth. Your net worth includes your assets and your annual income. If you’re married, include the value of your spouse’s assets and annual income too.',
   ),
   'ui:description': whatAreAssets,
-  householdIncome: yesNoUI({
+  'ui:options': {
+    updateSchema: (formData, formSchema) => {
+      // Use 'view:householdIncome' as UI value and householdIncome as RBPS value
+      // Set householdIncome to the opposite of view:householdIncome (as per RBPS)
+      // If view:householdIncome is undefined (user hasn't seen the question yet), leave householdIncome alone
+      if (formData['view:householdIncome'] !== undefined) {
+        const updated = formData;
+        updated.householdIncome = !formData['view:householdIncome'];
+      }
+
+      return formSchema;
+    },
+  },
+  'view:householdIncome': yesNoUI({
     title: netWorthTitle(),
     enableAnalytics: true,
     updateUiSchema: formData => ({

--- a/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
@@ -22,10 +22,20 @@ export const uiSchema = {
     updateSchema: (formData, formSchema) => {
       // Use 'view:householdIncome' as UI value and householdIncome as RBPS value
       // Set householdIncome to the opposite of view:householdIncome (as per RBPS)
+
+      const updated = formData;
       // If view:householdIncome is undefined (user hasn't seen the question yet), leave householdIncome alone
+      // If view:householdIncome is defined, set householdIncome to the opposite value
+      // If householdIncome is defined but view:householdIncome is undefined (user hasn't seen the question yet but in-progress form exists),
+      // set view:householdIncome to the opposite value of householdIncome
       if (formData['view:householdIncome'] !== undefined) {
-        const updated = formData;
         updated.householdIncome = !formData['view:householdIncome'];
+      }
+      if (
+        formData['view:householdIncome'] === undefined &&
+        formData.householdIncome !== undefined
+      ) {
+        updated['view:householdIncome'] = !formData.householdIncome;
       }
 
       return formSchema;

--- a/src/applications/dependents/686c-674/config/chapters/picklist/removeDependentPicklist.js
+++ b/src/applications/dependents/686c-674/config/chapters/picklist/removeDependentPicklist.js
@@ -1,0 +1,21 @@
+export default {
+  uiSchema: {
+    'view:removeDependentPickList': {
+      'ui:title': 'Which dependents would you like to remove?',
+      'ui:required': () => true,
+      'ui:errorMessages': {
+        required: 'Select at least one option',
+      },
+      'ui:options': {
+        tile: true,
+        labelHeaderLevel: '3',
+        enableAnalytics: true,
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+};

--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/index.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/index.js
@@ -156,7 +156,7 @@ const chapterPages = arrayBuilderPages(arrayBuilderOptions, pages => {
   };
 });
 
-export const chapter = {
+export default {
   title: 'Add one or more children',
   pages: {
     ...chapterPages,

--- a/src/applications/dependents/686c-674/config/form.js
+++ b/src/applications/dependents/686c-674/config/form.js
@@ -1,6 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/686C-674-V2-schema.json';
 import environment from 'platform/utilities/environment';
-import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import FormFooter from 'platform/forms/components/FormFooter';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import { VA_FORM_IDS } from 'platform/forms/constants';
@@ -10,61 +9,11 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../components/GetFormHelp';
 import { customSubmit686 } from '../analytics/helpers';
-import CurrentSpouse from '../components/CurrentSpouse';
+
+import manifest from '../manifest.json';
+import prefillTransformer from './prefill-transformer';
 
 // Chapter imports
-import {
-  formerSpouseInformation,
-  formerSpouseInformationPartThree,
-  formerSpouseInformationPartTwo,
-} from './chapters/report-divorce';
-import {
-  deceasedDependentOptions,
-  deceasedDependentIntroPage,
-  deceasedDependentSummaryPage,
-  deceasedDependentPersonalInfoPage,
-  deceasedDependentTypePage,
-  deceasedDependentChildTypePage,
-  deceasedDependentDateOfDeathPage,
-  deceasedDependentLocationOfDeathPage,
-  deceasedDependentIncomePage,
-} from './chapters/report-dependent-death/deceasedDependentArrayPages';
-import {
-  currentMarriageInformation,
-  currentMarriageInformationPartTwo,
-  currentMarriageInformationPartThree,
-  currentMarriageInformationPartFour,
-  currentMarriageInformationPartFive,
-  doesLiveWithSpouse,
-  spouseInformation,
-  spouseInformationPartTwo,
-  spouseInformationPartThree,
-} from './chapters/report-add-a-spouse';
-import {
-  spouseMarriageHistoryOptions,
-  spouseMarriageHistorySummaryPage,
-  formerMarriagePersonalInfoPage,
-  formerMarriageEndReasonPage,
-  formerMarriageStartDatePage,
-  formerMarriageEndDatePage,
-  formerMarriageStartLocationPage,
-  formerMarriageEndLocationPage,
-} from './chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages';
-import {
-  veteranMarriageHistoryOptions,
-  veteranMarriageHistorySummaryPage,
-  vetFormerMarriagePersonalInfoPage,
-  vetFormerMarriageEndReasonPage,
-  vetFormerMarriageStartDatePage,
-  vetFormerMarriageEndDatePage,
-  vetFormerMarriageStartLocationPage,
-  vetFormerMarriageEndLocationPage,
-} from './chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages';
-import {
-  addDependentOptions,
-  removeDependentOptions,
-  addOrRemoveDependents,
-} from './chapters/taskWizard';
 import {
   veteranInformation,
   veteranAddress,
@@ -72,71 +21,39 @@ import {
   checkVeteranPension,
 } from './chapters/veteran-information';
 import {
-  removeChildStoppedAttendingSchoolOptions,
-  removeChildStoppedAttendingSchoolIntroPage,
-  removeChildStoppedAttendingSchoolSummaryPage,
-  childInformationPage,
-  dateChildLeftSchoolPage,
-  childIncomeQuestionPage,
-} from './chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages';
-import {
-  removeMarriedChildIntroPage,
-  removeMarriedChildOptions,
-  removeMarriedChildSummaryPage,
-  marriedChildInformationPage,
-  marriedChildIncomeQuestionPage,
-  dateChildMarriedPage,
-} from './chapters/report-marriage-of-child/removeMarriedChildArrayPages';
-import {
-  addStudentsOptions,
-  addStudentsIntroPage,
-  addStudentsSummaryPage,
-  studentInformationPage,
-  studentIDInformationPage,
-  studentIncomePage,
-  studentAddressPage,
-  studentMaritalStatusPage,
-  studentEducationBenefitsPage,
-  studentProgramInfoPage,
-  studentEducationBenefitsStartDatePage,
-  studentStoppedAttendingDatePage,
-  studentAttendancePage,
-  schoolAccreditationPage,
-  studentTermDatesPage,
-  previousTermQuestionPage,
-  previousTermDatesPage,
-  claimsOrReceivesPensionPage,
-  studentEarningsPage,
-  studentFutureEarningsPage,
-  studentAssetsPage,
-  remarksPage,
-  studentMarriageDatePage,
-} from './chapters/674/addStudentsArrayPages';
-import {
-  childAddressPage,
-  householdChildInfoPage,
-  parentOrGuardianPage,
-  removeChildHouseholdIntroPage,
-  removeChildHouseholdOptions,
-  removeChildHouseholdSummaryPage,
-  stepchildLeftHouseholdDatePage,
-  supportAmountPage,
-  veteranSupportsChildPage,
-} from './chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages';
+  addDependentOptions,
+  removeDependentOptions,
+  addOrRemoveDependents,
+} from './chapters/taskWizard';
 import { householdIncome } from './chapters/household-income';
 
-import manifest from '../manifest.json';
-import prefillTransformer from './prefill-transformer';
-import { chapter as addChild } from './chapters/report-add-child';
 import { spouseAdditionalEvidence } from './chapters/additional-information/spouseAdditionalEvidence';
 import { childAdditionalEvidence as finalChildAdditionalEvidence } from './chapters/additional-information/childAdditionalEvidence';
+
+import {
+  removeDependentsPicklistOptions,
+  // removeDependentsPicklistPages,
+} from './chapters/formConfigRemovePicklist';
+import addChild from './chapters/report-add-child';
+import report674 from './chapters/formConfig674';
+import { addSpouse } from './chapters/formConfigAdd';
+import {
+  reportDivorce,
+  reportStepchildNotInHousehold,
+  deceasedDependents,
+  reportChildMarriage,
+  reportChildStoppedAttendingSchool,
+} from './chapters/formConfigRemoveV2';
 
 import {
   spouseEvidence,
   childEvidence,
   showPensionRelatedQuestions,
   showPensionBackupPath,
-  shouldShowStudentIncomeQuestions,
+  showV3Picklist,
+  noV3Picklist,
+  isAddingDependents,
+  isRemovingDependents,
 } from './utilities';
 import migrations from './migrations';
 
@@ -197,44 +114,6 @@ export const formConfig = {
   subTitle: 'VA Forms 21-686c and 21-674',
   defaultDefinitions: { ...fullSchema.definitions },
   chapters: {
-    optionSelection: {
-      title: 'Add or remove dependents',
-      pages: {
-        addOrRemoveDependents: {
-          title: 'What would you like to do?',
-          path: 'options-selection',
-          uiSchema: addOrRemoveDependents.uiSchema,
-          schema: addOrRemoveDependents.schema,
-          initialData: {
-            // Set in prefill, but included here because we're seeing v2
-            // submissions without it
-            useV2: true,
-          },
-        },
-        addDependentOptions: {
-          title: 'Add a dependent',
-          path: 'options-selection/add-dependents',
-          uiSchema: addDependentOptions.uiSchema,
-          schema: addDependentOptions.schema,
-          depends: form => form?.['view:addOrRemoveDependents']?.add,
-        },
-        removeDependentOptions: {
-          title: 'Remove a dependent',
-          path: 'options-selection/remove-dependents',
-          uiSchema: removeDependentOptions.uiSchema,
-          schema: removeDependentOptions.schema,
-          depends: form => form?.['view:addOrRemoveDependents']?.remove,
-        },
-        checkVeteranPension: {
-          depends: formData => showPensionBackupPath(formData),
-          path: 'check-veteran-pension',
-          title: 'Check Veteran Pension',
-          uiSchema: checkVeteranPension.uiSchema,
-          schema: checkVeteranPension.schema,
-        },
-      },
-    },
-
     veteranInformation: {
       title: "Veteran's information",
       pages: {
@@ -259,853 +138,61 @@ export const formConfig = {
       },
     },
 
-    addSpouse: {
-      title: 'Add your spouse',
+    optionSelection: {
+      title: ({ formData }) =>
+        showV3Picklist(formData)
+          ? 'Manage dependents'
+          : 'Add or remove dependents',
       pages: {
-        spouseNameInformation: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add,
-          title: 'Your spouse’s personal information',
-          path: 'add-spouse/current-legal-name',
-          CustomPage: CurrentSpouse,
-          CustomPageReview: null,
-          uiSchema: spouseInformation.uiSchema,
-          schema: spouseInformation.schema,
+        addOrRemoveDependents: {
+          title: 'What would you like to do?',
+          path: 'options-selection',
+          uiSchema: addOrRemoveDependents.uiSchema,
+          schema: addOrRemoveDependents.schema,
+          initialData: {
+            // Set in prefill, but included here because we're seeing v2
+            // submissions without it
+            useV2: true,
+          },
         },
-        spouseNameInformationPartTwo: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add,
-          title: 'Spouse’s identification information',
-          path: 'add-spouse/personal-information',
-          uiSchema: spouseInformationPartTwo.uiSchema,
-          schema: spouseInformationPartTwo.schema,
-        },
-        spouseNameInformationPartThree: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add &&
-            formData?.spouseInformation?.isVeteran,
-          title: 'Your spouse’s military service information',
-          path: 'add-spouse/military-service-information',
-          uiSchema: spouseInformationPartThree.uiSchema,
-          schema: spouseInformationPartThree.schema,
-        },
-        doesLiveWithSpouse: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add,
-          title: 'Information about your marriage',
-          path: 'current-marriage-information/living-together',
-          uiSchema: doesLiveWithSpouse.uiSchema,
-          schema: doesLiveWithSpouse.schema,
-        },
-        currentMarriageInformation: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add &&
-            !formData?.doesLiveWithSpouse?.spouseDoesLiveWithVeteran,
-          title: 'Spouse’s address',
-          path: 'current-marriage-information/spouse-address',
-          uiSchema: currentMarriageInformation.uiSchema,
-          schema: currentMarriageInformation.schema,
-        },
-        // TODO: Rename all of these files to be more dynamic in case we need to move pages around
-        currentMarriageInformationPartFive: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add &&
-            !formData?.doesLiveWithSpouse?.spouseDoesLiveWithVeteran,
-          title: 'Reason you live separately from your spouse',
-          path: 'current-marriage-information/reason-for-living-separately',
-          uiSchema: currentMarriageInformationPartFive.uiSchema,
-          schema: currentMarriageInformationPartFive.schema,
-        },
-        currentMarriageInformationPartTwo: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add &&
-            showPensionRelatedQuestions(formData),
-          title: 'Spouse’s income',
-          path: 'current-marriage-information/spouse-income',
-          uiSchema: currentMarriageInformationPartTwo.uiSchema,
-          schema: currentMarriageInformationPartTwo.schema,
-        },
-        currentMarriageInformationPartThree: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add,
-          title: 'Where did you get married?',
-          path: 'current-marriage-information/location-of-marriage',
-          uiSchema: currentMarriageInformationPartThree.uiSchema,
-          schema: currentMarriageInformationPartThree.schema,
-        },
-        currentMarriageInformationPartFour: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-            formData?.['view:addOrRemoveDependents']?.add,
-          title: 'How did you get married?',
-          path: 'current-marriage-information/type-of-marriage',
-          uiSchema: currentMarriageInformationPartFour.uiSchema,
-          schema: currentMarriageInformationPartFour.schema,
+        addDependentOptions: {
+          title: 'Add a dependent',
+          path: 'options-selection/add-dependents',
+          uiSchema: addDependentOptions.uiSchema,
+          schema: addDependentOptions.schema,
+          depends: isAddingDependents,
         },
 
-        ...arrayBuilderPages(spouseMarriageHistoryOptions, pageBuilder => ({
-          spouseMarriageHistorySummary: pageBuilder.summaryPage({
-            title: 'Spouse’s marital history',
-            path: 'current-spouse-marriage-history',
-            uiSchema: spouseMarriageHistorySummaryPage.uiSchema,
-            schema: spouseMarriageHistorySummaryPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          spouseMarriageHistoryPartOne: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Former spouse information',
-            path:
-              'current-spouse-marriage-history/:index/former-spouse-information',
-            uiSchema: formerMarriagePersonalInfoPage.uiSchema,
-            schema: formerMarriagePersonalInfoPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          spouseMarriageHistoryPartTwo: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Reason former marriage ended',
-            path:
-              'current-spouse-marriage-history/:index/reason-former-marriage-ended',
-            uiSchema: formerMarriageEndReasonPage.uiSchema,
-            schema: formerMarriageEndReasonPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          spouseMarriageHistoryPartThree: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Date former marriage started',
-            path:
-              'current-spouse-marriage-history/:index/date-marriage-started',
-            uiSchema: formerMarriageStartDatePage.uiSchema,
-            schema: formerMarriageStartDatePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          spouseMarriageHistoryPartFour: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Date former marriage ended',
-            path: 'current-spouse-marriage-history/:index/date-marriage-ended',
-            uiSchema: formerMarriageEndDatePage.uiSchema,
-            schema: formerMarriageEndDatePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          spouseMarriageHistoryPartFive: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Location where former marriage started',
-            path:
-              'current-spouse-marriage-history/:index/location-where-marriage-started',
-            uiSchema: formerMarriageStartLocationPage.uiSchema,
-            schema: formerMarriageStartLocationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          spouseMarriageHistoryPartSix: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Location where former marriage ended',
-            path:
-              'current-spouse-marriage-history/:index/location-where-marriage-ended',
-            uiSchema: formerMarriageEndLocationPage.uiSchema,
-            schema: formerMarriageEndLocationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-        })),
+        removeDependentOptions: {
+          title: 'Remove a dependent',
+          path: 'options-selection/remove-dependents',
+          uiSchema: removeDependentOptions.uiSchema,
+          schema: removeDependentOptions.schema,
+          depends: formData =>
+            noV3Picklist(formData) && isRemovingDependents(formData),
+        },
 
-        ...arrayBuilderPages(veteranMarriageHistoryOptions, pageBuilder => ({
-          veteranMarriageHistorySummary: pageBuilder.summaryPage({
-            title:
-              'Information needed to add your spouse: Former spouse information',
-            path: 'veteran-marriage-history',
-            uiSchema: veteranMarriageHistorySummaryPage.uiSchema,
-            schema: veteranMarriageHistorySummaryPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          veteranMarriageHistoryPartOne: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Former spouse information',
-            path: 'veteran-marriage-history/:index/former-spouse-information',
-            uiSchema: vetFormerMarriagePersonalInfoPage.uiSchema,
-            schema: vetFormerMarriagePersonalInfoPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          veteranMarriageHistoryPartTwo: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Reason former marriage ended',
-            path:
-              'veteran-marriage-history/:index/reason-former-marriage-ended',
-            uiSchema: vetFormerMarriageEndReasonPage.uiSchema,
-            schema: vetFormerMarriageEndReasonPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          veteranMarriageHistoryPartThree: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Date former marriage started',
-            path: 'veteran-marriage-history/:index/date-marriage-started',
-            uiSchema: vetFormerMarriageStartDatePage.uiSchema,
-            schema: vetFormerMarriageStartDatePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          veteranMarriageHistoryPartFour: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Date former marriage ended',
-            path: 'veteran-marriage-history/:index/date-marriage-ended',
-            uiSchema: vetFormerMarriageEndDatePage.uiSchema,
-            schema: vetFormerMarriageEndDatePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          veteranMarriageHistoryPartFive: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Location where former marriage started',
-            path:
-              'veteran-marriage-history/:index/location-where-marriage-started',
-            uiSchema: vetFormerMarriageStartLocationPage.uiSchema,
-            schema: vetFormerMarriageStartLocationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          veteranMarriageHistoryPartSix: pageBuilder.itemPage({
-            title:
-              'Information needed to add your spouse: Location where former marriage ended',
-            path:
-              'veteran-marriage-history/:index/location-where-marriage-ended',
-            uiSchema: vetFormerMarriageEndLocationPage.uiSchema,
-            schema: vetFormerMarriageEndLocationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-        })),
+        checkVeteranPension: {
+          title: 'Check Veteran Pension',
+          path: 'check-veteran-pension',
+          uiSchema: checkVeteranPension.uiSchema,
+          schema: checkVeteranPension.schema,
+          depends: formData => showPensionBackupPath(formData),
+        },
+
+        removeDependentsPicklistOptions,
       },
     },
 
+    // removeDependentsPicklistPages,
+    addSpouse,
     addChild,
-
-    report674: {
-      title: 'Add one or more students between ages 18 and 23',
-      pages: {
-        ...arrayBuilderPages(addStudentsOptions, pageBuilder => ({
-          addStudentsIntro: pageBuilder.introPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674',
-            uiSchema: addStudentsIntroPage.uiSchema,
-            schema: addStudentsIntroPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsSummary: pageBuilder.summaryPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students',
-            uiSchema: addStudentsSummaryPage.uiSchema,
-            schema: addStudentsSummaryPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartOne: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-information',
-            uiSchema: studentInformationPage.uiSchema,
-            schema: studentInformationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartTwo: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-identification',
-            uiSchema: studentIDInformationPage.uiSchema,
-            schema: studentIDInformationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartThree: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-income',
-            uiSchema: studentIncomePage.uiSchema,
-            schema: studentIncomePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              !formData?.vaDependentsNetWorthAndPension,
-          }),
-          addStudentsPartFour: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-address',
-            uiSchema: studentAddressPage.uiSchema,
-            schema: studentAddressPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartFive: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-marital-status',
-            uiSchema: studentMaritalStatusPage.uiSchema,
-            schema: studentMaritalStatusPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartSix: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-marriage-date',
-            uiSchema: studentMarriageDatePage.uiSchema,
-            schema: studentMarriageDatePage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              formData?.studentInformation?.[index]?.wasMarried,
-          }),
-          addStudentsPartSeven: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-education-benefits',
-            uiSchema: studentEducationBenefitsPage.uiSchema,
-            schema: studentEducationBenefitsPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartEight: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path:
-              'report-674/add-students/:index/student-education-benefits/start-date',
-            uiSchema: studentEducationBenefitsStartDatePage.uiSchema,
-            schema: studentEducationBenefitsStartDatePage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              ['ch35', 'fry', 'feca'].some(
-                key =>
-                  formData?.studentInformation?.[index]
-                    ?.typeOfProgramOrBenefit?.[key] === true,
-              ),
-          }),
-          addStudentsPartNine: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-program-information',
-            uiSchema: studentProgramInfoPage.uiSchema,
-            schema: studentProgramInfoPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartTen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path:
-              'report-674/add-students/:index/student-attendance-information',
-            uiSchema: studentAttendancePage.uiSchema,
-            schema: studentAttendancePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartEleven: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path:
-              'report-674/add-students/:index/date-student-stopped-attending',
-            uiSchema: studentStoppedAttendingDatePage.uiSchema,
-            schema: studentStoppedAttendingDatePage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              !formData?.studentInformation?.[index]?.schoolInformation
-                ?.studentIsEnrolledFullTime,
-          }),
-          addStudentsPartTwelve: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path:
-              'report-674/add-students/:index/school-or-program-accreditation',
-            uiSchema: schoolAccreditationPage.uiSchema,
-            schema: schoolAccreditationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartThirteen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/term-dates',
-            uiSchema: studentTermDatesPage.uiSchema,
-            schema: studentTermDatesPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartFourteen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-previously-attended',
-            uiSchema: previousTermQuestionPage.uiSchema,
-            schema: previousTermQuestionPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-          addStudentsPartFifteen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/previous-term-dates',
-            uiSchema: previousTermDatesPage.uiSchema,
-            schema: previousTermDatesPage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              formData?.studentInformation?.[index]?.schoolInformation
-                ?.studentDidAttendSchoolLastTerm,
-          }),
-          addStudentsPartSixteen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/additional-student-income',
-            uiSchema: claimsOrReceivesPensionPage.uiSchema,
-            schema: claimsOrReceivesPensionPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              !formData?.vaDependentsNetWorthAndPension,
-          }),
-          addStudentsPartSeventeen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/all-student-income',
-            uiSchema: studentEarningsPage.uiSchema,
-            schema: studentEarningsPage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              shouldShowStudentIncomeQuestions({ formData, index }),
-          }),
-          addStudentsPartEighteen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/expected-student-income',
-            uiSchema: studentFutureEarningsPage.uiSchema,
-            schema: studentFutureEarningsPage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              shouldShowStudentIncomeQuestions({ formData, index }),
-          }),
-          addStudentsPartNineteen: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/student-assets',
-            uiSchema: studentAssetsPage.uiSchema,
-            schema: studentAssetsPage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
-              shouldShowStudentIncomeQuestions({ formData, index }),
-          }),
-          addStudentsPartTwenty: pageBuilder.itemPage({
-            title: 'Add one or more students between ages 18 and 23',
-            path: 'report-674/add-students/:index/additional-remarks',
-            uiSchema: remarksPage.uiSchema,
-            schema: remarksPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.report674) &&
-              formData?.['view:addOrRemoveDependents']?.add,
-          }),
-        })),
-      },
-    },
-
-    reportDivorce: {
-      title: 'Remove a divorced spouse',
-      pages: {
-        formerSpouseInformation: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.reportDivorce) &&
-            formData?.['view:addOrRemoveDependents']?.remove,
-          title: 'Divorced spouse’s information',
-          path: 'report-a-divorce/former-spouse-information',
-          uiSchema: formerSpouseInformation.uiSchema,
-          schema: formerSpouseInformation.schema,
-        },
-        formerSpouseInformationPartTwo: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.reportDivorce) &&
-            formData?.['view:addOrRemoveDependents']?.remove,
-          title: 'When, where, and why did this marriage end?',
-          path: 'report-a-divorce/divorce-information',
-          uiSchema: formerSpouseInformationPartTwo.uiSchema,
-          schema: formerSpouseInformationPartTwo.schema,
-        },
-        formerSpouseInformationPartThree: {
-          depends: formData =>
-            isChapterFieldRequired(formData, TASK_KEYS.reportDivorce) &&
-            formData?.['view:addOrRemoveDependents']?.remove &&
-            !formData?.vaDependentsNetWorthAndPension,
-          title: 'Divorced spouse’s income',
-          path: 'report-a-divorce/former-spouse-income',
-          uiSchema: formerSpouseInformationPartThree.uiSchema,
-          schema: formerSpouseInformationPartThree.schema,
-        },
-      },
-    },
-
-    reportStepchildNotInHousehold: {
-      title: 'Remove one or more stepchildren who have left your household',
-      pages: {
-        ...arrayBuilderPages(removeChildHouseholdOptions, pageBuilder => ({
-          removeChildHouseholdIntro: pageBuilder.introPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path: '686-stepchild-no-longer-part-of-household',
-            uiSchema: removeChildHouseholdIntroPage.uiSchema,
-            schema: removeChildHouseholdIntroPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeChildHouseholdSummary: pageBuilder.summaryPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path: '686-stepchild-no-longer-part-of-household/summary',
-            uiSchema: removeChildHouseholdSummaryPage.uiSchema,
-            schema: removeChildHouseholdSummaryPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeChildHouseholdPartOne: pageBuilder.itemPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path:
-              '686-stepchild-no-longer-part-of-household/:index/child-information',
-            uiSchema: householdChildInfoPage.uiSchema,
-            schema: householdChildInfoPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          stepchildLeftHouseholdDate: pageBuilder.itemPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path:
-              '686-stepchild-no-longer-part-of-household/:index/date-child-left-household',
-            uiSchema: stepchildLeftHouseholdDatePage.uiSchema,
-            schema: stepchildLeftHouseholdDatePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeChildHouseholdPartTwo: pageBuilder.itemPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path:
-              '686-stepchild-no-longer-part-of-household/:index/veteran-supports-child',
-            uiSchema: veteranSupportsChildPage.uiSchema,
-            schema: veteranSupportsChildPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeChildHouseholdPartThree: pageBuilder.itemPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path:
-              '686-stepchild-no-longer-part-of-household/:index/child-support-amount',
-            uiSchema: supportAmountPage.uiSchema,
-            schema: supportAmountPage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) &&
-              formData?.['view:addOrRemoveDependents']?.remove &&
-              formData?.stepChildren?.[index]?.supportingStepchild,
-          }),
-          removeChildHouseholdPartFour: pageBuilder.itemPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path:
-              '686-stepchild-no-longer-part-of-household/:index/child-address',
-            uiSchema: childAddressPage.uiSchema,
-            schema: childAddressPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeChildHouseholdPartFive: pageBuilder.itemPage({
-            title:
-              'Information needed to report a stepchild is no longer part of your household',
-            path:
-              '686-stepchild-no-longer-part-of-household/:index/parent-or-guardian',
-            uiSchema: parentOrGuardianPage.uiSchema,
-            schema: parentOrGuardianPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportStepchildNotInHousehold,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-        })),
-      },
-    },
-
-    deceasedDependents: {
-      title: 'Remove one or more dependents who have died',
-      pages: {
-        ...arrayBuilderPages(deceasedDependentOptions, pageBuilder => ({
-          dependentAdditionalInformationIntro: pageBuilder.introPage({
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove,
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death',
-            uiSchema: deceasedDependentIntroPage.uiSchema,
-            schema: deceasedDependentIntroPage.schema,
-          }),
-          dependentAdditionalInformationSummary: pageBuilder.summaryPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/dependent-summary',
-            uiSchema: deceasedDependentSummaryPage.uiSchema,
-            schema: deceasedDependentSummaryPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          dependentAdditionalInformationPartOne: pageBuilder.itemPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/:index/dependent-information',
-            uiSchema: deceasedDependentPersonalInfoPage.uiSchema,
-            schema: deceasedDependentPersonalInfoPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          dependentAdditionalInformationPartTwo: pageBuilder.itemPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/:index/dependent-type',
-            uiSchema: deceasedDependentTypePage.uiSchema,
-            schema: deceasedDependentTypePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          dependentAdditionalInformationPartThree: pageBuilder.itemPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/:index/child-type',
-            uiSchema: deceasedDependentChildTypePage.uiSchema,
-            schema: deceasedDependentChildTypePage.schema,
-            depends: (formData, index) =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove &&
-              formData?.deaths?.[index]?.dependentType === 'CHILD',
-          }),
-          dependentAdditionalInformationPartFour: pageBuilder.itemPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/:index/date-of-death',
-            uiSchema: deceasedDependentDateOfDeathPage.uiSchema,
-            schema: deceasedDependentDateOfDeathPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          dependentAdditionalInformationPartFive: pageBuilder.itemPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/:index/location-of-death',
-            uiSchema: deceasedDependentLocationOfDeathPage.uiSchema,
-            schema: deceasedDependentLocationOfDeathPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          dependentAdditionalInformationPartSix: pageBuilder.itemPage({
-            title: 'Information needed to remove a dependent who has died',
-            path: '686-report-dependent-death/:index/dependent-income',
-            uiSchema: deceasedDependentIncomePage.uiSchema,
-            schema: deceasedDependentIncomePage.schema,
-            depends: formData =>
-              isChapterFieldRequired(formData, TASK_KEYS.reportDeath) &&
-              formData?.['view:addOrRemoveDependents']?.remove &&
-              !formData?.vaDependentsNetWorthAndPension,
-          }),
-        })),
-      },
-    },
-
-    reportChildMarriage: {
-      title: 'Remove one or more children who got married',
-      pages: {
-        ...arrayBuilderPages(removeMarriedChildOptions, pageBuilder => ({
-          removeMarriedChildIntro: pageBuilder.introPage({
-            title:
-              'Information needed to report the marriage of a child under 18',
-            path: '686-report-marriage-of-child',
-            uiSchema: removeMarriedChildIntroPage.uiSchema,
-            schema: removeMarriedChildIntroPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportMarriageOfChildUnder18,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeMarriedChildSummary: pageBuilder.summaryPage({
-            title:
-              'Information needed to report the marriage of a child under 18',
-            path: '686-report-marriage-of-child/summary',
-            uiSchema: removeMarriedChildSummaryPage.uiSchema,
-            schema: removeMarriedChildSummaryPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportMarriageOfChildUnder18,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeMarriedChildPartOne: pageBuilder.itemPage({
-            title:
-              'Information needed to report the marriage of a child under 18',
-            path: '686-report-marriage-of-child/:index/child-information',
-            uiSchema: marriedChildInformationPage.uiSchema,
-            schema: marriedChildInformationPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportMarriageOfChildUnder18,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeMarriedChildPartTwo: pageBuilder.itemPage({
-            title:
-              'Information needed to report the marriage of a child under 18',
-            path: '686-report-marriage-of-child/:index/date-child-married',
-            uiSchema: dateChildMarriedPage.uiSchema,
-            schema: dateChildMarriedPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportMarriageOfChildUnder18,
-              ) && formData?.['view:addOrRemoveDependents']?.remove,
-          }),
-          removeMarriedChildPartThree: pageBuilder.itemPage({
-            title:
-              'Information needed to report the marriage of a child under 18',
-            path: '686-report-marriage-of-child/:index/child-income',
-            uiSchema: marriedChildIncomeQuestionPage.uiSchema,
-            schema: marriedChildIncomeQuestionPage.schema,
-            depends: formData =>
-              isChapterFieldRequired(
-                formData,
-                TASK_KEYS.reportMarriageOfChildUnder18,
-              ) &&
-              formData?.['view:addOrRemoveDependents']?.remove &&
-              !formData?.vaDependentsNetWorthAndPension,
-          }),
-        })),
-      },
-    },
-
-    reportChildStoppedAttendingSchool: {
-      title:
-        'Remove one or more children between ages 18 and 23 who left school',
-      pages: {
-        ...arrayBuilderPages(
-          removeChildStoppedAttendingSchoolOptions,
-          pageBuilder => ({
-            childNoLongerInSchoolIntro: pageBuilder.introPage({
-              title:
-                'Information needed to report a child 18-23 years old stopped attending school',
-              path: 'report-child-stopped-attending-school',
-              uiSchema: removeChildStoppedAttendingSchoolIntroPage.uiSchema,
-              schema: removeChildStoppedAttendingSchoolIntroPage.schema,
-              depends: formData =>
-                isChapterFieldRequired(
-                  formData,
-                  TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
-                ) && formData?.['view:addOrRemoveDependents']?.remove,
-            }),
-            childNoLongerInSchoolSummary: pageBuilder.summaryPage({
-              title:
-                'Information needed to report a child 18-23 years old stopped attending school',
-              path: 'report-child-stopped-attending-school/summary',
-              uiSchema: removeChildStoppedAttendingSchoolSummaryPage.uiSchema,
-              schema: removeChildStoppedAttendingSchoolSummaryPage.schema,
-              depends: formData =>
-                isChapterFieldRequired(
-                  formData,
-                  TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
-                ) && formData?.['view:addOrRemoveDependents']?.remove,
-            }),
-            childNoLongerInSchoolPartOne: pageBuilder.itemPage({
-              title:
-                'Information needed to report a child 18-23 years old stopped attending school',
-              path:
-                'report-child-stopped-attending-school/:index/child-information',
-              uiSchema: childInformationPage.uiSchema,
-              schema: childInformationPage.schema,
-              depends: formData =>
-                isChapterFieldRequired(
-                  formData,
-                  TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
-                ) && formData?.['view:addOrRemoveDependents']?.remove,
-            }),
-            childNoLongerInSchoolPartTwo: pageBuilder.itemPage({
-              title:
-                'Information needed to report a child 18-23 years old stopped attending school',
-              path:
-                'report-child-stopped-attending-school/:index/date-child-left-school',
-              uiSchema: dateChildLeftSchoolPage.uiSchema,
-              schema: dateChildLeftSchoolPage.schema,
-              depends: formData =>
-                isChapterFieldRequired(
-                  formData,
-                  TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
-                ) && formData?.['view:addOrRemoveDependents']?.remove,
-            }),
-            childNoLongerInSchoolPartThree: pageBuilder.itemPage({
-              title:
-                'Information needed to report a child 18-23 years old stopped attending school',
-              path: 'report-child-stopped-attending-school/:index/child-income',
-              uiSchema: childIncomeQuestionPage.uiSchema,
-              schema: childIncomeQuestionPage.schema,
-              depends: formData =>
-                isChapterFieldRequired(
-                  formData,
-                  TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
-                ) &&
-                formData?.['view:addOrRemoveDependents']?.remove &&
-                !formData?.vaDependentsNetWorthAndPension,
-            }),
-          }),
-        ),
-      },
-    },
+    report674,
+    reportDivorce,
+    reportStepchildNotInHousehold,
+    deceasedDependents,
+    reportChildMarriage,
+    reportChildStoppedAttendingSchool,
 
     householdIncome: {
       title: 'Your net worth',
@@ -1128,7 +215,7 @@ export const formConfig = {
             const { needsSpouseUpload } = spouseEvidence(formData);
             return (
               isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
+              isAddingDependents(formData) &&
               needsSpouseUpload
             );
           },
@@ -1137,13 +224,14 @@ export const formConfig = {
           uiSchema: spouseAdditionalEvidence.uiSchema,
           schema: spouseAdditionalEvidence.schema,
         },
+
         childAdditionalEvidence: {
           depends: formData => {
             const { needsChildUpload } = childEvidence(formData);
             return (
               (isChapterFieldRequired(formData, TASK_KEYS.addChild) ||
                 isChapterFieldRequired(formData, TASK_KEYS.addDisabledChild)) &&
-              formData?.['view:addOrRemoveDependents']?.add &&
+              isAddingDependents(formData) &&
               needsChildUpload
             );
           },

--- a/src/applications/dependents/686c-674/config/prefill-transformer.js
+++ b/src/applications/dependents/686c-674/config/prefill-transformer.js
@@ -1,4 +1,5 @@
 import { NETWORTH_VALUE } from './constants';
+import { calculateAge } from '../../shared/utils';
 
 export default function prefillTransformer(pages, formData, metadata) {
   const {
@@ -13,9 +14,14 @@ export default function prefillTransformer(pages, formData, metadata) {
   const isMilitary =
     ['APO', 'FPO', 'DPO'].includes((address?.city || '').toUpperCase()) ||
     false;
-  const awardedDependents = dependents.filter(
-    dependent => dependent.awardIndicator === 'Y',
-  );
+  const awardedDependents = dependents
+    .filter(dependent => dependent.awardIndicator === 'Y')
+    .map(dependent => ({
+      ...dependent,
+      // Calculate and add age for dependents not awarded so we can display it
+      age: calculateAge(dependent.dateOfBirth, { dateInFormat: 'yyyy-MM-dd' })
+        .labeledAge,
+    }));
   const notAwardedDependents = dependents.filter(
     dependent => dependent.awardIndicator !== 'Y',
   );

--- a/src/applications/dependents/686c-674/config/utilities/data.js
+++ b/src/applications/dependents/686c-674/config/utilities/data.js
@@ -284,3 +284,26 @@ export const childEvidence = (formData = {}) => {
 
 export const showDupeModalIfEnabled = (formData = {}) =>
   !!formData.vaDependentsDuplicateModals;
+
+export const isAddingDependents = formData =>
+  !!formData?.['view:addOrRemoveDependents']?.add;
+export const isRemovingDependents = formData =>
+  !!formData?.['view:addOrRemoveDependents']?.remove;
+export const showV3Picklist = formData => !!formData?.vaDependentsV3;
+export const noV3Picklist = formData => !formData?.vaDependentsV3;
+
+export const hasAwardedDependents = (formData = {}) =>
+  Array.isArray(formData?.dependents?.awarded) &&
+  formData.dependents.awarded.length > 0;
+
+export const isVisiblePicklistPage = (formData, relationship) => {
+  const pickList = formData?.['view:removeDependentPickList'] || [];
+  return (
+    (showV3Picklist(formData) &&
+      formData?.['view:addOrRemoveDependents']?.remove &&
+      pickList.some(
+        item => item.selected && item.relationshipToVeteran === relationship,
+      )) ||
+    false
+  );
+};

--- a/src/applications/dependents/686c-674/config/utilities/index.js
+++ b/src/applications/dependents/686c-674/config/utilities/index.js
@@ -19,6 +19,12 @@ import {
   spouseEvidence,
   childEvidence,
   showDupeModalIfEnabled,
+  isAddingDependents,
+  isRemovingDependents,
+  showV3Picklist,
+  noV3Picklist,
+  hasAwardedDependents,
+  isVisiblePicklistPage,
 } from './data';
 
 export {
@@ -42,4 +48,10 @@ export {
   spouseEvidence,
   childEvidence,
   showDupeModalIfEnabled,
+  isAddingDependents,
+  isRemovingDependents,
+  showV3Picklist,
+  noV3Picklist,
+  hasAwardedDependents,
+  isVisiblePicklistPage,
 };

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -51,6 +51,7 @@ function App({
   useFormFeatureToggleSync([
     'vaDependentsNetWorthAndPension',
     'vaDependentsDuplicateModals',
+    'vaDependentsV3',
   ]);
   const dependentsModuleEnabled = useToggleValue(
     TOGGLE_NAMES.dependentsModuleEnabled,

--- a/src/applications/dependents/686c-674/tests/components/PicklistRemoveDependents.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/components/PicklistRemoveDependents.unit.spec.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { sub, format } from 'date-fns';
+
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+import { slugifyText } from 'platform/forms-system/src/js/patterns/array-builder';
+
+import PicklistRemoveDependents from '../../components/PicklistRemoveDependents';
+import optionPage from '../../config/chapters/picklist/removeDependentPicklist';
+
+describe('PicklistRemoveDependents', () => {
+  const createDoB = (yearsAgo = 0, monthsAgo = 0) =>
+    format(
+      sub(new Date(), { years: yearsAgo, months: monthsAgo }),
+      'yyyy-MM-dd',
+    );
+  const defaultData = {
+    dependents: {
+      hasDependents: true,
+      awarded: [
+        {
+          fullName: {
+            first: 'SPOUSY',
+            last: 'FOSTER',
+          },
+          dateOfBirth: createDoB(45),
+          ssn: '702023332',
+          relationshipToVeteran: 'Spouse',
+          awardIndicator: 'Y',
+        },
+        {
+          fullName: {
+            first: 'PENNY',
+            last: 'FOSTER',
+          },
+          dateOfBirth: createDoB(11),
+          ssn: '793473479',
+          relationshipToVeteran: 'Child',
+          awardIndicator: 'Y',
+        },
+        {
+          fullName: {
+            first: 'STACY',
+            last: 'FOSTER',
+          },
+          dateOfBirth: createDoB(0, 3),
+          ssn: '798703232',
+          relationshipToVeteran: 'Child',
+          awardIndicator: 'Y',
+        },
+        {
+          fullName: {
+            first: 'PETER',
+            last: 'FOSTER',
+          },
+          dateOfBirth: createDoB(82),
+          ssn: '997010104',
+          relationshipToVeteran: 'Parent',
+          awardIndicator: 'Y',
+        },
+      ],
+      notAwarded: [],
+    },
+  };
+
+  const renderComponent = ({
+    data = defaultData,
+    goBack = () => {},
+    goForward = () => {},
+    setFormData = () => {},
+    updatePage = () => {},
+    onReviewPage = false,
+    contentBeforeButtons = <div id="before">before</div>,
+    contentAfterButtons = <div id="after">after</div>,
+  } = {}) =>
+    render(
+      <>
+        <div name="topScrollElement" />
+        <PicklistRemoveDependents
+          name="PicklistRemoveDependents"
+          title="Spouse info"
+          data={data}
+          goBack={goBack}
+          goForward={goForward}
+          setFormData={setFormData}
+          updatePage={updatePage}
+          schema={optionPage.schema}
+          uiSchema={optionPage.uiSchema}
+          onReviewPage={onReviewPage}
+          contentBeforeButtons={contentBeforeButtons}
+          contentAfterButtons={contentAfterButtons}
+        />
+      </>,
+    );
+
+  it('should render dependent picklist checkboxes', () => {
+    const { container } = renderComponent();
+
+    const checkboxes = $$('va-checkbox', container);
+    expect(checkboxes.length).to.equal(4);
+    expect(checkboxes.map(cb => cb.getAttribute('label'))).to.deep.equal([
+      'SPOUSY FOSTER',
+      'PENNY FOSTER',
+      'STACY FOSTER',
+      'PETER FOSTER',
+    ]);
+    expect(checkboxes.map(cb => cb.textContent)).to.deep.equal([
+      'Spouse, 45 years old',
+      'Child, 11 years old',
+      'Child, 3 months old',
+      'Parent, 82 years oldNote: A parent dependent can only be removed if they have died',
+    ]);
+    expect($('va-additional-info', container)).to.exist;
+    expect($('.form-progress-buttons', container)).to.exist;
+    expect($('#before', container)).to.exist;
+    expect($('#after', container)).to.exist;
+  });
+
+  it('should update "view:removeDependentPickList" in form data on change', () => {
+    const setFormData = sinon.spy();
+    const { container } = renderComponent({ setFormData });
+
+    $('va-checkbox-group', container).__events.vaChange({
+      detail: { checked: true },
+      target: { getAttribute: () => 'penny-3479' },
+    });
+
+    const result = defaultData.dependents.awarded.map((dep, index) => ({
+      ...dep,
+      key: slugifyText(
+        `${dep.fullName.first.toLowerCase()}-${dep.ssn.slice(-4)}`,
+      ),
+      selected: index === 1,
+    }));
+
+    expect(setFormData.calledOnce).to.be.true;
+    expect(
+      setFormData.firstCall.args[0]['view:removeDependentPickList'],
+    ).to.deep.equal(result);
+  });
+
+  it('should show error message if form submitted with no checkboxes checked', async () => {
+    const goForward = sinon.spy();
+    const { container } = renderComponent({ goForward });
+
+    fireEvent.submit($('form', container));
+    await waitFor(() => {
+      expect(goForward.called).to.be.false;
+      expect($('va-checkbox-group[error]', container)).to.exist;
+    });
+  });
+});

--- a/src/applications/dependents/686c-674/tests/config/chapters/household-income/helpers.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/household-income/helpers.unit.spec.jsx
@@ -71,7 +71,7 @@ describe('household income helpers', () => {
       const result = netWorthTitle({ featureFlag: false });
 
       expect(result).to.equal(
-        `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`,
+        `Did your household have a net worth less than $${NETWORTH_VALUE} in the last tax year?`,
       );
     });
 
@@ -79,7 +79,7 @@ describe('household income helpers', () => {
       const result = netWorthTitle({});
 
       expect(result).to.equal(
-        `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`,
+        `Did your household have a net worth less than $${NETWORTH_VALUE} in the last tax year?`,
       );
     });
 
@@ -90,7 +90,7 @@ describe('household income helpers', () => {
       });
 
       expect(result).to.equal(
-        'Did the household have a net worth greater than $200,000 in the last tax year?',
+        'Did your household have a net worth less than $200,000 in the last tax year?',
       );
     });
 
@@ -101,7 +101,7 @@ describe('household income helpers', () => {
       });
 
       expect(result).to.equal(
-        'Did the household have a net worth greater than $1,500,000 in the last tax year?',
+        'Did your household have a net worth less than $1,500,000 in the last tax year?',
       );
     });
 
@@ -116,7 +116,7 @@ describe('household income helpers', () => {
         10,
       ).toLocaleString('en-US');
       expect(result).to.equal(
-        `Did the household have a net worth greater than $${expectedValue} in the last tax year?`,
+        `Did your household have a net worth less than $${expectedValue} in the last tax year?`,
       );
     });
 
@@ -132,7 +132,7 @@ describe('household income helpers', () => {
         10,
       ).toLocaleString('en-US');
       expect(result).to.equal(
-        `Did the household have a net worth greater than $${expectedValue} in the last tax year?`,
+        `Did your household have a net worth less than $${expectedValue} in the last tax year?`,
       );
     });
 
@@ -148,7 +148,7 @@ describe('household income helpers', () => {
         10,
       ).toLocaleString('en-US');
       expect(result).to.equal(
-        `Did the household have a net worth greater than $${expectedValue} in the last tax year?`,
+        `Did your household have a net worth less than $${expectedValue} in the last tax year?`,
       );
     });
 
@@ -159,7 +159,7 @@ describe('household income helpers', () => {
       });
 
       expect(result).to.equal(
-        'Did the household have a net worth greater than $12,345,678 in the last tax year?',
+        'Did your household have a net worth less than $12,345,678 in the last tax year?',
       );
     });
 
@@ -170,7 +170,7 @@ describe('household income helpers', () => {
       });
 
       expect(result).to.equal(
-        'Did the household have a net worth greater than $100 in the last tax year?',
+        'Did your household have a net worth less than $100 in the last tax year?',
       );
     });
   });

--- a/src/applications/dependents/686c-674/tests/config/chapters/picklist/removeDependentPicklist.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/picklist/removeDependentPicklist.unit.spec.jsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import formConfig from '../../../../config/form';
+
+describe('Remove Dependent Picklist options page', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.optionSelection.pages.removeDependentsPicklistOptions;
+
+  it('should render', () => {
+    const { container } = render(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    // Using a custom page, which isn't rendered by DefinitionTester
+    expect($('form', container)).to.exist;
+  });
+});

--- a/src/applications/dependents/686c-674/tests/config/prefill-transformer.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/prefill-transformer.unit.spec.jsx
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import { sub, format } from 'date-fns';
+
 import prefillTransformer from '../../config/prefill-transformer';
 import { NETWORTH_VALUE } from '../../config/constants';
 
@@ -8,7 +10,7 @@ const defaultDependents = [
       first: 'Jane',
       last: 'Doe',
     },
-    dateOfBirth: '1990-07-07',
+    dateOfBirth: format(sub(new Date(), { years: 35 }), 'yyyy-MM-dd'),
     ssn: '702023332',
     relationshipToVeteran: 'Spouse',
     awardIndicator: 'Y',
@@ -84,7 +86,9 @@ const buildData = ({
     dependents: {
       hasDependents:
         dependents.filter(d => d.awardIndicator === 'Y').length > 0,
-      awarded: dependents.filter(d => d.awardIndicator === 'Y'),
+      awarded: dependents
+        .filter(d => d.awardIndicator === 'Y')
+        .map(d => ({ ...d, age: '35 years old' })),
       notAwarded: dependents.filter(d => d.awardIndicator !== 'Y'),
     },
   },

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/686c-only-maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/686c-only-maximal.json
@@ -49,6 +49,7 @@
       "isEncrypted": false
     }
   ],
+  "view:householdIncome": true,
   "view:completedChildStoppedAttendingSchool": false,
   "view:completedMarriedChild": false,
   "view:completedDependent": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/add-child-add-674.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/add-child-add-674.json
@@ -2,6 +2,7 @@
   "vaDependentsNetWorthAndPension": false,
   "view:checkVeteranPension": true,
   "view:additionalEvidenceDescription": {},
+  "view:householdIncome": true,
   "householdIncome": false,
   "view:studentInformationMissingInformation": {},
   "view:completedStudent": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/add-child-report-divorce.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/add-child-report-divorce.json
@@ -1,5 +1,6 @@
 {
   "vaDependentsNetWorthAndPension": false,
+  "view:householdIncome": true,
   "householdIncome": false,
   "reportDivorce": {
     "spouseIncome": "NA",

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/ancillary-flows.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/ancillary-flows.json
@@ -1,5 +1,6 @@
 {
   "vaDependentsNetWorthAndPension": false,
+  "view:householdIncome": true,
   "householdIncome": false,
   "view:childStoppedAttendingSchoolMissingInformation": {},
   "view:completedChildStoppedAttendingSchool": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/duplicate-children.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/duplicate-children.json
@@ -36,6 +36,26 @@
         "ssn": "793473479",
         "relationshipToVeteran": "Child",
         "awardIndicator": "Y"
+      },
+      {
+        "fullName": {
+          "first": "STACY",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "2018-06-10",
+        "ssn": "798703232",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "Y"
+      },
+      {
+        "fullName": {
+          "first": "PETER",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "1943-03-01",
+        "ssn": "997010104",
+        "relationshipToVeteran": "Parent",
+        "awardIndicator": "Y"
       }
     ],
     "notAwarded": [
@@ -115,25 +135,6 @@
         },
         "dateOfBirth": "2005-05-05",
         "ssn": "780934232",
-        "relationshipToVeteran": "Child",
-        "awardIndicator": "N"
-      },
-      {
-        "fullName": {
-          "first": "STACY",
-          "last": "FOSTER"
-        },
-        "ssn": "798703232",
-        "relationshipToVeteran": "Child",
-        "awardIndicator": "N"
-      },
-      {
-        "fullName": {
-          "first": "PETER",
-          "last": "FOSTER"
-        },
-        "dateOfBirth": "2021-03-01",
-        "ssn": "997010104",
         "relationshipToVeteran": "Child",
         "awardIndicator": "N"
       },

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
@@ -105,7 +105,7 @@
             "first": "SPOUSY",
             "last": "FOSTER"
           },
-          "dateOfBirth": "1970-07-07",
+          "dateOfBirth": "1980-07-07",
           "ssn": "702023332",
           "relationshipToVeteran": "Spouse",
           "awardIndicator": "Y"
@@ -118,6 +118,26 @@
           "dateOfBirth": "2014-08-08",
           "ssn": "793473479",
           "relationshipToVeteran": "Child",
+          "awardIndicator": "Y"
+        },
+        {
+          "fullName": {
+            "first": "STACY",
+            "last": "FOSTER"
+          },
+          "dateOfBirth": "2025-06-10",
+          "ssn": "798703232",
+          "relationshipToVeteran": "Child",
+          "awardIndicator": "Y"
+        },
+        {
+          "fullName": {
+            "first": "PETER",
+            "last": "FOSTER"
+          },
+          "dateOfBirth": "1943-03-01",
+          "ssn": "997010104",
+          "relationshipToVeteran": "Parent",
           "awardIndicator": "Y"
         }
       ],

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
@@ -15,6 +15,7 @@
         "isEncrypted": false
       }
     ],
+    "view:householdIncome": true,
     "view:completedChildStoppedAttendingSchool": false,
     "view:completedMarriedChild": false,
     "view:completedDependent": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/report-death.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/report-death.json
@@ -1,5 +1,6 @@
 {
   "vaDependentsNetWorthAndPension": false,
+  "view:householdIncome": true,
   "householdIncome": false,
   "view:deathsMissingInformation": {},
   "view:completedDependent": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/report-married-child-report-student-left-school.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/report-married-child-report-student-left-school.json
@@ -1,5 +1,6 @@
 {
   "vaDependentsNetWorthAndPension": false,
+  "view:householdIncome": true,
   "householdIncome": false,
   "view:childStoppedAttendingSchoolMissingInformation": {},
   "view:completedChildStoppedAttendingSchool": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/spouse-child-all-fields.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/spouse-child-all-fields.json
@@ -1,5 +1,6 @@
 {
   "vaDependentsNetWorthAndPension": false,
+  "view:householdIncome": true,
   "householdIncome": false,
   "view:childrenToAddMissingInformation": {},
   "view:completedAddChild": false,

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/spouse-report-divorce.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/spouse-report-divorce.json
@@ -1,5 +1,6 @@
 {
   "vaDependentsNetWorthAndPension": false,
+  "view:householdIncome": true,
   "householdIncome": false,
   "reportDivorce": {
     "spouseIncome": "NA",

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/transformed-maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/transformed-maximal.json
@@ -107,6 +107,7 @@
       "isEncrypted": false
     }
   ],
+  "view:householdIncome": true,
   "householdIncome": false,
 
   "reportDivorce": {

--- a/src/applications/dependents/686c-674/tests/mock-api-full-data.js
+++ b/src/applications/dependents/686c-674/tests/mock-api-full-data.js
@@ -11,7 +11,7 @@ const mockUser = require('./e2e/user.json');
 const mockVaFileNumber = require('./e2e/fixtures/va-file-number.json');
 const mockMaxData = require('./e2e/fixtures/maximal.json');
 
-const returnUrl = '/review-and-submit';
+const returnUrl = '/options-selection/remove-active-dependents'; // '/review-and-submit';
 
 const submission = {
   formSubmissionId: '123fake-submission-id-567',
@@ -97,6 +97,8 @@ const responses = {
       features: [
         { name: 'vaDependentsV2', value: true },
         { name: 'va_dependents_v2', value: true },
+        { name: 'vaDependentsV3', value: true },
+        { name: 'va_dependents_v3', value: true },
         { name: 'vaDependentsNetWorthAndPension', value: true },
         { name: 'va_dependents_net_worth_and_pension', value: true },
         { name: 'vaDependentsDuplicateModals', value: true },

--- a/src/applications/dependents/shared/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/dependents/shared/tests/utils/utils.unit.spec.jsx
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { format, sub } from 'date-fns';
 
 import {
   getFullName,
@@ -7,6 +8,7 @@ import {
   maskID,
   isEmptyObject,
   getRootParentUrl,
+  calculateAge,
 } from '../../utils';
 
 describe('getFullName', () => {
@@ -128,5 +130,123 @@ describe('getFormatedDate', () => {
   it('should return formatted date for valid Date object', () => {
     const formattedDate = getFormatedDate('12/05/2022', 'MM/dd/yyyy', 'PPPP');
     expect(formattedDate).to.equal('Monday, December 5th, 2022');
+  });
+});
+
+describe('calculateAge', () => {
+  it('should return 0 age and empty strings if dob is not provided', () => {
+    const result = calculateAge();
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: '',
+      labeledAge: '',
+    });
+  });
+
+  it('should return 0 age and empty strings if dob is invalid', () => {
+    const result = calculateAge('');
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: '',
+      labeledAge: '',
+    });
+  });
+
+  it('should return 0 age and correct dobStr for future dates', () => {
+    const testDate = sub(new Date(), {
+      months: -1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: 'Date in the future',
+    });
+  });
+
+  it('should correctly calculate age an 18 year old', () => {
+    const testDate = sub(new Date(), {
+      years: 18,
+      months: 1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 18,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '18 years old',
+    });
+  });
+
+  it('should correctly calculate age for a 1 year old', () => {
+    const testDate = sub(new Date(), {
+      years: 1,
+      days: 3,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 1,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '1 year old',
+    });
+  });
+
+  it('should correctly calculate age for a 4 month old', () => {
+    const testDate = sub(new Date(), {
+      months: 4,
+      days: 3,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '4 months old',
+    });
+  });
+
+  it('should correctly calculate age for a 1 month old', () => {
+    const testDate = sub(new Date(), {
+      months: 1,
+      days: 1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '1 month old',
+    });
+  });
+
+  it('should correctly calculate age for a 10 day old', () => {
+    const testDate = sub(new Date(), {
+      days: 10,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '10 days old',
+    });
+  });
+
+  it('should correctly calculate age for a 1 day old', () => {
+    const testDate = sub(new Date(), {
+      days: 1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '1 day old',
+    });
+  });
+
+  it('should correctly calculate age for a baby born today', () => {
+    const testDate = new Date();
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: 'Newborn',
+    });
   });
 });

--- a/src/applications/dependents/shared/utils/dates.js
+++ b/src/applications/dependents/shared/utils/dates.js
@@ -1,0 +1,97 @@
+import {
+  parse,
+  isValid,
+  differenceInYears,
+  differenceInMonths,
+  differenceInDays,
+  format,
+} from 'date-fns';
+
+/**
+ *
+ * @param {String} date - date string that matches the `startFormat`
+ * @param {String} startFormat - input date string format using Date-fn patterns
+ * @param {String} endFormat - output date string format using Date-fn patterns
+ * @returns {String} - formatted date string, or 'Unknown date' if invalid
+ */
+export const getFormatedDate = (
+  date,
+  startFormat = 'yyyy-MM-dd',
+  endFormat = 'MMMM d, yyyy',
+) => {
+  const dobObj = parse(date, startFormat, new Date());
+  return isValid(dobObj) ? format(dobObj, endFormat) : date || 'Unknown date';
+};
+
+/**
+ * @typedef {Object} CalculateAgeReturn
+ * @property {Number} age - age in years (0 if less than 1 year old or invalid)
+ * @property {String} dobStr - formatted date of birth
+ * @property {String} labeledAge - age with label ("2 years old", "5 months old",
+ *  "Newborn", "Date in the future", or "" if invalid)
+ */
+/**
+ * Calculate age from date of birth and return formatted age and dob string
+ * @param {String} dob - any date format that matches `dateInFormat`
+ * @param {Object} options
+ * @param {String} options.dateInFormat - input date string format using Date-fn
+ *  patterns
+ * @param {String} options.dateOutFormat - output date string format using
+ *  Date-fn patterns
+ * @param {String} options.futureDateError - message to return if future date is
+ *  provided
+ * @returns {CalculateAgeReturn}
+ */
+export const calculateAge = (
+  dob,
+  {
+    dateInFormat = 'MM/dd/yyyy',
+    dateOutFormat = 'MMMM d, yyyy',
+    futureDateError = 'Date in the future',
+  } = {},
+) => {
+  if (!dob) {
+    return { age: 0, dobStr: '', labeledAge: '' };
+  }
+
+  const dobObj = parse(dob, dateInFormat, new Date());
+  const dobStr = isValid(dobObj) ? format(dobObj, dateOutFormat) : '';
+  const invalid = { age: 0, dobStr, labeledAge: '' };
+
+  if (!dobStr) {
+    return invalid;
+  }
+
+  const ageInYears = differenceInYears(new Date(), dobObj);
+  if (ageInYears > 0) {
+    return {
+      age: ageInYears,
+      dobStr,
+      labeledAge: `${ageInYears} year${ageInYears > 1 ? 's' : ''} old`,
+    };
+  }
+
+  // If less than 1 year old, show months
+  const ageInMonths =
+    ageInYears > 0 ? 0 : differenceInMonths(new Date(), dobObj);
+  if (ageInMonths > 0) {
+    return {
+      age: 0,
+      dobStr,
+      labeledAge: `${ageInMonths} month${ageInMonths > 1 ? 's' : ''} old`,
+    };
+  }
+
+  // If less than a month old, show days
+  const ageInDays = ageInMonths > 0 ? 0 : differenceInDays(new Date(), dobObj);
+  return ageInDays >= 0
+    ? {
+        age: 0,
+        dobStr,
+        labeledAge:
+          ageInDays === 0
+            ? 'Newborn'
+            : `${ageInDays} day${ageInDays > 1 ? 's' : ''} old`,
+      }
+    : { age: 0, dobStr, labeledAge: futureDateError };
+};

--- a/src/applications/dependents/shared/utils/index.js
+++ b/src/applications/dependents/shared/utils/index.js
@@ -1,6 +1,8 @@
-import { parse, isValid, format } from 'date-fns';
-
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
+
+import { getFormatedDate, calculateAge } from './dates';
+
+export { getFormatedDate, calculateAge };
 
 /**
  * Return formatted full name from name object
@@ -14,22 +16,6 @@ import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-str
 export const getFullName = ({ first, middle, last, suffix } = {}) =>
   [first || '', middle || '', last || ''].filter(Boolean).join(' ') +
   (suffix ? `, ${suffix}` : '');
-
-/**
- *
- * @param {String} date - date string that matches the `startFormat`
- * @param {String} startFormat - input date string format using Date-fn patterns
- * @param {String} endFormat - output date string format using Date-fn patterns
- * @returns {String} - formatted date string, or 'Unknown date' if invalid
- */
-export const getFormatedDate = (
-  date,
-  startFormat = 'yyyy-MM-dd',
-  endFormat = 'MMMM d, yyyy',
-) => {
-  const dobObj = parse(date, startFormat, new Date());
-  return isValid(dobObj) ? format(dobObj, endFormat) : date || 'Unknown date';
-};
 
 /**
  * Separate each number so the screen reader reads "number ending with 1 2 3 4"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Update net worth question to read `less than` rather than `greater than`
  - Reverse value for question (`Y` == `N` and `N` === `Y`) so that RBPS gets values correctly
  - Update fixtures to contain the `view:householdIncome` ui field so that local development works correctly
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Lifestage Benefits - Dependents Management
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _https://github.com/department-of-veterans-affairs/va.gov-team/issues/120615_

## Testing done

- _Describe what the old behavior was prior to the change_
  - Net worth question read `greater than {{value}}`, answers were sent to RBPS as value in UI 
- _Describe the steps required to verify your changes are working as expected_
  1.  Run 686c/674 locally
  2. Make sure `va_dependents_net_worth_and_pension` feature flag is turned on
  3. Login with `vets.gov.user+1@gmail.com` user
  4. Navigate to http://localhost:3001/manage-dependents/add-remove-form-21-686c-674/net-worth
  5. Click 'Continue your Application'
  6. Select 'No' for net worth question
  7. Navigate to http://localhost:3001/manage-dependents/add-remove-form-21-686c-674/review-and-submit
  8. Submit Application
  9. Check that the POST to http://localhost:3000/dependents_benefits/v0/claims submitted `househouseIncome` = `true`
  10. Do the same for selecting 'Yes' for net worth question (`householdIncome` = `false`)
- _Describe the tests completed and the results_
  - Manual Testing and updated unit testing 
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |  
<img width="619" height="565" alt="Screenshot 2025-10-07 at 1 09 56 PM" src="https://github.com/user-attachments/assets/13b38a50-63df-4ce0-91ee-6ccdc25fda80" />|<img width="587" height="565" alt="Screenshot 2025-10-07 at 1 08 14 PM" src="https://github.com/user-attachments/assets/43373a35-c6a6-4867-aba2-fb7ec0748966" />|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
- 686c-674-v2

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
