### PR TITLE
[119478] Fix incorrect OH integration domain listing after BlueButtonReport calls

### DIFF
--- a/src/applications/mhv-medical-records/reducers/careSummariesAndNotes.js
+++ b/src/applications/mhv-medical-records/reducers/careSummariesAndNotes.js
@@ -343,7 +343,6 @@ export const careSummariesAndNotesReducer = (state = initialState, action) => {
     }
     case Actions.CareSummariesAndNotes.GET_UNIFIED_LIST: {
       const data = action.response.data || [];
-      const oldList = state.careSummariesAndNotesList;
       const newList =
         data
           ?.map(note => {
@@ -358,9 +357,7 @@ export const careSummariesAndNotesReducer = (state = initialState, action) => {
         ...state,
         listCurrentAsOf: action.isCurrent ? new Date() : null,
         listState: loadStates.FETCHED,
-        careSummariesAndNotesList:
-          typeof oldList === 'undefined' ? newList : oldList,
-        updatedList: typeof oldList !== 'undefined' ? newList : undefined,
+        careSummariesAndNotesList: newList,
       };
     }
     case Actions.CareSummariesAndNotes.GET_LIST: {

--- a/src/applications/mhv-medical-records/reducers/conditions.js
+++ b/src/applications/mhv-medical-records/reducers/conditions.js
@@ -190,7 +190,6 @@ export const conditionReducer = (state = initialState, action) => {
     }
     case Actions.Conditions.GET_UNIFIED_LIST: {
       const data = action.response?.data || [];
-      const oldList = state.conditionsList;
       const newList =
         data
           .map(condition => {
@@ -205,8 +204,7 @@ export const conditionReducer = (state = initialState, action) => {
         ...state,
         listCurrentAsOf: action.isCurrent ? new Date() : null,
         listState: loadStates.FETCHED,
-        conditionsList: typeof oldList === 'undefined' ? newList : oldList,
-        updatedList: typeof oldList !== 'undefined' ? newList : undefined,
+        conditionsList: newList,
       };
     }
     case Actions.Conditions.COPY_UPDATED_LIST: {

--- a/src/applications/mhv-medical-records/reducers/vaccines.js
+++ b/src/applications/mhv-medical-records/reducers/vaccines.js
@@ -191,7 +191,6 @@ export const vaccineReducer = (state = initialState, action) => {
       };
     }
     case Actions.Vaccines.GET_UNIFIED_LIST: {
-      const oldList = state.vaccinesList;
       const metadata = action.response.meta;
       const newList =
         action.response.data
@@ -199,15 +198,11 @@ export const vaccineReducer = (state = initialState, action) => {
           .filter(record => record !== null)
           .sort((a, b) => new Date(b.date) - new Date(a.date)) || [];
 
-      const vaccinesList = typeof oldList === 'undefined' ? newList : oldList;
-      const updatedList = typeof oldList !== 'undefined' ? newList : undefined;
-
       return {
         ...state,
         listCurrentAsOf: action.isCurrent ? new Date() : null,
         listState: loadStates.FETCHED,
-        vaccinesList,
-        updatedList,
+        vaccinesList: newList,
         listMetadata: metadata,
         updateNeeded: false,
       };

--- a/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.jsx
@@ -805,4 +805,84 @@ describe('careSummariesAndNotesReducer', () => {
       [3, 2, 1, 'NULL1', 'NULL2'],
     );
   });
+
+  it('creates a unified list (GET_UNIFIED_LIST) with descending date order and sets current timestamp when isCurrent is true', () => {
+    const response = {
+      data: [
+        {
+          id: 'one',
+          attributes: {
+            name: 'First Note',
+            noteType: 'consult',
+            date: '2024-10-02T10:00:00Z',
+            dateEntered: '2024-10-02T10:05:00Z',
+          },
+        },
+        {
+          id: 'two',
+          attributes: {
+            name: 'Second Note',
+            noteType: 'consult',
+            date: '2024-10-03T09:00:00Z',
+            dateEntered: '2024-10-03T09:05:00Z',
+          },
+        },
+        {
+          id: 'three',
+          attributes: {
+            name: 'Third Note',
+            noteType: 'consult',
+            date: '2024-10-01T12:00:00Z',
+            dateEntered: '2024-10-01T12:05:00Z',
+          },
+        },
+      ],
+    };
+    const newState = careSummariesAndNotesReducer(
+      {},
+      {
+        type: Actions.CareSummariesAndNotes.GET_UNIFIED_LIST,
+        response,
+        isCurrent: true,
+      },
+    );
+    // Expect list ordered by descending date (ids: two, one, three)
+    expect(newState.careSummariesAndNotesList.map(r => r.id)).to.deep.equal([
+      'two',
+      'one',
+      'three',
+    ]);
+    expect(newState.listState).to.equal('fetched');
+    expect(newState.listCurrentAsOf).to.be.an.instanceof(Date);
+    // Verify one converted field (name preserved)
+    expect(newState.careSummariesAndNotesList[0].name).to.equal('Second Note');
+  });
+
+  it('creates a unified list with listCurrentAsOf = null when isCurrent is false', () => {
+    const response = {
+      data: [
+        {
+          id: 'n1',
+          attributes: {
+            name: 'Note 1',
+            noteType: 'consult',
+            date: '2024-10-05T11:00:00Z',
+          },
+        },
+      ],
+    };
+    const newState = careSummariesAndNotesReducer(
+      {},
+      {
+        type: Actions.CareSummariesAndNotes.GET_UNIFIED_LIST,
+        response,
+        isCurrent: false,
+      },
+    );
+    expect(newState.careSummariesAndNotesList.map(r => r.id)).to.deep.equal([
+      'n1',
+    ]);
+    expect(newState.listCurrentAsOf).to.equal(null);
+    expect(newState.listState).to.equal('fetched');
+  });
 });

--- a/src/applications/mhv-medical-records/tests/reducers/vaccines.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/reducers/vaccines.unit.spec.jsx
@@ -936,7 +936,7 @@ describe('vaccineReducer - GET_UNIFIED_LIST action', () => {
     expect(newState.vaccinesList[1].date).to.equal('January 15, 2023');
   });
 
-  it('should preserve existing list and put new data in updatedList when oldList exists', () => {
+  it('should put new data in vaccinesList', () => {
     const initialState = {
       vaccinesList: [
         { id: '1', name: 'Previous Vaccine 1' },
@@ -963,13 +963,9 @@ describe('vaccineReducer - GET_UNIFIED_LIST action', () => {
       isCurrent: true,
     });
 
-    // Should preserve the original list
-    expect(newState.vaccinesList).to.have.lengthOf(2);
-    expect(newState.vaccinesList[0].id).to.equal('1');
-    expect(newState.vaccinesList[1].id).to.equal('2');
-    // Should store new items in updatedList
-    expect(newState.updatedList).to.have.lengthOf(1);
-    expect(newState.updatedList[0].id).to.equal('123');
+    // Should store new items in the original list
+    expect(newState.vaccinesList).to.have.lengthOf(1);
+    expect(newState.vaccinesList[0].id).to.equal('123');
   });
 
   it('should handle empty data array', () => {
@@ -989,6 +985,34 @@ describe('vaccineReducer - GET_UNIFIED_LIST action', () => {
 
     expect(newState.vaccinesList).to.have.lengthOf(0);
     expect(newState.listState).to.equal(loadStates.FETCHED);
+  });
+
+  it('should set listCurrentAsOf to null when isCurrent is false', () => {
+    const response = {
+      data: [
+        {
+          id: '999',
+          attributes: {
+            groupName: 'Test Vaccine',
+            date: '2023-08-01T10:00:00Z',
+          },
+        },
+      ],
+      meta: { pagination: { totalEntries: 1 } },
+    };
+
+    const newState = vaccineReducer(
+      {},
+      {
+        type: Actions.Vaccines.GET_UNIFIED_LIST,
+        response,
+        isCurrent: false,
+      },
+    );
+
+    expect(newState.vaccinesList).to.have.lengthOf(1);
+    expect(newState.listCurrentAsOf).to.equal(null);
+    expect(newState.updateNeeded).to.be.false;
   });
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

The BlueButtonReport function currently fetches data for non-accelerated domains from the existing v1 endpoints without checking whether the isAccelerating feature toggle is enabled. As a result, the OH domains - Care Summaries and Notes, Health Conditions, and Vaccines - display Blue Button data instead of the OH accelerated data when the user immediately navigates to the domains listing

This PR fixes the issue by updating the domains listing data (instead of updatedList) when fetching accelerated data, ensuring the correct OH data is displayed.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#119478

## Testing done
- Local test steps:
  1) Go download a blue button report for all domains
  2) Go to Care summaries and notes page and click on one of the record. The details page should display without errors.
  3) Repeat step 2 to verify the other OH domains - Health Conditions and Vaccines

- Test specs added


## Screenshots
N/A

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
