### PR TITLE
[VACMS-22475] Update Facility Locator warning banner title and description

### DIFF
--- a/src/applications/facility-locator/components/CommunityCareWarningBanner.jsx
+++ b/src/applications/facility-locator/components/CommunityCareWarningBanner.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CommunityCareWarningBanner = ({ shouldShow = false }) => {
+  if (!shouldShow) {
+    return null;
+  }
+  return (
+    <va-alert
+      full-width
+      status="warning"
+      class="vads-u-margin-bottom--1"
+      data-testid="community-care-warning-banner"
+      id="community-care-warning-banner"
+    >
+      <h2 slot="headline">
+        What to know about community health care facilities
+      </h2>
+      <div>
+        If you go to a community care facility, call first to confirm they can
+        provide the care you need. Because facilities may move or experience
+        other changes, we may not always have the most current information.
+      </div>
+    </va-alert>
+  );
+};
+
+CommunityCareWarningBanner.propTypes = {
+  shouldShow: PropTypes.bool,
+};
+
+export default CommunityCareWarningBanner;

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -930,19 +930,8 @@ const FacilitiesMap = props => {
       {props.showNonVACareWarningBanner && (
         <Alert
           displayType="warning"
-          title="Notice about non-VA urgent and emergency care"
-          description={
-            <>
-              Before you go to a non-VA facility, call to confirm hours and
-              available services. We’ve received reports that some non-VA
-              facilities listed as providing urgent or emergency care can’t
-              currently provide those services to Veterans. If you think your
-              health or life is in danger, call 911.
-              <br />
-              <br />
-              Note: This issue isn’t related to the government shutdown.
-            </>
-          }
+          title="What to know about community health care facilities"
+          description="If you go to a community care facility, call first to confirm they can provide the care you need. Because facilities may move or experience other changes, we may not always have the most current information."
         />
       )}
       {renderView()}

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -11,6 +11,7 @@ import { mapboxToken } from 'platform/utilities/facilities-and-mapbox';
 
 // Components
 import Alert from '../components/Alert';
+import CommunityCareWarningBanner from '../components/CommunityCareWarningBanner';
 import ControlResultsHolder from '../components/ControlResultsHolder';
 import ControlsAndMapContainer from '../components/ControlsAndMapContainer';
 import EmergencyCareAlert from '../components/EmergencyCareAlert';
@@ -927,13 +928,7 @@ const FacilitiesMap = props => {
           type.
         </p>
       )}
-      {props.showNonVACareWarningBanner && (
-        <Alert
-          displayType="warning"
-          title="What to know about community health care facilities"
-          description="If you go to a community care facility, call first to confirm they can provide the care you need. Because facilities may move or experience other changes, we may not always have the most current information."
-        />
-      )}
+      <CommunityCareWarningBanner shouldShow={props.showCommunityCareBanner} />
       {renderView()}
       {mapboxTokenValid && otherToolsLink()}
     </>
@@ -948,7 +943,7 @@ const mapStateToProps = state => ({
   resultTime: state.searchResult.resultTime,
   results: state.searchResult.results,
   searchError: state.searchResult.error,
-  showNonVACareWarningBanner: showFacilityLocatorNoticeAboutNonVACare(state),
+  showCommunityCareBanner: showFacilityLocatorNoticeAboutNonVACare(state),
   specialties: state.searchQuery.specialties,
   suppressPPMS: facilitiesPpmsSuppressAll(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
- Adjusts wording of the Community Care provider warning on the facility locator
- Additionally pulls warning into separate component for clarity
- Facilities Team owned and maintained


## AI Generated Summary
This pull request refactors how the community care warning banner is displayed in the facility locator application. The main change is the replacement of the previous generic alert component with a new, dedicated `CommunityCareWarningBanner` component, which improves clarity and maintainability. The relevant prop and state mapping have also been updated to match the new component.

**Component Refactoring:**

* Added a new `CommunityCareWarningBanner` component to encapsulate the warning banner logic and content, replacing the previous use of the generic `Alert` component. (`src/applications/facility-locator/components/CommunityCareWarningBanner.jsx`)
* Updated the import in `FacilitiesMap.jsx` to use `CommunityCareWarningBanner` instead of `Alert`. (`src/applications/facility-locator/containers/FacilitiesMap.jsx`)

**Prop and State Mapping Updates:**

* Changed the prop from `showNonVACareWarningBanner` to `showCommunityCareBanner` throughout `FacilitiesMap.jsx` to align with the new component. (`src/applications/facility-locator/containers/FacilitiesMap.jsx`) [[1]](diffhunk://#diff-533a34ba46c2ebdcea4c6bcd99aab69051b6c1cf80092e1a8061b4060eb425acL930-R931) [[2]](diffhunk://#diff-533a34ba46c2ebdcea4c6bcd99aab69051b6c1cf80092e1a8061b4060eb425acL962-R946)


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22475
- https://github.com/department-of-veterans-affairs/vets-website/pull/39304

## Testing done

- Tested banner appearing on the Facility Locator in local dev env when feature flag is enabled

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="686" height="757" alt="Screenshot 2025-10-09 at 1 42 16 PM" src="https://github.com/user-attachments/assets/62df56d9-a659-42e3-a3a0-23b8ea3f217e" /> | <img width="701" height="977" alt="Screenshot 2025-10-15 at 11 49 18 AM" src="https://github.com/user-attachments/assets/d359a738-2023-42da-90f3-b2da54eb62a2" /> |
| Desktop | <img width="1050" height="1297" alt="Screenshot 2025-10-09 at 1 41 54 PM" src="https://github.com/user-attachments/assets/704b6e56-4cf2-4609-8db0-ff74d667b834" /> | <img width="1232" height="1034" alt="Screenshot 2025-10-15 at 11 48 56 AM" src="https://github.com/user-attachments/assets/cfce4d39-1510-4f2d-a42b-5687c75b3a93" /> |

## What areas of the site does it impact?

Facility Locator `/find-locations`

## Acceptance criteria
Banner displays with updated text, only when feature flag is enabled

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

