### PR TITLE
BIO 21P-8416 add custom submit transformer to form

### DIFF
--- a/src/applications/medical-expense-report/config/form.js
+++ b/src/applications/medical-expense-report/config/form.js
@@ -9,7 +9,7 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import FormSavedPage from '../containers/FormSavedPage';
-import { submit } from './submit';
+import { submit, transform } from './submit';
 // import { defaultDefinitions } from './definitions';
 import reportingPeriod from './chapters/02-expenses/reportingPeriod';
 import claimantRelationship from './chapters/01-applicant-information/claimantRelationship';
@@ -30,6 +30,7 @@ const formConfig = {
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/medical_expense_reports/v0/form8416`,
   submit,
+  transformForSubmit: transform,
   trackingPrefix: 'med-expense-8416',
   v3SegmentedProgressBar: true,
   dev: {

--- a/src/applications/medical-expense-report/config/submit.js
+++ b/src/applications/medical-expense-report/config/submit.js
@@ -4,26 +4,29 @@ import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import { format } from 'date-fns-tz';
 // import { ensureValidCSRFToken } from '../utils/ensureValidCSRFToken';
 
-const usaPhoneKeys = ['phone', 'mobilePhone', 'dayPhone', 'nightPhone'];
-
-export function replacer(key, value) {
-  if (usaPhoneKeys.includes(key) && value?.length) {
-    // Strip spaces, dashes, and parens from phone numbers
-    return value.replace(/[^\d]/g, '');
+export function replacer(_key, value) {
+  const transformedValue = value;
+  if (
+    value?.claimantNotVeteran === false &&
+    value.claimantFullName.first &&
+    value.claimantFullName.last &&
+    !value.veteranFullName?.first &&
+    !value.veteranFullName?.last
+  ) {
+    transformedValue.veteranFullName = {
+      first: value.claimantFullName.first,
+      middle: value.claimantFullName.middle,
+      last: value.claimantFullName.last,
+      suffix: value.claimantFullName.suffix,
+    };
+    transformedValue.claimantFullName = {
+      first: undefined,
+      middle: undefined,
+      last: undefined,
+      suffix: undefined,
+    };
   }
-
-  // clean up empty objects, which we have no reason to send
-  if (typeof value === 'object') {
-    const fields = Object.keys(value);
-    if (
-      fields.length === 0 ||
-      fields.every(field => value[field] === undefined)
-    ) {
-      return undefined;
-    }
-  }
-
-  return value;
+  return transformedValue;
 }
 
 export function transform(formConfig, form) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds new custom submit transformer to conditionally switch claimaintFullName to veteranFullName

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122713

## Testing done

- Manual testing
- To test:
  - Fill out the form as a veteran, when submitting the form, check the submit POST payload and make sure claimantFullName is empty and the veteranFullName has the values entered at the start of the form.
  - Fill out the form as not a veteran, when submitting make sure the values are correctly entered in the claimantFullName and veteranFullName in the POST payload. 

## Screenshots

N/A

## What areas of the site does it impact?

The POST submit for the 8416 form. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
