### PR TITLE
Update payment information confirmation view to show prefilled data

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -5,7 +5,7 @@ import { paymentRows } from './PaymentViewObjectField';
 
 const ConfirmationPaymentInformation = ({ formData }) => {
   const hasPrefilledBankInfo =
-    Boolean(formData?.['view:bankAccount']?.['view:hasPrefilledBank']) || false;
+    Boolean(formData?.['view:bankAccount']?.['view:hasPrefilledBank']);
   const hasNewBankingInfo = Boolean(
     formData?.['view:bankAccount']?.bankAccountType ||
       formData?.['view:bankAccount']?.bankAccountNumber ||

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -97,8 +97,6 @@ const ConfirmationPaymentInformation = ({ formData }) => {
     );
   }
 
-  // Default return if no conditions are met
-  return null;
 };
 
 ConfirmationPaymentInformation.propTypes = {

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -9,7 +9,8 @@ const ConfirmationPaymentInformation = ({ formData }) => {
   const hasNewBankingInfo = Boolean(
     formData?.['view:bankAccount']?.bankAccountType ||
       formData?.['view:bankAccount']?.bankAccountNumber ||
-      formData?.['view:bankAccount']?.bankRoutingNumber,
+      formData?.['view:bankAccount']?.bankRoutingNumber ||
+      formData?.['view:bankAccount']?.bankName,
   );
 
   // Return null if no prefilled bank information and no new banking information (it is optional)

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -4,8 +4,9 @@ import { reviewEntry } from 'platform/forms-system/src/js/components/Confirmatio
 import { paymentRows } from './PaymentViewObjectField';
 
 const ConfirmationPaymentInformation = ({ formData }) => {
-  const hasPrefilledBankInfo =
-    Boolean(formData?.['view:bankAccount']?.['view:hasPrefilledBank']);
+  const hasPrefilledBankInfo = Boolean(
+    formData?.['view:bankAccount']?.['view:hasPrefilledBank'],
+  );
   const hasNewBankingInfo = Boolean(
     formData?.['view:bankAccount']?.bankAccountType ||
       formData?.['view:bankAccount']?.bankAccountNumber ||
@@ -97,9 +98,12 @@ const ConfirmationPaymentInformation = ({ formData }) => {
     );
   }
 
+  // Default return if no conditions are met
+  return null;
 };
 
 ConfirmationPaymentInformation.propTypes = {
   formData: PropTypes.object,
 };
+
 export default ConfirmationPaymentInformation;

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPaymentInformation.jsx
@@ -4,46 +4,100 @@ import { reviewEntry } from 'platform/forms-system/src/js/components/Confirmatio
 import { paymentRows } from './PaymentViewObjectField';
 
 const ConfirmationPaymentInformation = ({ formData }) => {
-  const bankingInformation = formData?.['view:bankAccount'];
+  const hasPrefilledBankInfo =
+    Boolean(formData?.['view:bankAccount']?.['view:hasPrefilledBank']) || false;
+  const hasNewBankingInfo = Boolean(
+    formData?.['view:bankAccount']?.bankAccountType ||
+      formData?.['view:bankAccount']?.bankAccountNumber ||
+      formData?.['view:bankAccount']?.bankRoutingNumber,
+  );
 
-  // Return null if bankingInformation is undefined, null, or an empty object
-  if (!bankingInformation || Object.keys(bankingInformation).length === 0) {
+  // Return null if no prefilled bank information and no new banking information (it is optional)
+  if (!hasNewBankingInfo && !hasPrefilledBankInfo) {
     return null;
   }
 
-  const bankingEntries = {
-    bankAccountType: {
-      label: paymentRows.bankAccountType,
-      data: bankingInformation.bankAccountType || '',
-    },
-    bankName: {
-      label: paymentRows.bankName,
-      data: bankingInformation.bankName || '',
-    },
-    bankAccountNumber: {
-      label: paymentRows.bankAccountNumber,
-      data: bankingInformation.bankAccountNumber
-        ? `******${bankingInformation.bankAccountNumber.slice(-4)}`
-        : '',
-    },
-    bankRoutingNumber: {
-      label: paymentRows.bankRoutingNumber,
-      data: bankingInformation.bankRoutingNumber
-        ? `*****${bankingInformation.bankRoutingNumber.slice(-4)}`
-        : '',
-    },
-  };
+  const newBankingInformation = formData?.['view:bankAccount'];
+  const prefilledBankingInformation = formData?.['view:originalBankAccount'];
 
-  return (
-    <li>
-      <h4>Payment Information</h4>
-      <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
-        {Object.entries(bankingEntries).map(([key, value]) =>
-          reviewEntry(null, key, null, value.label, value.data),
-        )}
-      </ul>
-    </li>
-  );
+  // Use new banking info if it exists
+  if (hasNewBankingInfo) {
+    const newBankingInfoEntries = {
+      bankAccountType: {
+        label: paymentRows.bankAccountType,
+        data: newBankingInformation.bankAccountType || '',
+      },
+      bankName: {
+        label: paymentRows.bankName,
+        data: newBankingInformation.bankName || '',
+      },
+      bankAccountNumber: {
+        label: paymentRows.bankAccountNumber,
+        data: newBankingInformation.bankAccountNumber
+          ? `******${newBankingInformation.bankAccountNumber.slice(-4)}`
+          : '',
+      },
+      bankRoutingNumber: {
+        label: paymentRows.bankRoutingNumber,
+        data: newBankingInformation.bankRoutingNumber
+          ? `*****${newBankingInformation.bankRoutingNumber.slice(-4)}`
+          : '',
+      },
+    };
+
+    return (
+      <li>
+        <h4>Payment Information</h4>
+        <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
+          {Object.entries(newBankingInfoEntries).map(([key, value]) =>
+            reviewEntry(null, key, null, value.label, value.data),
+          )}
+        </ul>
+      </li>
+    );
+  }
+
+  if (hasPrefilledBankInfo && !hasNewBankingInfo) {
+    const prefilledBankingInfoEntries = {
+      bankAccountType: {
+        label: paymentRows.bankAccountType,
+        data: prefilledBankingInformation?.['view:bankAccountType'] || '',
+      },
+      bankName: {
+        label: paymentRows.bankName,
+        data: prefilledBankingInformation?.['view:bankName'] || '',
+      },
+      bankAccountNumber: {
+        label: paymentRows.bankAccountNumber,
+        data: prefilledBankingInformation?.['view:bankAccountNumber']
+          ? `******${prefilledBankingInformation[
+              'view:bankAccountNumber'
+            ].slice(-4)}`
+          : '',
+      },
+      bankRoutingNumber: {
+        label: paymentRows.bankRoutingNumber,
+        data: prefilledBankingInformation?.['view:bankRoutingNumber']
+          ? `*****${prefilledBankingInformation['view:bankRoutingNumber'].slice(
+              -4,
+            )}`
+          : '',
+      },
+    };
+    return (
+      <li>
+        <h4>Payment Information</h4>
+        <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
+          {Object.entries(prefilledBankingInfoEntries).map(([key, value]) =>
+            reviewEntry(null, key, null, value.label, value.data),
+          )}
+        </ul>
+      </li>
+    );
+  }
+
+  // Default return if no conditions are met
+  return null;
 };
 
 ConfirmationPaymentInformation.propTypes = {

--- a/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
@@ -228,8 +228,15 @@ describe('Confirmation view - ui:confirmationField with custom ConfirmationPayme
     const confirmationField = uiSchema['ui:confirmationField']({ formData });
     const { container } = render(confirmationField);
 
+    // Check that new bank info is displayed
     expect(container.textContent).to.contain('New Bank');
+    expect(container.textContent).to.contain('******7890'); // new account number
+    expect(container.textContent).to.contain('*****6789'); // new routing number
+
+    // Check that old bank info is not displayed
     expect(container.textContent).not.to.contain('Old Bank');
+    expect(container.textContent).not.to.contain('******3210'); // old account number
+    expect(container.textContent).not.to.contain('*****4321'); // old routing number
   });
 
   it('should not display if neither prefilled nor new banking info is provided', () => {
@@ -272,6 +279,29 @@ describe('Confirmation view - ui:confirmationField with custom ConfirmationPayme
     const { container } = render(confirmationField);
 
     expect(container.textContent).to.contain('Checking');
+    expect(container.textContent).not.to.contain('******');
+    expect(container.textContent).not.to.contain('*****');
+  });
+
+  it('should render when only bankName is provided', () => {
+    const formData = {
+      'view:bankAccount': {
+        bankName: 'Test Bank Only',
+        // No other banking fields provided
+      },
+    };
+
+    const confirmationField = uiSchema['ui:confirmationField']({ formData });
+    const { container } = render(confirmationField);
+
+    const heading = container.querySelector('h4');
+    expect(heading).to.exist;
+    expect(heading.textContent).to.equal('Payment Information');
+
+    // Bank name should be displayed
+    expect(container.textContent).to.contain('Test Bank Only');
+
+    // Other fields should be empty but not show masked values
     expect(container.textContent).not.to.contain('******');
     expect(container.textContent).not.to.contain('*****');
   });

--- a/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
@@ -157,7 +157,7 @@ describe('526 -- paymentInformation', () => {
 });
 
 describe('Confirmation view - ui:confirmationField with custom ConfirmationPaymentInformation component', () => {
-  it('should render payment information correctly', () => {
+  it('should render new payment information when provided', () => {
     const formData = {
       'view:bankAccount': {
         bankAccountType: 'Checking',
@@ -181,11 +181,98 @@ describe('Confirmation view - ui:confirmationField with custom ConfirmationPayme
     expect(container.textContent).to.contain('*****6789');
   });
 
-  it('should not display if optional paymentInformation is not provided', () => {
+  it('should render prefilled bank information when available and no new info provided', () => {
+    const formData = {
+      'view:bankAccount': {
+        'view:hasPrefilledBank': true,
+      },
+      'view:originalBankAccount': {
+        'view:bankAccountType': 'Savings',
+        'view:bankAccountNumber': '9876543210',
+        'view:bankRoutingNumber': '987654321',
+        'view:bankName': 'Prefilled Bank',
+      },
+    };
+
+    const confirmationField = uiSchema['ui:confirmationField']({ formData });
+    const { container } = render(confirmationField);
+
+    const heading = container.querySelector('h4');
+    expect(heading).to.exist;
+    expect(heading.textContent).to.equal('Payment Information');
+
+    // Check that prefilled banking details are displayed
+    expect(container.textContent).to.contain('Savings');
+    expect(container.textContent).to.contain('Prefilled Bank');
+    expect(container.textContent).to.contain('******3210');
+    expect(container.textContent).to.contain('*****4321');
+  });
+
+  it('should display new banking info over prefilled info when both exist', () => {
+    const formData = {
+      'view:bankAccount': {
+        'view:hasPrefilledBank': true,
+        bankAccountType: 'Checking',
+        bankAccountNumber: '1234567890',
+        bankRoutingNumber: '123456789',
+        bankName: 'New Bank',
+      },
+      'view:originalBankAccount': {
+        bankAccountType: 'Savings',
+        bankAccountNumber: '9876543210',
+        bankRoutingNumber: '987654321',
+        bankName: 'Old Bank',
+      },
+    };
+
+    const confirmationField = uiSchema['ui:confirmationField']({ formData });
+    const { container } = render(confirmationField);
+
+    expect(container.textContent).to.contain('New Bank');
+    expect(container.textContent).not.to.contain('Old Bank');
+  });
+
+  it('should not display if neither prefilled nor new banking info is provided', () => {
     const confirmationField = uiSchema['ui:confirmationField']({
       formData: {},
     });
     const { container } = render(confirmationField);
     expect(container.firstChild).to.be.null;
+  });
+
+  it('should handle undefined view:bankAccount', () => {
+    const confirmationField = uiSchema['ui:confirmationField']({
+      formData: {
+        'view:bankAccount': undefined,
+      },
+    });
+    const { container } = render(confirmationField);
+    expect(container.firstChild).to.be.null;
+  });
+
+  it('should handle null view:bankAccount', () => {
+    const confirmationField = uiSchema['ui:confirmationField']({
+      formData: {
+        'view:bankAccount': null,
+      },
+    });
+    const { container } = render(confirmationField);
+    expect(container.firstChild).to.be.null;
+  });
+
+  it('should handle partial new banking info', () => {
+    const formData = {
+      'view:bankAccount': {
+        bankAccountType: 'Checking',
+        // Missing bankAccountNumber and bankRoutingNumber
+      },
+    };
+
+    const confirmationField = uiSchema['ui:confirmationField']({ formData });
+    const { container } = render(confirmationField);
+
+    expect(container.textContent).to.contain('Checking');
+    expect(container.textContent).not.to.contain('******');
+    expect(container.textContent).not.to.contain('*****');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
This PR builds off of a [previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39343) that added the payment information section to the confirmation page. This PR handles showing data for different states.
- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Benefits Crew Core Form team and we own this feature
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
This feature is gated under `disability_526_show_confirmation_review`

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120153
- Previous PR: https://github.com/department-of-veterans-affairs/vets-website/pull/39343

## Testing done

- _Describe what the old behavior was prior to the change_
Originally, the confirmation page did not display any data for the payment information page. One fix was added in [previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39343) to show the page, but it did not completely handle all states. Expected behavior, to match the review and submit page:
  - if no bank account data (the page is optional) => do not show the "Payment Information" heading
  - if only new bank data (entered on the page) => show new bank info
  - if only prefilled bank data (prefilled by LH, user-based) => show prefilled bank info
  - if new + prefilled data => show new bank info

There is a known issue with a LH direct deposit call where a claim cannot be submitted locally without bank data. To work around this issue - and because this PR only affects the post-submission confirmation page - I tested the confirmation page using the devOnly "simulate submission" option with mockdata (screenshots below). I will do more validation on staging.

Mockdata for pre-filled bank info:
```
 "view:originalBankAccount": {
    "view:bankAccountType": "Checking",
    "view:bankAccountNumber": "*****3444",
    "view:bankRoutingNumber": "*****4808",
    "view:bankName": "BANK OF AMERICA, N.A."
  },
  "view:bankAccount": {
    "view:newAccountAlert": {},
    "view:hasPrefilledBank": true
  },
```

- _Describe the steps required to verify your changes are working as expected

In the additional information section, go to "/disability/file-disability-claim-form-21-526ez/payment-information"
- complete all fields for new bank information

Continue filling out the form, submit, and verify that the new bank data you entered displays correctly on the confirmation page.

- _Describe the tests completed and the results_
Unit tests added
Manual testing with mockdata on confirmation page
Proof of submission with new bank info entered:

<img width="704" height="873" alt="Screenshot 2025-10-16 at 4 07 44 PM" src="https://github.com/user-attachments/assets/ee5dd0ec-c012-4475-bd17-57d083ca1fa2" />

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| No bank data | <img width="283" height="135" alt="Screenshot 2025-10-16 at 4 19 03 PM" src="https://github.com/user-attachments/assets/36888632-39be-4a20-9e9c-3bfbaf2e9df0" /> | <img width="257" height="145" alt="Screenshot 2025-10-16 at 4 23 28 PM" src="https://github.com/user-attachments/assets/76ee9a82-5667-48de-816f-ec0d1fa0f17d" /> |
| New only (no change) | <img width="256" height="291" alt="Screenshot 2025-10-16 at 4 10 09 PM" src="https://github.com/user-attachments/assets/279221a0-704f-4299-8337-7a73785577a6" /> | <img width="256" height="291" alt="Screenshot 2025-10-16 at 4 10 09 PM" src="https://github.com/user-attachments/assets/279221a0-704f-4299-8337-7a73785577a6" /> |
| Prefill only | <img width="283" height="135" alt="Screenshot 2025-10-16 at 4 19 03 PM" src="https://github.com/user-attachments/assets/2af883bc-1320-43bf-a129-0eba98fc7918" /> | <img width="245" height="289" alt="Screenshot 2025-10-16 at 4 05 25 PM" src="https://github.com/user-attachments/assets/e25f580e-5258-47bb-b4b7-e9f6e71746f8" /> |
| Prefill + new (no change) | <img width="296" height="297" alt="Screenshot 2025-10-16 at 4 12 42 PM" src="https://github.com/user-attachments/assets/69bb258d-408d-46ce-94f7-5fed7907c6d4" /> | <img width="296" height="297" alt="Screenshot 2025-10-16 at 4 12 42 PM" src="https://github.com/user-attachments/assets/69bb258d-408d-46ce-94f7-5fed7907c6d4" /> |

## What areas of the site does it impact?
This affects the confirmation page of the 526 form

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
