### PR TITLE
114813 empty state benefit letters

### DIFF
--- a/src/applications/letters/components/EmptyStateTest.jsx
+++ b/src/applications/letters/components/EmptyStateTest.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import LetterList from '../containers/LetterList';
+
+// Mock Redux store with empty letters
+const mockStore = createStore(() => ({
+  letters: {
+    letters: [], // Empty letters array
+    lettersAvailability: 'available',
+    letterDownloadStatus: {},
+    optionsAvailable: false,
+  },
+  featureToggles: {
+    empty_state_benefit_letters: true, // Enable feature flag
+  },
+}));
+
+// Test component to view empty state
+export const EmptyStateTest = () => (
+  <Provider store={mockStore}>
+    <div style={{ padding: '20px', maxWidth: '800px' }}>
+      <h1>Your VA benefit letters and documents</h1>
+      <h2>Benefit letters and documents</h2>
+      <LetterList />
+    </div>
+  </Provider>
+);
+
+export default EmptyStateTest;

--- a/src/applications/letters/components/EmptyStateTest.jsx
+++ b/src/applications/letters/components/EmptyStateTest.jsx
@@ -12,6 +12,7 @@ const mockStore = createStore(() => ({
     optionsAvailable: false,
   },
   featureToggles: {
+    // eslint-disable-next-line camelcase
     empty_state_benefit_letters: true, // Enable feature flag
   },
 }));

--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -223,6 +223,33 @@ export class LetterList extends React.Component {
             {letterItems}
           </va-accordion>
         )}
+        <Toggler toggleName={Toggler.TOGGLE_NAMES.emptyStateBenefitLetters}>
+          <Toggler.Enabled>
+            {letterItems.length === 0 &&
+              !eligibilityMessage && (
+                <div className="vads-u-margin-top--2">
+                  <h3>
+                    You don't have any benefit letters or documents available.
+                  </h3>
+                  <p>
+                    Most Veterans find benefit letters and documents here such
+                    as:
+                  </p>
+                  <ul>
+                    <li>Benefit Summary and Service Verification Letter</li>
+                    <li>Proof of Service Card</li>
+                    <li>Civil Service Preference Letter</li>
+                  </ul>
+                  <p>
+                    If you think you should have a benefit letter and document
+                    that's not here, call the VA benefits hotline at{' '}
+                    <va-telephone contact="8008271000" /> (
+                    <va-telephone contact="711" tty />) for help.
+                  </p>
+                </div>
+              )}
+          </Toggler.Enabled>
+        </Toggler>
         {eligibilityMessage}
 
         <Toggler.Hoc toggleName={Toggler.TOGGLE_NAMES.lettersPageNewDesign}>

--- a/src/applications/letters/tests/03-letters-new-design.cypress.spec.js
+++ b/src/applications/letters/tests/03-letters-new-design.cypress.spec.js
@@ -86,7 +86,8 @@ describe('New letters page design', () => {
     cy.get('va-accordion-item:nth-of-type(4)')
       .shadow()
       .find('button[aria-expanded=false]')
-      .click();
+      .wait(500)
+      .click({ force: true });
     cy.get('va-button')
       .shadow()
       .find('button')
@@ -114,7 +115,8 @@ describe('New letters page design', () => {
     cy.get('va-accordion-item:nth-of-type(4)')
       .shadow()
       .find('button[aria-expanded=false]')
-      .click();
+      .wait(500)
+      .click({ force: true });
     // Get array of checkboxes, loop to click through all but the first one
     cy.get('input[type="checkbox"]').each(($el, index) => {
       if (index > 0) {

--- a/src/applications/letters/tests/04-empty-state-feature-flag.cypress.spec.js
+++ b/src/applications/letters/tests/04-empty-state-feature-flag.cypress.spec.js
@@ -29,13 +29,17 @@ describe('Letters Empty State Feature Flag', () => {
 
   context('when feature flag is enabled', () => {
     beforeEach(() => {
-      // Enable the feature flag
+      // Enable the feature flags
       cy.intercept('GET', '/v0/feature_toggles*', {
         data: {
           type: 'feature_toggles',
           features: [
             {
               name: 'empty_state_benefit_letters',
+              value: true,
+            },
+            {
+              name: 'letters_page_new_design',
               value: true,
             },
           ],
@@ -134,7 +138,7 @@ describe('Letters Empty State Feature Flag', () => {
 
   context('when feature flag is disabled', () => {
     beforeEach(() => {
-      // Disable the feature flag
+      // Disable the empty state feature flag but enable new design
       cy.intercept('GET', '/v0/feature_toggles*', {
         data: {
           type: 'feature_toggles',
@@ -142,6 +146,10 @@ describe('Letters Empty State Feature Flag', () => {
             {
               name: 'empty_state_benefit_letters',
               value: false,
+            },
+            {
+              name: 'letters_page_new_design',
+              value: true,
             },
           ],
         },

--- a/src/applications/letters/tests/04-empty-state-feature-flag.cypress.spec.js
+++ b/src/applications/letters/tests/04-empty-state-feature-flag.cypress.spec.js
@@ -1,0 +1,193 @@
+import Timeouts from 'platform/testing/e2e/timeouts';
+import {
+  benefitSummaryOptions,
+  address,
+  countries,
+  states,
+  mockUserData,
+} from './e2e/fixtures/mocks/lh_letters';
+
+describe('Letters Empty State Feature Flag', () => {
+  const emptyLettersResponse = {
+    fullName: 'William Shakespeare',
+    letters: [], // Empty letters array to trigger empty state
+  };
+
+  beforeEach(() => {
+    // Mock API responses
+    cy.intercept(
+      'GET',
+      '/v0/letters_generator/beneficiary',
+      benefitSummaryOptions,
+    ).as('benefitSummaryOptions');
+    cy.intercept('GET', '/v0/address', address).as('address');
+    cy.intercept('GET', '/v0/address/countries', countries).as('countries');
+    cy.intercept('GET', '/v0/address/states', states).as('states');
+
+    cy.login(mockUserData);
+  });
+
+  context('when feature flag is enabled', () => {
+    beforeEach(() => {
+      // Enable the feature flag
+      cy.intercept('GET', '/v0/feature_toggles*', {
+        data: {
+          type: 'feature_toggles',
+          features: [
+            {
+              name: 'empty_state_benefit_letters',
+              value: true,
+            },
+          ],
+        },
+      }).as('featureToggles');
+
+      // Mock empty letters response
+      cy.intercept('GET', '/v0/letters_generator', emptyLettersResponse).as(
+        'emptyLetters',
+      );
+    });
+
+    it('should display empty state content when no letters are available', () => {
+      cy.visit('/records/download-va-letters/letters/');
+
+      // Wait for the page to load and API calls to complete
+      cy.wait('@emptyLetters', { timeout: Timeouts.slow });
+      cy.wait('@featureToggles');
+
+      // Verify page loads correctly
+      cy.get('body').should('be.visible');
+      cy.title().should(
+        'contain',
+        'Your VA benefit letters and documents | Veterans Affairs',
+      );
+
+      // Verify the letters accordion is not present
+      cy.get('[data-test-id="letters-accordion"]').should('not.exist');
+
+      // Verify empty state content is displayed
+      cy.get('h3')
+        .contains("You don't have any benefit letters or documents available.")
+        .should('be.visible');
+
+      cy.get('p')
+        .contains('Most Veterans find benefit letters and documents here such as:')
+        .should('be.visible');
+
+      // Verify the list of typical letters is shown
+      cy.contains('Most Veterans find benefit letters and documents here such as:')
+        .next('ul')
+        .within(() => {
+          cy.contains('Benefit Summary and Service Verification Letter').should(
+            'be.visible',
+          );
+          cy.contains('Proof of Service Card').should('be.visible');
+          cy.contains('Civil Service Preference Letter').should('be.visible');
+        });
+
+      // Verify contact information is displayed
+      cy.get('p')
+        .contains(
+          "If you think you should have a benefit letter and document that's not here",
+        )
+        .should('be.visible');
+
+      // Verify VA telephone components are present
+      cy.get('va-telephone[contact="8008271000"]').should('be.visible');
+      cy.get('va-telephone[contact="711"][tty]').should('be.visible');
+
+      // Run accessibility check
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('should not display empty state when letters are available', () => {
+      // Override with letters available
+      const lettersWithData = {
+        fullName: 'William Shakespeare',
+        letters: [
+          { name: 'Commissary Letter', letterType: 'commissary' },
+          { name: 'Proof of Service Letter', letterType: 'proof_of_service' },
+        ],
+      };
+
+      cy.intercept('GET', '/v0/letters_generator', lettersWithData).as(
+        'lettersWithData',
+      );
+
+      cy.visit('/records/download-va-letters/letters/');
+
+      cy.wait('@lettersWithData', { timeout: Timeouts.slow });
+
+      // Verify letters accordion is present
+      cy.get('[data-test-id="letters-accordion"]', {
+        timeout: Timeouts.slow,
+      }).should('be.visible');
+
+      // Verify empty state is not displayed
+      cy.get('h3')
+        .contains("You don't have any benefit letters or documents available.")
+        .should('not.exist');
+
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  context('when feature flag is disabled', () => {
+    beforeEach(() => {
+      // Disable the feature flag
+      cy.intercept('GET', '/v0/feature_toggles*', {
+        data: {
+          type: 'feature_toggles',
+          features: [
+            {
+              name: 'empty_state_benefit_letters',
+              value: false,
+            },
+          ],
+        },
+      }).as('featureTogglesDisabled');
+
+      // Mock empty letters response
+      cy.intercept('GET', '/v0/letters_generator', emptyLettersResponse).as(
+        'emptyLetters',
+      );
+    });
+
+    it('should not display empty state content when feature flag is disabled', () => {
+      cy.visit('/records/download-va-letters/letters/');
+
+      cy.wait('@emptyLetters', { timeout: Timeouts.slow });
+      cy.wait('@featureTogglesDisabled');
+
+      // Verify page loads correctly
+      cy.get('body').should('be.visible');
+      cy.title().should(
+        'contain',
+        'Your VA benefit letters and documents | Veterans Affairs',
+      );
+
+      // Verify the letters accordion is not present
+      cy.get('[data-test-id="letters-accordion"]').should('not.exist');
+
+      // Verify empty state content is NOT displayed when flag is disabled
+      cy.get('h3')
+        .contains("You don't have any benefit letters or documents available.")
+        .should('not.exist');
+
+      cy.get('p')
+        .contains('Most Veterans find benefit letters and documents here such as:')
+        .should('not.exist');
+
+      // The page should be relatively empty (just the header and address section)
+      cy.get('h1')
+        .contains('Your VA benefit letters and documents')
+        .should('be.visible');
+
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  // Note: Eligibility error testing would require understanding the complex reducer logic
+  // that determines when AVAILABILITY_STATUSES.letterEligibilityError is set.
+  // This is typically triggered by backend service issues, not empty letter arrays.
+});

--- a/src/applications/letters/tests/04-empty-state-feature-flag.cypress.spec.js
+++ b/src/applications/letters/tests/04-empty-state-feature-flag.cypress.spec.js
@@ -75,11 +75,15 @@ describe('Letters Empty State Feature Flag', () => {
         .should('be.visible');
 
       cy.get('p')
-        .contains('Most Veterans find benefit letters and documents here such as:')
+        .contains(
+          'Most Veterans find benefit letters and documents here such as:',
+        )
         .should('be.visible');
 
       // Verify the list of typical letters is shown
-      cy.contains('Most Veterans find benefit letters and documents here such as:')
+      cy.contains(
+        'Most Veterans find benefit letters and documents here such as:',
+      )
         .next('ul')
         .within(() => {
           cy.contains('Benefit Summary and Service Verification Letter').should(
@@ -183,7 +187,9 @@ describe('Letters Empty State Feature Flag', () => {
         .should('not.exist');
 
       cy.get('p')
-        .contains('Most Veterans find benefit letters and documents here such as:')
+        .contains(
+          'Most Veterans find benefit letters and documents here such as:',
+        )
         .should('not.exist');
 
       // The page should be relatively empty (just the header and address section)

--- a/src/applications/letters/tests/e2e/fixtures/mocks/empty_letters.js
+++ b/src/applications/letters/tests/e2e/fixtures/mocks/empty_letters.js
@@ -1,0 +1,9 @@
+// Temporary mock for testing empty state
+const emptyLetters = {
+  fullName: 'William Shakespeare',
+  letters: [], // Empty array to trigger empty state
+};
+
+module.exports = {
+  emptyLetters,
+};

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -74,6 +74,7 @@
   "disputeDebt": "dispute_debt",
   "dslogonInterstitialRedirect": "dslogon_interstitial_redirect",
   "dslogonButtonDisabled": "dslogon_button_disabled",
+  "emptyStateBenefitLetters": "empty_state_benefit_letters",
   "enrollmentVerification": "enrollment_verification",
   "ezrDownloadPdfEnabled": "ezr_download_pdf_enabled",
   "ezrProdEnabled": "ezr_prod_enabled",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Added text to letters page when no letters are available
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
BMT-3
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#0000
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114813)- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
Previously the header "Benefit letters and documents" would appear with no text below it
- _Describe the steps required to verify your changes are working as expected_
Toggle the feature flag `empty_state_benefit_letters` on.  For user that has no letter, verify on the Benefit Letters and Document page, that the correct text appears under the header
- _Describe the tests completed and the results_
Added cypress tests and manually tested, images attached.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | <img width="509"  alt="flag_off_no_empty_state_text" src="https://github.com/user-attachments/assets/23e62912-8b78-4f14-bced-9a61f595a575" />|<img width="509" alt="flag_on_empty_state_text" src="https://github.com/user-attachments/assets/c6314cb6-626f-4e72-a4e7-53b99f1cb5e3" /><img width="509" alt="flag_on_with_letters" src="https://github.com/user-attachments/assets/9c2e8463-d68b-49bf-a923-6de44e1deb51" />|

## What areas of the site does it impact?
Benefit Letters page

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
