### PR TITLE
Add checked-in status during fetch for OH appointments

### DIFF
--- a/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('VAOS Backend Service Alert', () => {
       start,
       end,
       response: [appointment],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       backendServiceFailures: true,
     });
 
@@ -79,7 +79,7 @@ describe('VAOS Backend Service Alert', () => {
       start,
       end,
       response: [appointment],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
     mockAppointmentsApi({
       start: subDays(now, 120),
@@ -116,7 +116,7 @@ describe('VAOS Backend Service Alert', () => {
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [appointment],
       start,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -149,7 +149,7 @@ describe('VAOS Backend Service Alert', () => {
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [appointment],
       start,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -47,21 +47,21 @@ describe('VAOS Page: AppointmentsPage', () => {
     mockAppointmentsApi({
       start: subDays(new Date(), 30),
       end: addDays(new Date(), 395),
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       response: [new MockAppointmentResponse()],
     });
     mockAppointmentsApi({
       start: subDays(new Date(), 30),
       end: addDays(new Date(), 395),
       includes: ['facilities', 'clinics', 'eps'],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       response: [new MockAppointmentResponse()],
     });
     mockAppointmentsApi({
       start: subMonths(new Date(), 3),
       end: new Date(),
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       response: [new MockAppointmentResponse()],
     });
     mockAppointmentsApi({

--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
@@ -49,7 +49,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -69,7 +69,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -99,7 +99,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     mockAppointmentsApi({
@@ -107,7 +107,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end: now,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [response],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -142,7 +142,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [response],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -194,7 +194,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [response],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -246,7 +246,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [new MockAppointmentResponse({ localStartTime: pastDate })],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -272,7 +272,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: responses,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -339,7 +339,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       start,
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       response: [response],
     });
 
@@ -381,7 +381,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       start,
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       response: [response],
     });
 

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.unit.spec.jsx
@@ -124,7 +124,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       mockAppointmentsApi({
         end: addDays(new Date(), 395),
         start: subDays(new Date(), 30),
-        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
         response: [response],
       });
 

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start,
       end,
       response: [appointment],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -93,7 +93,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start,
       end,
       response: responses,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -131,7 +131,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start,
       end,
       response: responses,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -169,7 +169,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start,
       end,
       response: responses,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     // Act
@@ -208,7 +208,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start,
       end,
       response: responses,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsPage />, {
@@ -248,7 +248,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start,
       end,
       response: responses,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsPage />, {

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -294,7 +294,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
     mockAppointmentsApi({
       start,
       end,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
     setDateTimeSelectMockFetchesDateFns({
@@ -957,7 +957,7 @@ describe('When preferred date is immediate care', () => {
       mockAppointmentsApi({
         start: subDays(new Date(), 30),
         end: addDays(new Date(), 395),
-        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       });
       mockEligibilityFetches({
         facilityId,
@@ -1117,7 +1117,7 @@ describe('When preferred date is not immediate care', () => {
       mockAppointmentsApi({
         start: subDays(new Date(), 30),
         end: addDays(new Date(), 395),
-        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       });
       mockEligibilityFetches({
         facilityId,

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -83,7 +83,7 @@ export async function fetchAppointments({
     const allAppointments = await getAppointments({
       startDate,
       endDate,
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
       avs,
       fetchClaimStatus,
       includeEPS,

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -353,7 +353,13 @@ describe('VAOS Services: Appointment ', () => {
           end: range.end,
           useRFC3339: false,
           response: [],
-          statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+          statuses: [
+            'booked',
+            'arrived',
+            'fulfilled',
+            'cancelled',
+            'checked-in',
+          ],
         });
       });
 

--- a/src/applications/vaos/tests/mocks/mockApis.js
+++ b/src/applications/vaos/tests/mocks/mockApis.js
@@ -701,7 +701,7 @@ export function mockEligibilityFetches({
       end: range.end,
       useRFC3339: false,
       response: pastClinics ? pastAppointments : [],
-      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
   });
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We need to add the 'checked-in' status to our appointments fetches to account for this status that is used for OH appointments
- United Appointments Experience
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121250

## Testing done

- Tested locally
- Updated unit tests

## Screenshots

| Before | After |
| ------ | ----- |
|    <img width="967" height="241" alt="image" src="https://github.com/user-attachments/assets/464a2ff1-8720-46af-ac2f-191b7714df0e" />   |   <img width="967" height="256" alt="image" src="https://github.com/user-attachments/assets/3b38d194-6b5c-428a-ac3f-7c8a802d8be7" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
