### PR TITLE
21P-8416 change upload size limit to 99mb in kb

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/03-additional-information/uploadDocuments.js
+++ b/src/applications/medical-expense-report/config/chapters/03-additional-information/uploadDocuments.js
@@ -6,9 +6,6 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import environment from 'platform/utilities/environment';
 
-const MAX_FILE_SIZE_MB = 20;
-const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2;
-
 const UploadMessage = (
   <p>
     <strong>Note:</strong> You can choose to submit your supporting documents
@@ -29,7 +26,7 @@ export default {
         'You can upload a .pdf, .jpg, .jpeg, or .png file. Your file should be no larger than 50 MB (non-PDF) or 99 MB (PDF only).',
       required: false,
       fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
-      maxSize: MAX_FILE_SIZE_BYTES,
+      maxFileSize: 103809024, // 99 MB for PDFs
       accept: '.pdf,.jpg,.jpeg,.png',
       formNumber: '21P-8416',
     }),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The file size limit was set too small and only pngs seemed to pass it. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122362

## Testing done

- Manually tested multiple different file types and some files that were previously failing.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="702" height="412" alt="502011969-7f2b1aa6-7f92-4496-b0bf-95cda55ad1c8" src="https://github.com/user-attachments/assets/baf1eb24-7f22-49d5-9f5e-f2e8ab767091" /> | <img width="589" height="897" alt="Screenshot 2025-10-17 at 12 27 15 PM" src="https://github.com/user-attachments/assets/c5f88591-8dae-4893-8c2e-b45597981e6e" /> <img width="721" height="753" alt="Screenshot 2025-10-17 at 12 27 28 PM" src="https://github.com/user-attachments/assets/d0b29f2e-d2f6-4ead-85ea-e65ee4a35ca3" /> |

## What areas of the site does it impact?

This only updates the upload field on the 8416 form. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
