### PR TITLE
10-10d extended | Update conditional flow for address selection

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -54,7 +54,9 @@ import {
 } from '../../10-10D/components/Sponsor/sponsorFileUploads';
 import { isInRange } from '../../10-10D/helpers/utilities';
 import { ApplicantDependentStatusPage } from '../../10-10D/pages/ApplicantDependentStatus';
-import AddressSelectionPage from '../components/FormPages/AddressSelectionPage';
+import AddressSelectionPage, {
+  NOT_SHARED,
+} from '../components/FormPages/AddressSelectionPage';
 import CustomPrefillMessage from '../components/CustomPrefillAlert';
 
 import { validateMarriageAfterDob } from '../helpers/validations';
@@ -757,6 +759,9 @@ export const applicantPages = arrayBuilderPages(
     page15: pageBuilder.itemPage({
       path: 'applicant-mailing-address/:index',
       title: 'Mailing address',
+      depends: (formData, index) =>
+        get('view:sharesAddressWith', formData.applicants?.[index]) ===
+        NOT_SHARED,
       ...applicantMailingAddressPage,
     }),
     page16: pageBuilder.itemPage({

--- a/src/applications/ivc-champva/10-10d-extended/components/FormPages/AddressSelectionPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormPages/AddressSelectionPage.jsx
@@ -4,14 +4,26 @@ import PropTypes from 'prop-types';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { applicantWording } from '../../../shared/utilities';
 import { VaRadio, VaRadioOption } from '../../imports';
+import content from '../../locales/en/content.json';
 
 // declare reusable constants
 export const FIELD_NAME = 'view:sharesAddressWith';
 export const NOT_SHARED = 'na';
 
-// declare option content
-export const OPTION_NO_LABEL = 'No, use a new address';
-export const OPTION_YES_LABEL = 'Yes, use';
+// declare static content
+const APPLICANT_SINGULAR = content['noun--applicant'];
+const ERROR_MSG_REQUIRED = content['error--required'];
+const LABEL_TEXT = content['address-selection--label-text'];
+export const OPTION_NO_LABEL = content['address-selection--no-option'];
+export const OPTION_YES_LABEL = content['address-selection--yes-option'];
+const PAGE_TITLE = content['address-selection--page-title'];
+const PAGE_DESCRIPTION = content['address-selection--page-description'];
+const PROMPT_THIRD = content['address-selection--prompt-third'];
+const PROMPT_SECOND = content['address-selection--prompt-second'];
+const UPDATE_BTN_TEXT = content['button--update-page'];
+const UPDATE_BTN_ARIA_LABEL = content['address-selection--update-aria-label'];
+const VETERAN_SINGULAR = content['noun--veteran-singular'];
+const VETERAN_POSSESSIVE = content['noun--veteran-possessive'];
 
 // convert address objects to formatted strings
 export const formatAddress = ({ street, street2, city, state, country } = {}) =>
@@ -25,10 +37,12 @@ export const getInputLabel = ({
   isArrayMode = false,
   itemIndex = null,
 }) => {
-  const party = isArrayMode ? 'applicant' : 'Veteran';
+  const party = isArrayMode ? APPLICANT_SINGULAR : VETERAN_SINGULAR;
   const prompt =
-    role === 'applicant' && itemIndex === 0 ? 'Do you' : `Does the ${party}`;
-  return `${prompt} have the same mailing address as one previously entered in this application?`;
+    role === 'applicant' && itemIndex === 0
+      ? PROMPT_SECOND
+      : `${PROMPT_THIRD} ${party}`;
+  return `${prompt} ${LABEL_TEXT}`;
 };
 
 // build unique radio options from form data
@@ -142,7 +156,7 @@ const AddressSelectionPage = props => {
   const handleSubmit = useCallback(
     e => {
       e.preventDefault();
-      if (!currentValue) return setError('You must provide a response');
+      if (!currentValue) return setError(ERROR_MSG_REQUIRED);
       return goForward({ formData: data });
     },
     [currentValue, data, goForward],
@@ -192,12 +206,14 @@ const AddressSelectionPage = props => {
 
   const pageTitle = useMemo(
     () => {
-      const party = isArrayMode ? applicantWording(localData) : 'Veteran’s';
+      const party = isArrayMode
+        ? applicantWording(localData)
+        : VETERAN_POSSESSIVE;
       return titleUI(
         <>
-          <span data-dd-privacy="hidden">{party}</span> address selection
+          <span data-dd-privacy="hidden">{party}</span> {PAGE_TITLE}
         </>,
-        'We’ll send any important information about this application to this address.',
+        PAGE_DESCRIPTION,
       )['ui:title'];
     },
     [isArrayMode, localData],
@@ -234,8 +250,8 @@ const AddressSelectionPage = props => {
       ) : (
         <va-button
           onClick={updatePage}
-          text="Update page"
-          label="Update Veteran’s address"
+          text={UPDATE_BTN_TEXT}
+          label={UPDATE_BTN_ARIA_LABEL}
           class="vads-u-margin-bottom--4"
         />
       )}

--- a/src/applications/ivc-champva/10-10d-extended/components/FormReview/AddressSelectionReviewPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormReview/AddressSelectionReviewPage.jsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  FIELD_NAME,
+  formatAddress,
+  getInputLabel,
+  NOT_SHARED,
+  OPTION_NO_LABEL,
+  OPTION_YES_LABEL,
+  safeParse,
+} from '../FormPages/AddressSelectionPage';
+
+// parse the stored data value in to human-friendly text
+export const formatDataValue = (storedValue, { withPrefix = true } = {}) => {
+  if (!storedValue) return '';
+  if (storedValue === NOT_SHARED) return OPTION_NO_LABEL.split(',')[0];
+
+  const parsed = safeParse(storedValue);
+  const addr = parsed ? formatAddress(parsed) : String(storedValue);
+  return withPrefix ? `${OPTION_YES_LABEL} ${addr}` : addr;
+};
+
+// ensure we have the correct data whether in array mode or not
+export const getScopedData = (data, pagePerItemIndex) => {
+  const n = Number(pagePerItemIndex);
+  const isArrayMode = Number.isFinite(n) && n >= 0;
+  if (isArrayMode && data?.applicants) return data.applicants?.[n] ?? {};
+  return data ?? {};
+};
+
+const AddressSelectionReviewPage = props => {
+  const { data, editPage, pagePerItemIndex, title } = props;
+
+  const { itemIndex, isArrayMode } = useMemo(
+    () => {
+      const n = Number(pagePerItemIndex);
+      const valid = Number.isFinite(n) && n >= 0;
+      return { itemIndex: valid ? n : null, isArrayMode: valid };
+    },
+    [pagePerItemIndex],
+  );
+
+  const localData = useMemo(() => getScopedData(data, pagePerItemIndex), [
+    data,
+    pagePerItemIndex,
+  ]);
+
+  const inputLabel = useMemo(
+    () => getInputLabel({ role: data.certifierRole, isArrayMode, itemIndex }),
+    [data.certifierRole, isArrayMode, itemIndex],
+  );
+
+  const valueText = useMemo(() => formatDataValue(localData?.[FIELD_NAME]), [
+    localData,
+  ]);
+
+  return (
+    <div className="form-review-panel-page">
+      <form className="rjsf" noValidate="">
+        <div className="form-review-panel-page-header-row">
+          <h4 className="form-review-panel-page-header vads-u-font-size--h5">
+            {title}
+          </h4>
+          <va-button
+            text="Edit"
+            label={`Edit ${title}`}
+            onClick={editPage}
+            secondary
+          />
+        </div>
+        <dl className="review">
+          <div className="review-row">
+            <dt>{inputLabel}</dt>
+            <dd className="dd-privacy-hidden" data-dd-action-name="data value">
+              {valueText || '—'}
+            </dd>
+          </div>
+        </dl>
+      </form>
+    </div>
+  );
+};
+
+AddressSelectionReviewPage.propTypes = {
+  data: PropTypes.object,
+  editPage: PropTypes.func,
+  pagePerItemIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  title: PropTypes.string,
+};
+
+export default AddressSelectionReviewPage;

--- a/src/applications/ivc-champva/10-10d-extended/components/FormReview/AddressSelectionReviewPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormReview/AddressSelectionReviewPage.jsx
@@ -60,7 +60,7 @@ const AddressSelectionReviewPage = props => {
 
   return (
     <div className="form-review-panel-page">
-      <form className="rjsf" noValidate="">
+      <form className="rjsf" noValidate>
         <div className="form-review-panel-page-header-row">
           <h4 className="form-review-panel-page-header vads-u-font-size--h5">
             {title}

--- a/src/applications/ivc-champva/10-10d-extended/components/FormReview/AddressSelectionReviewPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormReview/AddressSelectionReviewPage.jsx
@@ -5,15 +5,19 @@ import {
   formatAddress,
   getInputLabel,
   NOT_SHARED,
-  OPTION_NO_LABEL,
   OPTION_YES_LABEL,
   safeParse,
 } from '../FormPages/AddressSelectionPage';
+import content from '../../locales/en/content.json';
+
+// declare static content
+const EDIT_BTN_TEXT = content['button--edit'];
+const REVIEW_OPTION_NO = content['review--no-option'];
 
 // parse the stored data value in to human-friendly text
 export const formatDataValue = (storedValue, { withPrefix = true } = {}) => {
   if (!storedValue) return '';
-  if (storedValue === NOT_SHARED) return OPTION_NO_LABEL.split(',')[0];
+  if (storedValue === NOT_SHARED) return REVIEW_OPTION_NO;
 
   const parsed = safeParse(storedValue);
   const addr = parsed ? formatAddress(parsed) : String(storedValue);
@@ -62,8 +66,8 @@ const AddressSelectionReviewPage = props => {
             {title}
           </h4>
           <va-button
-            text="Edit"
-            label={`Edit ${title}`}
+            text={EDIT_BTN_TEXT}
+            label={`${EDIT_BTN_TEXT} ${title}`}
             onClick={editPage}
             secondary
           />

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -38,7 +38,10 @@ import {
   medicareProofOfIneligibilityPage,
 } from '../chapters/medicareInformation';
 import { healthInsurancePages } from '../chapters/healthInsuranceInformation';
-import AddressSelectionPage from '../components/FormPages/AddressSelectionPage';
+import AddressSelectionPage, {
+  NOT_SHARED,
+} from '../components/FormPages/AddressSelectionPage';
+import AddressSelectionReviewPage from '../components/FormReview/AddressSelectionReviewPage';
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -180,7 +183,7 @@ const formConfig = {
         },
         page10b0: {
           path: 'veteran-address',
-          title: 'Veteran’s address selection',
+          title: 'Veteran’s address',
           depends: formData =>
             !get('sponsorIsDeceased', formData) &&
             get('certifierRole', formData) !== 'sponsor' &&
@@ -189,14 +192,16 @@ const formConfig = {
             const opts = { ...props, dataKey: 'sponsorAddress' };
             return AddressSelectionPage(opts);
           },
-          CustomPageReview: null,
+          CustomPageReview: AddressSelectionReviewPage,
           uiSchema: {},
           schema: blankSchema,
         },
         page10: {
           path: 'veteran-mailing-address',
           title: 'Veteran’s mailing address',
-          depends: formData => !get('sponsorIsDeceased', formData),
+          depends: formData =>
+            !get('sponsorIsDeceased', formData) &&
+            get('view:sharesAddressWith', formData) === NOT_SHARED,
           ...sponsorAddress,
         },
         page11: {

--- a/src/applications/ivc-champva/10-10d-extended/locales/en/content.json
+++ b/src/applications/ivc-champva/10-10d-extended/locales/en/content.json
@@ -9,6 +9,7 @@
   "address-selection--update-aria-label": "Update address",
   "button--edit": "Edit",
   "button--update-page": "Update page",
+  "error--required": "You must provide a response",
   "form-title": "Apply for CHAMPVA benefits",
   "form-subtitle": "Application for CHAMPVA benefits (VA Form 10-10d)",
   "form-start-text": "Start the form",

--- a/src/applications/ivc-champva/10-10d-extended/locales/en/content.json
+++ b/src/applications/ivc-champva/10-10d-extended/locales/en/content.json
@@ -1,5 +1,19 @@
 {
+  "address-selection--page-title": "address",
+  "address-selection--page-description": "We\u2019ll send any important information about this claim to this address.",
+  "address-selection--label-text": "have the same mailing address as one previously entered in this application?",
+  "address-selection--prompt-third": "Does the",
+  "address-selection--prompt-second": "Do you",
+  "address-selection--no-option": "No, use a new address",
+  "address-selection--yes-option": "Yes, use",
+  "address-selection--update-aria-label": "Update address",
+  "button--edit": "Edit",
+  "button--update-page": "Update page",
   "form-title": "Apply for CHAMPVA benefits",
   "form-subtitle": "Application for CHAMPVA benefits (VA Form 10-10d)",
-  "form-start-text": "Start the form"
+  "form-start-text": "Start the form",
+  "noun--applicant": "applicant",
+  "noun--veteran-singular": "Veteran",
+  "noun--veteran-possessive": "Veteran\u2019s",
+  "review--no-option": "No"
 }

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
@@ -90,7 +90,7 @@
     "certifierEmail": "certifier@email.gov",
     "sponsorName": {
       "first": "Joe",
-      "middle": "James",
+      "middle": "J",
       "last": "Johnson",
       "suffix": "Jr."
     },

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/components/FormReview/AddressSelectionReviewPage.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/components/FormReview/AddressSelectionReviewPage.unit.spec.jsx
@@ -10,6 +10,10 @@ import {
   NOT_SHARED,
   OPTION_YES_LABEL,
 } from '../../../../components/FormPages/AddressSelectionPage';
+import content from '../../../../locales/en/content.json';
+
+// declare static content
+const REVIEW_OPTION_NO = content['review--no-option'];
 
 describe('10-10d <AddressSelectionReviewPage>', () => {
   const subject = ({
@@ -91,7 +95,7 @@ describe('10-10d `formatDataValue` helper', () => {
   });
 
   it('should return the NOT_SHARED label for "na"', () => {
-    expect(formatDataValue('na')).to.equal('No');
+    expect(formatDataValue('na')).to.equal(REVIEW_OPTION_NO);
   });
 
   it('should format JSON address with prefix by default', () => {

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/components/FormReview/AddressSelectionReviewPage.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/components/FormReview/AddressSelectionReviewPage.unit.spec.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import AddressSelectionReviewPage, {
+  formatDataValue,
+  getScopedData,
+} from '../../../../components/FormReview/AddressSelectionReviewPage';
+import {
+  FIELD_NAME,
+  NOT_SHARED,
+  OPTION_YES_LABEL,
+} from '../../../../components/FormPages/AddressSelectionPage';
+
+describe('10-10d <AddressSelectionReviewPage>', () => {
+  const subject = ({
+    title = 'Address selection',
+    index = undefined,
+    data = {},
+  } = {}) => {
+    const props = { pagePerItemIndex: index, editPage: () => {}, data, title };
+    const { container } = render(<AddressSelectionReviewPage {...props} />);
+    const dt = () => container.querySelector('dt');
+    const dd = () => container.querySelector('dd');
+    return { dt, dd };
+  };
+
+  it('should render an em dash when there is no selected value', () => {
+    const { dd } = subject();
+    expect(dd().textContent.trim()).to.equal('—');
+  });
+
+  it('should render `No` when an option is not applicable', () => {
+    const { dd } = subject({ data: { [FIELD_NAME]: NOT_SHARED } });
+    expect(dd().textContent.trim()).to.equal('No');
+  });
+
+  it('should render a formatted JSON address with the `Yes, use` prefix when an option is applicable', () => {
+    const value = JSON.stringify({
+      street: '123 A St',
+      street2: 'Apt 4',
+      city: 'Denver',
+      state: 'CO',
+      country: 'USA',
+    });
+    const { dd } = subject({ data: { [FIELD_NAME]: value } });
+    expect(dd().textContent.trim()).to.equal(
+      `${OPTION_YES_LABEL} 123 A St, Apt 4, Denver, CO, USA`,
+    );
+  });
+
+  it('should render `Do you` when role=applicant and pagePerItemIndex=0', () => {
+    const data = { certifierRole: 'applicant', applicants: [{}] };
+    const { dt } = subject({ data, index: 0 });
+    expect(dt().textContent).to.match(/^Do you/i);
+  });
+
+  it('should render `Does the applicant` when role=applicant and index>0', () => {
+    const data = { certifierRole: 'applicant', applicants: [{}, {}] };
+    const { dt } = subject({ data, index: 1 });
+    expect(dt().textContent).to.match(/^Does the applicant/i);
+  });
+
+  it('should render `Does the Veteran` when not in array mode', () => {
+    const data = { certifierRole: 'veteran' };
+    const { dt } = subject({ data });
+    expect(dt().textContent).to.match(/^Does the Veteran/i);
+  });
+
+  it('should properly scope data in array mode (reads applicants[index])', () => {
+    const first = { [FIELD_NAME]: NOT_SHARED };
+    const second = {
+      [FIELD_NAME]: JSON.stringify({
+        street: '55 B Rd',
+        city: 'Austin',
+        state: 'TX',
+      }),
+    };
+    const data = { certifierRole: 'applicant', applicants: [first, second] };
+    const { dd } = subject({ data, index: 1 });
+    expect(dd().textContent.trim()).to.equal(
+      `${OPTION_YES_LABEL} 55 B Rd, Austin, TX`,
+    );
+  });
+});
+
+describe('10-10d `formatDataValue` helper', () => {
+  it('should return empty string for falsy input', () => {
+    expect(formatDataValue('')).to.equal('');
+    expect(formatDataValue(null)).to.equal('');
+    expect(formatDataValue(undefined)).to.equal('');
+  });
+
+  it('should return the NOT_SHARED label for "na"', () => {
+    expect(formatDataValue('na')).to.equal('No');
+  });
+
+  it('should format JSON address with prefix by default', () => {
+    const v = JSON.stringify({ street: 'X', city: 'Y', state: 'Z' });
+    expect(formatDataValue(v)).to.equal(`${OPTION_YES_LABEL} X, Y, Z`);
+  });
+
+  it('should format JSON address without prefix when withPrefix=false', () => {
+    const v = JSON.stringify({ street: 'X', city: 'Y', state: 'Z' });
+    expect(formatDataValue(v, { withPrefix: false })).to.equal('X, Y, Z');
+  });
+
+  it('should fall back to string when JSON parse fails', () => {
+    expect(formatDataValue('not-json')).to.equal(
+      `${OPTION_YES_LABEL} not-json`,
+    );
+  });
+});
+
+describe('10-10d `getScopedData` helper', () => {
+  it('should return root data when not in array mode', () => {
+    const d = { foo: 1 };
+    expect(getScopedData(d, null)).to.deep.equal(d);
+    expect(getScopedData(d, '')).to.deep.equal(d);
+  });
+
+  it('should return applicants[n] in array mode', () => {
+    const d = { applicants: [{ id: 1 }, { id: 2 }] };
+    expect(getScopedData(d, 0)).to.deep.equal({ id: 1 });
+    expect(getScopedData(d, '1')).to.deep.equal({ id: 2 });
+  });
+});

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
@@ -2,6 +2,10 @@ import { expect } from 'chai';
 import formConfig from '../../../config/form';
 import transformForSubmit from '../../../config/submitTransformer';
 import { toHash } from '../../../../shared/utilities';
+import {
+  NOT_SHARED,
+  FIELD_NAME as SHARED_ADDRESS_FIELD_NAME,
+} from '../../../components/FormPages/AddressSelectionPage';
 
 const APPLICANT_SSN = '345345345';
 const SSN_HASH = toHash(APPLICANT_SSN);
@@ -349,6 +353,7 @@ describe('10-10d-extended transform for submit', () => {
     it('should properly format sponsor address fields', () => {
       const testData = {
         data: {
+          [SHARED_ADDRESS_FIELD_NAME]: NOT_SHARED,
           sponsorAddress: {
             street: '123 Main Street',
             street2: 'Apartment 4B',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates conditional flow for address pages when utilizing the address selection options. The PR also updates the review page settings to allow for adjusting address selection on that page.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118201

## Testing done

- Previously, when you select an address from the list, you still got taken to the address input page
- Now, when you select an address from the list, you bypass the address input page

## Screenshots

| Yes | No | Edit |
| ---- | -- | ---- |
| <img width="636" height="177" alt="Screenshot 2025-10-10 at 12 09 20" src="https://github.com/user-attachments/assets/799d0e3f-ea52-41dd-a7e9-71df814fe4a9" /> | <img width="636" height="177" alt="Screenshot 2025-10-10 at 12 09 47" src="https://github.com/user-attachments/assets/17002f04-30bd-4741-9a68-984f3312f038" /> | <img width="636" height="367" alt="Screenshot 2025-10-10 at 12 10 33" src="https://github.com/user-attachments/assets/16852ab8-a261-49d9-87aa-e935ec346c83" /> |

## Acceptance criteria

- Page conditional allow user to skip unnecessary pages
- Users can update their selection on the review page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
