### PR TITLE
[4920] 21-4140 Can enter a date in the future and a date prior to start date in end date

### DIFF
--- a/src/applications/simple-forms/21-4140/pages/employers.js
+++ b/src/applications/simple-forms/21-4140/pages/employers.js
@@ -24,20 +24,20 @@ const options = {
   nounSingular: 'employer',
   nounPlural: 'employers',
   required: false,
-  isItemIncomplete: item => !item?.employerName || !item?.employmentStartDate,
+  isItemIncomplete: item => !item?.employerName || !item?.employmentDates?.from,
   maxItems: 4,
   text: {
     getItemName: (item, index) => item?.employerName || `Employer ${index + 1}`,
     cardDescription: itemData => {
-      if (itemData?.employmentStartDate && itemData?.employmentEndDate) {
+      if (itemData?.employmentDates?.from && itemData?.employmentDates?.to) {
         try {
-          const startDate = formatDateLong(itemData.employmentStartDate);
-          const endDate = formatDateLong(itemData.employmentEndDate);
+          const startDate = formatDateLong(itemData.employmentDates?.from);
+          const endDate = formatDateLong(itemData.employmentDates?.to);
           return `${startDate} to ${endDate}`;
         } catch (error) {
           // Fallback to raw dates if formatting fails
-          return `${itemData.employmentStartDate} to ${
-            itemData.employmentEndDate
+          return `${itemData.employmentDates?.from} to ${
+            itemData.employmentDates?.to
           }`;
         }
       }

--- a/src/applications/simple-forms/21-4140/pages/employers.js
+++ b/src/applications/simple-forms/21-4140/pages/employers.js
@@ -5,8 +5,8 @@ import {
   arrayBuilderItemSubsequentPageTitleUI,
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
-  currentOrPastDateSchema,
-  currentOrPastDateUI,
+  currentOrPastDateRangeSchema,
+  currentOrPastDateRangeUI,
   textUI,
   textSchema,
   addressUI,
@@ -127,30 +127,28 @@ const employmentDatesPage = {
           ? `Dates you were employed at ${formData.employerName}`
           : 'Employment dates',
     ),
-    employmentStartDate: {
-      ...currentOrPastDateUI({
+    employmentDates: currentOrPastDateRangeUI(
+      {
         title: 'Employment start date',
         errorMessages: {
           required: 'Enter start date of employment',
         },
-      }),
-    },
-    employmentEndDate: {
-      ...currentOrPastDateUI({
+      },
+      {
         title: 'Employment end date',
         errorMessages: {
           required: 'Enter end date of employment',
         },
-      }),
-    },
+      },
+      'End date must be after start date',
+    ),
   },
   schema: {
     type: 'object',
     properties: {
-      employmentStartDate: currentOrPastDateSchema,
-      employmentEndDate: currentOrPastDateSchema,
+      employmentDates: currentOrPastDateRangeSchema,
     },
-    required: ['employmentStartDate', 'employmentEndDate'],
+    required: ['employmentDates'],
   },
 };
 

--- a/src/applications/simple-forms/21-4140/tests/fixtures/data/maximal-test.json
+++ b/src/applications/simple-forms/21-4140/tests/fixtures/data/maximal-test.json
@@ -55,16 +55,20 @@
         "hoursPerWeek": "22",
         "lostTimeFromIllness": "22",
         "highestGrossIncomePerMonth": 22,
-        "employmentStartDate": "1999-01-03",
-        "employmentEndDate": "1999-01-03"
+        "employmentDates": {
+          "from": "1999-01-03",
+          "to": "1999-01-03"
+        }
       },
       {
         "typeOfWork": "test",
         "hoursPerWeek": "223",
         "lostTimeFromIllness": "223",
         "highestGrossIncomePerMonth": 2200,
-        "employmentStartDate": "1999-01-03",
-        "employmentEndDate": "1999-01-03",
+        "employmentDates": {
+          "from": "1999-01-03",
+          "to": "1999-01-03"
+        },
         "employerName": "Employer 2",
         "employerAddress": {
           "view:militaryBaseDescription": {},

--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -92,13 +92,17 @@ class SchemaForm extends React.Component {
   }
 
   onError(hasSubmitted = true) {
+    // hasSubmitted is sometimes an Array of errors
     const formContext = set(
       'submitted',
       !!hasSubmitted,
       this.state.formContext,
     );
     this.setState({ formContext });
-    scrollToFirstError(this.props.formOptions);
+    scrollToFirstError({
+      ...this.props.formOptions,
+      errorContext: hasSubmitted,
+    });
   }
 
   onBlur(id) {

--- a/src/platform/utilities/scroll/scroll.js
+++ b/src/platform/utilities/scroll/scroll.js
@@ -1,6 +1,8 @@
+/* eslint-disable no-console */
 import { getScrollOptions, getElementPosition } from './utils';
 import { focusElement, focusByOrder, defaultFocusSelector } from '../ui/focus';
 import { ERROR_ELEMENTS, SCROLL_ELEMENT_SUFFIX } from '../constants';
+import environment from '../environment';
 
 // Let the form system control scroll behavior
 window.history.scrollRestoration = 'manual';
@@ -74,7 +76,7 @@ export const scrollToTop = async (
  */
 export const scrollToFirstError = async (options = {}) => {
   return new Promise(resolve => {
-    const { focusOnAlertRole = false } = options;
+    const { focusOnAlertRole = false, errorContext } = options;
     const selectors = ERROR_ELEMENTS.join(',');
     const timeout = 500;
     const observerConfig = { childList: true, subtree: true };
@@ -83,8 +85,28 @@ export const scrollToFirstError = async (options = {}) => {
     let observer;
 
     const runCleanup = el => {
-      // eslint-disable-next-line no-console
-      if (!el) console.warn('scrollToFirstError: Error element not found', el);
+      if (!el) {
+        console.warn('scrollToFirstError: Error element not found', el);
+        if (
+          !environment.isProduction() &&
+          Array.isArray(errorContext) &&
+          errorContext.length &&
+          errorContext.some(err =>
+            err?.stack?.includes('You must provide a response'),
+          )
+        ) {
+          const fieldKeys = errorContext
+            .filter(err => err?.stack?.includes('You must provide a response'))
+            .map(err => err.stack.split(':')[0]);
+          console.warn(
+            `Schema validation error: The following fields are marked as required in your schema but do not exist in the page:\n${fieldKeys
+              .map(key => `- "${key}"`)
+              .join(
+                '\n',
+              )}\nCheck your required fields in the schema match the fields in your UI.`,
+          );
+        }
+      }
       clearTimeout(fallbackTimer);
       observer?.disconnect();
       resolve();


### PR DESCRIPTION
## Summary

This PR fixes a bug on Step 4 in 21-4140: Employment History.  The user is able to incorrectly set their employment end date before their employment start date.

The schemas and validations have been updated, so now the end date can only be at or after the start date.  Additionally, both start and end dates cannot be future dates.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4920

## Testing done

Local testing

## Screenshots

<img width="644" height="852" alt="image" src="https://github.com/user-attachments/assets/6593ca1d-b911-4f13-b0c4-612caca9aae0" />


## Acceptance criteria

- [X] Prevent the user from adding a year in the future for both start / end dates, add validation message
- [X] Prevent the user from adding a year on the end date before the start year, add validation message

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

