### PR TITLE
Update syntax for defining geolcation prop on navigator

### DIFF
--- a/src/applications/ask-va/tests/actions/geoLocateUser.unit.spec.jsx
+++ b/src/applications/ask-va/tests/actions/geoLocateUser.unit.spec.jsx
@@ -17,11 +17,20 @@ describe('geoLocateUser Action Creator', () => {
 
   beforeEach(() => {
     store = mockStore({});
-    global.navigator = {
-      geolocation: {
+
+    if (!global.navigator) {
+      Object.defineProperty(global, 'navigator', {
+        value: {},
+        writable: true,
+      });
+    }
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: {
         getCurrentPosition: sinon.stub(),
       },
-    };
+      writable: true,
+    });
   });
 
   it('should dispatch GEOLOCATE_USER and GEOCODE_COMPLETE on successful geolocation', async () => {
@@ -57,7 +66,10 @@ describe('geoLocateUser Action Creator', () => {
   });
 
   it('should dispatch GEOCODE_FAILED if geolocation is not supported', async () => {
-    delete global.navigator.geolocation;
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: undefined,
+      writable: true,
+    });
 
     await store.dispatch(geoLocateUser());
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Related issue(s)

- Closes department-of-veterans-affairs/ask-va#1942

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- [x] The unit test for `geoLocateUser` passes successfully on Node 22.
  > GIVEN The test environment is set up for `geoLocateUser`\
  > WHEN The test `"should dispatch GEOLOCATE_USER and GEOCODE_COMPLETE on successful geolocation"` runs\
  > THEN It completes without throwing the `navigator` error.

- [x] Any changes made maintain backward compatibility with Node 14 tests.
