### PR TITLE
Update pension list and loop text

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -23,8 +23,10 @@ const options = {
         ? formatFullName(item.previousFullName)
         : undefined,
     summaryTitleWithoutItems: 'Other service names',
+    cancelAddTitle: 'Cancel adding this previous name',
     cancelAddYes: 'Yes, cancel adding this previous name',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this previous name',
     cancelEditYes: 'Yes, cancel editing this previous name',
     cancelEditNo: 'No',
     cancelNo: 'No',
@@ -53,10 +55,6 @@ const summaryPage = {
       },
       {
         title: 'Do you have another previous name to report?',
-        labels: {
-          Y: 'Yes, I have another previous name to report',
-          N: 'No, I don’t have anymore previous names to report',
-        },
       },
     ),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistoryPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistoryPages.js
@@ -26,8 +26,10 @@ const options = {
   text: {
     getItemName: item => item?.jobType,
     summaryTitleWithoutItems: 'Current employment',
+    cancelAddTitle: 'Cancel adding this current job',
     cancelAddYes: 'Yes, cancel adding this current job',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this current job',
     cancelEditYes: 'Yes, cancel editing this current job',
     cancelEditNo: 'No',
     cancelNo: 'No',

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/federalMedicalCentersPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/federalMedicalCentersPages.js
@@ -18,11 +18,15 @@ const options = {
   isItemIncomplete: item => !item?.medicalCenter, // include all required fields here
   text: {
     getItemName: item => item?.medicalCenter,
-    summaryTitleWithoutItems: 'Treatment from federal medical facilities',
-    cancelEditTitle: 'Cancel editing this federal medical facility',
+    summaryTitleWithoutItems: 'Treatment from federal medical centers',
+    cancelAddTitle: 'Cancel adding this federal medical center',
+    cancelAddYes: 'Yes, Cancel adding this federal medical center',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this federal medical center',
+    cancelEditYes: 'Yes, Cancel editing this federal medical center',
+    cancelEditNo: 'No',
     cancelNo: 'No',
-    deleteTitle: 'Delete federal medical facility',
+    deleteTitle: 'Delete this federal medical center',
     deleteNo: 'No',
   },
 };
@@ -36,10 +40,10 @@ const summaryPage = {
   uiSchema: {
     'view:isAddingFederalMedicalCenters': arrayBuilderYesNoUI(options, {
       title:
-        'Have you received treatment from any non-VA federal medical facilities within the past year?',
+        'Have you received treatment from any non-VA federal medical centers within the past year?',
       labelHeaderLevel: ' ',
       hint:
-        'Examples of federal medical facilities include military bases and prisons',
+        'Examples of federal medical centers include military bases and prisons',
     }),
   },
   schema: {
@@ -74,7 +78,7 @@ export const federalMedicalCentersPages = arrayBuilderPages(
   options,
   pageBuilder => ({
     federalMedicalCentersSummary: pageBuilder.summaryPage({
-      title: 'Federal medical facilities',
+      title: 'Federal medical centers',
       path: 'medical/history/federal-medical-centers/summary',
       depends: () => showMultiplePageResponse(),
       uiSchema: summaryPage.uiSchema,

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistoryPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistoryPages.js
@@ -32,8 +32,10 @@ const options = {
   text: {
     getItemName: item => item?.jobType,
     summaryTitleWithoutItems: 'Previous employment',
+    cancelAddTitle: 'Cancel adding this previous job',
     cancelAddYes: 'Yes, cancel adding this previous job',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this previous job',
     cancelEditYes: 'Yes, cancel editing this previous job',
     cancelEditNo: 'No',
     cancelNo: 'No',

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/vaMedicalCentersPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/vaMedicalCentersPages.js
@@ -18,13 +18,15 @@ const options = {
   isItemIncomplete: item => !item?.medicalCenter, // include all required fields here
   text: {
     getItemName: item => item?.medicalCenter,
-    summaryTitleWithoutItems: 'Treatment from VA medical facilities',
-    cancelAddYes: 'Yes, cancel adding this VA medical facility',
+    summaryTitleWithoutItems: 'Treatment from VA medical centers',
+    cancelAddTitle: 'Cancel adding this VA medical center',
+    cancelAddYes: 'Yes, cancel adding this VA medical center',
     cancelAddNo: 'No',
-    cancelEditYes: 'Yes, cancel editing this VA medical facility',
+    cancelEditTitle: 'Cancel editing this VA medical center',
+    cancelEditYes: 'Yes, cancel editing this VA medical center',
     cancelEditNo: 'No',
     cancelNo: 'No',
-    deleteTitle: 'Delete VA medical facility',
+    deleteTitle: 'Delete this VA medical center',
     deleteNo: 'No',
   },
 };
@@ -75,7 +77,7 @@ export const vaMedicalCentersPages = arrayBuilderPages(
   options,
   pageBuilder => ({
     vaMedicalCentersSummary: pageBuilder.summaryPage({
-      title: 'VA medical facilities',
+      title: 'VA medical centers',
       path: 'medical/history/va-medical-centers/summary',
       depends: () => showMultiplePageResponse(),
       uiSchema: summaryPage.uiSchema,

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
@@ -70,6 +70,15 @@ const options = {
     getItemName: item =>
       item.fullName ? formatFullName(item.fullName) : undefined,
     summaryTitleWithoutItems: 'Dependent children',
+    cancelAddTitle: 'Cancel adding this dependent child',
+    cancelAddYes: 'Yes, cancel adding this dependent child',
+    cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this dependent child',
+    cancelEditYes: 'Yes, cancel editing this dependent child',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this dependent child',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/config/chapters/05-financial-information/careExpensesPages.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/careExpensesPages.js
@@ -76,8 +76,10 @@ const options = {
           </li>
         </ul>
       ),
+    cancelAddTitle: 'Cancel adding this care expense',
     cancelAddYes: 'Yes, cancel adding this care expense',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this care expense',
     cancelEditYes: 'Yes, cancel editing this care expense',
     cancelEditNo: 'No',
     cancelNo: 'No',

--- a/src/applications/pensions/config/chapters/05-financial-information/incomeSourcesPages.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/incomeSourcesPages.js
@@ -57,8 +57,10 @@ const options = {
           </li>
         </ul>
       ),
+    cancelAddTitle: 'Cancel adding this income source',
     cancelAddYes: 'Yes, cancel adding this income source',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this income source',
     cancelEditYes: 'Yes, cancel editing this income source',
     cancelEditNo: 'No',
     cancelNo: 'No',

--- a/src/applications/pensions/config/chapters/05-financial-information/medicalExpensesPages.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/medicalExpensesPages.js
@@ -62,8 +62,10 @@ const options = {
           </li>
         </ul>
       ),
+    cancelAddTitle: 'Cancel adding this medical expense',
     cancelAddYes: 'Yes, cancel adding this medical expense',
     cancelAddNo: 'No',
+    cancelEditTitle: 'Cancel editing this medical expense',
     cancelEditYes: 'Yes, cancel editing this medical expense',
     cancelEditNo: 'No',
     cancelNo: 'No',

--- a/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/federalMedicalCentersPages.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/federalMedicalCentersPages.unit.spec.jsx
@@ -29,7 +29,7 @@ describe('federal medical centers summary page', () => {
     federalMedicalCentersSummary.schema,
     federalMedicalCentersSummary.uiSchema,
     [
-      `va-radio[label="Have you received treatment from any non-VA federal medical facilities within the past year?"]`,
+      `va-radio[label="Have you received treatment from any non-VA federal medical centers within the past year?"]`,
     ],
     pageTitle,
   );


### PR DESCRIPTION
## Summary

This PR updates **text content** across the **multiple page list-and-loop patterns** used in the **Pension Benefits form (VA Form 21P-527EZ)**.  
The updates refine modal titles and button text to improve clarity, align with VA Design System guidance, and provide a more consistent user experience.  

These changes are gated behind the **`pension_multiple_page_response`** feature toggle and only affect the new multi-page list-and-loop implementations.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118520

## Related issue(s)

- Ongoing refinements for multiple page list-and-loop usability and content clarity

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/pension_multiple_page_response`  
4. Navigate to the Pension Benefits form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Proceed through any list-and-loop chapter that supports multiple pages (e.g., income, dependents, or medical expenses)

## How to verify

1. With **`pension_multiple_page_response`** enabled:  
   - Confirm modal title and button text reflect the updated, simplified language.  
   - Verify “Add another” and “Yes/No” prompts use consistent text across all affected list-and-loop pages.  
   - Ensure pages correctly reflect updated copy and button labels
2. With **`pension_multiple_page_response`** disabled:  
   - Confirm legacy list-and-loop pages and text remain unchanged.  
3. Validate accessibility (heading levels, focus states, and screen reader output).  
4. Confirm no console errors and successful navigation through multi-page sections.  

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ)  
- List-and-loop patterns across income, dependent, and medical expense sections  
- Conditional UI text and summary page content behind the `pension_multiple_page_response` toggle  

## Screenshots

| Before | After |
|--------|-------|
| Inconsistent text across list-and-loop pages | Updated text for clarity, consistency, and alignment with VADS |

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

- Post-MVP text and content improvements for multiple page list-and-loop flows  
- **Behind** `pension_multiple_page_response` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm the updated list-and-loop text is aligned with the Design QA recommendations and provides consistent phrasing across all multi-page list-and-loop flows.
