### PR TITLE
fix(scroll): prevent scroll when focusing on target element in scrollAndFocus function

### DIFF
--- a/src/platform/utilities/scroll/scroll.js
+++ b/src/platform/utilities/scroll/scroll.js
@@ -178,7 +178,7 @@ export const scrollAndFocus = (target, options) =>
   new Promise(resolve => {
     if (target) {
       scrollTo(target, options);
-      focusElement(target);
+      focusElement(target, { preventScroll: true });
     }
     resolve();
   });

--- a/src/platform/utilities/tests/scroll.unit.spec.jsx
+++ b/src/platform/utilities/tests/scroll.unit.spec.jsx
@@ -618,6 +618,7 @@ describe('scrollAndFocus', () => {
       behavior: 'smooth',
     });
     expect(focusSpy.args[0][0].id).to.eq('second');
+    expect(focusSpy.args[0][1]).to.deep.equal({ preventScroll: true });
     focusSpy.restore();
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
The change adds { preventScroll: true } option to the focusElement() call within the scrollAndFocus function.
What it fixes:
Prevents double-scrolling behavior that can occur when focusing an element
The function was calling scrollTo(target) to scroll to the element, but then focusElement(target) would trigger the browser's default behavior of scrolling to the focused element again
By adding [preventScroll](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#preventscroll): true, the focus is set without triggering additional automatic scrolling

Result:
The element is scrolled to once (via the explicit scrollTo call) and then focused without additional scroll movement, providing smoother and more predictable scroll behavior.
This is a fix for a scroll-with-focus conflict where the two operations were interfering with each other.

## Related issue(s)
discovered while working on the ticket
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121299
Ticket:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122553

## Testing done

- old behavior:
  - when scrolling to an anchor link using the scrollAndFocus method, it would smoothly scroll the element as long as the element was in view, otherwise would immediately bring the element into view or stop part of the way. I assume there was a race condition of how long the scrollTo was taking to scroll vs the call to focus(). 
  - steps to verify:
    1. checkout main and run mock data server and cst entry point:
        ```
        yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
        yarn watch --env entry=claims-status
        ```
    1. Upload any document to show the confirmation alert (resulting from a mocked endpoint)
    <img width="821" height="366" alt="Screenshot 2025-10-16 at 3 39 43 PM" src="https://github.com/user-attachments/assets/0d6a03f0-5135-4e85-84e4-94c9d7109313" />
    2. With zoom at 100%, click the link in the alert "Check the status of your submission" which prevents default click action and uses the scrollAndFocus function from platform utilities on click. It should smoothly scroll to the File submissions in progress section.
    3. Set zoom to 125% and click the link again. It should immediately jump to the section or start to scroll and be interrupted before bringing the section to the top of the page. 
    4. Zoom in more and try and see same buggy behavior. 

- new behavior:
  - scrolls and focuses the element but do not use the focus function to do the scrolling that is already being done by the call to scrollTo 
  - steps to verify:
    1. checkout this branch and run mock data server and cst entry point:
        ```
        yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
        yarn watch --env entry=claims-status
        ```
    1. Upload any document to show the confirmation alert (resulting from a mocked endpoint)
    2. With zoom at 100%, click the link in the alert. It should smoothly scroll to the `File submissions in progress` section.
    3. Repeat at any zoom level, and it should smoothly scroll to the section.

## Screenshots
NA

## What areas of the site does it impact?
Any code that calls the scrollAndFocus method will be affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
