### PR TITLE
Feat(526): End to end maximal submission validation

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -86,7 +86,7 @@
         "confirmationCode": "fa0c0f47-a42f-4bbc-88f3-873c5bea6ce7",
         "attachmentId": "L023"
       },
-       {
+      {
         "name": "foo_protected.PDF",
         "isEncrypted": true,
         "confirmationCode": "9f153a64-29f7-4b5b-9053-c788f45942cd",
@@ -134,7 +134,6 @@
       "view:hasOtherEvidence": true
     },
     "view:evidenceTypeHelp": {},
-    "view:unemployable": false,
     "view:aidAndAttendance": true,
     "view:modifyingHome": true,
     "view:modifyingCar": true,
@@ -159,7 +158,8 @@
         "cause": "NEW",
         "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
         "condition": "asthma",
-        "view:descriptionInfo": {}
+        "view:descriptionInfo": {},
+        "unemployabilityDisability": true
       },
       {
         "cause": "SECONDARY",
@@ -211,7 +211,8 @@
         "decisionText": "Service Connected",
         "ratingPercentage": 100,
         "disabilityActionType": "NONE",
-        "view:selected": true
+        "view:selected": true,
+        "unemployabilityDisability": true
       },
       {
         "name": "De-selected",
@@ -267,43 +268,145 @@
     "view:ptsdTypeHelp": {},
     "view:upload781ChoiceHelp": {},
     "incident0": {
-      "unitAssignedDates": {},
+      "unitAssignedDates": {
+        "from": "2010-03-15",
+        "to": "2011-06-30"
+      },
       "incidentLocation": {
+        "country": "USA",
+        "city": "San Diego",
+        "state": "CA"
+      },
+      "incidentDate": "2010-08-15",
+      "incidentDescription": "Test incident description for incident 0",
+      "militaryReports": {
+        "restricted": true,
+        "unrestricted": true
+      },
+      "otherReports": {
+        "police": true
+      },
+      "unlistedReport": "Additional incident report filed with base security",
+      "policeReportLocation": {
+        "agency": "San Diego Police Department",
+        "city": "San Diego",
+        "state": "California",
         "country": "USA"
       }
     },
     "incident1": {
-      "unitAssignedDates": {},
+      "unitAssignedDates": {
+        "from": "2012-01-10",
+        "to": "2013-04-20"
+      },
       "incidentLocation": {
+        "country": "USA",
+        "city": "Norfolk",
+        "state": "VA"
+      },
+      "incidentDate": "2012-11-22",
+      "incidentDescription": "Test incident description for incident 1",
+      "militaryReports": {
+        "pre2005": true
+      },
+      "otherReports": {
+        "unsure": true
+      },
+      "policeReportLocation": {
+        "agency": "Norfolk Police Department",
+        "city": "Norfolk",
+        "state": "Virginia",
+        "township": "Norfolk County",
         "country": "USA"
       }
     },
     "incident2": {
-      "unitAssignedDates": {},
+      "unitAssignedDates": {
+        "from": "2014-06-01",
+        "to": "2015-12-31"
+      },
       "incidentLocation": {
-        "country": "USA"
+        "country": "Iraq",
+        "city": "Baghdad",
+        "state": "Baghdad Province"
+      },
+      "incidentDate": "2015-03-10",
+      "incidentDescription": "Test incident description for incident 2",
+      "noReport": {
+        "none": true
       }
     },
     "view:upload781aChoiceHelp": {},
     "secondaryIncident0": {
-      "unitAssignedDates": {},
+      "unitAssignedDates": {
+        "from": "2016-02-01",
+        "to": "2017-08-31"
+      },
       "incidentLocation": {
+        "country": "USA",
+        "city": "Fort Hood",
+        "state": "TX"
+      },
+      "incidentDate": "2016-09-15",
+      "incidentDescription": "Secondary incident 0 description",
+      "militaryReports": {
+        "restricted": true
+      },
+      "otherReports": {
+        "police": true
+      },
+      "policeReportLocation": {
+        "agency": "Fort Hood Military Police",
+        "city": "Fort Hood",
+        "state": "Texas",
         "country": "USA"
       },
       "otherSourcesHelp": {}
     },
     "view:otherSourcesHelp": {},
     "secondaryIncident1": {
-      "unitAssignedDates": {},
+      "unitAssignedDates": {
+        "from": "2018-01-01",
+        "to": "2019-06-30"
+      },
       "incidentLocation": {
-        "country": "USA"
+        "country": "Germany",
+        "city": "Ramstein",
+        "state": "Rhineland-Palatinate"
+      },
+      "incidentDate": "2018-10-20",
+      "incidentDescription": "Secondary incident 1 description",
+      "militaryReports": {
+        "unrestricted": true,
+        "pre2005": true
+      },
+      "otherReports": {
+        "police": true,
+        "unsure": true
+      },
+      "unlistedReport": "Filed report with base legal office",
+      "policeReportLocation": {
+        "agency": "Polizei Ramstein",
+        "city": "Ramstein-Miesenbach",
+        "state": "Rhineland-Palatinate",
+        "country": "Germany"
       },
       "otherSourcesHelp": {}
     },
     "secondaryIncident2": {
-      "unitAssignedDates": {},
+      "unitAssignedDates": {
+        "from": "2020-03-01",
+        "to": "2021-12-31"
+      },
       "incidentLocation": {
-        "country": "USA"
+        "country": "Japan",
+        "city": "Okinawa",
+        "state": "Okinawa Prefecture"
+      },
+      "incidentDate": "2020-07-04",
+      "incidentDescription": "Secondary incident 2 description",
+      "noReport": {
+        "none": true
       },
       "otherSourcesHelp": {}
     },
@@ -312,18 +415,282 @@
     "workBehaviorChanges": {},
     "socialBehaviorChanges": {},
     "view:ancillaryFormsWizardIntro": {},
-    "view:unemployabilityHelp": {},
-    "unemployability": {
-      "view:recordsInfo": {},
-      "view:unemployabilityDatesDesc": {},
-      "view:grossIncomeAdditionalInfo": {},
-      "view:supplementalBenefitsHelp": {},
-      "view:substantiallyGainfulEmploymentInfo": {},
-      "view:statementsAreTrue": {},
-      "view:informOfReturnToWork": {}
+    "view:ancillaryFormsWizard": true,
+    "toxicExposure": {
+      "specifyOtherExposures": {
+        "description": "It makes no sense for this particular condition, but hey, this is only test data."
+      },
+      "view:additionalExposuresAdditionalInfo": {},
+      "otherExposuresDetails": {
+        "asbestos": {
+          "startDate": "1995-03-12",
+          "endDate": "2023-01-28"
+        },
+        "chemical": {
+          "startDate": "1998-06-15",
+          "endDate": "2000-09-30"
+        },
+        "water": {
+          "startDate": "1985-01-01",
+          "endDate": "1987-12-31"
+        },
+        "mos": {
+          "startDate": "2005-03-10",
+          "endDate": "2010-08-20"
+        },
+        "mustardgas": {
+          "startDate": "1991-02-01",
+          "endDate": "1991-04-15"
+        },
+        "radiation": {
+          "startDate": "2002-07-01",
+          "endDate": "2003-01-31"
+        }
+      },
+      "view:otherExposuresAdditionalInfo": {},
+      "otherExposures": {
+        "asbestos": true,
+        "chemical": true,
+        "water": true,
+        "mos": true,
+        "mustardgas": true,
+        "radiation": true
+      },
+      "otherHerbicideLocations": {
+        "startDate": "2014-01-28",
+        "endDate": "2016-01-12",
+        "description": "It makes no sense for this particular condition, but hey, this is only test data."
+      },
+      "view:herbicideAdditionalInfo": {},
+      "herbicideDetails": {
+        "cambodia": {
+          "startDate": "1969-05-01",
+          "endDate": "1970-06-30"
+        },
+        "guam": {
+          "startDate": "1968-01-15",
+          "endDate": "1969-12-31"
+        },
+        "koreandemilitarizedzone": {
+          "startDate": "2023-01-12",
+          "endDate": "2024-01-12"
+        },
+        "johnston": {
+          "startDate": "1972-04-01",
+          "endDate": "1973-09-30"
+        },
+        "laos": {
+          "startDate": "1965-12-01",
+          "endDate": "1971-03-31"
+        },
+        "c123": {
+          "startDate": "1972-01-01",
+          "endDate": "1982-12-31"
+        },
+        "thailand": {
+          "startDate": "1967-02-01",
+          "endDate": "1975-05-31"
+        },
+        "vietnam": {
+          "startDate": "1965-01-09",
+          "endDate": "1975-04-30"
+        }
+      },
+      "herbicide": {
+        "cambodia": true,
+        "guam": true,
+        "koreandemilitarizedzone": true,
+        "johnston": true,
+        "laos": true,
+        "c123": true,
+        "thailand": true,
+        "vietnam": true
+      },
+      "gulfWar2001Details": {
+        "djibouti": {
+          "startDate": "2002-10-01",
+          "endDate": "2005-03-31"
+        },
+        "lebanon": {
+          "startDate": "2006-07-12",
+          "endDate": "2006-08-14"
+        },
+        "uzbekistan": {
+          "startDate": "2001-10-15",
+          "endDate": "2003-05-20"
+        },
+        "yemen": {
+          "startDate": "2009-12-01",
+          "endDate": "2011-06-30"
+        },
+        "airspace": {
+          "startDate": "2020-01-30",
+          "endDate": "2023-06-21",
+          "view:notSure": true
+        }
+      },
+      "view:gulfWar2001AdditionalInfo": {},
+      "gulfWar2001": {
+        "djibouti": true,
+        "lebanon": true,
+        "uzbekistan": true,
+        "yemen": true,
+        "airspace": true
+      },
+      "gulfWar1990Details": {
+        "afghanistan": {
+          "startDate": "2000-02-12",
+          "endDate": "2015-12-12"
+        },
+        "bahrain": {
+          "startDate": "1990-08-15",
+          "endDate": "1991-06-30"
+        },
+        "iraq": {
+          "startDate": "1991-01-17",
+          "endDate": "1991-02-28"
+        },
+        "kuwait": {
+          "startDate": "1991-01-20",
+          "endDate": "1991-03-15"
+        },
+        "saudiarabia": {
+          "startDate": "1990-08-02",
+          "endDate": "1991-07-31"
+        },
+        "turkey": {
+          "startDate": "2015-03-21",
+          "endDate": "2020-06-21",
+          "view:notSure": true
+        },
+        "waters": {
+          "startDate": "1990-09-01",
+          "endDate": "1991-04-30"
+        },
+        "airspace": {
+          "startDate": "1990-08-10",
+          "endDate": "1991-05-15"
+        }
+      },
+      "view:gulfWar1990AdditionalInfo": {},
+      "gulfWar1990": {
+        "afghanistan": true,
+        "bahrain": true,
+        "iraq": true,
+        "kuwait": true,
+        "saudiarabia": true,
+        "turkey": true,
+        "waters": true,
+        "airspace": true
+      },
+      "conditions": {
+        "asthma": true,
+        "cranialnerveparalysisorcranialneuritisinflammationofcranialnerves": true
+      }
     },
+    "view:unemployabilityHelp": {},
+    "view:unemployabilityUploadChoice": "answerQuestions",
+    "view:unemployable": true,
+    "unemployability": {
+      "view:statementsAreTrue": {
+        "view:statementsAreTrueAccept": true
+      },
+      "view:informOfReturnToWork": {
+        "view:informOfReturnToWorkAccept": true
+      },
+      "remarks": "It makes no sense for this particular condition, but hey, this is only test data.",
+      "receivedOtherEducationTrainingPostUnemployability": false,
+      "education": "Some college",
+      "receivedOtherEducationTrainingPreUnemployability": false,
+      "attemptedToObtainEmploymentSinceUnemployability": false,
+      "view:substantiallyGainfulEmploymentInfo": {},
+      "disabilityPreventMilitaryDuties": "no",
+      "receiveExpectDisabilityRetirement": true,
+      "receiveExpectWorkersCompensation": true,
+      "view:supplementalBenefitsHelp": {},
+      "past12MonthsEarnedIncome": 12000,
+      "view:grossIncomeAdditionalInfo": {},
+      "view:isEmployed": false,
+      "leftLastJobDueToDisability": false,
+      "previousEmployers": [
+        {
+          "name": "The Employer Inc",
+          "employerAddress": {
+            "country": "USA",
+            "addressLine1": "5333 Side Street",
+            "city": "Richmond",
+            "state": "VA",
+            "zipCode": "23173"
+          },
+          "dates": {}
+        }
+      ],
+      "mostEarningsInAYear": "100000",
+      "yearOfMostEarnings": "2024",
+      "occupationDuringMostEarnings": "Software Engineer",
+      "disabilityAffectedEmploymentFullTimeDate": "2020-01-08",
+      "lastWorkedFullTimeDate": "2024-01-01",
+      "becameTooDisabledToWorkDate": "2022-01-01",
+      "view:unemployabilityDatesDesc": {},
+      "doctorProvidedCare": [
+        {
+          "name": "Dr Good",
+          "address": {
+            "country": "USA",
+            "addressLine1": "122 Main St",
+            "state": "DC",
+            "zipCode": "20001"
+          },
+          "dates": "For a while, for testing."
+        }
+      ],
+      "view:medicalCare": true,
+      "underDoctorHospitalCarePast12M": true,
+      "view:recordsInfo": {}
+    },
+    "view:uploadUnemployabilitySupportingDocumentsChoice": false,
     "view:privateMedicalFacility": {},
-    "view:upload4192Choice": {},
+    "serviceTreatmentRecordsAttachments": [
+      {
+        "name": "service-treatment-record.pdf",
+        "confirmationCode": "abc123-456-789-def",
+        "attachmentId": "L048"
+      }
+    ],
+    "providerFacility": [
+      {
+        "providerFacilityName": "VA Medical Center",
+        "treatmentDateRange": {
+          "from": "2020-01-15",
+          "to": "2023-12-01"
+        },
+        "providerFacilityAddress": {
+          "country": "USA",
+          "street": "123 Medical Drive",
+          "city": "Washington",
+          "state": "DC",
+          "postalCode": "20001"
+        }
+      },
+      {
+        "providerFacilityName": "Private Health Clinic",
+        "treatmentDateRange": {
+          "from": "2019-06-01",
+          "to": "2022-08-15"
+        },
+        "providerFacilityAddress": {
+          "country": "USA",
+          "street": "456 Healthcare Blvd",
+          "city": "Arlington",
+          "state": "VA",
+          "postalCode": "22201"
+        }
+      }
+    ],
+    "view:upload4192Choice": {
+      "view:upload4192": false,
+      "view:sendRequests": true
+    },
     "view:downloadInfo": {},
     "view:privateRecordsChoiceHelp": {},
     "view:faqAccordion": {},

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
@@ -77,7 +77,8 @@
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "disabilityActionType": "INCREASE"
+        "disabilityActionType": "INCREASE",
+        "unemployabilityDisability": true
       },
       {
         "name": "De-selected",
@@ -111,11 +112,76 @@
         }
       ]
     },
+    "toxicExposure": {
+      "specifyOtherExposures": {
+        "description": "It makes no sense for this particular condition, but hey, this is only test data."
+      },
+      "otherExposuresDetails": {
+        "asbestos": { "startDate": "1995-03-12", "endDate": "2023-01-28" },
+        "chemical": { "startDate": "1998-06-15", "endDate": "2000-09-30" },
+        "water": { "startDate": "1985-01-01", "endDate": "1987-12-31" },
+        "mos": { "startDate": "2005-03-10", "endDate": "2010-08-20" },
+        "mustardgas": { "startDate": "1991-02-01", "endDate": "1991-04-15" },
+        "radiation": { "startDate": "2002-07-01", "endDate": "2003-01-31" }
+      },
+      "otherExposures": {
+        "asbestos": true, "chemical": true, "water": true,
+        "mos": true, "mustardgas": true, "radiation": true
+      },
+      "otherHerbicideLocations": {
+        "startDate": "2014-01-28", "endDate": "2016-01-12",
+        "description": "It makes no sense for this particular condition, but hey, this is only test data."
+      },
+      "herbicideDetails": {
+        "cambodia": { "startDate": "1969-05-01", "endDate": "1970-06-30" },
+        "guam": { "startDate": "1968-01-15", "endDate": "1969-12-31" },
+        "koreandemilitarizedzone": { "startDate": "2023-01-12", "endDate": "2024-01-12" },
+        "johnston": { "startDate": "1972-04-01", "endDate": "1973-09-30" },
+        "laos": { "startDate": "1965-12-01", "endDate": "1971-03-31" },
+        "c123": { "startDate": "1972-01-01", "endDate": "1982-12-31" },
+        "thailand": { "startDate": "1967-02-01", "endDate": "1975-05-31" },
+        "vietnam": { "startDate": "1965-01-09", "endDate": "1975-04-30" }
+      },
+      "herbicide": {
+        "cambodia": true, "guam": true, "koreandemilitarizedzone": true,
+        "johnston": true, "laos": true, "c123": true, "thailand": true, "vietnam": true
+      },
+      "gulfWar2001Details": {
+        "djibouti": { "startDate": "2002-10-01", "endDate": "2005-03-31" },
+        "lebanon": { "startDate": "2006-07-12", "endDate": "2006-08-14" },
+        "uzbekistan": { "startDate": "2001-10-15", "endDate": "2003-05-20" },
+        "yemen": { "startDate": "2009-12-01", "endDate": "2011-06-30" },
+        "airspace": { "startDate": "2020-01-30", "endDate": "2023-06-21" }
+      },
+      "gulfWar2001": {
+        "djibouti": true, "lebanon": true, "uzbekistan": true,
+        "yemen": true, "airspace": true
+      },
+      "gulfWar1990Details": {
+        "afghanistan": { "startDate": "2000-02-12", "endDate": "2015-12-12" },
+        "bahrain": { "startDate": "1990-08-15", "endDate": "1991-06-30" },
+        "iraq": { "startDate": "1991-01-17", "endDate": "1991-02-28" },
+        "kuwait": { "startDate": "1991-01-20", "endDate": "1991-03-15" },
+        "saudiarabia": { "startDate": "1990-08-02", "endDate": "1991-07-31" },
+        "turkey": { "startDate": "2015-03-21", "endDate": "2020-06-21" },
+        "waters": { "startDate": "1990-09-01", "endDate": "1991-04-30" },
+        "airspace": { "startDate": "1990-08-10", "endDate": "1991-05-15" }
+      },
+      "gulfWar1990": {
+        "afghanistan": true, "bahrain": true, "iraq": true, "kuwait": true,
+        "saudiarabia": true, "turkey": true, "waters": true, "airspace": true
+      },
+      "conditions": {
+        "asthma": true,
+        "cranialnerveparalysisorcranialneuritisinflammationofcranialnerves": true
+      }
+    },
     "newPrimaryDisabilities": [
       {
         "cause": "NEW",
         "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
-        "condition": "asthma"
+        "condition": "asthma",
+        "unemployabilityDisability": true
       },
       {
         "cause": "WORSENED",
@@ -133,11 +199,57 @@
         "specialIssues": ["POW"]
       },
       {
+        "condition": "Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)",
         "cause": "NEW",
-        "primaryDescription": "Secondary to Diabetes Mellitus0\nAgain, this doesn't really make sense.",
-        "condition": "Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)"
+        "primaryDescription": "Secondary to Diabetes Mellitus0\nAgain, this doesn't really make sense."
       }
     ],
+    "form8940": {
+      "unemployability": {
+        "remarks": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "receivedOtherEducationTrainingPostUnemployability": false,
+        "education": "Some college",
+        "receivedOtherEducationTrainingPreUnemployability": false,
+        "attemptedToObtainEmploymentSinceUnemployability": false,
+        "disabilityPreventMilitaryDuties": false,
+        "receiveExpectDisabilityRetirement": true,
+        "receiveExpectWorkersCompensation": true,
+        "past12MonthsEarnedIncome": 12000,
+        "leftLastJobDueToDisability": false,
+        "previousEmployers": [
+          {
+            "name": "The Employer Inc",
+            "employerAddress": {
+              "country": "USA",
+              "addressLine1": "5333 Side Street",
+              "city": "Richmond",
+              "state": "VA",
+              "zipCode": "23173"
+            }
+          }
+        ],
+        "mostEarningsInAYear": "100000",
+        "yearOfMostEarnings": "2024",
+        "occupationDuringMostEarnings": "Software Engineer",
+        "disabilityAffectedEmploymentFullTimeDate": "2020-01-08",
+        "lastWorkedFullTimeDate": "2024-01-01",
+        "becameTooDisabledToWorkDate": "2022-01-01",
+        "doctorProvidedCare": [
+          {
+            "name": "Dr Good",
+            "address": {
+              "country": "USA",
+              "addressLine1": "122 Main St",
+              "state": "DC",
+              "zipCode": "20001"
+            },
+            "dates": "For a while, for testing."
+          }
+        ],
+        "disabilityPreventingEmployment": "Diabetes mellitus1,asthma",
+        "underDoctorHospitalCarePast12M": true
+      }
+    },
     "attachments": [
       {
         "name": "AngleSettingJig_9_25_15.pdf",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Previously, we did not have the `maximal-test.json` fully updated with all the new features that had been developed, making the maximal-test.json file to have a reduced code coverage. This ticket sought to add those fields, and ensure that all tests ran successfully with the new level of validation.
- The solution to the maximal test not being maximal was to create the data inside of `maximal-test.json` and then also update the transformed data to match, so that all tests would pass, and we'd be covering items in our E2E that need coverage.
- Disability Benefits Pathways Team and yes 

## Related issue(s)

- (https://github.com/department-of-veterans-affairs/va.gov-team/issues/113295)

## Testing done

- The old behavior was that the old maximal file was missing quite a bit of more modern work, such as `otherToxicExposures` or even the `toxicExposure` pathway at all. This adds not only the required data, but also making sure required views and fields are filled in during this maximal path.
- Run the test suites, both unit and cypress.
- The tests completed were running the cypress e2e tests first in the console, then on cy:open to watch and ensure the maximal test was indeed maximal and filling the data that was updated. Then ran the unit tests, purposely breaking some tests in order to show the errors and that the data matches what is now in the transformed maximal file.

## Screenshots

N/A This is a validation and fixture change that doesn't face the user but for the test suite.

## What areas of the site does it impact?

The `maximal-test.json` and the attached transformed-data file.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

