### PR TITLE
21p 8416 step3 conditional flow

### DIFF
--- a/src/applications/medical-expense-report/components/ActionLink.jsx
+++ b/src/applications/medical-expense-report/components/ActionLink.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import { VaLinkAction } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const ActionLink = ({ path, router, primary, onClick, ...props }) => {
+  const href = path?.charAt(0) === '/' ? path : `/${path}`;
+
+  return (
+    <VaLinkAction
+      {...props}
+      href={href}
+      onClick={event => {
+        event.preventDefault();
+
+        if (onClick) {
+          onClick(event);
+        }
+
+        if (path && router) {
+          router.push(path);
+        }
+      }}
+      type={primary ? 'primary' : 'secondary'}
+    />
+  );
+};
+
+ActionLink.propTypes = {
+  path: PropTypes.string,
+  primary: PropTypes.bool,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+  onClick: PropTypes.func,
+};
+
+export default withRouter(ActionLink);

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/expensesReview.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/expensesReview.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import ActionLink from '../../../components/ActionLink';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Review expenses',
+  path: 'expenses/review',
+  uiSchema: {
+    ...titleUI('Review the expenses you’re submitting'),
+    'view:noExpensesAlert': {
+      'ui:description': (
+        <>
+          <va-alert status="warning">
+            <h3 slot="headline">You didn't report any expenses</h3>
+            <p className="vads-u-margin-y--0">
+              We may adjust your benefits based on any expenses you report. If
+              you want to report expenses, go back and add them to the form.
+            </p>
+          </va-alert>
+          <div className="vads-u-margin-top--3">
+            <ActionLink
+              path="expenses/care/add"
+              primary
+              text="Add an expense"
+            />
+          </div>
+        </>
+      ),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      'view:noExpensesAlert': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/helpers.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/helpers.js
@@ -5,3 +5,27 @@ export const transformDate = dateStr => {
   const date = parseISO(dateStr);
   return format(date, 'MM/dd/yyyy');
 };
+
+/**
+ * @param formData
+ * @returns boolean - true if no expenses have been added, false otherwise.
+ */
+export const hasNoExpenses = formData => {
+  const careExpenses = formData.careExpenses || [];
+  const medicalExpenses = formData.medicalExpenses || [];
+  const mileageExpenses = formData.mileageExpenses || [];
+  return (
+    careExpenses.length === 0 &&
+    medicalExpenses.length === 0 &&
+    mileageExpenses.length === 0
+  );
+};
+
+/**
+ * @param formData
+ * @returns boolean - true if care expenses, false otherwise.
+ */
+export const hasCareExpenses = formData => {
+  const careExpenses = formData.careExpenses || [];
+  return careExpenses.length > 0;
+};

--- a/src/applications/medical-expense-report/config/chapters/03-additional-information/supportingDocuments.js
+++ b/src/applications/medical-expense-report/config/chapters/03-additional-information/supportingDocuments.js
@@ -15,15 +15,15 @@ const SupportingDocumentsContent = (
     <ul>
       <li>
         <va-link
-          href="#"
-          text="Residential Care, Adult Daycare, or a Similar Facility worksheet (opens in a new tab)"
+          href="https://www.va.gov/find-forms/about-form-21p-8416/"
+          text="Residential Care, Adult Daycare, or a Similar Facility worksheet"
           external
         />
       </li>
       <li>
         <va-link
-          href="#"
-          text="In-Home Attendant Expenses worksheet (opens in a new tab)"
+          href="https://www.va.gov/find-forms/about-form-21p-8416/"
+          text="In-Home Attendant Expenses worksheet"
           external
         />
       </li>
@@ -40,7 +40,7 @@ const SupportingDocumentsContent = (
         and Attendance (
         <va-link
           href="https://www.va.gov/find-forms/about-form-21-0779/"
-          text="VA Form 21-0779 (opens in a new tab)"
+          text="VA Form 21-0779"
           external
         />
         )
@@ -50,7 +50,7 @@ const SupportingDocumentsContent = (
         Attendance form (
         <va-link
           href="https://www.va.gov/find-forms/about-form-21-2680/"
-          text="VA Form 21-2680 (opens in a new tab)"
+          text="VA Form 21-2680"
           external
         />
         )

--- a/src/applications/medical-expense-report/config/chapters/03-additional-information/supportingDocuments.js
+++ b/src/applications/medical-expense-report/config/chapters/03-additional-information/supportingDocuments.js
@@ -1,226 +1,81 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 
-export const childAttendsCollege = child => child.attendingCollege;
-export const childIsDisabled = child => child.disabled;
-export const childIsAdopted = child => child.childRelationship === 'ADOPTED';
-
-const SupportingDocument = ({ formId, formName }) => (
-  <li>
-    A completed {formName} (VA Form {formId})<br />
-    <va-link
-      href={`https://www.va.gov/find-forms/about-form-${formId.toLowerCase()}`}
-      external
-      text={`Get VA Form ${formId} to download`}
-    />
-  </li>
-);
-
-SupportingDocument.propTypes = {
-  formId: PropTypes.string.isRequired,
-  formName: PropTypes.string.isRequired,
-};
-
-const SpecialMonthlyPensionAccordionItems = () => (
+const SupportingDocumentsContent = (
   <>
-    <va-accordion-item header="If you need the help of another person for daily living">
-      <p>
-        You’ll need to submit evidence that shows one of these is true:
-        <ul>
-          <li>
-            You need another person to help you perform daily activities, like
-            bathing, feeding, and dressing, <strong>or</strong>
-          </li>
-          <li>
-            You have to stay in bed—or spend a large portion of the day in
-            bed—because of illness, <strong>or</strong>
-          </li>
-          <li>
-            You’re a patient in a nursing home due to the loss of mental or
-            physical abilities related to a disability, <strong>or</strong>
-          </li>
-          <li>
-            Your eyesight is limited (even with glasses or contact lenses you
-            have only 5/200 or less in both eyes, or concentric contraction of
-            the visual field to 5 degrees or less)
-          </li>
-        </ul>
-      </p>
-    </va-accordion-item>
-    <va-accordion-item header="If you’re housebound and you live independently ">
-      <p>
-        You’ll need to submit additional evidence that shows one of these is
-        true:
-        <ul>
-          <li>
-            You have a single, permanent disability that’s rated as 100%
-            disabling, and this means you’ll always need to be in your home or
-            another living space most of the time, <strong>or</strong>
-          </li>
-          <li>
-            You have a single, permanent disability rated as 100% disabling and
-            at least one other disability rated as 60% or more disabling
-          </li>
-        </ul>
-      </p>
-    </va-accordion-item>
+    <p>
+      On the next screen, we’ll ask you to submit supporting documents and
+      additional evidence for your expenses. If you upload all of this
+      information online now, you may be able to get a faster decision for your
+      claim.
+    </p>
+
+    <p>You’ll need to submit one of these supporting documents:</p>
+
+    <ul>
+      <li>
+        <va-link
+          href="#"
+          text="Residential Care, Adult Daycare, or a Similar Facility worksheet (opens in a new tab)"
+          external
+        />
+      </li>
+      <li>
+        <va-link
+          href="#"
+          text="In-Home Attendant Expenses worksheet (opens in a new tab)"
+          external
+        />
+      </li>
+    </ul>
+
+    <p>
+      If you have nursing home expenses, you may need to submit one of these
+      supporting documents:
+    </p>
+
+    <ul>
+      <li>
+        Request for Nursing Home Information in Connection with Claim for Aid
+        and Attendance (
+        <va-link
+          href="https://www.va.gov/find-forms/about-form-21-0779/"
+          text="VA Form 21-0779 (opens in a new tab)"
+          external
+        />
+        )
+      </li>
+      <li>
+        Examination for Housebound Status or Permanent Need for Regular Aid and
+        Attendance form (
+        <va-link
+          href="https://www.va.gov/find-forms/about-form-21-2680/"
+          text="VA Form 21-2680 (opens in a new tab)"
+          external
+        />
+        )
+      </li>
+    </ul>
   </>
 );
 
-function Documents({ formData }) {
-  const hasDisabledChild = (formData.dependents || []).some(childIsDisabled);
-  const hasSchoolChild = (formData.dependents || []).some(childAttendsCollege);
-  const hasAdoptedChild = (formData.dependents || []).some(childIsAdopted);
-  const hasSpecialMonthlyPension = formData.specialMonthlyPension;
-  const hasSocialSecurityDisability = formData.socialSecurityDisability;
-  const livesInNursingHome = formData.nursingHome;
-  const assetsOverThreshold = formData.totalNetWorth; // over $25,000 in assets
-  const homeAcreageMoreThanTwo =
-    formData.homeOwnership && formData.homeAcreageMoreThanTwo;
-  const hasTransferredAssets = formData.transferredAssets;
-  const needsIncomeAndAssetStatement =
-    assetsOverThreshold || homeAcreageMoreThanTwo || hasTransferredAssets;
-
-  const showDocumentsList =
-    hasSchoolChild ||
-    hasSpecialMonthlyPension ||
-    livesInNursingHome ||
-    needsIncomeAndAssetStatement;
-
-  const showAccordionsList =
-    hasAdoptedChild ||
-    hasDisabledChild ||
-    hasSocialSecurityDisability ||
-    hasSpecialMonthlyPension;
-
-  return (
-    <>
-      {showDocumentsList && (
-        <>
-          <p> You'll need to submit these supporting documents: </p>
-          <ul data-testid="supporting-documents-list">
-            {hasSpecialMonthlyPension && (
-              <SupportingDocument
-                formName="Examination for Housebound Status or Permanent Need
-          for Regular Aid and Attendance"
-                formId="21-2680"
-              />
-            )}
-            {livesInNursingHome && (
-              <SupportingDocument
-                formName="Request for Nursing Home Information in Connection
-          with Claim for Aid and Attendance"
-                formId="21-0779"
-              />
-            )}
-            {hasSchoolChild && (
-              <SupportingDocument
-                formName="Request for Approval of School Attendance"
-                formId="21-674"
-              />
-            )}
-            {needsIncomeAndAssetStatement && (
-              <SupportingDocument
-                formName="Income and Asset Statement in Support of Claim for
-          Pension or Parents' Dependency and Indemnity Compensation"
-                formId="21P-0969"
-              />
-            )}
-          </ul>
-        </>
-      )}
-
-      {showAccordionsList && (
-        <>
-          <p className="vads-u-margin-top--6">
-            You’ll also need to submit certain additional evidence depending on
-            your situation.
-          </p>
-          <va-accordion data-testid="additional-evidence-list">
-            {hasAdoptedChild && (
-              <va-accordion-item header="If you have any dependent children who are adopted">
-                <p>You’ll need to submit copies of one of these documents:</p>
-                <ul>
-                  <li>
-                    Adoption papers, <strong>or</strong>
-                  </li>
-                  <li>An amended birth certificate</li>
-                </ul>
-              </va-accordion-item>
-            )}
-            {hasDisabledChild && (
-              <va-accordion-item header="If you have any dependent children who are seriously disabled">
-                <p>
-                  You’ll need to submit medical evidence that shows the child
-                  became permanently disabled because of a physical or mental
-                  disability before their 18th birthday.
-                </p>
-                <p>
-                  The medical evidence you submit will need to show the nature
-                  and extent of the child’s disability. You can submit these
-                  types of medical evidence:
-                </p>
-                <ul>
-                  <li>Doctor’s reports</li>
-                  <li>Medical labs</li>
-                  <li>Test results</li>
-                </ul>
-              </va-accordion-item>
-            )}
-            {hasSocialSecurityDisability && (
-              <va-accordion-item header="If you receive Social Security disability payments">
-                <p>
-                  You’ll need to submit additional evidence that shows one of
-                  these is true:
-                </p>
-                <ul>
-                  <li>
-                    You’re unemployed due to a permanent disability (a
-                    disability that’s not expected to improve),{' '}
-                    <strong>or</strong>
-                  </li>
-                  <li>
-                    You have a permanent and total disability (a disability that
-                    we’ve rated as 100% disabling and that’s not expected to
-                    improve)
-                  </li>
-                </ul>
-              </va-accordion-item>
-            )}
-            {hasSpecialMonthlyPension && (
-              <SpecialMonthlyPensionAccordionItems />
-            )}
-          </va-accordion>
-        </>
-      )}
-    </>
-  );
-}
-
-Documents.propTypes = {
-  formData: PropTypes.shape({
-    dependents: PropTypes.arrayOf(PropTypes.object),
-    specialMonthlyPension: PropTypes.bool,
-    socialSecurityDisability: PropTypes.bool,
-    nursingHome: PropTypes.bool,
-    totalNetWorth: PropTypes.bool,
-    homeOwnership: PropTypes.bool,
-    homeAcreageMoreThanTwo: PropTypes.bool,
-    transferredAssets: PropTypes.bool,
-  }).isRequired,
-};
-
+/** @type {PageSchema} */
 export default {
+  title: 'Supporting documents',
+  path: 'expenses/additional-information/supporting-documents',
   uiSchema: {
-    ...titleUI(
-      'Supporting documents',
-      'On the next screen, we’ll ask you to submit supporting documents and additional evidence for your pension claim. If you upload all this information online now, you may be able to get a faster decision on your claim.',
-    ),
-    'ui:description': Documents,
+    ...titleUI('Supporting documents'),
+    'view:supportingDocuments': {
+      'ui:description': SupportingDocumentsContent,
+    },
   },
   schema: {
     type: 'object',
-    properties: {},
+    properties: {
+      'view:supportingDocuments': {
+        type: 'object',
+        properties: {},
+      },
+    },
   },
 };

--- a/src/applications/medical-expense-report/config/form.js
+++ b/src/applications/medical-expense-report/config/form.js
@@ -22,7 +22,26 @@ import { medicalExpensesPages } from './chapters/02-expenses/medicalExpensesPage
 import { mileageExpensesPages } from './chapters/02-expenses/mileageExpensesPage';
 import supportingDocuments from './chapters/03-additional-information/supportingDocuments';
 import uploadDocuments from './chapters/03-additional-information/uploadDocuments';
+import expensesReview from './chapters/02-expenses/expensesReview';
 import GetFormHelp from '../components/GetFormHelp';
+
+// Helper function to check if no expenses have been added
+const hasNoExpenses = formData => {
+  const careExpenses = formData.careExpenses || [];
+  const medicalExpenses = formData.medicalExpenses || [];
+  const mileageExpenses = formData.mileageExpenses || [];
+  return (
+    careExpenses.length === 0 &&
+    medicalExpenses.length === 0 &&
+    mileageExpenses.length === 0
+  );
+};
+
+// Helper function to check if user has care expenses
+const hasCareExpenses = formData => {
+  const careExpenses = formData.careExpenses || [];
+  return careExpenses.length > 0;
+};
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -127,6 +146,13 @@ const formConfig = {
         ...careExpensesPages,
         ...medicalExpensesPages,
         ...mileageExpensesPages,
+        expensesReview: {
+          title: 'Review expenses',
+          path: 'expenses/review',
+          depends: formData => hasNoExpenses(formData),
+          uiSchema: expensesReview.uiSchema,
+          schema: expensesReview.schema,
+        },
       },
     },
     additionalInformation: {
@@ -135,12 +161,14 @@ const formConfig = {
         supportingDocuments: {
           title: 'Supporting documents',
           path: 'expenses/additional-information/supporting-documents',
+          depends: formData => hasCareExpenses(formData),
           uiSchema: supportingDocuments.uiSchema,
           schema: supportingDocuments.schema,
         },
         uploadDocuments: {
           title: 'Upload documents',
           path: 'expenses/additional-information/upload-documents',
+          depends: formData => !hasNoExpenses(formData),
           uiSchema: uploadDocuments.uiSchema,
           schema: uploadDocuments.schema,
         },

--- a/src/applications/medical-expense-report/config/form.js
+++ b/src/applications/medical-expense-report/config/form.js
@@ -24,24 +24,7 @@ import supportingDocuments from './chapters/03-additional-information/supporting
 import uploadDocuments from './chapters/03-additional-information/uploadDocuments';
 import expensesReview from './chapters/02-expenses/expensesReview';
 import GetFormHelp from '../components/GetFormHelp';
-
-// Helper function to check if no expenses have been added
-const hasNoExpenses = formData => {
-  const careExpenses = formData.careExpenses || [];
-  const medicalExpenses = formData.medicalExpenses || [];
-  const mileageExpenses = formData.mileageExpenses || [];
-  return (
-    careExpenses.length === 0 &&
-    medicalExpenses.length === 0 &&
-    mileageExpenses.length === 0
-  );
-};
-
-// Helper function to check if user has care expenses
-const hasCareExpenses = formData => {
-  const careExpenses = formData.careExpenses || [];
-  return careExpenses.length > 0;
-};
+import { hasNoExpenses, hasCareExpenses } from './chapters/02-expenses/helpers';
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -168,7 +151,6 @@ const formConfig = {
         uploadDocuments: {
           title: 'Upload documents',
           path: 'expenses/additional-information/upload-documents',
-          depends: formData => !hasNoExpenses(formData),
           uiSchema: uploadDocuments.uiSchema,
           schema: uploadDocuments.schema,
         },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request adds a new alert page when no expenses are added, and a refactors the supporting documents page to provide clearer instructions. Added new helper functions to help determine the navigational workflow of the form.

**Navigation improvements**
* Added a new `ActionLink` React component to standardize navigation and support routing within the app. (`src/applications/medical-expense-report/components/ActionLink.jsx`)
* Introduced an "expenses review" page that alerts users when no expenses have been reported and provides a clear call-to-action to add expenses.

**Conditional Page Display Logic**
* Added helper functions `hasNoExpenses` and `hasCareExpenses` to determine whether to show the expenses review and supporting documents pages, respectively, based on user input. (`src/applications/medical-expense-report/config/chapters/02-expenses/helpers.js`)
* Updated the form configuration to use these helper functions for conditional page display: the expenses review page is shown only if no expenses are reported, and the supporting documents page is shown only if care expenses exist. (`src/applications/medical-expense-report/config/form.js`) [[1]](diffhunk://#diff-b046d43206703dddea2cb0c1ef1876e5b817604b5c9a6a041a82f8d227db01dbR25-R27) [[2]](diffhunk://#diff-b046d43206703dddea2cb0c1ef1876e5b817604b5c9a6a041a82f8d227db01dbR132-R138) [[3]](diffhunk://#diff-b046d43206703dddea2cb0c1ef1876e5b817604b5c9a6a041a82f8d227db01dbR147)

**Supporting Documents Page Refactor**
* Refactored the supporting documents page to provide clearer instructions and simplified content, removing complex conditional rendering and accordion sections. The new content lists required documents and links for users in a more straightforward manner. (`src/applications/medical-expense-report/config/chapters/03-additional-information/supportingDocuments.js`)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team/issues/122451

## Testing done

Previously users were not presented with an alert/notification if no expenses are added. If care expenses existed the user was not provided with details on support documents. Now we have a dedicated page with an alert and a way for the user to quickly navigate back to the expenses portion of the form or to move forward without. To test this we performed the following manual steps to confirm functionality. 
- If the user adds ONLY medical and mileage you skip right on through to upload document
- If the user adds care expenses (regardless of if they do or do not add either of the other two types of expenses) we show them the Supporting documents page
- If the user doesn't add any of the 3 types of expenses we show them the new Warning alert screen and allow them to upload documents just in case they have any. 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |N/A| <img width="664" height="808" alt="image" src="https://github.com/user-attachments/assets/3e453ffa-aeff-4e8d-ac66-df864b1283d4" />|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
