### PR TITLE
10-10d extended | Add intro pages for OHI & Medicare

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
@@ -91,8 +91,6 @@ export const healthInsuranceOptions = {
   isItemIncomplete: item =>
     !(item.provider && item.insuranceType && item.effectiveDate),
   text: {
-    summaryTitle: 'Report other health insurance',
-    summaryTitleWithoutItems: 'Report other health insurance',
     getItemName: item => item?.provider,
     cardDescription: item => (
       <ul className="no-bullets">

--- a/src/applications/ivc-champva/10-10d-extended/components/FormPages/MedicareIntroduction.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormPages/MedicareIntroduction.jsx
@@ -7,11 +7,8 @@ const MedicareIntroduction = props => {
   return (
     <>
       <h1 className="vads-u-color--black vads-u-margin-top--0 mobile-lg:vads-u-font-size--h2 vads-u-font-size--h3">
-        Submit your Other Health Insurance Certification (VA Form 10-7959c)
-      </h1>
-      <h2 className="mobile-lg:vads-u-font-size--h3 vads-u-font-size--h4">
         Report Medicare
-      </h2>
+      </h1>
       <ul className="vads-u-margin-y--4">
         <li>
           <strong>If you currently have Medicare</strong>, provide your plan

--- a/src/applications/ivc-champva/10-10d-extended/components/FormPages/MedicareIntroduction.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormPages/MedicareIntroduction.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormNavButtonContinue } from 'platform/forms-system/src/js/components/FormNavButtons';
+
+const MedicareIntroduction = props => {
+  const { contentAfterButtons, contentBeforeButtons, goForward } = props;
+  return (
+    <>
+      <h1 className="vads-u-color--black vads-u-margin-top--0 mobile-lg:vads-u-font-size--h2 vads-u-font-size--h3">
+        Submit your Other Health Insurance Certification (VA Form 10-7959c)
+      </h1>
+      <h2 className="mobile-lg:vads-u-font-size--h3 vads-u-font-size--h4">
+        Report Medicare
+      </h2>
+      <ul className="vads-u-margin-y--4">
+        <li>
+          <strong>If you currently have Medicare</strong>, provide your plan
+          information to help us complete your CHAMPVA benefits application.
+          This also helps us coordinate benefits and process your claims faster.
+        </li>
+        <li>
+          <strong>If you’re pre-enrolled in Medicare</strong> with a future
+          effective date, you need to submit using the Other Health Insurance
+          Certification (VA Form 10-7959c) before you file your first claim.
+        </li>
+      </ul>
+
+      {contentBeforeButtons}
+      <FormNavButtonContinue goForward={goForward} useWebComponents />
+      {contentAfterButtons}
+    </>
+  );
+};
+
+MedicareIntroduction.propTypes = {
+  contentAfterButtons: PropTypes.element,
+  contentBeforeButtons: PropTypes.element,
+  goForward: PropTypes.func,
+};
+
+export default MedicareIntroduction;

--- a/src/applications/ivc-champva/10-10d-extended/components/FormPages/OhiIntroduction.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormPages/OhiIntroduction.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormNavButtonContinue } from 'platform/forms-system/src/js/components/FormNavButtons';
+
+const OhiIntroduction = props => {
+  const { contentAfterButtons, contentBeforeButtons, goForward } = props;
+  return (
+    <>
+      <h1 className="vads-u-color--black vads-u-margin-top--0 mobile-lg:vads-u-font-size--h2 vads-u-font-size--h3">
+        Submit your Other Health Insurance Certification (VA Form 10-7959c)
+      </h1>
+      <h2 className="vads-u-margin-bottom--4 mobile-lg:vads-u-font-size--h3 vads-u-font-size--h4">
+        Report Medicare and other health insurance
+      </h2>
+      <p>
+        We’ll now ask you questions about Medicare and any other health
+        insurance you have. We need this information to process your application
+        for CHAMPVA benefits.
+      </p>
+      <p>
+        <strong>What to know before filling out this form</strong>
+      </p>
+      <ul className="vads-u-margin-bottom--4">
+        <li>
+          <strong>If you have Medicare or other health insurance</strong>,
+          you’ll need to submit the front and back of your Medicare or other
+          health insurance cards or documents about your coverage.
+        </li>
+        <li>
+          <strong>If you don’t have Medicare or other health insurance</strong>,
+          you won’t need to submit additional information.
+        </li>
+      </ul>
+
+      {contentBeforeButtons}
+      <FormNavButtonContinue goForward={goForward} useWebComponents />
+      {contentAfterButtons}
+    </>
+  );
+};
+
+OhiIntroduction.propTypes = {
+  contentAfterButtons: PropTypes.element,
+  contentBeforeButtons: PropTypes.element,
+  goForward: PropTypes.func,
+};
+
+export default OhiIntroduction;

--- a/src/applications/ivc-champva/10-10d-extended/components/FormPages/OtherHealthInsuranceInformation.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormPages/OtherHealthInsuranceInformation.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormNavButtonContinue } from 'platform/forms-system/src/js/components/FormNavButtons';
+
+const OtherHealthInsuranceInformation = props => {
+  const { contentAfterButtons, contentBeforeButtons, goForward } = props;
+  return (
+    <>
+      <h1 className="vads-u-color--black vads-u-margin-top--0 mobile-lg:vads-u-font-size--h2 vads-u-font-size--h3">
+        Report other health insurance
+      </h1>
+      <p className="vads-u-margin-top--4">
+        Now we’ll ask you about current health insurance policies that the
+        applicants listed on this application have. This information ensures
+        accurate payment processing.
+      </p>
+      <p className="vads-u-margin-bottom--4">
+        You can also include past policies that were active during the time that
+        you first became eligible to apply for CHAMPVA. You can submit claims
+        for care you received up to 180 days after you receive your CHAMPVA
+        welcome packet.
+      </p>
+
+      {contentBeforeButtons}
+      <FormNavButtonContinue goForward={goForward} useWebComponents />
+      {contentAfterButtons}
+    </>
+  );
+};
+
+OtherHealthInsuranceInformation.propTypes = {
+  contentAfterButtons: PropTypes.element,
+  contentBeforeButtons: PropTypes.element,
+  goForward: PropTypes.func,
+};
+
+export default OtherHealthInsuranceInformation;

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -40,6 +40,7 @@ import {
 import { healthInsurancePages } from '../chapters/healthInsuranceInformation';
 import OhiIntroduction from '../components/FormPages/OhiIntroduction';
 import MedicareIntroduction from '../components/FormPages/MedicareIntroduction';
+import OtherHealthInsuranceInformation from '../components/FormPages/OtherHealthInsuranceInformation';
 import AddressSelectionPage, {
   NOT_SHARED,
 } from '../components/FormPages/AddressSelectionPage';
@@ -220,7 +221,7 @@ const formConfig = {
       pages: applicantPages,
     },
     medicareInformation: {
-      title: 'Medicare information',
+      title: 'Other Health Insurance Certification: Medicare information',
       pages: {
         ohiIntro: {
           path: 'medicare-and-other-health-insurance',
@@ -244,8 +245,19 @@ const formConfig = {
       },
     },
     healthInsuranceInformation: {
-      title: 'Health insurance information',
-      pages: healthInsurancePages,
+      title:
+        'Other Health Insurance Certification: Health insurance information',
+      pages: {
+        healthInsuranceIntro: {
+          path: 'other-health-insurance-introduction',
+          title: 'Report other health insurance',
+          CustomPage: OtherHealthInsuranceInformation,
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: blankSchema,
+        },
+        ...healthInsurancePages,
+      },
     },
   },
 };

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -38,6 +38,8 @@ import {
   medicareProofOfIneligibilityPage,
 } from '../chapters/medicareInformation';
 import { healthInsurancePages } from '../chapters/healthInsuranceInformation';
+import OhiIntroduction from '../components/FormPages/OhiIntroduction';
+import MedicareIntroduction from '../components/FormPages/MedicareIntroduction';
 import AddressSelectionPage, {
   NOT_SHARED,
 } from '../components/FormPages/AddressSelectionPage';
@@ -220,6 +222,22 @@ const formConfig = {
     medicareInformation: {
       title: 'Medicare information',
       pages: {
+        ohiIntro: {
+          path: 'medicare-and-other-health-insurance',
+          title: 'Report Medicare and other health insurance',
+          CustomPage: OhiIntroduction,
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: blankSchema,
+        },
+        medicareIntro: {
+          path: 'medicare-introduction',
+          title: 'Report Medicare',
+          CustomPage: MedicareIntroduction,
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: blankSchema,
+        },
         ...medicarePages,
         page22: medicareStatusPage,
         page23: medicareProofOfIneligibilityPage,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds two custom content pages for the OHI section of the app. The one intro page covers the entire OHI section, while the other is an intro with Medicare-specific data.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#121140

## Testing done

- N/A

## Screenshots

| OHI intro | Medicare intro |
| ------ | ----- |
| <img width="532" height="553" alt="Screenshot 2025-10-16 at 15 58 35" src="https://github.com/user-attachments/assets/6091df30-21d6-43bb-9528-485c15c5354e" /> | <img width="532" height="444" alt="Screenshot 2025-10-16 at 15 58 15" src="https://github.com/user-attachments/assets/c02cb549-865a-479e-9e2c-1c44a2ca0d6b" /> |

## Acceptance criteria

 - Content meets C/IA standards

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user