### PR TITLE
21P-8416 add ui:webComponentField to veteran full name

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/veteranInformation.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/veteranInformation.js
@@ -9,6 +9,10 @@ import {
   vaFileNumberUI,
   vaFileNumberSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  VaTextInputField,
+  VaSelectField,
+} from 'platform/forms-system/src/js/web-component-fields';
 import { parse, isValid, startOfDay, subYears } from 'date-fns';
 import { isSameOrAfter } from '../../../utils/helpers';
 
@@ -53,6 +57,7 @@ export default {
       ...fullNameUI(),
       first: {
         'ui:title': 'First name',
+        'ui:webComponentField': VaTextInputField,
         'ui:required': formData => formData.claimantNotVeteran === true,
         'ui:errorMessages': {
           required: 'Please enter a first name',
@@ -63,12 +68,14 @@ export default {
       },
       middle: {
         'ui:title': 'Middle name',
+        'ui:webComponentField': VaTextInputField,
         'ui:options': {
           hideIf: formData => formData.claimantNotVeteran === false,
         },
       },
       last: {
         'ui:title': 'Last name',
+        'ui:webComponentField': VaTextInputField,
         'ui:required': formData => formData.claimantNotVeteran === true,
         'ui:errorMessages': {
           required: 'Please enter a last name',
@@ -79,6 +86,7 @@ export default {
       },
       suffix: {
         'ui:title': 'Suffix',
+        'ui:webComponentField': VaSelectField,
         'ui:options': {
           hideIf: formData => formData.claimantNotVeteran === false,
         },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds explicit web component field value to veteran full name fields, which were missing it to have the custom required states. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122450

## Testing done

- Manual testing using console tools to look at markup. 

## Screenshots

N/A

## What areas of the site does it impact?

The veteran info page when filling out as a non-veteran. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
