### PR TITLE
[Bugfix] My VA status card links

### DIFF
--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -147,6 +147,7 @@ export const getAllFormLinks = getAppUrlImpl => {
     }
   };
 
+  // the string passed to tryGetAppUrl() must match the app's entryName from the manifest catalog
   return {
     [VA_FORM_IDS.FEEDBACK_TOOL]: `${tryGetAppUrl('feedback-tool')}/`,
     [VA_FORM_IDS.FORM_10_10D]: `${tryGetAppUrl('10-10D')}/`,
@@ -199,25 +200,35 @@ export const getAllFormLinks = getAppUrlImpl => {
     )}/`,
 
     [VA_FORM_IDS.FORM_DISPUTE_DEBT]: `${tryGetAppUrl('dispute-debt')}/`,
-    [VA_FORM_IDS.FORM_1330M2]: `${tryGetAppUrl('1330M2')}/`,
-    [VA_FORM_IDS.FORM_1330M]: `${tryGetAppUrl('1330M')}/`,
+    [VA_FORM_IDS.FORM_1330M2]: `${tryGetAppUrl('1330m2-medallions')}/`,
+    [VA_FORM_IDS.FORM_1330M]: `${tryGetAppUrl('1330m-medallions')}/`,
     [VA_FORM_IDS.FORM_22_10216]: `${tryGetAppUrl('10216-edu-benefits')}/`,
-    [VA_FORM_IDS.FORM_10_10D_EXTENDED]: `${tryGetAppUrl('10-10D-EXTENDED')}/`,
+    [VA_FORM_IDS.FORM_10_10D_EXTENDED]: `${tryGetAppUrl('10-10d-extended')}/`,
     [VA_FORM_IDS.FORM_21_0538]: `${tryGetAppUrl(
       '0538-dependents-verification',
     )}/`,
     [VA_FORM_IDS.FORM_22_10297]: `${tryGetAppUrl('10297-edu-benefits')}/`,
-    [VA_FORM_IDS.FORM_22_0839]: `${tryGetAppUrl('22-0839')}/`,
-    [VA_FORM_IDS.FORM_22_10275]: `${tryGetAppUrl('22-10275')}/`,
-    [VA_FORM_IDS.FORM_40_4962]: `${tryGetAppUrl('40-4962')}/`,
-    [VA_FORM_IDS.FORM_21_4140]: `${tryGetAppUrl('21-4140')}/`,
-    [VA_FORM_IDS.FORM_21_2680]: `${tryGetAppUrl('21-2680')}/`,
+    [VA_FORM_IDS.FORM_22_0839]: `${tryGetAppUrl('0839-edu-benefits')}/`,
+    [VA_FORM_IDS.FORM_22_10275]: `${tryGetAppUrl('10275-edu-benefits')}/`,
+    [VA_FORM_IDS.FORM_40_4962]: `${tryGetAppUrl('40-xxxx-ton')}/`,
+    [VA_FORM_IDS.FORM_21_4140]: `${tryGetAppUrl(
+      '21-4140-income-verification',
+    )}/`,
+    [VA_FORM_IDS.FORM_21_2680]: `${tryGetAppUrl(
+      '21-2680-house-bound-status',
+    )}/`,
     [VA_FORM_IDS.FORM_21_8940]: `${tryGetAppUrl('21-8940')}/`,
-    [VA_FORM_IDS.FORM_21_4192]: `${tryGetAppUrl('21-4192')}/`,
-    [VA_FORM_IDS.FORM_21_0779]: `${tryGetAppUrl('21-0779')}/`,
-    [VA_FORM_IDS.FORM_21P_530A]: `${tryGetAppUrl('21P-530A')}/`,
-    [VA_FORM_IDS.FORM_21P_0537]: `${tryGetAppUrl('21P-0537')}/`,
-    [VA_FORM_IDS.FORM_21P_8416]: `${tryGetAppUrl('21P-8416')}/`,
+    [VA_FORM_IDS.FORM_21_4192]: `${tryGetAppUrl(
+      '21-4192-employment-information',
+    )}/`,
+    [VA_FORM_IDS.FORM_21_0779]: `${tryGetAppUrl(
+      '21-0779-nursing-home-information',
+    )}/`,
+    [VA_FORM_IDS.FORM_21P_530A]: `${tryGetAppUrl(
+      '21p-530a-interment-allowance',
+    )}/`,
+    [VA_FORM_IDS.FORM_21P_0537]: `${tryGetAppUrl('21p-0537')}/`,
+    [VA_FORM_IDS.FORM_21P_8416]: `${tryGetAppUrl('medical-expense-report')}/`,
     [VA_FORM_IDS.FORM_21_0779_UPLOAD]: `${tryGetAppUrl(
       'form-upload-flow',
     )}/21-0779/introduction/`,
@@ -287,7 +298,7 @@ export const getAllFormLinks = getAppUrlImpl => {
     [VA_FORM_IDS.FORM_21P_4185_UPLOAD]: `${tryGetAppUrl(
       'form-upload-flow',
     )}/21P-4185/introduction/`,
-    [VA_FORM_IDS.FORM_21P_534EZ]: `${tryGetAppUrl('21P-534EZ')}/`,
+    [VA_FORM_IDS.FORM_21P_534EZ]: `${tryGetAppUrl('survivors-benefits')}/`,
   };
 };
 


### PR DESCRIPTION
## Summary

This PR updates the string values passed to `getAllFormLinks` in `src/platform/forms/constants.js` for the following forms:
- 1330M
- 1330M2
- 10-10D Extended
- 22-10297
- 22-0839
- 22-10275
- 40-4962
- 21-4140
- 21-2680
- 21-4192
- 21-0779
- 21P-530A
- 21P-0537
- 21P-8416

The strings corresponding to each of these forms must equal that form's `entryName` as defined in the `manifest` files.
The purpose of this is to fix the "Continue your application" links for the Form Status cards on My VA page.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-website/pull/39017
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2122

## Testing done

- Local test
- Unit test

## Screenshots

#### BEFORE

<img width="719" height="408" alt="image" src="https://github.com/user-attachments/assets/e14984a4-0b6c-4e78-aebc-89d58c2bae22" />


#### AFTER

<img width="820" height="418" alt="image" src="https://github.com/user-attachments/assets/15bf9da1-9e85-4c79-9d93-bfc0801c8a9b" />


## What areas of the site does it impact?

Forms platform

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
