### PR TITLE
[VACMS-22424] Add warning notice about non va emergency and urgent care to Facility Locator

### DIFF
--- a/src/applications/facility-locator/components/AccessToCare.jsx
+++ b/src/applications/facility-locator/components/AccessToCare.jsx
@@ -51,7 +51,7 @@ export default function AccessToCare({ location }) {
 
   return (
     <div className="vads-u-margin-bottom--4">
-      <h4 className="highlight">Veteran-reported Satisfaction Scores</h4>
+      <h3 className="highlight">Veteran-reported Satisfaction Scores</h3>
       <div className="vads-u-margin-bottom--4">
         <p>
           Current as of{' '}

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -45,6 +45,7 @@ import {
   facilityLocatorAutosuggestVAMCServices,
   facilitiesUseFlProgressiveDisclosure,
   facilityLocatorPredictiveLocationSearch,
+  showFacilityLocatorNoticeAboutNonVACare,
 } from '../utils/featureFlagSelectors';
 import { FacilitiesMapTypes } from '../types';
 import { setFocus, buildMarker, resetMapElements } from '../utils/helpers';
@@ -926,6 +927,24 @@ const FacilitiesMap = props => {
           type.
         </p>
       )}
+      {props.showNonVACareWarningBanner && (
+        <Alert
+          displayType="warning"
+          title="Notice about non-VA urgent and emergency care"
+          description={
+            <>
+              Before you go to a non-VA facility, call to confirm hours and
+              available services. We’ve received reports that some non-VA
+              facilities listed as providing urgent or emergency care can’t
+              currently provide those services to Veterans. If you think your
+              health or life is in danger, call 911.
+              <br />
+              <br />
+              Note: This issue isn’t related to the government shutdown.
+            </>
+          }
+        />
+      )}
       {renderView()}
       {mapboxTokenValid && otherToolsLink()}
     </>
@@ -940,6 +959,7 @@ const mapStateToProps = state => ({
   resultTime: state.searchResult.resultTime,
   results: state.searchResult.results,
   searchError: state.searchResult.error,
+  showNonVACareWarningBanner: showFacilityLocatorNoticeAboutNonVACare(state),
   specialties: state.searchQuery.specialties,
   suppressPPMS: facilitiesPpmsSuppressAll(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -19,3 +19,8 @@ export const facilityLocatorAutosuggestVAMCServices = state =>
   toggleValues(state)[
     FEATURE_FLAG_NAMES.facilitiesAutoSuggestVAMCServicesEnabled
   ];
+
+export const showFacilityLocatorNoticeAboutNonVACare = state =>
+  toggleValues(state)[
+    FEATURE_FLAG_NAMES.showFacilityLocatorNoticeAboutNonVACare
+  ];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -86,6 +86,7 @@
   "facilitiesPpmsSuppressAll": "facilities_ppms_suppress_all",
   "facilityLocatorMobileMapUpdate": "facility_locator_mobile_map_update",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
+  "showFacilityLocatorNoticeAboutNonVACare": "show_facility_locator_notice_about_non_va_care",
   "facilitiesUseFlProgressiveDisclosure": "facilities_use_fl_progressive_disclosure",
   "fileUploadShortWorkflowEnabled": "file_upload_short_workflow_enabled",
   "financialStatusReportDebtsApiModule": "financial_status_report_debts_api_module",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This adds a warning banner to the top of the Facility Locator when `show_facility_locator_notice_about_non_va_care` feature flag is enabled
- Facilities team, owned and maintained
- Flipper has no exact end date

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22424
- PR introducing feature flag https://github.com/department-of-veterans-affairs/vets-api/pull/24585

## Testing done

- Enabled/Disabled the Feature Flag in local development and verified that banner displays only when enabled.

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile | <img width="503" height="725" alt="Screenshot 2025-10-10 at 9 58 45 AM" src="https://github.com/user-attachments/assets/68d41719-5aa0-4354-af67-d2bc48b0f379" /> | <img width="686" height="757" alt="Screenshot 2025-10-09 at 1 42 16 PM" src="https://github.com/user-attachments/assets/62df56d9-a659-42e3-a3a0-23b8ea3f217e" /> |
| Desktop | <img width="1134" height="902" alt="Screenshot 2025-10-10 at 9 58 34 AM" src="https://github.com/user-attachments/assets/6aeea208-b768-4f53-9efa-2b1200318cbb" /> | <img width="1050" height="1297" alt="Screenshot 2025-10-09 at 1 41 54 PM" src="https://github.com/user-attachments/assets/704b6e56-4cf2-4609-8db0-ff74d667b834" /> |




## What areas of the site does it impact?
Facility Locator

## Acceptance criteria
Warning banner displays when feature flag is enabled

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

