### PR TITLE
Fixed focus when specifically selecting page 1 from a list

### DIFF
--- a/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
@@ -19,27 +19,51 @@ const RecordList = props => {
 
   const history = useHistory();
   const location = useLocation();
+
+  const urlParams = new URLSearchParams(location.search);
+  const hasPageParam = urlParams.has('page');
+
   const paramPage = getParamValue(location.search, 'page');
   const [currentRecords, setCurrentRecords] = useState([]);
-  const [currentPage, setCurrentPage] = useState(paramPage);
+  const [currentPage, setCurrentPage] = useState(Number(paramPage) || 1);
   const paginatedRecords = useRef([]);
+
+  const shouldFocusShowing = useRef(false);
 
   const onPageChange = page => {
     sendDataDogAction(`Pagination - ${type}`);
-    const newURL = `${history.location.pathname}?page=${page}`;
-    history.push(newURL);
+
+    // When user clicks to a new page, focus to "Showing"
+    shouldFocusShowing.current = true;
+
+    history.push(`${history.location.pathname}?page=${page}`);
     setCurrentRecords(paginatedRecords.current[page - 1]);
-    setCurrentPage(page);
+    setCurrentPage(Number(page));
   };
+
+  useEffect(() => {
+    // On deep link to a specific page, focus to "Showing"
+    if (hasPageParam) shouldFocusShowing.current = true;
+    // We only want to set this once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // tracks url param
   useEffect(
     () => {
       const historyParamVal = getParamValue(history.location.search, 'page');
-      setCurrentRecords(paginatedRecords.current[historyParamVal - 1]);
-      setCurrentPage(historyParamVal);
+
+      const pageNum = Number(historyParamVal) || 1;
+      // Only update if it actually changed to avoid churn on the first click
+      if (pageNum !== currentPage) {
+        setCurrentRecords(paginatedRecords.current[pageNum - 1]);
+        setCurrentPage(pageNum);
+      } else {
+        // keep currentRecords in sync even if pageNum is same
+        setCurrentRecords(paginatedRecords.current[pageNum - 1]);
+      }
     },
-    [history.location.search],
+    [currentPage, history.location.search],
   );
 
   useEffect(
@@ -54,9 +78,8 @@ const RecordList = props => {
 
   useEffect(
     () => {
-      if (paramPage && records?.length) {
+      if (shouldFocusShowing.current && records?.length) {
         focusElement(document.querySelector('#showingRecords'));
-
         // calculate height of "showing records" and scrolls to it.
         const showRecordsHeight = document
           .querySelector('#showingRecords')

--- a/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
@@ -30,12 +30,6 @@ const RecordList = props => {
     history.push(newURL);
     setCurrentRecords(paginatedRecords.current[page - 1]);
     setCurrentPage(page);
-
-    // calculate height of "showing records" and scrolls to it.
-    const showRecordsHeight = document
-      .querySelector('#showingRecords')
-      .getBoundingClientRect();
-    window.scrollTo({ top: showRecordsHeight.top + window.scrollY, left: 0 });
   };
 
   // tracks url param
@@ -60,11 +54,20 @@ const RecordList = props => {
 
   useEffect(
     () => {
-      if (currentPage > 1 && records?.length) {
+      if (paramPage && records?.length) {
         focusElement(document.querySelector('#showingRecords'));
+
+        // calculate height of "showing records" and scrolls to it.
+        const showRecordsHeight = document
+          .querySelector('#showingRecords')
+          .getBoundingClientRect();
+        window.scrollTo({
+          top: showRecordsHeight.top + window.scrollY,
+          left: 0,
+        });
       }
     },
-    [currentPage, records],
+    [currentPage, paramPage, records],
   );
 
   return (

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-validate-record-list-pagination-focus.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-validate-record-list-pagination-focus.cypress.spec.js
@@ -1,0 +1,49 @@
+import MedicalRecordsSite from './mr_site/MedicalRecordsSite';
+import VaccinesListPage from './pages/VaccinesListPage';
+
+describe('Medical Records View Vaccines', () => {
+  const site = new MedicalRecordsSite();
+
+  beforeEach(() => {
+    site.login();
+  });
+
+  it('focuses correctly when deep-linking to a specific page', () => {
+    VaccinesListPage.goToVaccinesPage(2);
+
+    cy.get('#showingRecords').should('be.focused');
+
+    // Axe check
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+
+  it('maintains correct focus while changing page via pagination', () => {
+    VaccinesListPage.goToVaccines();
+
+    // With no page specified, default is page 1 but focus should be on <h1>
+    cy.get('h1').should('be.focused');
+
+    // Click page 2 in the pagination
+    cy.get('va-pagination')
+      .shadow()
+      .find('a[aria-label="page 2, last page"]')
+      .click();
+
+    // After page change, focus should be on "Showing..."
+    cy.get('#showingRecords').should('be.focused');
+
+    // Click page 1 in the pagination
+    cy.get('va-pagination')
+      .shadow()
+      .find('a[aria-label="page 1, first page"]')
+      .click();
+
+    // After page change back to page 1, focus should remain on "Showing..."
+    cy.get('#showingRecords').should('be.focused');
+
+    // Axe check
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medical-records/tests/e2e/pages/VaccinesListPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/VaccinesListPage.js
@@ -4,15 +4,20 @@ import defaultVaccines from '../fixtures/vaccines/vaccines.json';
 import BaseListPage from './BaseListPage';
 
 class VaccinesListPage extends BaseListPage {
-  goToVaccines = (vaccines = defaultVaccines) => {
-    // cy.intercept('POST', '/my_health/v1/medical_records/session').as('session');
-    // cy.wait('@session');
+  goToVaccinesPage = (page, vaccines = defaultVaccines) => {
     cy.intercept('GET', '/my_health/v1/medical_records/vaccines', vaccines).as(
       'VaccinesList',
     );
-    // cy.get('[data-testid="vaccines-landing-page-link"]').click();
-    cy.visit('my-health/medical-records/vaccines');
+    const url =
+      page != null
+        ? `my-health/medical-records/vaccines?page=${page}`
+        : 'my-health/medical-records/vaccines';
+    cy.visit(url);
     cy.wait('@VaccinesList');
+  };
+
+  goToVaccines = (vaccines = defaultVaccines) => {
+    this.goToVaccinesPage(null, vaccines);
   };
 
   clickVaccinesDetailsLink = (vaccinesIndex = 0) => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Modification to focus when page changes in record lists:
  - When the page loads _without_ a `?page` param set, focus goes to `<h1>`
  - When the page loads _with_ a `?page` param set, focus goes to the record count ("Showing...")
  - When a pagination element is clicked (e.g. page, next, etc.), focus goes to the record count ("Showing...")

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122245

## Testing done

- Added some e2e tests that check all the possible conditions

## Screenshots

N/A

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
