### PR TITLE
Add custom ui:confirmationField component for ancillaryFormWizard pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationAncillaryFormsWizard.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationAncillaryFormsWizard.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { reviewEntry } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
+
+// The boolean questions on these ancillary forms wizard pages are not required and may have null or undefined values
+const convertToYesNo = value => {
+  if (value === null || value === undefined) return null;
+  return value === true ? 'Yes' : 'No';
+};
+
+const ConfirmationAncillaryFormsWizard = ({ formData }) => {
+  const isAnswering = formData?.['view:ancillaryFormsWizard'];
+  const modifyingHome = formData?.['view:modifyingHome'];
+  const modifyingCar = formData?.['view:modifyingCar'];
+  const alreadyClaimedVehicleAllowance =
+    formData?.['view:needsCarHelp']?.['view:alreadyClaimedVehicleAllowance'];
+  const needingAid = formData?.['view:aidAndAttendance'];
+
+  // Do not show this confirmation component if no selection is made for formData?.['view:ancillaryFormsWizard'] === true
+  if (isAnswering === undefined || isAnswering === null) {
+    return null;
+  }
+
+  const additionalEntries = {
+    isAnswering: {
+      label:
+        'Do you want to answer questions to determine if you may be eligible for additional benefits?',
+      data: convertToYesNo(isAnswering),
+    },
+    modifyingHome: {
+      label: 'Do you need help buying or modifying your home?',
+      data: convertToYesNo(modifyingHome),
+    },
+    modifyingCar: {
+      label: 'Do you need help buying or modifying your car?',
+      data: convertToYesNo(modifyingCar),
+    },
+    alreadyClaimedVehicleAllowance: {
+      label: 'Have you ever been granted an automobile allowance?',
+      data: convertToYesNo(alreadyClaimedVehicleAllowance),
+    },
+    needingAid: {
+      label:
+        'Are you confined to your home or need help with everyday activities?',
+      data: convertToYesNo(needingAid),
+    },
+  };
+
+  return (
+    <li>
+      <h4>Additional disability benefits</h4>
+      <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
+        {Object.entries(additionalEntries)
+          .filter(([_, value]) => value.data !== null)
+          .map(([key, value]) =>
+            reviewEntry(null, key, null, value.label, value.data),
+          )}
+      </ul>
+    </li>
+  );
+};
+
+ConfirmationAncillaryFormsWizard.propTypes = {
+  formData: PropTypes.object,
+};
+export default ConfirmationAncillaryFormsWizard;

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationAncillaryFormsWizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationAncillaryFormsWizard.unit.spec.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import ConfirmationAncillaryFormsWizard from './ConfirmationAncillaryFormsWizard';
+
+describe('ConfirmationAncillaryFormsWizard', () => {
+  it('should not render when view:ancillaryFormsWizard is null', () => {
+    const formData = {
+      'view:ancillaryFormsWizard': null,
+    };
+
+    const { container } = render(
+      <ConfirmationAncillaryFormsWizard formData={formData} />,
+    );
+    expect(container).to.be.empty;
+  });
+
+  it('should not render when view:ancillaryFormsWizard is undefined', () => {
+    const formData = {};
+
+    const { container } = render(
+      <ConfirmationAncillaryFormsWizard formData={formData} />,
+    );
+    expect(container).to.be.empty;
+  });
+
+  it('should render all answered questions with their values', () => {
+    const formData = {
+      'view:ancillaryFormsWizard': true,
+      'view:modifyingHome': true,
+      'view:modifyingCar': false,
+      'view:needsCarHelp': {
+        'view:alreadyClaimedVehicleAllowance': true,
+      },
+      'view:aidAndAttendance': true,
+    };
+
+    const { queryByText, queryAllByText } = render(
+      <ConfirmationAncillaryFormsWizard formData={formData} />,
+    );
+
+    // Check that all questions are rendered
+    expect(
+      queryByText(
+        'Do you want to answer questions to determine if you may be eligible for additional benefits?',
+      ),
+    ).to.exist;
+    expect(queryByText('Do you need help buying or modifying your home?')).to
+      .exist;
+    expect(queryByText('Do you need help buying or modifying your car?')).to
+      .exist;
+    expect(queryByText('Have you ever been granted an automobile allowance?'))
+      .to.exist;
+    expect(
+      queryByText(
+        'Are you confined to your home or need help with everyday activities?',
+      ),
+    ).to.exist;
+
+    // Check the answers are correct
+    const yesAnswers = queryAllByText('Yes');
+    const noAnswers = queryAllByText('No');
+    expect(yesAnswers).to.have.lengthOf(4); // Should have 4 'Yes' answers
+    expect(noAnswers).to.have.lengthOf(1); // Should have 1 'No' answer
+  });
+});
+
+it('should only render answered questions', () => {
+  const formData = {
+    'view:ancillaryFormsWizard': true,
+    'view:modifyingHome': true,
+    // modifyingCar is undefined
+    'view:needsCarHelp': {
+      // alreadyClaimedVehicleAllowance is undefined
+    },
+    'view:aidAndAttendance': false,
+  };
+
+  const { queryByText, queryAllByText } = render(
+    <ConfirmationAncillaryFormsWizard formData={formData} />,
+  );
+
+  // These questions should be rendered
+  expect(
+    queryByText(
+      'Do you want to answer questions to determine if you may be eligible for additional benefits?',
+    ),
+  ).to.exist;
+
+  expect(queryByText('Do you need help buying or modifying your home?')).to
+    .exist;
+
+  expect(
+    queryByText(
+      'Are you confined to your home or need help with everyday activities?',
+    ),
+  ).to.exist;
+
+  // These questions should not be rendered
+  expect(queryByText('Do you need help buying or modifying your car?')).to.be
+    .null;
+
+  expect(queryByText('Have you ever been granted an automobile allowance?')).to
+    .be.null;
+
+  // Check the answers
+  expect(queryAllByText('Yes')).to.have.lengthOf(2);
+  expect(queryAllByText('No')).to.have.lengthOf(1);
+});

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -135,6 +135,7 @@ import reviewErrors from '../reviewErrors';
 import manifest from '../manifest.json';
 import CustomReviewTopContent from '../components/CustomReviewTopContent';
 import getPreSubmitInfo from '../content/preSubmitInfo';
+import ConfirmationAncillaryFormsWizard from '../components/ConfirmationAncillaryFormsWizard';
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -503,6 +504,7 @@ const formConfig = {
                 'Do you want to answer questions to determine if you may be eligible for additional benefits?',
               'ui:widget': 'yesNo',
             },
+            'ui:confirmationField': ConfirmationAncillaryFormsWizard,
           },
           schema: {
             type: 'object',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- _(Summarize the changes that have been made to the platform)_
 This PR adds confirmation page support for a previously missing section in the 526 disability benefits form: the Additional disability benefits pages (in the AncillaryForms form config). The implementation uses the ui:confirmationField property with a custom confirmation component property to display the data from these pages on the form's confirmation page.

  - Adds confirmation display for Additional Disability Benefits pages
  - Includes comprehensive unit tests for both new confirmation field implementations
- _(What is the solution, why is this the solution)_
This PR uses the `ui:confirmationField` property to customize data display on the confirmation page.
- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Benefits Crew Core Form team and we own this feature
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
This feature is gated under `disability_526_show_confirmation_review`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/120144

## Testing done
- _Describe what the old behavior was prior to the change_
The confirmation page did not display data for the following pages:
  - Additional Disability Benefits pages, with the following optional questions:
    - Do you want to answer questions to determine if you may be eligible for additional benefits?
    - Do you need help buying or modifying your home?
    - Do you need help buying or modifying your car?
    - Have you ever been granted an automobile allowance?
    - Are you confined to your home or need help with everyday activities?


- _Describe the steps required to verify your changes are working as expected_. 

**Set up for verification**
- Make sure the `disability_526_form4142_use_2024_version` and `disability_526_show_confirmation_review` flippers are on (they should be on by default)
- Start filling out the 526 form, no other special set up needed

1. Navigate through the conditions chapter until the additional disability benefits page "/disability/file-disability-claim-form-21-526ez/additional-disability-benefits"
Select `yes`, this will display the follow-up pages
Continue

2. On the next page, "/disability/file-disability-claim-form-21-526ez/adaptive-benefits"
Select `yes` to all questions, triggering the follow-up questions on the same page
Continue

3. On the next page "/disability/file-disability-claim-form-21-526ez/aid-and-attendance"
Select `yes` to all questions
Continue

4. On the next page "/disability/file-disability-claim-form-21-526ez/individual-unemployability"
Select `no` - this page is out of scope for this PR, plus it is no longer in use
Continue filling out the form until you get review and submit page

5. Confirm the review and submit page shows the correct additional disability benefits selections
Submit 

6. Confirm the confirmation page shows the correct additional disability benefits selections

7. Go back and repeat these steps with different answers to the optional boolean questions and confirm they display correctly on the confirmation page.

- _Describe the tests completed and the results_
- Unit tests added
- Manual submission verified (screenshot below):
<img width="619" height="923" alt="Screenshot 2025-10-15 at 9 51 34 AM" src="https://github.com/user-attachments/assets/f752f164-dc82-47d7-9257-7d39dbbdc127" />


## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Additional disability benefits  |   did not display     | <img width="517" height="312" alt="Screenshot 2025-10-15 at 9 38 52 AM" src="https://github.com/user-attachments/assets/0e49d98a-6d7d-43dd-9a8a-f97a6c5163e4" />  | 

## What areas of the site does it impact?
This affects the confirmation page of the 526 form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
