### PR TITLE
VADBC 120153 copy of submission fixes - missing pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/Authorization.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Authorization.jsx
@@ -15,7 +15,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import PropTypes from 'prop-types';
 import { PrivacyActStatementContent } from './privacyActStatementContent';
 
-const AUTHORIZATION_LABEL =
+export const AUTHORIZATION_LABEL =
   'I acknowledge and authorize this release of information';
 
 const AUTH_ERROR =

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reviewEntry } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
+import { paymentRows } from './PaymentViewObjectField';
 
 const ConfirmationPaymentInformation = ({ formData }) => {
   const bankingInformation = formData?.['view:bankAccount'];
@@ -12,28 +13,27 @@ const ConfirmationPaymentInformation = ({ formData }) => {
 
   const bankingEntries = {
     bankAccountType: {
-      label: 'Account type',
+      label: paymentRows.bankAccountType,
       data: bankingInformation.bankAccountType || '',
     },
     bankName: {
-      label: 'Bank name',
+      label: paymentRows.bankName,
       data: bankingInformation.bankName || '',
     },
     bankAccountNumber: {
-      label: 'Account number',
+      label: paymentRows.bankAccountNumber,
       data: bankingInformation.bankAccountNumber
         ? `******${bankingInformation.bankAccountNumber.slice(-4)}`
         : '',
     },
     bankRoutingNumber: {
-      label: 'Routing number',
+      label: paymentRows.bankRoutingNumber,
       data: bankingInformation.bankRoutingNumber
         ? `*****${bankingInformation.bankRoutingNumber.slice(-4)}`
         : '',
     },
   };
 
-  // export const reviewEntry = (description, key, uiSchema, label, data) => {
   return (
     <li>
       <h4>Payment Information</h4>

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { reviewEntry } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
+
+const ConfirmationPaymentInformation = ({ formData }) => {
+  const bankingInformation = formData?.['view:bankAccount'];
+
+  // Return null if bankingInformation is undefined, null, or an empty object
+  if (!bankingInformation || Object.keys(bankingInformation).length === 0) {
+    return null;
+  }
+
+  const bankingEntries = {
+    bankAccountType: {
+      label: 'Account type',
+      data: bankingInformation.bankAccountType || '',
+    },
+    bankName: {
+      label: 'Bank name',
+      data: bankingInformation.bankName || '',
+    },
+    bankAccountNumber: {
+      label: 'Account number',
+      data: bankingInformation.bankAccountNumber
+        ? `******${bankingInformation.bankAccountNumber.slice(-4)}`
+        : '',
+    },
+    bankRoutingNumber: {
+      label: 'Routing number',
+      data: bankingInformation.bankRoutingNumber
+        ? `*****${bankingInformation.bankRoutingNumber.slice(-4)}`
+        : '',
+    },
+  };
+
+  // export const reviewEntry = (description, key, uiSchema, label, data) => {
+  return (
+    <li>
+      <h4>Payment Information</h4>
+      <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
+        {Object.entries(bankingEntries).map(([key, value]) =>
+          reviewEntry(null, key, null, value.label, value.data),
+        )}
+      </ul>
+    </li>
+  );
+};
+
+ConfirmationPaymentInformation.propTypes = {
+  formData: PropTypes.object,
+};
+export default ConfirmationPaymentInformation;

--- a/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
@@ -8,6 +8,7 @@ import {
   addAccountAlert,
   paymentInformationTitle,
 } from '../content/paymentInformation';
+import ConfirmationPaymentInformation from '../components/ConfirmationPaymentInformation';
 
 const {
   bankAccountType,
@@ -64,6 +65,7 @@ export const uiSchema = {
       'ui:required': bankFieldsHaveInput,
     },
   },
+  'ui:confirmationField': ConfirmationPaymentInformation,
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalAuthorizeRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalAuthorizeRelease.js
@@ -1,3 +1,5 @@
+import { AUTHORIZATION_LABEL } from '../components/Authorization';
+
 export const uiSchema = {
   patient4142Acknowledgement: {
     'ui:title':
@@ -11,6 +13,12 @@ export const uiSchema = {
         }
       },
     ],
+    'ui:confirmationField': value => {
+      return {
+        data: value.formData ? 'Yes' : 'No',
+        label: AUTHORIZATION_LABEL,
+      };
+    },
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
@@ -4,9 +4,8 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { waitFor } from '@testing-library/dom';
-
+import { render } from '@testing-library/react';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
-
 import formConfig from '../../config/form';
 
 const {
@@ -154,5 +153,39 @@ describe('526 -- paymentInformation', () => {
       expect(form.find('.usa-input-error-message').length).to.equal(0);
       form.unmount();
     });
+  });
+});
+
+describe('Confirmation view - ui:confirmationField with custom ConfirmationPaymentInformation component', () => {
+  it('should render payment information correctly', () => {
+    const formData = {
+      'view:bankAccount': {
+        bankAccountType: 'Checking',
+        bankAccountNumber: '1234567890',
+        bankRoutingNumber: '123456789',
+        bankName: 'Test Bank',
+      },
+    };
+
+    const confirmationField = uiSchema['ui:confirmationField']({ formData });
+    const { container } = render(confirmationField);
+
+    const heading = container.querySelector('h4');
+    expect(heading).to.exist;
+    expect(heading.textContent).to.equal('Payment Information');
+
+    // Check that banking details are displayed
+    expect(container.textContent).to.contain('Checking');
+    expect(container.textContent).to.contain('Test Bank');
+    expect(container.textContent).to.contain('******7890');
+    expect(container.textContent).to.contain('*****6789');
+  });
+
+  it('should not display if optional paymentInformation is not provided', () => {
+    const confirmationField = uiSchema['ui:confirmationField']({
+      formData: {},
+    });
+    const { container } = render(confirmationField);
+    expect(container.firstChild).to.be.null;
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalAuthorizeRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalAuthorizeRelease.unit.spec.jsx
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+import { AUTHORIZATION_LABEL } from '../../components/Authorization';
+
+const {
+  uiSchema,
+} = formConfig.chapters.supportingEvidence.pages.privateMedicalAuthorizeRelease;
+
+describe('ui:confirmationField', () => {
+  it('should display "Yes" when authorization is given', () => {
+    const result = uiSchema.patient4142Acknowledgement['ui:confirmationField']({
+      formData: true,
+    });
+    expect(result).to.deep.equal({
+      data: 'Yes',
+      label: AUTHORIZATION_LABEL,
+    });
+  });
+
+  // Authorization is required, so this case should not occur in practice
+  it('should display "No" when authorization is not given', () => {
+    const result = uiSchema.patient4142Acknowledgement['ui:confirmationField']({
+      formData: false,
+    });
+    expect(result).to.deep.equal({
+      data: 'No',
+      label: AUTHORIZATION_LABEL,
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- _(Summarize the changes that have been made to the platform)_
Copilot summary: This PR adds confirmation page support for two previously missing sections in the 526 disability benefits form: the Non-VA treatment records authorization checkbox and payment information. The implementation uses the ui:confirmationField property to customize how these pages display their data on the form's confirmation page.

  - Adds confirmation display for Non-VA treatment records authorization status
  - Adds confirmation display for payment information with masked account/routing numbers
  - Includes comprehensive unit tests for both new confirmation field implementations
- _(What is the solution, why is this the solution)_
This PR uses the `ui:confirmationField` property to customize data display on the confirmation page.
- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Benefits Crew Core Form team and we own this feature
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
This feature is gated under `disability_526_show_confirmation_review`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/120153

## Testing done
- _Describe what the old behavior was prior to the change_
The confirmation page did not display data for the following pages:
  - Non-VA treatment records (authorization checkbox)
  - Payment information

- _Describe the steps required to verify your changes are working as expected_. 

**Set up for verification**
- Make sure the `disability_526_form4142_use_2024_version` and `disability_526_show_confirmation_review` flippers are on (they should be on by default)
- Start filling out the 526 form, no other special set up needed

**To test the Non-VA treatment records (4142) Auth checkbox**
1. In the supporting evidence section, go to the types of supporting evidence page "disability/file-disability-claim-form-21-526ez/supporting-evidence/evidence-types":
`"Is there any evidence you’d like us to review as part of your claim?"` select Yes
`"What type of evidence do you want us to review as part of your claim? (*Required)"` select Non-VA treatment records 
Continue

2. On the next page, "/disability/file-disability-claim-form-21-526ez/supporting-evidence/private-medical-records"
`Do you want to upload your private medical records? (*Required)` select  No, get my non-VA treatment records from my providers
Continue

3. The next page, `/disability/file-disability-claim-form-21-526ez/supporting-evidence/private-medical-records-authorize-release` is the very long authorization page, you must select the checkbox to continue  
`I acknowledge and authorize this release of information (*Required)`
Continue filling out the form until you get to the payment information page

**To test the Payment Information page** 
4. In the additional information section, go to "/disability/file-disability-claim-form-21-526ez/payment-information" and fill in all required fields. 
Continue filling out the form, submit, and verify that the data you entered displays correctly on the confirmation page.

- _Describe the tests completed and the results_
- Unit tests added
- Manual submission verified (screenshot below):
<img width="616" height="925" alt="Screenshot 2025-10-13 at 12 59 59 PM" src="https://github.com/user-attachments/assets/5ad7e97e-bf31-4796-b279-1fd4105a56ce" />

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Non-VA treatment records release  |   did not display     |  <img width="420" height="155" alt="Screenshot 2025-10-13 at 12 59 25 PM" src="https://github.com/user-attachments/assets/0c24f10f-feb6-47c5-8f96-86b94c500dca" /> | 
| Payment information  |   did not display      | <img width="280" height="298" alt="Screenshot 2025-10-13 at 12 59 38 PM" src="https://github.com/user-attachments/assets/87f009f7-c336-4adc-912e-ed21f1217690" />

## What areas of the site does it impact?

This affects the confirmation page of the 526 form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
