### PR TITLE
0969 | Update royalties chapter

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
@@ -25,13 +25,13 @@ import {
   generateDeleteDescription,
   isDefined,
   otherRecipientRelationshipTypeUI,
+  requireExpandedArrayField,
   sharedRecipientRelationshipBase,
   showUpdatedContent,
   sharedYesNoOptionsBase,
   updatedIsRecipientInfoIncomplete,
   updatedRecipientNameRequired,
   updatedResolveRecipientFullName,
-  requireExpandedArrayField,
 } from '../../../helpers';
 
 import SupplementaryFormsAlert, {

--- a/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -27,15 +27,15 @@ import {
   fullNameUIHelper,
   generateDeleteDescription,
   isDefined,
-  isRecipientInfoIncomplete,
-  otherGeneratedIncomeTypeExplanationRequired,
   otherRecipientRelationshipTypeUI,
-  recipientNameRequired,
+  otherGeneratedIncomeTypeExplanationRequired,
   requireExpandedArrayField,
-  resolveRecipientFullName,
   sharedRecipientRelationshipBase,
   showUpdatedContent,
   sharedYesNoOptionsBase,
+  updatedIsRecipientInfoIncomplete,
+  updatedRecipientNameRequired,
+  updatedResolveRecipientFullName,
 } from '../../../helpers';
 import {
   custodianRelationshipLabels,
@@ -53,7 +53,7 @@ export const options = {
   nounPlural: 'royalties',
   required: false,
   isItemIncomplete: item =>
-    isRecipientInfoIncomplete(item) ||
+    updatedIsRecipientInfoIncomplete(item) ||
     typeof item.canBeSold !== 'boolean' ||
     !isDefined(item.grossMonthlyIncome) ||
     !isDefined(item.fairMarketValue) ||
@@ -70,7 +70,7 @@ export const options = {
       if (!isDefined(item?.recipientRelationship)) {
         return undefined;
       }
-      const fullName = resolveRecipientFullName(item, formData);
+      const fullName = updatedResolveRecipientFullName(item, formData);
       const possessiveName = formatPossessiveString(fullName);
       return `${possessiveName} income from ${lowercase(
         generatedIncomeTypeLabels[item.incomeGenerationMethod],
@@ -640,7 +640,11 @@ export const royaltiesAndOtherPropertyPages = arrayBuilderPages(
       path: 'royalties/:index/recipient-name',
       depends: (formData, index) =>
         (!showUpdatedContent() || formData.claimantType !== 'CHILD') &&
-        recipientNameRequired(formData, index, 'royaltiesAndOtherProperties'),
+        updatedRecipientNameRequired(
+          formData,
+          index,
+          'royaltiesAndOtherProperties',
+        ),
       uiSchema: recipientNamePage.uiSchema,
       schema: recipientNamePage.schema,
     }),


### PR DESCRIPTION
## Summary

Implements **Design QA** updates across the **Royalties and other assets** chapter in the **Income and Asset Statement form (VA Form 21P-0969)** and replaces ad-hoc logic with the **updated shared helper functions** (e.g., title/summary generators, claimant-type utilities, possessive formatting, empty-state copy helpers).  
This brings the Royalties chapter in line with post-MVP patterns used elsewhere (Recurring income, Financial accounts) and reduces duplication.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116441

## Related issue(s)
- Part of ongoing post-MVP content and UX consistency work for 0969

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Open the form:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Navigate to **Royalties and other assets**

## How to verify
1. Walk through the Royalties list-and-loop (intro → recipient/relationship → recipient name → royalty income info → summary).  
2. Confirm the chapter uses the updated shared helpers for:
   - Page and summary titles (including empty state: _summaryTitleWithoutItems_)  
   - Claimant-type sensitive copy and labels  
   - Possessive name rendering in item cards and summaries  
3. Validate Design QA changes:
   - Hint text placement and content match guidance
   - Heading hierarchy and spacing are consistent with other post-MVP chapters
4. Add, edit, and remove royalty items; verify summary pages (with and without items) render correct copy.  
5. Confirm Review & Submit reflects entered data and headings are consistent.  
6. Check for no console errors and passing validations.

## What areas of the site does it impact?
- Income and Asset Statement (VA Form 21P-0969)  
- **Royalties and other assets** chapter (all pages, item cards, and summary states)

## Screenshots
N/A

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone
- 0969 Post-MVP content & helper standardization  
- **Behind** `income_and_assets_content_updates` feature toggle

## Requested Feedback
(OPTIONAL) Please confirm that Royalties now fully leverages the shared helper functions and that Design QA alignment (titles, hint text, and empty-state copy) matches expectations across claimant types.
