### PR TITLE
21P-8416 update submit url to match new vets-api endpoint

### DIFF
--- a/src/applications/medical-expense-report/config/form.js
+++ b/src/applications/medical-expense-report/config/form.js
@@ -27,7 +27,7 @@ import uploadDocuments from './chapters/03-additional-information/uploadDocument
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/v0/api/medical_expense_reports`,
+  submitUrl: `${environment.API_URL}/medical_expense_reports/v0/form8416`,
   submit,
   trackingPrefix: 'med-expense-8416',
   v3SegmentedProgressBar: true,

--- a/src/applications/medical-expense-report/config/submit.js
+++ b/src/applications/medical-expense-report/config/submit.js
@@ -40,7 +40,7 @@ export function transform(formConfig, form) {
 export async function submit(
   form,
   formConfig,
-  apiPath = '/v0/api/medical_expense_reports',
+  apiPath = '/medical_expense_reports/v0/form8416',
 ) {
   const headers = { 'Content-Type': 'application/json' };
   const body = transform(formConfig, form);

--- a/src/applications/medical-expense-report/tests/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/medical-expense-report/tests/fixtures/mocks/local-mock-responses.js
@@ -61,7 +61,7 @@ const responses = {
       },
     });
   },
-  'POST /v0/api/medical_expense_reports': (req, res) => {
+  'POST /medical_expense_reports/v0/form8416': (req, res) => {
     return res.json({
       formSubmissionId: '123fake-submission-id-567',
       confirmationNumber: '123fake-submission-id-567',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update the submit url for the form to match new vets-api endpoint

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122498

## Testing done

- Mocks updated, need to test on staging where it was failing. 

## Screenshots
N/A

## What areas of the site does it impact?

Just 8416 medical expense form.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
