### PR TITLE
Fix `<DashboardCards>` component test for loading state that is failing under Node 22 

### DIFF
--- a/src/applications/ask-va/tests/containers/DashboardCards.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/DashboardCards.unit.spec.jsx
@@ -4,7 +4,6 @@ import {
   createGetHandler,
   jsonResponse,
   setupServer,
-  delayedJsonResponse,
 } from 'platform/testing/unit/msw-adapter';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -692,8 +691,8 @@ describe('<DashboardCards>', () => {
     before(() => {
       server = setupServer(
         createGetHandler(`${apiRequestWithUrl}`, () => {
-          // Use the adapter's delayedResponse helper instead of manual Promise
-          return delayedJsonResponse(
+          // Use the adapter's jsonResponse helper instead of manual Promise
+          return jsonResponse(
             {
               data: [
                 {
@@ -710,7 +709,7 @@ describe('<DashboardCards>', () => {
                 },
               ],
             },
-            100, // delay in milliseconds
+            { status: 200 },
           );
         }),
       );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


### Acceptance criteria
- [x] The `<DashboardCards>` test passes successfully on Node 22.
- [x] Any changes maintain backward compatibility with Node 14 tests.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Related Issue
- Closes department-of-veterans-affairs/ask-va#1944

