### PR TITLE
21P-8416 add expandUnder to date fields

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/02-expenses/reportingPeriod.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/reportingPeriod.js
@@ -71,6 +71,8 @@ export default {
         },
       ),
       'ui:options': {
+        expandUnder: 'firstTimeReporting',
+        expandUnderCondition: field => field === false,
         hideIf: formData =>
           formData?.firstTimeReporting === true ||
           formData?.firstTimeReporting === undefined,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add expandUnder to reporting period dates to add blue bar.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122269

## Testing done

- manual testing

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="494" height="662" alt="Screenshot 2025-10-16 at 10 18 23 AM" src="https://github.com/user-attachments/assets/56f2e9ba-f0c3-4fe9-8890-6e2b5b9584f3" /> | <img width="651" height="531" alt="Screenshot 2025-10-16 at 10 18 33 AM" src="https://github.com/user-attachments/assets/0b0da975-1d2f-4940-8808-ebd3b9c97736" /> |

## What areas of the site does it impact?

Just reporting period page of form. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
