### PR TITLE
[Disability Benefits Crew Core Form] Update TE conditions on confirmation page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reviewEntry } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
+import { sippableId } from '../../utils';
 
 const ToxicExposureConditions = ({ formData }) => {
-  const conditions = formData?.toxicExposure?.conditions || {};
-
-  const claimedKeys = Object.keys(conditions).filter(
-    key => key !== 'none' && conditions[key] === true,
+  // first, get list of toxic exposure conditions the user has claimed
+  // then, cross-check that with the list of conditions they checked
+  // and display the readable (non-Sippable) names of those conditions
+  const teConditions = formData?.toxicExposure?.conditions || {};
+  const claimedKeys = Object.keys(teConditions).filter(
+    key => key !== 'none' && teConditions[key] === true,
   );
+  const conditionsContainer = formData?.newDisabilities;
+  const finalList = conditionsContainer
+    .filter(condition => claimedKeys.includes(sippableId(condition.condition)))
+    .map(condition => condition.condition);
 
   return (
     <li>
       <h4>Toxic Exposure </h4>
       <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
-        {conditions?.none === true
+        {teConditions?.none === true
           ? reviewEntry(
               null,
               'toxicExposureNone',
@@ -21,7 +28,7 @@ const ToxicExposureConditions = ({ formData }) => {
               'Toxic exposure conditions',
               'None claimed',
             )
-          : claimedKeys.map(key => reviewEntry(null, key, {}, key, 'Claimed'))}
+          : finalList.map(key => reviewEntry(null, key, {}, key, 'Claimed'))}
       </ul>
     </li>
   );

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reviewEntry } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
-import { sippableId } from '../../utils';
+import { sippableId, capitalizeEachWord } from '../../utils';
 
 const ToxicExposureConditions = ({ formData }) => {
   // first, get list of toxic exposure conditions the user has claimed
@@ -14,7 +14,7 @@ const ToxicExposureConditions = ({ formData }) => {
   const conditionsContainer = formData?.newDisabilities || [];
   const finalList = conditionsContainer
     .filter(condition => claimedKeys.includes(sippableId(condition.condition)))
-    .map(condition => condition.condition);
+    .map(condition => capitalizeEachWord(condition.condition));
 
   return (
     <li>

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
@@ -9,7 +9,7 @@ const ToxicExposureConditions = ({ formData }) => {
   // and display the readable (non-Sippable) names of those conditions
   const teConditions = formData?.toxicExposure?.conditions || {};
   const claimedKeys = Object.keys(teConditions).filter(
-    key => key !== 'none' && teConditions[key] === true,
+    key => key !== 'none' && teConditions[key],
   );
   const conditionsContainer = formData?.newDisabilities || [];
   const finalList = conditionsContainer
@@ -20,7 +20,7 @@ const ToxicExposureConditions = ({ formData }) => {
     <li>
       <h4>Toxic Exposure </h4>
       <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
-        {teConditions?.none === true
+        {teConditions?.none
           ? reviewEntry(
               null,
               'toxicExposureNone',

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
@@ -11,7 +11,7 @@ const ToxicExposureConditions = ({ formData }) => {
   const claimedKeys = Object.keys(teConditions).filter(
     key => key !== 'none' && teConditions[key] === true,
   );
-  const conditionsContainer = formData?.newDisabilities;
+  const conditionsContainer = formData?.newDisabilities || [];
   const finalList = conditionsContainer
     .filter(condition => claimedKeys.includes(sippableId(condition.condition)))
     .map(condition => condition.condition);

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationNewDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationNewDisabilities.jsx
@@ -8,11 +8,12 @@ const ConfirmationNewDisabilities = ({ formData }) => {
   return (
     <div>
       {newDisabilities.map(dis => {
+        // guard is necessary for legacy 0781 conditions that do not have a cause
+        const cause = dis?.cause || 'Claimed';
         const capitalizedCause =
-          dis.cause === 'VA'
+          cause === 'VA'
             ? 'VA'
-            : dis.cause.charAt(0).toUpperCase() +
-              dis.cause.slice(1).toLowerCase();
+            : cause.charAt(0).toUpperCase() + cause.slice(1).toLowerCase();
         return (
           <div key={dis.condition}>
             <h4>{capitalizeEachWord(dis.condition)} </h4>

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
@@ -63,41 +63,6 @@ describe('Toxic Exposure Conditions', () => {
     expect(queryByText(/none claimed/i)).to.be.null;
   });
 
-  it('renders nothing if no toxic exposure data is present', () => {
-    const formData = {
-      newDisabilities: [{ condition: 'Asthma' }],
-    };
-    const { getByRole, queryByText } = render(
-      <ToxicExposureConditions formData={formData} />,
-    );
-    expect(getByRole('heading', { name: /toxic exposure/i })).to.exist;
-    expect(queryByText(/none claimed/i)).to.be.null;
-    expect(queryByText(/asthma/i)).to.be.null;
-  });
-
-  it('renders only matching claimed conditions', () => {
-    const formData = {
-      toxicExposure: {
-        conditions: {
-          asthma: true,
-          copd: true,
-          none: false,
-        },
-      },
-      newDisabilities: [
-        { condition: 'Asthma' },
-        { condition: 'COPD' },
-        { condition: 'Sleep Apnea' },
-      ],
-    };
-    const { getByText, queryByText } = render(
-      <ToxicExposureConditions formData={formData} />,
-    );
-    expect(getByText(/asthma/i)).to.exist;
-    expect(getByText(/copd/i)).to.exist;
-    expect(queryByText(/sleep apnea/i)).to.be.null;
-  });
-
   it('should render conditions page with multiple conditions', async () => {
     const formData = {
       newDisabilities: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
@@ -13,12 +13,90 @@ import {
   noneAndConditionError,
 } from '../../../content/toxicExposure';
 import formConfig from '../../../config/form';
+import ToxicExposureConditions from '../../../components/ConfirmationFields/ToxicExposureConditions';
 
 describe('Toxic Exposure Conditions', () => {
   const {
     schema,
     uiSchema,
   } = formConfig.chapters.disabilities.pages.toxicExposureConditions;
+
+  it('renders "None claimed" when no toxic exposure conditions are selected', () => {
+    const formData = {
+      toxicExposure: {
+        conditions: {
+          none: true,
+        },
+      },
+      newDisabilities: [{ condition: 'Asthma' }, { condition: 'COPD' }],
+    };
+    const { getByRole, queryByText } = render(
+      <ToxicExposureConditions formData={formData} />,
+    );
+    expect(getByRole('heading', { name: /toxic exposure/i })).to.exist;
+    expect(queryByText(/none claimed/i)).to.exist;
+    expect(queryByText(/asthma/i)).to.be.null;
+    expect(queryByText(/copd/i)).to.be.null;
+  });
+
+  it('renders claimed toxic exposure conditions', () => {
+    const formData = {
+      toxicExposure: {
+        conditions: {
+          asthma: true,
+          copd: true,
+        },
+      },
+      newDisabilities: [
+        { condition: 'Asthma' },
+        { condition: 'COPD' },
+        { condition: 'Sleep Apnea' },
+      ],
+    };
+    const { getByRole, queryByText, getByText } = render(
+      <ToxicExposureConditions formData={formData} />,
+    );
+    expect(getByRole('heading', { name: /toxic exposure/i })).to.exist;
+    expect(getByText(/asthma/i)).to.exist;
+    expect(getByText(/copd/i)).to.exist;
+    expect(queryByText(/sleep apnea/i)).to.be.null;
+    expect(queryByText(/none claimed/i)).to.be.null;
+  });
+
+  it('renders nothing if no toxic exposure data is present', () => {
+    const formData = {
+      newDisabilities: [{ condition: 'Asthma' }],
+    };
+    const { getByRole, queryByText } = render(
+      <ToxicExposureConditions formData={formData} />,
+    );
+    expect(getByRole('heading', { name: /toxic exposure/i })).to.exist;
+    expect(queryByText(/none claimed/i)).to.be.null;
+    expect(queryByText(/asthma/i)).to.be.null;
+  });
+
+  it('renders only matching claimed conditions', () => {
+    const formData = {
+      toxicExposure: {
+        conditions: {
+          asthma: true,
+          copd: true,
+          none: false,
+        },
+      },
+      newDisabilities: [
+        { condition: 'Asthma' },
+        { condition: 'COPD' },
+        { condition: 'Sleep Apnea' },
+      ],
+    };
+    const { getByText, queryByText } = render(
+      <ToxicExposureConditions formData={formData} />,
+    );
+    expect(getByText(/asthma/i)).to.exist;
+    expect(getByText(/copd/i)).to.exist;
+    expect(queryByText(/sleep apnea/i)).to.be.null;
+  });
 
   it('should render conditions page with multiple conditions', async () => {
     const formData = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- This PR shifts Toxic Exposure condition names back to their original names. 
- TE condition names are stored as `sippableIds` which stands for save-in-progress IDs. At some point it was deemed necessary to remove spaces and downcase condition names for storing in the data store, so that's why the function exists. We just need to undo that in order to display the human-readable condition name.
- This also fixes issue with legacy 0781 conditions breaking the capitalization logic on the confirmation page by defining 'Claimed condition' as the cause when cause is null.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120223

## Testing done

- I tested locally:
<img width="820" height="889" alt="image" src="https://github.com/user-attachments/assets/3d649117-70f8-4e3a-b497-5feb19541226" />

- Updated unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="561" height="97" alt="image" src="https://github.com/user-attachments/assets/1113772b-fa36-4310-a763-855bb5e2c1d9" />|<img width="497" height="122" alt="image" src="https://github.com/user-attachments/assets/b85d9266-6456-4085-9c42-03261d6ea68d" />|

## What areas of the site does it impact?

This just touches the Toxic Exposure Confirmation Page component, so it won't impact anything else. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

## Steps to Test Locally:
1. Ensure disability_526_show_confirmation_review flipper is on 
2. Claim only NEW conditions on the claim-type page
3. Enter at least one condition on the add-a-disability page
4. Select a condition as affected by Toxic Exposure
5. Answer other required fields and submit
6. On submission page, click accordion to review submitted information
7. Confirm your condition is rendered under Toxic Exposure with proper condition name