### PR TITLE
Add Primary Care Mental Health Initiative as a supported MH service

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.jsx
@@ -189,7 +189,10 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
       const store = createTestStore(defaultState);
       await setTypeOfCare(store, /mental health/i);
-      await setTypeOfMentalHealth(store, /Mental health services/);
+      await setTypeOfMentalHealth(
+        store,
+        /Mental health care with a specialist/,
+      );
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -1010,7 +1013,10 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
         const store = createTestStore(defaultState);
         await setTypeOfCare(store, /mental health/i);
-        await setTypeOfMentalHealth(store, /Mental health services/);
+        await setTypeOfMentalHealth(
+          store,
+          /Mental health care with a specialist/,
+        );
 
         // Act
         const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -1075,7 +1081,10 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
         const store = createTestStore(defaultState);
         await setTypeOfCare(store, /mental health/i);
-        await setTypeOfMentalHealth(store, /Mental health services/);
+        await setTypeOfMentalHealth(
+          store,
+          /Mental health care with a specialist/,
+        );
 
         // Act
         const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -1145,7 +1154,10 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
           featureToggles: {},
         });
         await setTypeOfCare(store, /mental health/i);
-        await setTypeOfMentalHealth(store, /Mental health services/);
+        await setTypeOfMentalHealth(
+          store,
+          /Mental health care with a specialist/,
+        );
 
         // Act
         const screen = renderWithStoreAndRouter(<VAFacilityPage />, {

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -3,6 +3,7 @@ import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring
 import {
   selectFeatureOHDirectSchedule,
   selectFeatureOHRequest,
+  selectFeaturePCMHI,
   selectFeatureSubstanceUseDisorder,
   selectRegisteredCernerFacilityIds,
 } from '../redux/selectors';
@@ -299,7 +300,10 @@ export default function getNewAppointmentFlow(state) {
         }
         if (isMentalHealth(state)) {
           dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-          if (selectFeatureSubstanceUseDisorder(state)) {
+          if (
+            selectFeatureSubstanceUseDisorder(state) ||
+            selectFeaturePCMHI(state)
+          ) {
             return 'typeOfMentalHealth';
           }
           return VA_FACILITY_V2_KEY;

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -64,8 +64,8 @@ export function getTypeOfCare(data) {
   if (data.typeOfCareId === TYPE_OF_CARE_IDS.MENTAL_HEALTH_ID) {
     // When featureSubstanceUseDisorder and featurePCMHI are off, there will be no
     // typeOfMentalHealthId in the form data. In this case, we should use the existing
-    // Mental Health Services type of care (stop code 502). This can be removed once
-    // the features are released.
+    // Mental health care with a specialist type of care (stop code 502). This can be
+    // removed once the features are released.
     if (!data.typeOfMentalHealthId) {
       return TYPES_OF_MENTAL_HEALTH.find(
         care => care.id === TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -62,10 +62,10 @@ export function getTypeOfCare(data) {
   }
 
   if (data.typeOfCareId === TYPE_OF_CARE_IDS.MENTAL_HEALTH_ID) {
-    // When featureSubstanceUseDisorder is off, there will be no typeOfMentalHealthId
-    // in the form data. In these cases, we should use the existing Mental Health
-    // Services type of care (stop code 502). This can be removed once the feature
-    // is released.
+    // When featureSubstanceUseDisorder and featurePCMHI are off, there will be no
+    // typeOfMentalHealthId in the form data. In this case, we should use the existing
+    // Mental Health Services type of care (stop code 502). This can be removed once
+    // the features are released.
     if (!data.typeOfMentalHealthId) {
       return TYPES_OF_MENTAL_HEALTH.find(
         care => care.id === TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -117,6 +117,9 @@ export const selectFeatureMentalHealthHistoryFiltering = state =>
 export const selectFeatureSubstanceUseDisorder = state =>
   toggleValues(state).vaOnlineSchedulingAddSubstanceUseDisorder;
 
+export const selectFeaturePCMHI = state =>
+  toggleValues(state).vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative;
+
 export const selectFeatureListViewClinicInfo = state =>
   toggleValues(state).vaOnlineSchedulingListViewClinicInfo;
 

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -18,6 +18,10 @@ module.exports = [
   { name: 'travelPaySubmitMileageExpense', value: true },
   { name: 'vaOnlineSchedulingMentalHealthHistoryFiltering', value: true },
   { name: 'vaOnlineSchedulingAddSubstanceUseDisorder', value: true },
+  {
+    name: 'vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative',
+    value: true,
+  },
   { name: 'vaOnlineSchedulingListViewClinicInfo', value: true },
   { name: 'vaOnlineSchedulingAddOhAvs', value: true },
   { name: 'vaOnlineSchedulingImmediateCareAlert', value: true },

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -859,4 +859,4 @@ const responses = {
   // End of required v0 APIs
 };
 
-module.exports = delay(responses, 100);
+module.exports = delay(responses, 1000);

--- a/src/applications/vaos/services/mocks/v2/scheduling_configurations.json
+++ b/src/applications/vaos/services/mocks/v2/scheduling_configurations.json
@@ -155,6 +155,28 @@
             }
           },
           {
+            "id": "primaryCareMentalHealth",
+            "name": "Primary Care Mental Health",
+            "stopCodes": [
+              {
+                "primary": "534"
+              }
+            ],
+            "direct": {
+              "patientHistoryRequired": true,
+              "patientHistoryDuration": 730,
+              "canCancel": true,
+              "enabled": true
+            },
+            "request": {
+              "patientHistoryRequired": false,
+              "patientHistoryDuration": 365,
+              "submittedRequestLimit": 2,
+              "enterpriseSubmittedRequestLimit": 2,
+              "enabled": false
+            }
+          },
+          {
             "id": "audiology",
             "name": "Audiology",
             "stopCodes": [

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
@@ -135,7 +135,7 @@ describe('VAOS direct schedule flow - Mental health', () => {
       mockVamcEhrApi();
     });
 
-    describe('And patient chooses mental health services', () => {
+    describe('And patient chooses mental health care with a specialist', () => {
       const { idV2: typeOfCareId, name: typeOfCareName } = getTypeOfCareById(
         TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
       );
@@ -180,7 +180,7 @@ describe('VAOS direct schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(/Mental health services/i)
+            .selectTypeOfMentalHealth(/Mental health care with a specialist/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()
@@ -264,7 +264,7 @@ describe('VAOS direct schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(/Mental health services/i)
+            .selectTypeOfMentalHealth(/Mental health care with a specialist/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()
@@ -356,6 +356,99 @@ describe('VAOS direct schedule flow - Mental health', () => {
 
           TypeOfMentalHealthPageObject.assertUrl()
             .selectTypeOfMentalHealth(/Substance use problem services/i)
+            .clickNextButton();
+
+          VAFacilityPageObject.assertUrl()
+            .assertSingleLocation({
+              locationName: /Cheyenne VA Medical Center/i,
+            })
+            .clickNextButton();
+
+          ClinicChoicePageObject.assertUrl()
+            .selectClinic({ selection: /Clinic 1/i })
+            .clickNextButton();
+
+          PreferredDatePageObject.assertUrl()
+            .typeDate()
+            .clickNextButton();
+
+          DateTimeSelectPageObject.assertUrl()
+            .selectFirstAvailableDate()
+            .clickNextButton();
+
+          ReasonForAppointmentPageObject.assertUrl()
+            .selectReasonForAppointment()
+            .typeAdditionalText({ content: 'This is a test' })
+            .clickNextButton();
+
+          ContactInfoPageObject.assertUrl()
+            .typeEmailAddress('veteran@va.gov')
+            .typePhoneNumber('5555555555')
+            .clickNextButton();
+
+          ReviewPageObject.assertUrl()
+            .assertHeading({
+              name: /Review and confirm your appointment details/i,
+            })
+            .assertSomeText({ text: typeOfCareName })
+            .clickConfirmButton();
+
+          ConfirmationPageObject.assertUrl().assertText({
+            text: /We.ve scheduled and confirmed your appointment/i,
+          });
+
+          // Assert
+          cy.axeCheckBestPractice();
+        });
+      });
+    });
+
+    describe('And patient chooses mental health care in a primary care setting services', () => {
+      const { idV2: typeOfCareId, name: typeOfCareName } = getTypeOfCareById(
+        TYPE_OF_CARE_IDS.MENTAL_HEALTH_PRIMARY_CARE_ID,
+      );
+      const typeOfCareRegex = /Mental health/i;
+
+      describe('And patient has history and one facility requires past history to schedule', () => {
+        const setup = () => {
+          mockExistingAppointments(true);
+          mocksBase(typeOfCareId, false, false, true);
+        };
+        beforeEach(setup);
+        it('should submit form', () => {
+          // Arrange
+          const mockUser = new MockUser({
+            addressLine1: '123 Main St.',
+          });
+
+          mockClinicsApi({
+            locationId: '983',
+            response: MockClinicResponse.createResponses({
+              count: 2,
+            }),
+          });
+          mockSlotsApi({
+            locationId: '983',
+            clinicId: '1',
+            response: MockSlotResponse.createResponses({
+              startTimes: [addMonths(new Date(), 1)],
+            }),
+          });
+
+          // Act
+          cy.login(mockUser);
+
+          AppointmentListPageObject.visit().scheduleAppointment();
+
+          TypeOfCarePageObject.assertUrl()
+            .assertAddressAlert({ exist: false })
+            .selectTypeOfCare(typeOfCareRegex)
+            .clickNextButton();
+
+          TypeOfMentalHealthPageObject.assertUrl()
+            .selectTypeOfMentalHealth(
+              /Mental health care in a primary care setting/i,
+            )
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
@@ -40,7 +40,7 @@ import TypeOfVisitPageObject from '../../page-objects/TypeOfVisitPageObject';
 const typeOfCareRegex = /Mental health/i;
 
 describe('VAOS request schedule flow - Mental health', () => {
-  describe('When patient chooses mental health services', () => {
+  describe('When patient chooses mental health care with a specialist', () => {
     const { idV2: typeOfCareId } = getTypeOfCareById(
       TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
     );
@@ -123,7 +123,7 @@ describe('VAOS request schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(/Mental health services/i)
+            .selectTypeOfMentalHealth(/Mental health care with a specialist/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -96,6 +96,7 @@ export const TYPE_OF_CARE_IDS = {
   AUDIOLOGY_HEARING_ID: 'CCAUDHEAR',
   PODIATRY_ID: 'tbd-podiatry',
   MENTAL_HEALTH_ID: 'MENTAL_HEALTH',
+  MENTAL_HEALTH_PRIMARY_CARE_ID: '534',
   MENTAL_HEALTH_SERVICES_ID: '502',
   MENTAL_HEALTH_SUBSTANCE_USE_ID: '513',
 };
@@ -221,16 +222,32 @@ export const TYPES_OF_EYE_CARE = [
 
 export const TYPES_OF_MENTAL_HEALTH = [
   {
+    id: TYPE_OF_CARE_IDS.MENTAL_HEALTH_PRIMARY_CARE_ID,
+    idV2: 'primaryCareMentalHealth',
+    name: 'Mental health care in a primary care setting',
+    group: 'mentalHealth',
+    description:
+      'Brief follow-up care with your primary care mental health provider for ' +
+      'concerns such as stress, anxiety, irritability, or trouble sleeping.',
+  },
+  {
     id: TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
     idV2: 'outpatientMentalHealth',
-    name: 'Mental health services',
+    name: 'Mental health care with a specialist',
     group: 'mentalHealth',
+    description:
+      'Therapy, medication, and other services to help with posttraumatic ' +
+      'stress disorder (PTSD), psychological effects of military sexual ' +
+      'trauma (MST), depression, grief, anxiety, and other needs.',
   },
   {
     id: TYPE_OF_CARE_IDS.MENTAL_HEALTH_SUBSTANCE_USE_ID,
     idV2: 'individualSubstanceUseDisorder',
     name: 'Substance use problem services',
     group: 'mentalHealth',
+    description:
+      'Counseling, recovery support, and treatment options for Veterans ' +
+      'seeking help with alcohol or other substance use.',
   },
 ];
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -236,7 +236,7 @@ export const TYPES_OF_MENTAL_HEALTH = [
     name: 'Mental health care with a specialist',
     group: 'mentalHealth',
     description:
-      'Therapy, medication, and other services to help with posttraumatic ' +
+      'For therapy, medication, and other services to help with posttraumatic ' +
       'stress disorder (PTSD), psychological effects of military sexual ' +
       'trauma (MST), depression, grief, anxiety, and other needs.',
   },
@@ -246,7 +246,7 @@ export const TYPES_OF_MENTAL_HEALTH = [
     name: 'Substance use problem services',
     group: 'mentalHealth',
     description:
-      'Counseling, recovery support, and treatment options for Veterans ' +
+      'For counseling, recovery support, and treatment options for Veterans ' +
       'seeking help with alcohol or other substance use.',
   },
 ];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -333,6 +333,7 @@
   "vaOnlineSchedulingImmediateCareAlert": "va_online_scheduling_immediate_care_alert",
   "vaOnlineSchedulingRemoveFacilityConfigCheck": "va_online_scheduling_remove_facility_config_check",
   "vaOnlineSchedulingUseBrowserTimezone": "va_online_scheduling_use_browser_timezone",
+  "vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative": "va_online_scheduling_add_primary_care_mental_health_initiative",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",
   "vetStatusPdfLogging": "vet_status_pdf_logging",
   "veteranOnboardingShowWelcomeMessageToNewUsers": "veteran_onboarding_show_welcome_message_to_new_users",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR adds Primary Care Mental Health Initiative as a mental health service option
- This option should only be available when `vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative` is enabled
- The availability of this option should be independent of the Substance Use Disorder controlled by `vaOnlineSchedulingAddSubstanceUseDisorder`
- Notes on omitted implementations from the [Figma design file](https://www.figma.com/design/HnExAM5SGNXzUlv9yRS87t/Working-File-%7C-Appointments-FE?node-id=7612-46900&t=EFeCiU2uAacPMLtX-0)
  - The "You can't schedule this appointment page" is being put on hold for now for a more comprehensive redesign, see [this comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/122167#issuecomment-3417139432).
  - Question: will the eligibility call return request is enabled for PCMHI so we need to override that in our code?
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122167

## Testing done

- Tested locally, see screenshots
- Added unit and e2e tests

## Screenshots

Flag1 =  vaOnlineSchedulingAddSubstanceUseDisorder, Flag2 = vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative

| Flag1 = false, Flag2 = false | Flag1 = true, Flag2 = false | Flag1 = false, Flag2 = true | Flag1 = true, Flag2 = true |
| ------ | ----- | ------ | ----- |
|    <img width="750" height="4832" alt="image" src="https://github.com/user-attachments/assets/d04bc30b-6949-46d9-aa63-e2436702b8c8" />   |   <img width="750" height="3968" alt="image" src="https://github.com/user-attachments/assets/84798784-29ee-47f7-9ea4-854a6cae55be" />   |   <img width="750" height="4070" alt="image" src="https://github.com/user-attachments/assets/57a86a5b-e8d1-4888-80d1-92a19828cdf0" />   |   <img width="750" height="4314" alt="image" src="https://github.com/user-attachments/assets/d4c7c48a-342b-4f96-a726-cccd29d39708" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

