### PR TITLE
arc/update_vets_json_schema_to_25_2_13

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#14254416545e9d35bc4f4924248d0d564360dd2e",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6967c515bdaf1e140e05c5e24534c3a023b7e105",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22724,9 +22724,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#14254416545e9d35bc4f4924248d0d564360dd2e":
-  version "25.2.12"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#14254416545e9d35bc4f4924248d0d564360dd2e"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6967c515bdaf1e140e05c5e24534c3a023b7e105":
+  version "25.2.13"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6967c515bdaf1e140e05c5e24534c3a023b7e105"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Summary

- Updated the vets-json-schema version number. Following up here. See related PRs below

## Related issue(s)

- json schema - https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1067

- vets-api - https://github.com/department-of-veterans-affairs/vets-api/pull/24694