### PR TITLE
#98827 [10-10EZR]: Spouse V2 Confirmation Flow: Spouse Information Su…

### DIFF
--- a/src/applications/ezr/components/FormAlerts/SpouseInformationReviewWarning.jsx
+++ b/src/applications/ezr/components/FormAlerts/SpouseInformationReviewWarning.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SpouseInformationReviewWarning = props => {
+  return !props.isFormReviewPage ? (
+    <>
+      <div className="vads-u-margin-top--4">
+        <va-alert slim status="info" tabIndex={-1} visible>
+          <p className="vads-u-margin-y--0 vads-u-font-weight--normal">
+            You can review and edit your spouse information. Or select{' '}
+            <strong>Continue</strong> to go to the next part of this form.
+          </p>
+        </va-alert>
+      </div>
+    </>
+  ) : null;
+};
+
+SpouseInformationReviewWarning.propTypes = {
+  isFormReviewPage: PropTypes.bool,
+};
+
+export default SpouseInformationReviewWarning;

--- a/src/applications/ezr/components/FormDescriptions/SpouseSummaryCardDescription.jsx
+++ b/src/applications/ezr/components/FormDescriptions/SpouseSummaryCardDescription.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+const SpouseSummaryCardDescription = item => {
+  const { data: formData } = useSelector(state => state.form);
+  const { maritalStatus } = formData['view:maritalStatus'];
+  return item && <p className="vads-u-margin-bottom--0">{maritalStatus}</p>;
+};
+
+export default SpouseSummaryCardDescription;

--- a/src/applications/ezr/config/chapters/householdInformation/spouseInformation.js
+++ b/src/applications/ezr/config/chapters/householdInformation/spouseInformation.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import spouseInformationSummaryPage from '../../../definitions/spouseInformationSummary';
+import spousePersonalInformationPage from '../../../definitions/spousePersonalInformation';
+
+import content from '../../../locales/en/content.json';
+import SpouseSummaryCardDescription from '../../../components/FormDescriptions/SpouseSummaryCardDescription';
+import SpouseInformationReviewWarning from '../../../components/FormAlerts/SpouseInformationReviewWarning';
+
+/** @type {ArrayBuilderOptions} */
+const options = {
+  arrayPath: 'spouseInformation',
+  nounSingular: 'spouse',
+  nounPlural: 'spouse',
+  required: false,
+  maxItems: 1,
+  hideMaxItemsAlert: true,
+  text: {
+    getItemName: item => {
+      return `${item.spouseFullName.first} ${item.spouseFullName.last}`;
+    },
+    summaryDescription: () => (
+      <SpouseInformationReviewWarning
+        isFormReviewPage={window?.location?.pathname.includes(
+          'review-and-submit',
+        )}
+      />
+    ),
+    cardDescription: item => {
+      return item && <SpouseSummaryCardDescription item={item} />;
+    },
+    cancelAddDescription: () =>
+      content['household-spouse-add-cancel-modal-text'],
+    cancelEditDescription: () =>
+      content['household-spouse-edit-cancel-modal-text'],
+    cancelAddYes: () => content['household-spouse-add-cancel-modal-button-yes'],
+    cancelAddNo: () => content['household-spouse-add-cancel-modal-button-no'],
+    cancelEditNo: () => content['household-spouse-edit-cancel-modal-button-no'],
+    cancelEditYes: () =>
+      content['household-spouse-edit-cancel-modal-button-yes'],
+    cancelAddTitle: () => content['household-spouse-add-cancel-modal-title'],
+    cancelEditTitle: () => content['household-spouse-edit-cancel-modal-title'],
+  },
+};
+
+/**
+ * Schemas for spouse information summary page.
+ *
+ * @returns {PageSchema}
+ */
+const spouseInformationSummaryPageSchema = spouseInformationSummaryPage(
+  options,
+);
+
+/**
+ * Schemas for spouse personal information page.
+ *
+ * @returns {PageSchema}
+ */
+const spousePersonalInformationPageSchema = spousePersonalInformationPage(
+  options,
+);
+
+const spousalInformationPages = arrayBuilderPages(options, pageBuilder => ({
+  spouseInformationSummaryPage: pageBuilder.summaryPage({
+    title: content['household-spouse-information-summary-title'],
+    path: 'household-information/spouse-information',
+    uiSchema: spouseInformationSummaryPageSchema.uiSchema,
+    schema: spouseInformationSummaryPageSchema.schema,
+  }),
+  spousePersonalInformationPage: pageBuilder.itemPage({
+    title: content['household-spouse-information-title'],
+    path:
+      'household-information/spouse-information/:index/spouse-personal-information',
+    uiSchema: spousePersonalInformationPageSchema.uiSchema,
+    schema: spousePersonalInformationPageSchema.schema,
+  }),
+}));
+
+export default spousalInformationPages;

--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -10,6 +10,8 @@ import content from '../locales/en/content.json';
 import { SHARED_PATHS, VIEW_FIELD_SCHEMA } from '../utils/constants';
 import {
   includeSpousalInformation,
+  includeSpousalInformationV1,
+  includeSpousalInformationV2,
   includeHouseholdInformation,
   includeHouseholdInformationV1,
   includeHouseholdInformationV2,
@@ -75,6 +77,7 @@ import veteranAnnualIncome from './chapters/householdInformation/veteranAnnualIn
 import spouseAnnualIncome from './chapters/householdInformation/spouseAnnualIncome';
 import deductibleExpenses from './chapters/householdInformation/deductibleExpenses';
 import FinancialInformationPages from './chapters/householdInformation/financialInformation';
+import spousalInformationPages from './chapters/householdInformation/spouseInformation';
 import MaritalStatusPage from '../components/FormPages/MaritalStatusPage';
 
 // chapter 3 Military Service
@@ -370,11 +373,19 @@ const formConfig = {
           uiSchema: maritalStatus.uiSchema,
           schema: maritalStatus.schema,
         },
+        spouseInformationSummary: {
+          ...spousalInformationPages.spouseInformationSummaryPage,
+          depends: includeSpousalInformationV2,
+        },
+        spousePersonalInformationV2: {
+          ...spousalInformationPages.spousePersonalInformationPage,
+          depends: includeSpousalInformationV2,
+        },
         spousePersonalInformation: {
           path: 'household-information/spouse-personal-information',
           title: 'Spouse\u2019s personal information',
           initialData: {},
-          depends: includeSpousalInformation,
+          depends: includeSpousalInformationV1,
           uiSchema: spousePersonalInformation.uiSchema,
           schema: spousePersonalInformation.schema,
         },

--- a/src/applications/ezr/definitions/spouseInformationSummary.js
+++ b/src/applications/ezr/definitions/spouseInformationSummary.js
@@ -1,0 +1,28 @@
+import {
+  arrayBuilderYesNoSchema,
+  arrayBuilderYesNoUI,
+} from '~/platform/forms-system/src/js/web-component-patterns';
+import content from '../locales/en/content.json';
+
+/**
+ * Spouse information summary page. Review cards are populated on this page
+ * if spouse information is present.
+ *
+ * @returns {PageSchema}
+ */
+const spouseInformationSummaryPage = (options = {}) => ({
+  uiSchema: {
+    'view:hasSpouseInformationToAdd': arrayBuilderYesNoUI(options, {
+      hint: content['household-spouse-information-summary-hint'],
+    }),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      'view:hasSpouseInformationToAdd': arrayBuilderYesNoSchema,
+    },
+    required: ['view:hasSpouseInformationToAdd'],
+  },
+});
+
+export default spouseInformationSummaryPage;

--- a/src/applications/ezr/definitions/spousePersonalInformation.js
+++ b/src/applications/ezr/definitions/spousePersonalInformation.js
@@ -1,0 +1,47 @@
+import ezrSchema from 'vets-json-schema/dist/10-10EZR-schema.json';
+import {
+  arrayBuilderItemFirstPageTitleUI,
+  fullNameUI,
+  ssnUI,
+  ssnSchema,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import content from '../locales/en/content.json';
+
+const { spouseFullName } = ezrSchema.properties;
+
+/** @returns {PageSchema} */
+const spousePersonalInformationPage = (options = {}) => ({
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: content['household-spouse-information-title'],
+      nounSingular: options.nounSingular,
+    }),
+    spouseFullName: fullNameUI(
+      title => `${content['household-spouse-name-prefix']} ${title}`,
+    ),
+    spouseSocialSecurityNumber: ssnUI(content['household-spouse-ssn-label']),
+    spouseDateOfBirth: currentOrPastDateUI(
+      content['household-spouse-dob-label'],
+    ),
+    dateOfMarriage: currentOrPastDateUI(
+      content['household-spouse-marriage-date-label'],
+    ),
+  },
+  schema: {
+    type: 'object',
+    required: [
+      'spouseSocialSecurityNumber',
+      'spouseDateOfBirth',
+      'dateOfMarriage',
+    ],
+    properties: {
+      spouseFullName,
+      spouseSocialSecurityNumber: ssnSchema,
+      spouseDateOfBirth: currentOrPastDateSchema,
+      dateOfMarriage: currentOrPastDateSchema,
+    },
+  },
+});
+export default spousePersonalInformationPage;

--- a/src/applications/ezr/sass/_listLoopPattern.scss
+++ b/src/applications/ezr/sass/_listLoopPattern.scss
@@ -15,3 +15,6 @@ va-select[name$="_contactType"] { display: none; }
 
 // Hide the delete button for the financial information list & loop
 va-card[name^="income and deductible"] va-button-icon[data-action="remove"] { display: none; }
+
+// Hide the delete button for the spousal information summary card.
+va-card[name^="spouse_"] va-button-icon[data-action="remove"] { display: none; }

--- a/src/applications/ezr/tests/unit/components/FormAlerts/SpouseInformationReviewWarning.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/components/FormAlerts/SpouseInformationReviewWarning.unit.spec.jsx
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import React from 'react';
+import SpouseInformationReviewWarning from '../../../../components/FormAlerts/SpouseInformationReviewWarning';
+import { renderProviderWrappedComponent } from '../../../helpers';
+
+describe('ezr <SpouseInformationReviewWarning>', () => {
+  context(`when 'isFormReviewPage' is true`, () => {
+    it('should not render', () => {
+      const { container } = renderProviderWrappedComponent(
+        {},
+        <SpouseInformationReviewWarning isFormReviewPage />,
+      );
+      const selector = container.querySelector('va-alert');
+
+      expect(selector).to.not.exist;
+    });
+  });
+
+  context(`when 'isFormReviewPage' is false`, () => {
+    it('should render `va-alert` with status of `info`', () => {
+      const { container } = renderProviderWrappedComponent(
+        {},
+        <SpouseInformationReviewWarning isFormReviewPage={false} />,
+      );
+      const selector = container.querySelector('va-alert');
+
+      expect(selector).to.exist;
+      expect(selector).to.have.attr('status', 'info');
+    });
+
+    it('should render the correct message text', () => {
+      const { container } = renderProviderWrappedComponent(
+        {},
+        <SpouseInformationReviewWarning isFormReviewPage={false} />,
+      );
+      const messageText = container.textContent;
+
+      expect(messageText).to.include(
+        'You can review and edit your spouse information',
+      );
+      expect(messageText).to.include('Continue');
+    });
+  });
+});

--- a/src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import React from 'react';
+import SpouseSummaryCardDescription from '../../../../components/FormDescriptions/SpouseSummaryCardDescription';
+import { renderProviderWrappedComponent } from '../../../helpers';
+
+describe('ezr <SpouseSummaryCardDescription>', () => {
+  context('when item is null', () => {
+    it('should still render the marital status', () => {
+      const { container } = renderProviderWrappedComponent(
+        {
+          'view:maritalStatus': {
+            maritalStatus: 'married',
+          },
+        },
+        <SpouseSummaryCardDescription item={null} />,
+      );
+
+      // Component renders marital status regardless of item prop
+      expect(container).to.not.be.empty;
+      expect(container.textContent.trim()).to.equal('married');
+    });
+  });
+
+  context('when item is not null and marital status is married', () => {
+    it('should render the marital status', () => {
+      const { container } = renderProviderWrappedComponent(
+        {
+          'view:maritalStatus': {
+            maritalStatus: 'married',
+          },
+        },
+        <SpouseSummaryCardDescription item={{}} />,
+      );
+
+      expect(container).to.not.be.empty;
+      expect(container.textContent.trim()).to.equal('married');
+    });
+  });
+
+  context('when item is not null and marital status is separated', () => {
+    it('should render the marital status', () => {
+      const { container } = renderProviderWrappedComponent(
+        {
+          'view:maritalStatus': {
+            maritalStatus: 'separated',
+          },
+        },
+        <SpouseSummaryCardDescription item={{}} />,
+      );
+
+      expect(container).to.not.be.empty;
+      expect(container.textContent.trim()).to.equal('separated');
+    });
+  });
+
+  context('when item is not null and marital status is divorced', () => {
+    it('should render the marital status', () => {
+      const { container } = renderProviderWrappedComponent(
+        {
+          'view:maritalStatus': {
+            maritalStatus: 'divorced',
+          },
+        },
+        <SpouseSummaryCardDescription item={{}} />,
+      );
+
+      expect(container).to.not.be.empty;
+      expect(container.textContent.trim()).to.equal('divorced');
+    });
+  });
+});

--- a/src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx
@@ -8,8 +8,12 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
     it('should still render the marital status', () => {
       const { container } = renderProviderWrappedComponent(
         {
-          'view:maritalStatus': {
-            maritalStatus: 'married',
+          form: {
+            data: {
+              'view:maritalStatus': {
+                maritalStatus: 'married',
+              },
+            },
           },
         },
         <SpouseSummaryCardDescription item={null} />,
@@ -25,8 +29,12 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
     it('should render the marital status', () => {
       const { container } = renderProviderWrappedComponent(
         {
-          'view:maritalStatus': {
-            maritalStatus: 'married',
+          form: {
+            data: {
+              'view:maritalStatus': {
+                maritalStatus: 'married',
+              },
+            },
           },
         },
         <SpouseSummaryCardDescription item={{}} />,
@@ -41,8 +49,12 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
     it('should render the marital status', () => {
       const { container } = renderProviderWrappedComponent(
         {
-          'view:maritalStatus': {
-            maritalStatus: 'separated',
+          form: {
+            data: {
+              'view:maritalStatus': {
+                maritalStatus: 'separated',
+              },
+            },
           },
         },
         <SpouseSummaryCardDescription item={{}} />,
@@ -57,8 +69,12 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
     it('should render the marital status', () => {
       const { container } = renderProviderWrappedComponent(
         {
-          'view:maritalStatus': {
-            maritalStatus: 'divorced',
+          form: {
+            data: {
+              'view:maritalStatus': {
+                maritalStatus: 'divorced',
+              },
+            },
           },
         },
         <SpouseSummaryCardDescription item={{}} />,

--- a/src/applications/ezr/tests/unit/definitions/spouseInformationSummary.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/definitions/spouseInformationSummary.unit.spec.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { expect } from 'chai';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../../config/form';
+import spouseInformationSummaryPage from '../../../definitions/spouseInformationSummary';
+import { renderProviderWrappedComponent } from '../../helpers';
+
+describe('ezr spouseInformationSummaryPage config', () => {
+  const { schema, uiSchema } = spouseInformationSummaryPage();
+  const definitions = {
+    ...formConfig.defaultDefinitions,
+  };
+
+  it('should render', () => {
+    const mockStoreData = {
+      'view:householdEnabled': true,
+      'view:isProvidersAndDependentsPrefillEnabled': true,
+    };
+    const { container } = renderProviderWrappedComponent(
+      mockStoreData,
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(container).to.exist;
+  });
+
+  it('should render with custom options', () => {
+    const options = { nounSingular: 'spouse' };
+    const {
+      schema: customSchema,
+      uiSchema: customUiSchema,
+    } = spouseInformationSummaryPage(options);
+    const mockStoreData = {
+      'view:householdEnabled': true,
+      'view:isProvidersAndDependentsPrefillEnabled': true,
+    };
+    const { container } = renderProviderWrappedComponent(
+      mockStoreData,
+      <DefinitionTester
+        schema={customSchema}
+        definitions={definitions}
+        uiSchema={customUiSchema}
+      />,
+    );
+
+    expect(container).to.exist;
+  });
+
+  it('should have required field', () => {
+    expect(schema.required).to.include('view:hasSpouseInformationToAdd');
+  });
+
+  it('should have correct property', () => {
+    expect(schema.properties).to.have.property(
+      'view:hasSpouseInformationToAdd',
+    );
+  });
+
+  it('should have array builder yes/no schema', () => {
+    expect(schema.properties['view:hasSpouseInformationToAdd'].type).to.equal(
+      'boolean',
+    );
+  });
+
+  it('should have hint in uiSchema when rendered with form data', () => {
+    const mockStoreData = {
+      'view:householdEnabled': true,
+      'view:isProvidersAndDependentsPrefillEnabled': true,
+      // Add some spouse data to trigger the hint
+      spouseInformation: [],
+    };
+    const { container } = renderProviderWrappedComponent(
+      mockStoreData,
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    // The hint should be present in the rendered form
+    expect(container).to.exist;
+  });
+});

--- a/src/applications/ezr/tests/unit/definitions/spousePersonalInformation.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/definitions/spousePersonalInformation.unit.spec.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { expect } from 'chai';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../../config/form';
+import spousePersonalInformationPage from '../../../definitions/spousePersonalInformation';
+import { renderProviderWrappedComponent } from '../../helpers';
+
+describe('ezr spousePersonalInformationPage config', () => {
+  const { schema, uiSchema } = spousePersonalInformationPage();
+  const definitions = {
+    ...formConfig.defaultDefinitions,
+  };
+
+  it('should render', () => {
+    const mockStoreData = {
+      'view:householdEnabled': true,
+      'view:isProvidersAndDependentsPrefillEnabled': true,
+    };
+    const { container } = renderProviderWrappedComponent(
+      mockStoreData,
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(container).to.exist;
+  });
+
+  it('should render with custom options', () => {
+    const options = { nounSingular: 'spouse' };
+    const {
+      schema: customSchema,
+      uiSchema: customUiSchema,
+    } = spousePersonalInformationPage(options);
+    const mockStoreData = {
+      'view:householdEnabled': true,
+      'view:isProvidersAndDependentsPrefillEnabled': true,
+    };
+    const { container } = renderProviderWrappedComponent(
+      mockStoreData,
+      <DefinitionTester
+        schema={customSchema}
+        definitions={definitions}
+        uiSchema={customUiSchema}
+      />,
+    );
+
+    expect(container).to.exist;
+  });
+
+  it('should have required fields', () => {
+    expect(schema.required).to.include('spouseSocialSecurityNumber');
+    expect(schema.required).to.include('spouseDateOfBirth');
+    expect(schema.required).to.include('dateOfMarriage');
+  });
+
+  it('should have correct properties', () => {
+    expect(schema.properties).to.have.property('spouseFullName');
+    expect(schema.properties).to.have.property('spouseSocialSecurityNumber');
+    expect(schema.properties).to.have.property('spouseDateOfBirth');
+    expect(schema.properties).to.have.property('dateOfMarriage');
+  });
+});

--- a/src/applications/ezr/utils/helpers/form-config.js
+++ b/src/applications/ezr/utils/helpers/form-config.js
@@ -320,6 +320,30 @@ export function includeSpousalInformationWithV1Prefill(formData) {
   );
 }
 
+/**
+ * Helper that determines if the form data contains values that require users
+ * to fill out spousal information for V1 confirmation flow.
+ * @param {Object} formData - the current data object passed from the form
+ * @returns {Boolean} - true if the V2 feature flag is disabled, and the
+ * Veteran has a marital status of 'married' or 'separated'.
+ */
+export function includeSpousalInformationV1(formData) {
+  if (formData['view:isSpouseConfirmationFlowEnabled']) return false;
+  return includeSpousalInformation(formData);
+}
+
+/**
+ * Helper that determines if the form data contains values that require users
+ * to fill out spousal information (V2)
+ * @param {Object} formData - the current data object passed from the form
+ * @returns {Boolean} - true if the V2 feature flag is enabled, and the
+ * Veteran has a marital status of 'married' or 'separated'.
+ */
+export function includeSpousalInformationV2(formData) {
+  if (!formData['view:isSpouseConfirmationFlowEnabled']) return false;
+  return includeSpousalInformation(formData);
+}
+
 export function includeSpousalInformationWithV2Prefill(formData) {
   if (!includeHouseholdInformationWithV2Prefill(formData)) return false;
   const { maritalStatus } = formData['view:maritalStatus'];


### PR DESCRIPTION
This PR merges the contents of https://github.com/department-of-veterans-affairs/vets-website/pull/37713 into main individually, to break up the 3500 lines of the overall https://github.com/department-of-veterans-affairs/vets-website/pull/37774.
When https://github.com/department-of-veterans-affairs/vets-website/pull/39334 is merged, ~we can change this one's target to `main` and merge it next~ this PR auto-updates to target `main` and can be merged in next. Original description follows:

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request introduces new spousal information pages in the EZR application for V2 (confirmation flow), including components, schemas, configuration updates, and tests. The changes add ArrayBuilder (List and Loop) summary and spouse personal information pages. Additional pages will following in subsequent PRs.

This work is behind the `isSpouseConfirmationFlowEnabled` feature flag.

### New Components for Spousal Information
* Added `SpouseInformationReviewWarning` component to display a warning message about reviewing and editing spousal information on non-review pages. (`src/applications/ezr/components/FormAlerts/SpouseInformationReviewWarning.jsx`)
* Added `SpouseSummaryCardDescription` component to display marital status information on summary cards. (`src/applications/ezr/components/FormDescriptions/SpouseSummaryCardDescription.jsx`)

### Configuration Updates for Spousal Information
* Introduced `spousalInformationPages` configuration to define schemas and UI for spousal information summary and personal information pages. (`src/applications/ezr/config/chapters/householdInformation/spouseInformation.js`)
* Updated `formConfig` to include new spousal information pages and conditional dependencies based on V1 and V2 feature flags. (`src/applications/ezr/config/form.js`) [[1]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bR13-R14) [[2]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bR81) [[3]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bR377-R389)

### Definitions for Spousal Information Pages
* Added schema and UI definitions for the spousal information summary page, including a yes/no array builder schema. (`src/applications/ezr/definitions/spouseInformationSummary.js`)
* Added schema and UI definitions for the spousal personal information page, including fields for full name, SSN, date of birth, and marriage date. (`src/applications/ezr/definitions/spousePersonalInformation.js`)

### Helper Methods for Conditional Dependencies
* Added helper methods `includeSpousalInformationV1` and `includeSpousalInformationV2` to determine conditional dependencies for spousal information based on feature flags. (`src/applications/ezr/utils/helpers/form-config.js`)

### Unit Tests for New Components and Definitions
* Added unit tests for `SpouseInformationReviewWarning` and `SpouseSummaryCardDescription` components to validate rendering and behavior. (`src/applications/ezr/tests/unit/components/FormAlerts/SpouseInformationReviewWarning.unit.spec.jsx`, `src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx`) [[1]](diffhunk://#diff-b7aeb38cfcdf460c2126a364ee036ecddc3bf47525d66883822e617346a1f137R1-R44) [[2]](diffhunk://#diff-b1c0b8acbe6b94178092a349307fe1fed0273e89507716253542a819f59ef05cR1-R71)
* Added unit tests for the spousal information summary and personal information page definitions to validate schema and UI properties. (`src/applications/ezr/tests/unit/definitions/spouseInformationSummary.unit.spec.jsx`, `src/applications/ezr/tests/unit/definitions/spousePersonalInformation.unit.spec.jsx`) [[1]](diffhunk://#diff-32592633ce306d742c3d085134fae61636695e1afe310c390a80b1625b4d95fdR1-R88) **[[2]](diffhunk://#diff-820341d36605cb8cc09eb1ff7973ca620c551bcf756630aba06b95d9a36006e9R1-R65)**

## Related issue(s)
 - **department-of-veterans-affairs/va.gov-team/issues/98827**

## Testing done
With ezr_spouse_confirmation_flow_enabled feature flag **disabled**:
Old behavior - the spouse information summary page, and the new spouse personal information page, is not visible/reachable in the form.

With ezr_spouse_confirmation_flow_enabled feature flag **enabled**:
New Behavior 
- New spouse information summary page. The summary page content is either an ArrayBuilder summary card as seen in EC, NoK, and other ArrayBuilder (List and Loop) patterned pages (if married, and spouse data exists from prefill), or a yes/no 'Do you have a spouse to add' question if no existing spouse data is present in the form.
- The next page is spouse personal information. Its the same as the V1 version, but within the ArrayBuilder's path `household-information/spouse-information/0/spouse-personal-information?add=true`.

### Current/V1 Test Steps (no spouse prefill):

1. Login to the test site (local, RI)
2. Visit the 10-10EZR form at /my-health/update-benefits-information-form-10-10ezr
3. Start the application process
4. Proceed filling the form up to the /my-health/update-benefits-information-form-10-10ezr/household-information/marital-status-information
5. Select a Married or Separated status
6. Click continue
7. Confirm you are at the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-personal-information page.
8.  Fill required fields and click continue
9. Verify you are at the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-additional-information page.

### New V2 Test Steps:

1. Steps 1-7 above
2. Confirm there is a yes/no question: 'Do you have a spouse to add?'
3. Select Yes and continue
4. Confirm you are on the  /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-information/0/spouse-personal-information?add=true page
5. Fill out the required fields and click Continue
6. Confirm you are back at the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-information and the page content is a summary card.
7. Click Continue.
8. Confirm you are now on the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-additional-information page.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="961" height="907" alt="Screenshot 2025-07-14 at 1 04 18 PM" src="https://github.com/user-attachments/assets/9f0e657c-2167-4e54-b3c3-95f65ae17d44" />  |  <img width="1128" height="929" alt="Screenshot 2025-07-14 at 12 52 42 PM" src="https://github.com/user-attachments/assets/1ad84365-e881-41b5-bad1-0b01212a868f" /> <img width="958" height="889" alt="Screenshot 2025-07-14 at 12 52 20 PM" src="https://github.com/user-attachments/assets/ea700791-db05-4daf-aad4-65353279a1ae" /> <img width="996" height="857" alt="Screenshot 2025-07-14 at 1 13 47 PM" src="https://github.com/user-attachments/assets/a4e6bcc7-4690-42a4-b751-0353ced5c5e9" />  |
| Desktop |   <img width="945" height="1080" alt="Screenshot 2025-07-14 at 1 04 13 PM" src="https://github.com/user-attachments/assets/3c4b125d-1857-45bd-823c-e439c9a9e995" /> |  <img width="1197" height="1076" alt="Screenshot 2025-07-14 at 12 52 29 PM" src="https://github.com/user-attachments/assets/2ffd4824-d171-4a07-8336-c9e34cff824a" /> <img width="921" height="895" alt="Screenshot 2025-07-14 at 12 52 15 PM" src="https://github.com/user-attachments/assets/dfbbf00b-1ac5-4d31-995f-05a610440675" /> <img width="899" height="722" alt="Screenshot 2025-07-14 at 1 13 41 PM" src="https://github.com/user-attachments/assets/5a359572-1142-488a-b693-0a2ea15dc5f7" /> |

## What areas of the site does it impact?
10-10EZR form.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
