### PR TITLE
10-10d extended | Use web component buttons for navigation/submission

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -67,6 +67,7 @@ const formConfig = {
     collapsibleNavLinks: true,
   },
   formOptions: {
+    useWebComponentForNavigation: true,
     filterInactiveNestedPageData: true,
   },
   ...minimalHeaderFormConfigOptions({

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/10-10d-extended.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/10-10d-extended.cypress.spec.js
@@ -63,7 +63,7 @@ const testConfig = createTestConfig(
                   cy.selectVaCheckbox($el, true),
                 );
               });
-            cy.findByText(/submit/i, { selector: 'button' }).click();
+            cy.get('va-button[text*="submit" i]').click();
           });
         });
       },

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
@@ -1,16 +1,12 @@
 export const goToNextPage = pagePath => {
-  cy.findAllByText(/continue|confirm/i, { selector: 'button' })
-    .first()
-    .click();
-  if (pagePath) {
-    cy.location('pathname').should('include', pagePath);
-  }
+  cy.clickFormContinue();
+  if (pagePath) cy.location('pathname').should('include', pagePath);
 };
 
 export const startAsGuestUser = () => {
-  cy.get('.schemaform-start-button')
-    .first()
-    .click();
+  cy.get('va-alert-sign-in').within(() => {
+    cy.get('a.schemaform-start-button').click();
+  });
   cy.location('pathname').should('include', '/who-is-applying');
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the app to utilize web component buttons for form navigation and submission.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118224

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- No imposter buttons are utilized in the app

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
