### PR TITLE
10-10d | Fix redirect errors

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/App.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/App.jsx
@@ -48,14 +48,6 @@ export default function App({ location, children }) {
     () => isLoadingFeatureFlags || isLoadingProfile,
     [isLoadingFeatureFlags, isLoadingProfile],
   );
-  const hasSavedForm = useMemo(
-    () =>
-      savedForms.some(
-        ({ form, metaData }) =>
-          form === formConfig.formId && !isExpired(metaData?.expiresAt),
-      ),
-    [savedForms],
-  );
 
   const [routeChecked, setRouteChecked] = useState(false);
 
@@ -74,14 +66,17 @@ export default function App({ location, children }) {
   useLayoutEffect(
     () => {
       if (isAppLoading) return;
+      const hasSavedForm = savedForms.some(
+        ({ form, metaData }) =>
+          form === formConfig.formId && !isExpired(metaData?.expiresAt),
+      );
       if (isMergedFormEnabled && !hasSavedForm) {
-        const targetUrl = getAppUrl('10-10d-extended');
-        window.location.replace(targetUrl);
+        window.location.replace(getAppUrl('10-10d-extended'));
         return;
       }
       setRouteChecked(true);
     },
-    [hasSavedForm, isAppLoading, isMergedFormEnabled],
+    [isAppLoading, isMergedFormEnabled, savedForms],
   );
 
   // Add Datadog RUM to the app

--- a/src/applications/ivc-champva/10-10d-extended/containers/App.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/App.jsx
@@ -27,14 +27,6 @@ const App = ({ location, children }) => {
     () => isLoadingFeatureFlags || isLoadingProfile,
     [isLoadingFeatureFlags, isLoadingProfile],
   );
-  const hasSavedForm = useMemo(
-    () =>
-      savedForms.some(
-        ({ form, metaData }) =>
-          form === VA_FORM_IDS.FORM_10_10D && !isExpired(metaData?.expiresAt),
-      ),
-    [savedForms],
-  );
 
   const [routeChecked, setRouteChecked] = useState(false);
 
@@ -42,14 +34,17 @@ const App = ({ location, children }) => {
   useLayoutEffect(
     () => {
       if (isAppLoading) return;
-      if (!isMergedFormEnabled || !hasSavedForm) {
-        const targetUrl = getAppUrl('10-10D');
-        window.location.replace(targetUrl);
+      const hasSavedForm = savedForms.some(
+        ({ form, metaData }) =>
+          form === VA_FORM_IDS.FORM_10_10D && !isExpired(metaData?.expiresAt),
+      );
+      if (!isMergedFormEnabled || hasSavedForm) {
+        window.location.replace(getAppUrl('10-10D'));
         return;
       }
       setRouteChecked(true);
     },
-    [hasSavedForm, isAppLoading, isMergedFormEnabled],
+    [isAppLoading, isMergedFormEnabled, savedForms],
   );
 
   const showLoadingIndicator = isAppLoading || !routeChecked;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR corrects minor errors in the redirect logic for the 10-10d apps. It also gates the logic until all has resolved to avoid any paint of the DOM, which produces a flicker of content before the redirect takes place.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#120486

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Redirects correctly function without error
- Content does not render before route check is complete

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user