### PR TITLE
10-10d extended | Update logic for >= age 65 calculations

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
@@ -3,10 +3,10 @@ import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/fo
 import {
   adjustYearString,
   concatStreets,
-  getAgeInYears,
   getObjectsWithAttachmentId,
   toHash,
 } from '../../shared/utilities';
+import { getAgeInYears } from '../helpers/utilities';
 
 /**
  * Formats a date string from YYYY-MM-DD to MM-DD-YYYY
@@ -290,9 +290,10 @@ export default function transformForSubmit(formConfig, form) {
   transformedData.supportingDocs = collectSupportingDocuments(transformedData);
 
   // Check if any applicants are over 65
-  transformedData.hasApplicantOver65 = transformedData.applicants.some(
-    applicant => getAgeInYears(applicant.applicantDob) >= 65,
-  );
+  transformedData.hasApplicantOver65 = transformedData.applicants.some(a => {
+    const age = getAgeInYears(a.applicantDob);
+    return Number.isFinite(age) && age >= 65;
+  });
 
   // Add certifier data
   transformedData.certifierRole = withConcatAddresses.certifierRole;

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
@@ -87,12 +87,7 @@ describe('10-10d-extended transform for submit', () => {
   });
 
   it('should set `hasApplicantOver65` to false if all applicants are under 65', () => {
-    const testData = {
-      data: {
-        applicants: [{ applicantDob: '2003-01-01' }],
-      },
-    };
-
+    const testData = { data: { applicants: [{ applicantDob: '2003-01-01' }] } };
     const transformed = JSON.parse(transformForSubmit(formConfig, testData));
     expect(transformed.hasApplicantOver65).to.be.false;
   });

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/helpers.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/helpers.unit.spec.jsx
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   page15aDepends,
   populateFirstApplicant,
+  getAgeInYears,
 } from '../../../helpers/utilities';
 
 describe('page15a depends function', () => {
@@ -99,5 +100,79 @@ describe('populateFirstApplicant', () => {
     expect(result.applicants.length).to.equal(2);
     expect(result.applicants[0].applicantEmailAddress).to.equal(undefined);
     expect(result.applicants[1].applicantEmailAddress).to.equal(undefined);
+  });
+});
+
+describe('1010d `getAgeInYears` util', () => {
+  const asOfUTC = (y, m, d) => new Date(Date.UTC(y, m - 1, d));
+
+  it('should return the same age for ISO and US formats', () => {
+    const asOf = asOfUTC(2025, 10, 14);
+    expect(getAgeInYears('2000-10-14', asOf)).to.equal(25); // yyyy-MM-dd
+    expect(getAgeInYears('10-14-2000', asOf)).to.equal(25); // MM-dd-yyyy
+  });
+
+  it('should handle `on the birthday` correctly (exact boundary)', () => {
+    const asOf = asOfUTC(2025, 10, 14);
+    expect(getAgeInYears('1960-10-14', asOf)).to.equal(65);
+  });
+
+  it('should be one year less the day before the birthday', () => {
+    const asOf = asOfUTC(2025, 10, 13);
+    expect(getAgeInYears('1960-10-14', asOf)).to.equal(64);
+  });
+
+  it('should increment the day after the birthday', () => {
+    const asOf = asOfUTC(2025, 10, 15);
+    expect(getAgeInYears('1960-10-14', asOf)).to.equal(65);
+  });
+
+  it('should respect the provided `asOf` date (historical calc)', () => {
+    const asOf = asOfUTC(2000, 1, 1);
+    expect(getAgeInYears('1990-01-01', asOf)).to.equal(10);
+    expect(getAgeInYears('1990-01-02', asOf)).to.equal(9);
+  });
+
+  it('should handle leap-day birthdays safely (non-leap target year)', () => {
+    // Person born Feb 29, 2004:
+    // On 2025-02-28 (non-leap year) they have NOT reached birthday yet -> 20
+    // On 2025-03-01 they HAVE reached birthday -> 21
+    expect(getAgeInYears('2004-02-29', asOfUTC(2025, 2, 28))).to.equal(20);
+    expect(getAgeInYears('2004-02-29', asOfUTC(2025, 3, 1))).to.equal(21);
+  });
+
+  it('should return `NaN` for invalid or unsupported formats', () => {
+    const asOf = asOfUTC(2025, 10, 14);
+    const cases = [
+      '',
+      'not-a-date',
+      '2025/10/14',
+      '2000-1-01',
+      '1-01-2000',
+      '13-40-2000',
+      '2000-13-01',
+      '2000-00-01',
+      null,
+      undefined,
+      0,
+      {},
+      [],
+      true,
+    ];
+    cases.forEach(input => {
+      expect(Number.isNaN(getAgeInYears(input, asOf))).to.equal(
+        true,
+        `Expected NaN for ${String(input)}`,
+      );
+    });
+  });
+
+  it('should be timezone-robust (time of day does not affect result)', () => {
+    // Same calendar day in different times; function normalizes to UTC midnight.
+    const dob = '1990-06-15';
+    const asOfMorningUTC = new Date(Date.UTC(2025, 5, 15, 0, 5, 0)); // 2025-06-15T00:05Z
+    const asOfEveningUTC = new Date(Date.UTC(2025, 5, 15, 23, 59, 59)); // same day late
+    expect(getAgeInYears(dob, asOfMorningUTC)).to.equal(35);
+    expect(getAgeInYears(dob, asOfEveningUTC)).to.equal(35);
   });
 });

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/helpers.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/helpers.unit.spec.jsx
@@ -158,6 +158,7 @@ describe('1010d `getAgeInYears` util', () => {
       {},
       [],
       true,
+      false,
     ];
     cases.forEach(input => {
       expect(Number.isNaN(getAgeInYears(input, asOf))).to.equal(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates a util that calculates the age of an applicant based on the DOB. A previously shared util was utilized and was creating issue, so the PR adds a new util to this app that correctly parses the dates.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#121355

## Testing done

- Prior to the update, we were seeing flakey values for the `hasApplicantOver65` flag set in the submit transformer
- After the update, we are seeing that value not be flakey because we're checking on the format of the date value

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Age value is correctly parsed regardless of date format

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user