### PR TITLE
Add label to VaLink components for screen reader accessibility

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -140,14 +140,14 @@ const FilesWeCouldntReceive = () => {
                           className="vads-u-margin-y--3"
                           data-testid={`failed-file-${file.id}`}
                         >
-                          <h4
+                          <h3
                             className="filename-title vads-u-margin-y--0 vads-u-margin-bottom--2"
                             data-dd-privacy="mask"
                             data-dd-action-name="document filename"
                           >
                             File name:
                             {file.fileName}
-                          </h4>
+                          </h3>
                           <div>Request type: {file.trackedItemDisplayName}</div>
                           <div>Date failed: {formatDate(file.failedDate)}</div>
                           <div>File type: {file.documentType}</div>
@@ -157,6 +157,9 @@ const FilesWeCouldntReceive = () => {
                               file.claimId
                             }/status`}
                             text="Go to claim this file was uploaded for"
+                            aria-label={`Go to the claim this file was uploaded for: ${
+                              file.fileName
+                            }`}
                           />
                         </VaCard>
                       </li>

--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -157,7 +157,7 @@ const FilesWeCouldntReceive = () => {
                               file.claimId
                             }/status`}
                             text="Go to claim this file was uploaded for"
-                            aria-label={`Go to the claim this file was uploaded for: ${
+                            label={`Go to the claim this file was uploaded for: ${
                               file.fileName
                             }`}
                           />

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -267,7 +267,7 @@ describe('<FilesWeCouldntReceive>', () => {
         const expectedAriaLabel = `Go to the claim this file was uploaded for: ${
           expectedFileOrder[index]
         }`;
-        expect(link).to.have.attribute('aria-label', expectedAriaLabel);
+        expect(link).to.have.attribute('label', expectedAriaLabel);
       });
     });
   });

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -264,10 +264,10 @@ describe('<FilesWeCouldntReceive>', () => {
       ];
 
       vaLinks.forEach((link, index) => {
-        const expectedAriaLabel = `Go to the claim this file was uploaded for: ${
+        const expectedLabel = `Go to the claim this file was uploaded for: ${
           expectedFileOrder[index]
         }`;
-        expect(link).to.have.attribute('label', expectedAriaLabel);
+        expect(link).to.have.attribute('label', expectedLabel);
       });
     });
   });

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -165,35 +165,35 @@ describe('<FilesWeCouldntReceive>', () => {
   });
 
   describe('Failed Files Display', () => {
-    it('should render failed files in sorted order and with proper accessibility', () => {
-      const mockFailedFiles = [
-        {
-          id: 1,
-          fileName: 'document1.pdf',
-          trackedItemDisplayName: '21-4142',
-          failedDate: '2025-01-15T10:35:00.000Z',
-          documentType: 'VA Form 21-4142',
-          claimId: '123',
-        },
-        {
-          id: 2,
-          fileName: 'document2.pdf',
-          trackedItemDisplayName: '21-4142',
-          failedDate: '2025-01-22T10:35:00.000Z',
-          documentType: 'VA Form 21-4142',
-          claimId: '456',
-        },
-        {
-          id: 3,
-          fileName: 'document3.pdf',
-          trackedItemDisplayName: '21-4142',
-          failedDate: '2025-01-10T10:35:00.000Z',
-          documentType: 'VA Form 21-4142',
-          claimId: '789',
-        },
-      ];
+    const mockFailedFilesWithSorting = [
+      {
+        id: 1,
+        fileName: 'document1.pdf',
+        trackedItemDisplayName: '21-4142',
+        failedDate: '2025-01-15T10:35:00.000Z',
+        documentType: 'VA Form 21-4142',
+        claimId: '123',
+      },
+      {
+        id: 2,
+        fileName: 'document2.pdf',
+        trackedItemDisplayName: '21-4142',
+        failedDate: '2025-01-22T10:35:00.000Z',
+        documentType: 'VA Form 21-4142',
+        claimId: '456',
+      },
+      {
+        id: 3,
+        fileName: 'document3.pdf',
+        trackedItemDisplayName: '21-4142',
+        failedDate: '2025-01-10T10:35:00.000Z',
+        documentType: 'VA Form 21-4142',
+        claimId: '789',
+      },
+    ];
 
-      const store = createMockStore(mockFailedFiles);
+    it('should render failed files in sorted order with proper structure', () => {
+      const store = createMockStore(mockFailedFilesWithSorting);
       const { container, getAllByTestId } = renderWithCustomStore(
         <FilesWeCouldntReceive />,
         store,
@@ -241,6 +241,33 @@ describe('<FilesWeCouldntReceive>', () => {
         expect(card.tagName.toLowerCase()).to.equal('va-card');
         // The parent should be an li element
         expect(card.parentElement.tagName.toLowerCase()).to.equal('li');
+      });
+    });
+
+    it('should render VaLink components with proper aria-labels for accessibility', () => {
+      const store = createMockStore(mockFailedFilesWithSorting);
+      const { container } = renderWithCustomStore(
+        <FilesWeCouldntReceive />,
+        store,
+      );
+
+      const vaLinks = container.querySelectorAll(
+        'ul[data-testid="failed-files-list"] va-link',
+      );
+      expect(vaLinks).to.have.length(3);
+
+      // Files are sorted by date (most recent first)
+      const expectedFileOrder = [
+        'document2.pdf', // 2025-01-22 (most recent)
+        'document1.pdf', // 2025-01-15 (middle)
+        'document3.pdf', // 2025-01-10 (oldest)
+      ];
+
+      vaLinks.forEach((link, index) => {
+        const expectedAriaLabel = `Go to the claim this file was uploaded for: ${
+          expectedFileOrder[index]
+        }`;
+        expect(link).to.have.attribute('aria-label', expectedAriaLabel);
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue in the **Files We Couldn't Receive** page where multiple "Go to claim this file was uploaded for" links lacked descriptive aria-labels, making them indistinguishable for screen reader users.

### Changes

- **Accessibility Fix:** Added `label` attributes to VaLink components with specific filenames
- **Testing:** Added unit test to verify aria-labels are properly set for accessibility compliance

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#121799
- **Ticket:** department-of-veterans-affairs/va.gov-team#121804

## How to Test Locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```

3. **Navigate to the page:**
   - Open your browser and go to: `/track-claims/your-claims/files-we-couldnt-receive`
   - Example: "Go to the claim this file was uploaded for: medical-record.pdf"

## Testing Done

- **Unit Tests:** Added test to verify aria-labels include filenames for accessibility
- **Manual Testing:** Verified my inspecting the page on the Chrome devtools

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Accessibility Fix - Aria Labels |
| ------- | ------ |
| Desktop | <img width="1425" height="342" alt="Screenshot 2025-10-13 at 11 32 01 AM" src="https://github.com/user-attachments/assets/4e286090-cd61-4dc9-987f-d96e7fa07212" /> |





## What areas of the site does it impact?

- Claims Status application - Files We Couldn't Receive page

## Acceptance Criteria

- [x] Add `aria-label` to VaLink components with filename differentiation
- [x] Ensure each link has unique, descriptive aria-label for screen readers
- [x] Use semantic HTML with `<h3>` elements for file names to improve heading structure
- [x] Maintain existing functionality while improving accessibility
- [x] Add unit test to verify aria-label implementation
- [x] Follow WCAG 2.1 guidelines for link accessibility

## Quality Assurance & Testing

- [x] I updated unit tests to verify aria-label functionality
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the accessibility fix is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors
- [x] Existing functionality remains unchanged
- [x] Graceful handling of missing filename data

### Authentication

- [x] Did you log in to a local build and verify all authenticated routes work as expected with a test user?
