### PR TITLE
[ARC/121997] - removing custom login ff

### DIFF
--- a/src/applications/accredited-representative-portal/tests/unit/components/Header.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/Header.unit.spec.jsx
@@ -19,8 +19,6 @@ const getStore = () =>
   createStore(() => ({
     featureToggles: {
       // eslint-disable-next-line camelcase
-      accredited_representative_portal_custom_login: true,
-      // eslint-disable-next-line camelcase
       accredited_representative_portal_search: true,
       // eslint-disable-next-line camelcase
       accredited_representative_portal_help: true,

--- a/src/applications/accredited-representative-portal/tests/unit/components/Header/Nav.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/Header/Nav.unit.spec.jsx
@@ -1,24 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 import Nav from '../../../../components/Header/Nav';
 import { renderTestComponent } from '../../helpers';
 
-const getStore = () =>
-  createStore(() => ({
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      accredited_representative_portal_custom_login: true,
-    },
-  }));
 describe('Nav', () => {
   it('should render the mobile logo with correct alt text and source', () => {
-    const { getByTestId } = renderTestComponent(
-      <Provider store={getStore()}>
-        <Nav />
-      </Provider>,
-    );
+    const { getByTestId } = renderTestComponent(<Nav />);
     const logo = getByTestId('mobile-logo');
     expect(logo).to.exist;
     expect(logo.alt).to.eq('Veteran Affairs');
@@ -26,11 +13,7 @@ describe('Nav', () => {
   });
 
   it('should render the desktop logo with correct alt text and source', () => {
-    const { getByTestId } = renderTestComponent(
-      <Provider store={getStore()}>
-        <Nav />
-      </Provider>,
-    );
+    const { getByTestId } = renderTestComponent(<Nav />);
     const logo = getByTestId('desktop-logo');
     expect(logo).to.exist;
     expect(logo.alt).to.eq(
@@ -40,11 +23,7 @@ describe('Nav', () => {
   });
 
   it('should have a link that navigates to the home page', () => {
-    const { getByTestId } = renderTestComponent(
-      <Provider store={getStore()}>
-        <Nav />
-      </Provider>,
-    );
+    const { getByTestId } = renderTestComponent(<Nav />);
     const link = getByTestId('nav-home-link');
     expect(link).to.exist;
   });

--- a/src/applications/accredited-representative-portal/utilities/constants.js
+++ b/src/applications/accredited-representative-portal/utilities/constants.js
@@ -11,16 +11,11 @@ import {
   OAUTH_KEYS as SIS_QUERY_PARAM_KEYS,
 } from '~/platform/utilities/oauth/constants';
 
-import { IsCustomLoginEnabled } from './featureToggles';
-
-const PLATFORM_SIGN_IN_URL = '/sign-in';
 const ARP_SIGN_IN_URL = '/representative/sign-in';
 const USIP_BASE_URL = environment.BASE_URL;
 
 export const getSignInUrl = ({ returnUrl } = {}) => {
-  // Get feature toggle with safe fallback
-  const useNewLogin = IsCustomLoginEnabled();
-  const signInPath = useNewLogin ? ARP_SIGN_IN_URL : PLATFORM_SIGN_IN_URL;
+  const signInPath = ARP_SIGN_IN_URL;
   const url = new URL(signInPath, USIP_BASE_URL);
   url.searchParams.set(USIP_QUERY_PARAMS.application, USIP_APPLICATIONS.ARP);
   url.searchParams.set(USIP_QUERY_PARAMS.OAuth, true);

--- a/src/applications/accredited-representative-portal/utilities/featureToggles.js
+++ b/src/applications/accredited-representative-portal/utilities/featureToggles.js
@@ -1,7 +1,0 @@
-import { useFeatureToggle } from 'platform/utilities/feature-toggles';
-
-export const IsCustomLoginEnabled = () => {
-  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
-
-  return useToggleValue(TOGGLE_NAMES.accreditedRepresentativePortalCustomLogin);
-};

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -1,6 +1,5 @@
 {
   "accreditedRepresentativePortalForm526ez": "accredited_representative_portal_form_526ez",
-  "accreditedRepresentativePortalCustomLogin": "accredited_representative_portal_custom_login",
   "accreditedRepresentativePortalFrontend": "accredited_representative_portal_frontend",
   "accreditedRepresentativePortalHomePage": "accredited_representative_portal_homepage",
   "accreditedRepresentativePortalPilot": "accredited_representative_portal_pilot",


### PR DESCRIPTION
Removing custom login from ARP, see ticket 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/121997

All tests pass locally:
<img width="767" height="260" alt="Screenshot 2025-10-13 at 4 14 54 PM" src="https://github.com/user-attachments/assets/9fa9bf88-4216-45eb-a1b9-172bb211f69b" />
<img width="720" height="322" alt="Screenshot 2025-10-13 at 4 14 41 PM" src="https://github.com/user-attachments/assets/e61090c7-b98c-4e1d-bc1a-651c6cd2d1c2" />
