### PR TITLE
updates broken link in terms of use

### DIFF
--- a/src/applications/terms-of-use/touData.jsx
+++ b/src/applications/terms-of-use/touData.jsx
@@ -247,7 +247,7 @@ export default [
             an individual as permitted by law and as outlined in the Veterans
             Health Administration (VHA) notice of privacy practices.{' '}
             <a
-              href="https://www.va.gov/files/2022-10/10-163p_(004)_-Notices_of_Privacy_Practices-_PRINT_ONLY.pdf"
+              href="https://www.va.gov/files/2025-10/NOPP_IB_163p_Revisions_Final_30SEP2025.pdf"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- update broken link on `/terms-of-use`

## Related issue(s)

- (Slack thread)[https://dsva.slack.com/archives/CSFV4QTKN/p1760731285684649]

## What areas of the site does it impact?

- `/terms-of-use`

## Acceptance criteria

- replace VHA notice of privacy link with new URL
