### PR TITLE
ArrayBuilder | Fix issue with onNavBack

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -757,9 +757,6 @@ export const medicareStatusPage = {
     const excluded = getEligibleApplicantsWithoutMedicare(formData) ?? [];
     return excluded.some(a => getAgeInYears(a.applicantDob) >= 65);
   },
-  onNavBack: ({ goPath }) => {
-    goPath('/report-medicare-plans');
-  },
   ...medicarePartADenialPage('hasProofMultipleApplicants'),
 };
 

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockArrayAddresses.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockArrayAddresses.js
@@ -5,7 +5,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { ArrayAddress } from '../components/viewElements';
 
-/** @type {PageSchema}  */
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     ...titleUI('Web component Address'),

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -586,6 +586,7 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
         defaultSummaryPageScrollAndFocusTarget,
       onNavForward: navForwardSummary,
       onNavBack: onNavBackKeepUrlParams,
+      isArrayBuilderSummary: true,
       ...pageConfig,
       CustomPageReview,
       CustomPage,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes an issue with back navigation in the ArrayBuilder. Due to the AB utilizing its own custom nav declaration, if you have two ABs back-to-back in the form flow, when navigating back from the second summary page, it would take you to the last page of the last item in the array of the previous page. This fix ensures that you always go back to the summary page if the previous page is a per-item array page. 

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118196

## Testing done

- Old behavior is described above
- New behavior ensures you always go back to the summary page

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Form flow navigates as expected

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
