### PR TITLE
10-10d extended | Update sponsor address source in submit transformer

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
@@ -209,9 +209,9 @@ export default function transformForSubmit(formConfig, form) {
   // Concat streets for addresses
   const withConcatAddresses = {
     ...initialTransform,
-    sponsorAddress: initialTransform.sponsorAddress
-      ? concatStreets(initialTransform.sponsorAddress)
-      : initialTransform.sponsorAddress,
+    sponsorAddress: form.data.sponsorAddress
+      ? concatStreets(form.data.sponsorAddress)
+      : form.data.sponsorAddress,
     certifierAddress: initialTransform.certifierAddress
       ? concatStreets(initialTransform.certifierAddress)
       : initialTransform.certifierAddress,

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
@@ -108,6 +108,6 @@
     "sponsorIsDeceased": true,
     "sponsorDOD": "2001-01-01",
     "sponsorDeathConditions": false,
-    "statementOfTruthSignature": "Certifier T Jones Sr."
+    "statementOfTruthSignature": "Certifier T Jones"
   }
 }

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
@@ -345,7 +345,7 @@ describe('10-10d-extended transform for submit', () => {
   });
 
   describe('address formatting', () => {
-    it('should properly format sponsor address fields', () => {
+    it('should properly format sponsor address fields when address is not shared', () => {
       const testData = {
         data: {
           [SHARED_ADDRESS_FIELD_NAME]: NOT_SHARED,
@@ -357,6 +357,40 @@ describe('10-10d-extended transform for submit', () => {
             postalCode: '12345',
             country: 'USA',
           },
+        },
+      };
+
+      const transformed = JSON.parse(transformForSubmit(formConfig, testData));
+
+      // Verify that the street fields were combined
+      expect(transformed.veteran.address.streetCombined).to.contain(
+        '123 Main Street',
+      );
+      expect(transformed.veteran.address.streetCombined).to.contain(
+        'Apartment 4B',
+      );
+
+      // Original fields should be preserved
+      expect(transformed.veteran.address.street).to.equal('123 Main Street');
+      expect(transformed.veteran.address.street2).to.equal('Apartment 4B');
+      expect(transformed.veteran.address.city).to.equal('Anytown');
+      expect(transformed.veteran.address.state).to.equal('CA');
+      expect(transformed.veteran.address.postalCode).to.equal('12345');
+    });
+
+    it('should properly format sponsor address fields when address is shared', () => {
+      const testAddress = {
+        street: '123 Main Street',
+        street2: 'Apartment 4B',
+        city: 'Anytown',
+        state: 'CA',
+        postalCode: '12345',
+        country: 'USA',
+      };
+      const testData = {
+        data: {
+          [SHARED_ADDRESS_FIELD_NAME]: JSON.stringify(testAddress),
+          sponsorAddress: testAddress,
         },
       };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the source of the Veteran address to be from the pre-transformed form data. This issue fixes data getting stripped out based on active/inactive.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118201

## Testing done

- Prior to the update, if you select a pre-existing address and attempt to submit a failure would occur do the address getting stripped out.
- After the update, the address is maintained due to being selected from the pre-transformed dataset

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Submissions can be completed with valid data

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
