### PR TITLE
10-7959a | Update claim ID info content

### DIFF
--- a/src/applications/ivc-champva/10-7959a/components/FormDescriptions/ClaimIdentificationInfo.jsx
+++ b/src/applications/ivc-champva/10-7959a/components/FormDescriptions/ClaimIdentificationInfo.jsx
@@ -10,7 +10,7 @@ const ClaimIdentificationInfo = (
     </p>
     <p>
       <strong>For control numbers</strong> include all of the numbers listed
-      under “Control Number” on the CHAMPVA Explanation of benefits.
+      under “Control Number” on the CHAMPVA Explanation of Benefits.
     </p>
 
     <va-additional-info
@@ -25,10 +25,9 @@ const ClaimIdentificationInfo = (
         </p>
         <p className="vads-u-margin-bottom--0">
           If you can’t find the PDI number, call us at{' '}
-          <va-telephone contact={CHAMPVA_PHONE_NUMBER} />{' '}
-          <va-telephone contact="711" tty />
-          {'. '}
-          We’re here Monday through Friday, 8:05a.m. to 7:30 p.m.{' '}
+          <va-telephone contact={CHAMPVA_PHONE_NUMBER} /> (
+          <va-telephone contact="711" tty />){'. '}
+          We’re here Monday through Friday, 8:05 a.m. to 7:30 p.m.{' '}
           <dfn>
             <abbr title="Eastern Time">ET</abbr>
           </dfn>
@@ -48,10 +47,9 @@ const ClaimIdentificationInfo = (
         </p>
         <p className="vads-u-margin-bottom--0">
           If you can’t find the control number, call us at{' '}
-          <va-telephone contact={CHAMPVA_PHONE_NUMBER} />
-          <va-telephone contact="711" tty />
-          {'. '}
-          We’re here Monday through Friday, 8:05a.m. to 7:30 p.m.{' '}
+          <va-telephone contact={CHAMPVA_PHONE_NUMBER} /> (
+          <va-telephone contact="711" tty />){'. '}
+          We’re here Monday through Friday, 8:05 a.m. to 7:30 p.m.{' '}
           <dfn>
             <abbr title="Eastern Time">ET</abbr>
           </dfn>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR performs some minor content edits to the Resubmission Claim Number page of the app.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#120249

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="537" height="595" alt="Screenshot 2025-10-15 at 14 57 08" src="https://github.com/user-attachments/assets/0553ec91-37f5-46a1-a51d-57d64a9612eb" /> | <img width="537" height="595" alt="Screenshot 2025-10-15 at 14 56 34" src="https://github.com/user-attachments/assets/a7cb94a8-7480-4aeb-86cb-1cbb993aad18" /> |

## Acceptance criteria

- Content meets C/IA standards

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
