### PR TITLE
VEBT-2700: 22-8794- Intro page link not opening in a new tab

### DIFF
--- a/src/applications/edu-benefits/8794/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/8794/containers/IntroductionPage.jsx
@@ -187,11 +187,13 @@ const IntroductionPage = ({ route }) => {
               ownership:
             </strong>{' '}
             Email your completed PDF to your State Approving Agency (SAA). If
-            you need help finding their email address,
+            you need help finding their email address,{' '}
             <va-link
-              text=" search the SAA contact directory (opens in a new tab)."
+              text="search the SAA contact directory"
               href="https://nasaa-vetseducation.com/nasaa-contacts/"
+              external
             />
+            .
           </p>
         </va-process-list-item>
       </va-process-list>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- The `va-link` for text `search the SAA contact directory` has been made `external` to open in a new tab
- Please note a slight change in the period `.` which is no longer a part of the link above

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-2700

**Bug Description** 

The intro page, the 3rd step has a link that should open on a new tab but it does not. 

**Acceptance Criteria Reference** 

AC1: Link that says "[search the SAA contact directory (opens in a new tab).](https://nasaa-vetseducation.com/nasaa-contacts/)" should open in a new tab.

## Testing done

- Local testing that link opens in a new tab
- No unit tests are impacted by this change

## Screenshots

**Before:**

<img width="704" height="292" alt="Introduction Page (Before)" src="https://github.com/user-attachments/assets/753dde97-af1f-42a0-91d8-35ec2b5306f6" />

**After:**

<img width="691" height="284" alt="Introduction Page (After)" src="https://github.com/user-attachments/assets/53620951-dfeb-4958-ac23-8f51f2e126a6" />

## What areas of the site does it impact?

- Form 22-8794 | Introduction Page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A