### PR TITLE
0969 | Add supplementary forms section to confirmation page

### DIFF
--- a/src/applications/income-and-asset-statement/components/FormAlerts/SupplementaryFormsAlert.jsx
+++ b/src/applications/income-and-asset-statement/components/FormAlerts/SupplementaryFormsAlert.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isReviewAndSubmitPage } from '../../helpers';
+import { isReviewAndSubmitPage, getIncompleteOwnedAssets } from '../../helpers';
 
 const assetTypeAllowlist = ['BUSINESS', 'FARM'];
 
@@ -119,26 +119,9 @@ SupplementaryFormsAlert.propTypes = {
 };
 
 export function SupplementaryFormsAlertUpdated({ formData, headingLevel }) {
-  const assets = formData?.ownedAssets || [];
-
-  // Filter for assets where user either declined to upload OR said yes but didn't upload
-  const alertAssets = assets.filter(asset => {
-    const isFarmOrBusiness = assetTypeAllowlist.includes(asset.assetType);
-    const declinedUpload = asset['view:addFormQuestion'] === false;
-    const saidYesButNoUpload =
-      asset['view:addFormQuestion'] === true &&
-      (!asset?.uploadedDocuments || !asset.uploadedDocuments.name);
-
-    return isFarmOrBusiness && (declinedUpload || saidYesButNoUpload);
-  });
-
-  if (alertAssets.length === 0) return null;
-
-  const missingAssetTypes = [
-    ...new Set(alertAssets.map(asset => asset.assetType)),
-  ];
-  const hasFarm = missingAssetTypes.includes('FARM');
-  const hasBusiness = missingAssetTypes.includes('BUSINESS');
+  const { hasFarm, hasBusiness, missingAssetTypes } = getIncompleteOwnedAssets(
+    formData,
+  );
 
   const Heading = headingLevel || (isReviewAndSubmitPage() ? 'h3' : 'h2');
 

--- a/src/applications/income-and-asset-statement/components/MailingAddress.jsx
+++ b/src/applications/income-and-asset-statement/components/MailingAddress.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const MailingAddress = () => (
+  <p className="va-address-block">
+    U.S. Department of Veterans Affairs
+    <br />
+    Pension Intake Center
+    <br />
+    PO Box 5365
+    <br />
+    Janesville, WI 53547-5365
+    <br />
+  </p>
+);
+
+export default MailingAddress;

--- a/src/applications/income-and-asset-statement/components/NextStepsSection.jsx
+++ b/src/applications/income-and-asset-statement/components/NextStepsSection.jsx
@@ -31,7 +31,10 @@ const NextStepsSection = ({ loggedIn }) => {
         If you submitted this form as part of your DIC application, you can
         submit your completed DIC application by mail or in person.
       </p>
-      <va-link href="" text="Apply for DIC compensation" />
+      <va-link
+        href="https://www.va.gov/family-and-caregiver-benefits/survivor-compensation/dependency-indemnity-compensation/"
+        text="Apply for DIC compensation"
+      />
     </>
   );
 

--- a/src/applications/income-and-asset-statement/components/OwnedAssetsDescriptions.jsx
+++ b/src/applications/income-and-asset-statement/components/OwnedAssetsDescriptions.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { getArrayIndexFromPathName } from 'platform/forms-system/src/js/patterns/array-builder/helpers';
+import MailingAddress from './MailingAddress';
 
 const MAX_FILE_SIZE_MB = 20;
 
@@ -27,16 +28,7 @@ export const DocumentMailingAddressDescription = () => {
         completed {formDescription}.
       </p>
       <p>Send it to this address:</p>
-      <p className="va-address-block">
-        U.S. Department of Veterans Affairs
-        <br />
-        Pension Intake Center
-        <br />
-        PO Box 5365
-        <br />
-        Janesville, WI 53547-5365
-        <br />
-      </p>
+      <MailingAddress />
     </>
   );
 };

--- a/src/applications/income-and-asset-statement/components/SupplementaryFormsSection.jsx
+++ b/src/applications/income-and-asset-statement/components/SupplementaryFormsSection.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MailingAddress from './MailingAddress';
+import { getIncompleteOwnedAssets } from '../helpers';
+
+const bodyTextMap = {
+  BUSINESS: 'Report of Income from Property or Business (VA Form 21P-4185)',
+  FARM: 'Questionnaire for Farm Income (VA Form 21P-4165)',
+};
+
+const formLinks = {
+  BUSINESS: {
+    text: 'Get VA Form 21P-4185 to download',
+    href: 'https://www.va.gov/find-forms/about-form-21p-4185/',
+  },
+  FARM: {
+    text: 'Get VA Form 21P-4165 to download',
+    href: 'https://www.va.gov/find-forms/about-form-21p-4165/',
+  },
+};
+
+/**
+ * Renders the appropriate VA form links for a given set of asset types.
+ * @param {string[]} types - An array of asset types to include links for.
+ */
+const renderFormLinks = types => {
+  return types.filter(type => formLinks[type]).map(type => {
+    const { text, href } = formLinks[type];
+    return (
+      <p key={type}>
+        <va-link external text={text} href={href} />
+      </p>
+    );
+  });
+};
+
+const SupplementaryFormsSection = ({ formData }) => {
+  const { alertAssets, hasFarm, hasBusiness } = getIncompleteOwnedAssets(
+    formData,
+  );
+
+  if (alertAssets.length === 0) return null;
+
+  const renderContent = () => {
+    if (hasFarm && hasBusiness) {
+      return (
+        <>
+          <p>
+            Since you decided to mail the {bodyTextMap.BUSINESS} and{' '}
+            {bodyTextMap.FARM}, complete the forms and send them to this
+            address:
+          </p>
+          <MailingAddress />
+          {renderFormLinks(['BUSINESS', 'FARM'])}
+        </>
+      );
+    }
+    if (hasBusiness) {
+      return (
+        <>
+          <p>
+            Since you decided to mail the {bodyTextMap.BUSINESS}, complete the
+            form and send it to this address:
+          </p>
+          <MailingAddress />
+          {renderFormLinks(['BUSINESS'])}
+        </>
+      );
+    }
+    if (hasFarm) {
+      return (
+        <>
+          <p>
+            Since you decided to mail the {bodyTextMap.FARM}, complete the form
+            and send it to this address:
+          </p>
+          <MailingAddress />
+          {renderFormLinks(['FARM'])}
+        </>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <section>
+      <h3>Where to mail supporting documents</h3>
+      {renderContent()}
+    </section>
+  );
+};
+
+SupplementaryFormsSection.propTypes = {
+  formData: PropTypes.shape({
+    ownedAssets: PropTypes.arrayOf(
+      PropTypes.shape({
+        assetType: PropTypes.string,
+        'view:addFormQuestion': PropTypes.bool,
+        uploadedDocuments: PropTypes.object,
+      }),
+    ),
+  }),
+};
+
+export default SupplementaryFormsSection;

--- a/src/applications/income-and-asset-statement/containers/ConfirmationPage.jsx
+++ b/src/applications/income-and-asset-statement/containers/ConfirmationPage.jsx
@@ -5,6 +5,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 import environment from 'platform/utilities/environment';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import NextStepsSection from '../components/NextStepsSection';
+import SupplementaryFormsSection from '../components/SupplementaryFormsSection';
 
 let mockData;
 if (!environment.isProduction() && !environment.isStaging()) {
@@ -53,6 +54,7 @@ export const ConfirmationPage = props => {
       <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
       <NextStepsSection loggedIn={loggedIn} />
+      <SupplementaryFormsSection formData={form.data} />
       <ConfirmationView.WhatsNextProcessList
         item1Content={
           loggedIn ? (


### PR DESCRIPTION
## Summary

Add the **Supplementary forms – “Where to mail supporting documents”** section component to the **Confirmation** page of the **Income and Asset Statement form (VA Form 21P-0969)**.  
When **owned asset supplemental forms are not uploaded**, the section is displayed with a **mailing address** and a **link to the appropriate form(s)** so applicants know how to complete their submission offline.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116522

## Related issue(s)

- Post-MVP confirmation experience enhancements for 0969

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Start at the 0969 base route:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Complete the flow through **Property and business assets**, and do not upload supporting documents and proceed to **Submit** to reach the **Confirmation** page

## How to verify

1. **Scenario: Missing owned asset supplemental forms**
   - In the **Owned assets** chapter, do **not** upload required supplemental forms
   - Submit the application
   - On **Confirmation**, verify the **“Where to mail supporting documents”** section appears with:
     - A valid **mailing address** for sending documents
     - A **link** to the required owned-asset supplemental form(s)

2. **Scenario: Required supplemental forms uploaded**
   - Re-run with the required owned asset documents uploaded in the flow
   - On **Confirmation**, verify the **mailing section is hidden**

3. **Error handling**
   - If document state cannot be determined (mock error), confirm the section uses safe default behavior (no broken links; copy instructs the user where to find mailing instructions)

4. **General checks**
   - Validate heading order on the Confirmation page
   - Confirm no console errors and that links are accessible and descriptive

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- **Confirmation page** supplemental guidance for owned asset documents

## Screenshots

| Condition                                         | Confirmation page behavior                                          |
|--------------------------------------------------|----------------------------------------------------------------------|
| Owned asset supplemental forms **not uploaded**  | Shows **“Where to mail supporting documents”** + address + form link |
| Owned asset supplemental forms **uploaded**      | Section **hidden**                                                   |

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

- 0969 Post-MVP confirmation experience  

## Requested Feedback

(OPTIONAL) Please review the visibility logic for the mailing section and confirm the address and form links match product/design expectations when owned asset supplemental forms are missing.