### PR TITLE
10-10d extended | Add prescription question to health insurance

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
@@ -235,6 +235,26 @@ const employer = {
   },
 };
 
+const prescriptionCoverage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) => `${formData?.provider} prescription coverage`,
+    ),
+    eob: yesNoUI({
+      title: 'Does the applicant(s) health insurance cover prescriptions?',
+      hint:
+        'You may find this information on the front of your health insurance card. You can also contact the phone number listed on the back of the card.',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['eob'],
+    properties: {
+      eob: yesNoSchema,
+    },
+  },
+};
+
 const additionalComments = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
@@ -339,6 +359,11 @@ export const healthInsurancePages = arrayBuilderPages(
       path: 'health-insurance-employer-sponsorship/:index',
       title: 'Type of insurance - through employer',
       ...employer,
+    }),
+    prescriptionCoverage: pageBuilder.itemPage({
+      path: 'health-insurance-prescription-coverage/:index',
+      title: 'Prescription coverage',
+      ...prescriptionCoverage,
     }),
     comments: pageBuilder.itemPage({
       path: 'health-insurance-additional-comments/:index',

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
@@ -108,6 +108,6 @@
     "sponsorIsDeceased": true,
     "sponsorDOD": "2001-01-01",
     "sponsorDeathConditions": false,
-    "statementOfTruthSignature": "Certifier Jones"
+    "statementOfTruthSignature": "Certifier T Jones Sr."
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds a new question to the Health Insurance section of the app about whether the declared plan covers prescription drugs.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#122388

## Testing done

- N/A

## Screenshots

|         |
| ---- |
| <img width="501" height="446" alt="Screenshot 2025-10-16 at 12 31 15" src="https://github.com/user-attachments/assets/71982cea-e1d7-4e60-9bb5-bc78b9aeccc0" /> |

## Acceptance criteria

- Question content meets C/IA standards

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
