### PR TITLE
[#115832] Travel Pay, Expense Selection

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
@@ -26,6 +26,12 @@ const ChooseExpenseType = () => {
   ];
 
   const handleContinue = () => {
+    // TODO: Handle error case for existing mileage expense
+    // if (selectedExpenseType === 'mileage' && hasExistingMileage) {
+    //   setShowError(true);
+    //   return;
+    // }
+
     if (!selectedExpenseType) {
       setShowError(true);
       return;

--- a/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import {
+  VaRadio,
+  VaButtonPair,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const ChooseExpenseType = () => {
+  const navigate = useNavigate();
+  const { apptId } = useParams();
+  const [selectedExpenseType, setSelectedExpenseType] = useState('');
+
+  const expenseOptions = [
+    { value: 'mileage', label: 'Mileage' },
+    { value: 'parking', label: 'Parking' },
+    { value: 'tolls', label: 'Tolls' },
+    {
+      value: 'public-transportation',
+      label: 'Public transportation, taxi, or rideshare',
+    },
+    { value: 'air-fare', label: 'Air fare' },
+    { value: 'lodging', label: 'Lodging' },
+    { value: 'meals', label: 'Meals' },
+    { value: 'other', label: 'Other travel expenses' },
+  ];
+
+  const handleContinue = () => {
+    if (selectedExpenseType === 'mileage') {
+      navigate(`/file-new-claim/complex/${apptId}/mileage`);
+    } else {
+      // For other expense types, navigate to appropriate pages when they're created
+      // TODO: Add navigation for other expense types
+    }
+  };
+
+  const handleBack = () => {
+    navigate(`/file-new-claim/complex/${apptId}`);
+  };
+
+  return (
+    <div className="vads-l-grid-container vads-u-padding-x--2p5">
+      <div className="vads-l-row">
+        <div className="vads-l-col--12 medium-screen:vads-l-col--8">
+          <h1 className="vads-u-margin-bottom--2">
+            What type of expense do you want to add?
+          </h1>
+          <p>
+            Start with one expense. You’ll be able to add other expenses later.
+          </p>
+          <p className="vads-u-margin-bottom--0">
+            To request reimbursement for air fare, lodging, and meals, you’ll
+            need a pre-approval letter.
+          </p>
+          <VaRadio
+            label="Choose an expense type"
+            required
+            class="vads-u-margin-top--0"
+            onVaValueChange={event =>
+              setSelectedExpenseType(event.detail.value)
+            }
+          >
+            {expenseOptions.map(option => (
+              <va-radio-option
+                tile
+                key={option.value}
+                label={option.label}
+                value={option.value}
+                checked={selectedExpenseType === option.value}
+              />
+            ))}
+          </VaRadio>
+
+          <VaButtonPair
+            class="vads-u-margin-y--2"
+            continue
+            disable-analytics
+            onPrimaryClick={handleContinue}
+            onSecondaryClick={handleBack}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChooseExpenseType;

--- a/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
@@ -9,6 +9,7 @@ const ChooseExpenseType = () => {
   const navigate = useNavigate();
   const { apptId } = useParams();
   const [selectedExpenseType, setSelectedExpenseType] = useState('');
+  const [showError, setShowError] = useState(false);
 
   const expenseOptions = [
     { value: 'mileage', label: 'Mileage' },
@@ -25,6 +26,12 @@ const ChooseExpenseType = () => {
   ];
 
   const handleContinue = () => {
+    if (!selectedExpenseType) {
+      setShowError(true);
+      return;
+    }
+
+    setShowError(false);
     if (selectedExpenseType === 'mileage') {
       navigate(`/file-new-claim/complex/${apptId}/mileage`);
     } else {
@@ -51,7 +58,11 @@ const ChooseExpenseType = () => {
         label="Choose an expense type"
         required
         class="vads-u-margin-top--0"
-        onVaValueChange={event => setSelectedExpenseType(event.detail.value)}
+        error={showError ? 'Please select an expense type' : null}
+        onVaValueChange={event => {
+          setSelectedExpenseType(event.detail.value);
+          if (showError) setShowError(false);
+        }}
       >
         {expenseOptions.map(option => (
           <va-radio-option

--- a/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
@@ -38,48 +38,40 @@ const ChooseExpenseType = () => {
   };
 
   return (
-    <div className="vads-l-grid-container vads-u-padding-x--2p5">
-      <div className="vads-l-row">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-          <h1 className="vads-u-margin-bottom--2">
-            What type of expense do you want to add?
-          </h1>
-          <p>
-            Start with one expense. You’ll be able to add other expenses later.
-          </p>
-          <p className="vads-u-margin-bottom--0">
-            To request reimbursement for air fare, lodging, and meals, you’ll
-            need a pre-approval letter.
-          </p>
-          <VaRadio
-            label="Choose an expense type"
-            required
-            class="vads-u-margin-top--0"
-            onVaValueChange={event =>
-              setSelectedExpenseType(event.detail.value)
-            }
-          >
-            {expenseOptions.map(option => (
-              <va-radio-option
-                tile
-                key={option.value}
-                label={option.label}
-                value={option.value}
-                checked={selectedExpenseType === option.value}
-              />
-            ))}
-          </VaRadio>
-
-          <VaButtonPair
-            class="vads-u-margin-y--2"
-            continue
-            disable-analytics
-            onPrimaryClick={handleContinue}
-            onSecondaryClick={handleBack}
+    <>
+      <h1 className="vads-u-margin-bottom--2">
+        What type of expense do you want to add?
+      </h1>
+      <p>Start with one expense. You’ll be able to add other expenses later.</p>
+      <p className="vads-u-margin-bottom--0">
+        To request reimbursement for air fare, lodging, and meals, you’ll need a
+        pre-approval letter.
+      </p>
+      <VaRadio
+        label="Choose an expense type"
+        required
+        class="vads-u-margin-top--0"
+        onVaValueChange={event => setSelectedExpenseType(event.detail.value)}
+      >
+        {expenseOptions.map(option => (
+          <va-radio-option
+            tile
+            key={option.value}
+            label={option.label}
+            value={option.value}
+            checked={selectedExpenseType === option.value}
           />
-        </div>
-      </div>
-    </div>
+        ))}
+      </VaRadio>
+
+      <VaButtonPair
+        class="vads-u-margin-y--2"
+        continue
+        disable-analytics
+        onPrimaryClick={handleContinue}
+        onSecondaryClick={handleBack}
+      />
+    </>
   );
 };
 

--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
   VaModal,
   VaButton,
@@ -7,6 +8,9 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const Mileage = () => {
+  const navigate = useNavigate();
+  const { apptId } = useParams();
+
   // TODO: Remove placeholder data
   const address = {
     addressLine1: '345 Home Address St.',
@@ -47,11 +51,12 @@ const Mileage = () => {
       // eslint-disable-next-line no-console
       console.log('Special case detected - would redirect to different page');
     } else {
-      // TODO: Replace with normal flow redirect logic
-      // Example: navigate('/next-step-page')
-      // eslint-disable-next-line no-console
-      console.log('Normal flow - would continue to next page');
+      navigate(`/file-new-claim/complex/${apptId}/review`);
     }
+  };
+
+  const handleBack = () => {
+    navigate(`/file-new-claim/complex/${apptId}/choose-expense`);
   };
 
   return (
@@ -153,7 +158,7 @@ const Mileage = () => {
         continue
         disable-analytics
         onPrimaryClick={handleContinue}
-        onSecondaryClick={() => {}}
+        onSecondaryClick={handleBack}
       />
     </>
   );

--- a/src/applications/travel-pay/routes.jsx
+++ b/src/applications/travel-pay/routes.jsx
@@ -4,6 +4,9 @@ import { MhvPageNotFound } from '@department-of-veterans-affairs/mhv/exports';
 
 import TravelPayStatusApp from './containers/TravelPayStatusApp';
 import TravelClaimDetails from './components/TravelClaimDetails';
+import Mileage from './components/complex-claims/pages/Mileage';
+import ChooseExpenseType from './components/complex-claims/pages/ChooseExpenseType';
+import ConfirmationPage from './components/complex-claims/pages/ConfirmationPage';
 import ClaimStatusExplainerPage from './containers/pages/ClaimStatusExplainerPage';
 import SubmitFlowWrapper from './containers/SubmitFlowWrapper';
 import ComplexClaimSubmitFlowWrapper from './containers/ComplexClaimSubmitFlowWrapper';
@@ -33,8 +36,8 @@ const routes = (
         element={<ComplexClaimSubmitFlowWrapper />}
       >
         <Route index element={<>Intro</>} />
-        {/* <Route path="choose-expense" element={<ChooseExpenseType />} />
-        <Route path="mileage" element={<Mileage />} /> */}
+        <Route path="choose-expense" element={<ChooseExpenseType />} />
+        <Route path="mileage" element={<Mileage />} />
         <Route path="review" element={<ReviewPage />} />
         <Route path="travel-agreement" element={<AgreementPage />} />
         <Route path="confirmation" element={<ConfirmationPage />} />

--- a/src/applications/travel-pay/routes.jsx
+++ b/src/applications/travel-pay/routes.jsx
@@ -11,8 +11,6 @@ import ConfirmationPage from './components/complex-claims/pages/ConfirmationPage
 import ClaimStatusExplainerPage from './containers/pages/ClaimStatusExplainerPage';
 import SubmitFlowWrapper from './containers/SubmitFlowWrapper';
 import ComplexClaimSubmitFlowWrapper from './containers/ComplexClaimSubmitFlowWrapper';
-import AgreementPage from './components/complex-claims/pages/AgreementPage';
-import ConfirmationPage from './components/complex-claims/pages/ConfirmationPage';
 import ReviewPage from './components/complex-claims/pages/ReviewPage';
 import App from './containers/App';
 

--- a/src/applications/travel-pay/routes.jsx
+++ b/src/applications/travel-pay/routes.jsx
@@ -5,6 +5,7 @@ import { MhvPageNotFound } from '@department-of-veterans-affairs/mhv/exports';
 import TravelPayStatusApp from './containers/TravelPayStatusApp';
 import TravelClaimDetails from './components/TravelClaimDetails';
 import Mileage from './components/complex-claims/pages/Mileage';
+import AgreementPage from './components/complex-claims/pages/AgreementPage';
 import ChooseExpenseType from './components/complex-claims/pages/ChooseExpenseType';
 import ConfirmationPage from './components/complex-claims/pages/ConfirmationPage';
 import ClaimStatusExplainerPage from './containers/pages/ClaimStatusExplainerPage';

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ChooseExpenseType.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ChooseExpenseType.unit.spec.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import ChooseExpenseType from '../../../../components/complex-claims/pages/ChooseExpenseType';
+
+describe('ChooseExpenseType', () => {
+  const defaultApptId = '12345';
+
+  const renderComponent = (apptId = defaultApptId) => {
+    return render(
+      <MemoryRouter
+        initialEntries={[`/file-new-claim/complex/${apptId}/expense-type`]}
+      >
+        <Routes>
+          <Route
+            path="/file-new-claim/complex/:apptId/expense-type"
+            element={<ChooseExpenseType />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+  };
+
+  it('renders the component with all required elements', () => {
+    const screen = renderComponent();
+
+    expect(screen.getByRole('heading', { level: 1 })).to.have.property(
+      'textContent',
+      'What type of expense do you want to add?',
+    );
+
+    expect(screen.getByText(/Start with one expense/)).to.exist;
+    expect(screen.getByText(/To request reimbursement for air fare/)).to.exist;
+
+    expect($('va-radio[label="Choose an expense type"]')).to.exist;
+    expect($('va-button-pair')).to.exist;
+  });
+
+  it('renders all expense type options', () => {
+    renderComponent();
+
+    const radioOptions = [
+      'Mileage',
+      'Parking',
+      'Tolls',
+      'Public transportation, taxi, or rideshare',
+      'Air fare',
+      'Lodging',
+      'Meals',
+      'Other travel expenses',
+    ];
+
+    radioOptions.forEach(option => {
+      expect($(`va-radio-option[label="${option}"]`)).to.exist;
+    });
+  });
+
+  it('renders expense options with correct values', () => {
+    renderComponent();
+
+    const expectedOptions = [
+      { value: 'mileage', label: 'Mileage' },
+      { value: 'parking', label: 'Parking' },
+      { value: 'tolls', label: 'Tolls' },
+      {
+        value: 'public-transportation',
+        label: 'Public transportation, taxi, or rideshare',
+      },
+      { value: 'air-fare', label: 'Air fare' },
+      { value: 'lodging', label: 'Lodging' },
+      { value: 'meals', label: 'Meals' },
+      { value: 'other', label: 'Other travel expenses' },
+    ];
+
+    expectedOptions.forEach(option => {
+      expect(
+        $(`va-radio-option[value="${option.value}"][label="${option.label}"]`),
+      ).to.exist;
+    });
+  });
+
+  it('renders radio options with tile property', () => {
+    renderComponent();
+
+    const radioOptions = document.querySelectorAll('va-radio-option');
+    expect(radioOptions.length).to.be.greaterThan(0);
+
+    // Check that all radio options have the tile attribute
+    radioOptions.forEach(option => {
+      expect(option.hasAttribute('tile')).to.be.true;
+    });
+  });
+
+  it('handles expense type selection', () => {
+    renderComponent();
+
+    const radioGroup = $('va-radio[label="Choose an expense type"]');
+    expect(radioGroup).to.exist;
+
+    fireEvent(
+      radioGroup,
+      new CustomEvent('vaValueChange', {
+        detail: { value: 'mileage' },
+      }),
+    );
+
+    // Check that the selection is reflected in the component
+    const mileageOption = $('va-radio-option[value="mileage"]');
+    expect(mileageOption.hasAttribute('checked')).to.be.true;
+  });
+
+  it('requires an expense type selection', () => {
+    renderComponent();
+
+    const radioGroup = $('va-radio[label="Choose an expense type"]');
+    expect(radioGroup.hasAttribute('required')).to.be.true;
+  });
+
+  it('renders button pair with correct properties', () => {
+    renderComponent();
+
+    const buttonPair = $('va-button-pair');
+    expect(buttonPair).to.exist;
+    expect(buttonPair.hasAttribute('continue')).to.be.true;
+    expect(buttonPair.hasAttribute('disable-analytics')).to.be.true;
+  });
+
+  it('displays correct heading text', () => {
+    const screen = renderComponent();
+
+    expect(screen.getByText('What type of expense do you want to add?')).to
+      .exist;
+  });
+
+  it('displays helpful instruction text', () => {
+    const screen = renderComponent();
+
+    expect(screen.getByText(/Start with one expense/)).to.exist;
+  });
+
+  it('displays pre-approval requirement notice', () => {
+    const screen = renderComponent();
+
+    expect(screen.getByText(/To request reimbursement for air fare/)).to.exist;
+  });
+});

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ChooseExpenseType.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ChooseExpenseType.unit.spec.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import ChooseExpenseType from '../../../../components/complex-claims/pages/ChooseExpenseType';
+import reducer from '../../../../redux/reducer';
 
 describe('ChooseExpenseType', () => {
   const defaultApptId = '12345';
 
   const renderComponent = (apptId = defaultApptId) => {
-    return render(
+    return renderWithStoreAndRouter(
       <MemoryRouter
         initialEntries={[`/file-new-claim/complex/${apptId}/expense-type`]}
       >
@@ -21,6 +23,10 @@ describe('ChooseExpenseType', () => {
           />
         </Routes>
       </MemoryRouter>,
+      {
+        initialState: {},
+        reducers: reducer,
+      },
     );
   };
 

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ChooseExpenseType.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ChooseExpenseType.unit.spec.jsx
@@ -152,4 +152,123 @@ describe('ChooseExpenseType', () => {
 
     expect(screen.getByText(/To request reimbursement for air fare/)).to.exist;
   });
+
+  describe('Error handling', () => {
+    it('shows error message when continue is clicked without selecting an expense type', () => {
+      renderComponent();
+
+      const buttonPair = $('va-button-pair');
+      const radioGroup = $('va-radio[label="Choose an expense type"]');
+
+      // Initially no error should be shown
+      expect(radioGroup.getAttribute('error')).to.be.null;
+
+      // Click continue button without selecting an expense type
+      fireEvent(
+        buttonPair,
+        new CustomEvent('primaryClick', {
+          detail: {},
+        }),
+      );
+
+      // Error message should now be displayed
+      expect(radioGroup.getAttribute('error')).to.equal(
+        'Please select an expense type',
+      );
+    });
+
+    it('clears error message when an expense type is selected after error', () => {
+      renderComponent();
+
+      const buttonPair = $('va-button-pair');
+      const radioGroup = $('va-radio[label="Choose an expense type"]');
+
+      // Click continue without selection to trigger error
+      fireEvent(
+        buttonPair,
+        new CustomEvent('primaryClick', {
+          detail: {},
+        }),
+      );
+
+      // Verify error is shown
+      expect(radioGroup.getAttribute('error')).to.equal(
+        'Please select an expense type',
+      );
+
+      // Select an expense type
+      fireEvent(
+        radioGroup,
+        new CustomEvent('vaValueChange', {
+          detail: { value: 'mileage' },
+        }),
+      );
+
+      // Error should be cleared
+      expect(radioGroup.getAttribute('error')).to.be.null;
+    });
+
+    it('does not show error when continue is clicked with a valid selection', () => {
+      renderComponent();
+
+      const buttonPair = $('va-button-pair');
+      const radioGroup = $('va-radio[label="Choose an expense type"]');
+
+      // Select an expense type first
+      fireEvent(
+        radioGroup,
+        new CustomEvent('vaValueChange', {
+          detail: { value: 'parking' },
+        }),
+      );
+
+      // Click continue button
+      fireEvent(
+        buttonPair,
+        new CustomEvent('primaryClick', {
+          detail: {},
+        }),
+      );
+
+      // No error should be shown
+      expect(radioGroup.getAttribute('error')).to.be.null;
+    });
+
+    it('prevents navigation when no expense type is selected', () => {
+      renderComponent();
+
+      const buttonPair = $('va-button-pair');
+
+      // Mock the navigate function to check if it was called
+      const originalLocation = window.location;
+
+      // Override window.location to detect navigation attempts
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...originalLocation,
+          pathname: '/file-new-claim/complex/12345/expense-type',
+        },
+        writable: true,
+      });
+
+      // Click continue without selection
+      fireEvent(
+        buttonPair,
+        new CustomEvent('primaryClick', {
+          detail: {},
+        }),
+      );
+
+      // Should still be on the same page (no navigation occurred)
+      expect(window.location.pathname).to.equal(
+        '/file-new-claim/complex/12345/expense-type',
+      );
+
+      // Restore original location
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
+    });
+  });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
@@ -1,13 +1,37 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import Mileage from '../../../../components/complex-claims/pages/Mileage';
+import reducer from '../../../../redux/reducer';
 
 describe('Complex Claims Mileage', () => {
+  const defaultApptId = '12345';
+
+  const renderComponent = (apptId = defaultApptId) => {
+    return renderWithStoreAndRouter(
+      <MemoryRouter
+        initialEntries={[`/file-new-claim/complex/${apptId}/mileage`]}
+      >
+        <Routes>
+          <Route
+            path="/file-new-claim/complex/:apptId/mileage"
+            element={<Mileage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+      {
+        initialState: {},
+        reducers: reducer,
+      },
+    );
+  };
+
   it('renders the component with all elements', () => {
-    const screen = render(<Mileage />);
+    const screen = renderComponent();
 
     expect(screen.getByRole('heading', { level: 1 })).to.have.property(
       'textContent',
@@ -21,7 +45,7 @@ describe('Complex Claims Mileage', () => {
   });
 
   it('renders mileage information in additional info component', () => {
-    render(<Mileage />);
+    renderComponent();
 
     const additionalInfo = $(
       'va-additional-info[trigger="How we calculate mileage"]',
@@ -44,7 +68,7 @@ describe('Complex Claims Mileage', () => {
   });
 
   it('renders external link for mileage rates', () => {
-    render(<Mileage />);
+    renderComponent();
 
     expect(
       $(
@@ -55,7 +79,7 @@ describe('Complex Claims Mileage', () => {
 
   describe('Departure Address Radio Group', () => {
     it('renders departure address radio group with correct properties', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const departureRadio = $('va-radio[id="departure-address"]');
       expect(departureRadio).to.exist;
@@ -66,7 +90,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('renders departure address radio options', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const departureRadio = $('va-radio[id="departure-address"]');
       expect(departureRadio).to.exist;
@@ -76,7 +100,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('handles departure address selection change', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const departureRadio = $('va-radio[id="departure-address"]');
       expect(departureRadio.value).to.equal('');
@@ -95,7 +119,7 @@ describe('Complex Claims Mileage', () => {
 
   describe('Trip Type Radio Group', () => {
     it('renders trip type radio group with correct properties', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const tripTypeRadio = $('va-radio[id="trip-type"]');
       expect(tripTypeRadio).to.exist;
@@ -106,7 +130,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('renders trip type radio options', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const tripTypeRadio = $('va-radio[id="trip-type"]');
       expect(tripTypeRadio).to.exist;
@@ -116,7 +140,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('handles trip type selection change', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const tripTypeRadio = $('va-radio[id="trip-type"]');
       expect(tripTypeRadio.value).to.equal('');
@@ -135,7 +159,7 @@ describe('Complex Claims Mileage', () => {
 
   describe('Button Pair', () => {
     it('renders button pair with correct properties', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const buttonPair = $('va-button-pair');
       expect(buttonPair).to.exist;
@@ -145,7 +169,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('handles primary button click', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const buttonPair = $('va-button-pair');
       expect(buttonPair).to.exist;
@@ -159,7 +183,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('handles secondary button click', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const buttonPair = $('va-button-pair');
       expect(buttonPair).to.exist;
@@ -175,7 +199,7 @@ describe('Complex Claims Mileage', () => {
 
   describe('Initial State', () => {
     it('starts with empty values for both radio groups', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const departureRadio = $('va-radio[id="departure-address"]');
       const tripTypeRadio = $('va-radio[id="trip-type"]');
@@ -185,7 +209,7 @@ describe('Complex Claims Mileage', () => {
     });
 
     it('has no radio options checked initially', () => {
-      render(<Mileage />);
+      renderComponent();
 
       const departureRadio = $('va-radio[id="departure-address"]');
       const tripTypeRadio = $('va-radio[id="trip-type"]');

--- a/src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx
@@ -10,6 +10,7 @@ import reducer from '../../redux/reducer';
 import ComplexClaimSubmitFlowWrapper from '../../containers/ComplexClaimSubmitFlowWrapper';
 import ReviewPage from '../../components/complex-claims/pages/ReviewPage';
 import AgreementPage from '../../components/complex-claims/pages/AgreementPage';
+import ConfirmationPage from '../../components/complex-claims/pages/ConfirmationPage';
 
 describe('ComplexClaimSubmitFlowWrapper', () => {
   const oldLocation = global.window.location;
@@ -37,12 +38,18 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
     initialState = {},
   ) => {
     return renderWithStoreAndRouter(
-      <MemoryRouter initialEntries={[`/confirmation/${appointmentId}`]}>
+      <MemoryRouter
+        initialEntries={[
+          `/file-new-claim/complex/${appointmentId}/confirmation`,
+        ]}
+      >
         <Routes>
           <Route
-            path="/confirmation/:apptId/"
+            path="/file-new-claim/complex/:apptId/confirmation"
             element={<ComplexClaimSubmitFlowWrapper />}
-          />
+          >
+            <Route path="confirmation" element={<ConfirmationPage />} />
+          </Route>
         </Routes>
       </MemoryRouter>,
       {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding the bones of a "choose an expense" page for the Travel Pay Complex Claims flow.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/115832

## Screenshots

| Mobile   | Desktop   |
| ------ | ----- |
| <img width="750" height="2671" alt="mobile" src="https://github.com/user-attachments/assets/8dd2e400-0969-4856-8542-8aaa727aaea8" /> | <img width="2394" height="2401" alt="desktop" src="https://github.com/user-attachments/assets/527f6b14-234b-496c-9113-d987d1ac7ac1" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user