### PR TITLE
10-10d extended | Update address concat method

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
@@ -2,11 +2,10 @@
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 import {
   adjustYearString,
-  concatStreets,
   getObjectsWithAttachmentId,
   toHash,
 } from '../../shared/utilities';
-import { getAgeInYears } from '../helpers/utilities';
+import { concatStreets, getAgeInYears } from '../helpers/utilities';
 
 /**
  * Formats a date string from YYYY-MM-DD to MM-DD-YYYY

--- a/src/applications/ivc-champva/10-10d-extended/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-10d-extended/helpers/utilities.js
@@ -98,3 +98,38 @@ export const getAgeInYears = (dateStr, asOf = new Date()) => {
 
   return differenceInYears(asOfUTC, dobUTC);
 };
+
+/**
+ * Builds a single `streetCombined` string from all properties in `addr` whose keys
+ * include "street" (case-insensitive). `undefined`, `null`, and empty-string values
+ * are skipped. Parts are joined by a space or newline.
+ *
+ * @typedef {Object} ConcatStreetOptions
+ * @property {boolean} [newLines=false] - If true, join parts with `\n` instead of a space.
+ *
+ * @param {Object} [addr={}] - Source address object (e.g., { street, street2, ... }).
+ * @param {ConcatStreetOptions} [options] - Optional settings.
+ * @returns {Object} A shallow copy of `addr` with an added `streetCombined` property.
+ *
+ * @example
+ * concatStreets({ street: '123 Main', street2: 'Apt 4B' });
+ * // => { street: '123 Main', street2: 'Apt 4B', streetCombined: '123 Main Apt 4B' }
+ *
+ * @example
+ * concatStreets({ Street: '123 Main', street2: '', street3: null }, true);
+ * // => { Street: '123 Main', street2: '', street3: null, streetCombined: '123 Main' }
+ */
+export const concatStreets = (addr = {}, options = {}) => {
+  const { newLines = false } = options;
+  const sep = newLines ? '\n' : ' ';
+
+  const streetCombined = Object.entries(addr)
+    .filter(
+      ([k, v]) => k.toLowerCase().includes('street') && v != null && v !== '',
+    )
+    .map(([, v]) => String(v).trim())
+    .join(sep)
+    .trim();
+
+  return { ...addr, streetCombined };
+};

--- a/src/applications/ivc-champva/10-10d-extended/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-10d-extended/helpers/utilities.js
@@ -116,7 +116,7 @@ export const getAgeInYears = (dateStr, asOf = new Date()) => {
  * // => { street: '123 Main', street2: 'Apt 4B', streetCombined: '123 Main Apt 4B' }
  *
  * @example
- * concatStreets({ Street: '123 Main', street2: '', street3: null }, true);
+ * concatStreets({ Street: '123 Main', street2: '', street3: null }, { newLines: true });
  * // => { Street: '123 Main', street2: '', street3: null, streetCombined: '123 Main' }
  */
 export const concatStreets = (addr = {}, options = {}) => {

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/helpers.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/helpers.unit.spec.jsx
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import {
+  concatStreets,
+  getAgeInYears,
   page15aDepends,
   populateFirstApplicant,
-  getAgeInYears,
 } from '../../../helpers/utilities';
 
 describe('page15a depends function', () => {
@@ -28,7 +29,7 @@ describe('page15a depends function', () => {
   });
 });
 
-describe('populateFirstApplicant', () => {
+describe('1010d `populateFirstApplicant` util', () => {
   const newAppInfo = {
     name: { first: 'First', last: 'Last' },
     email: 'fake@va.gov',
@@ -175,5 +176,77 @@ describe('1010d `getAgeInYears` util', () => {
     const asOfEveningUTC = new Date(Date.UTC(2025, 5, 15, 23, 59, 59)); // same day late
     expect(getAgeInYears(dob, asOfMorningUTC)).to.equal(35);
     expect(getAgeInYears(dob, asOfEveningUTC)).to.equal(35);
+  });
+});
+
+describe('1010d `concatStreets` util', () => {
+  it('should join street fields with spaces by default', () => {
+    const addr = { street: '123 Main', street2: 'Apt 4B' };
+    const result = concatStreets(addr);
+    expect(result.streetCombined).to.equal('123 Main Apt 4B');
+  });
+
+  it('should join with new lines when `options.newLines` is true', () => {
+    const addr = { street: '123 Main', street2: 'Apt 4B' };
+    const result = concatStreets(addr, { newLines: true });
+    expect(result.streetCombined).to.equal('123 Main\nApt 4B');
+  });
+
+  it('should filter out `undefined`, `null`, and `empty-string` values', () => {
+    const addr = {
+      street: '123 Main',
+      street2: undefined,
+      street3: null,
+      street4: '',
+    };
+    const result = concatStreets(addr);
+    expect(result.streetCombined).to.equal('123 Main');
+  });
+
+  it('should trim individual street parts before joining', () => {
+    const addr = { street: '  123 Main  ', street2: '  Apt 4B ' };
+    const result = concatStreets(addr);
+    expect(result.streetCombined).to.equal('123 Main Apt 4B');
+  });
+
+  it('should be case-insensitive for key names containing `street`', () => {
+    const addr = { Street: '123 Main', sTrEeT2: 'Apt 4B', avenue: 'Ignore me' };
+    const result = concatStreets(addr);
+    expect(result.streetCombined).to.equal('123 Main Apt 4B');
+  });
+
+  it('should ignore non-street keys entirely', () => {
+    const addr = { city: 'Indy', postalCode: '46204' };
+    const result = concatStreets(addr);
+    expect(result.streetCombined).to.equal('');
+  });
+
+  it('should return a new object and does not mutate the input', () => {
+    const addr = { street: '123 Main' };
+    const copy = { ...addr };
+    const result = concatStreets(addr);
+    expect(result).to.not.equal(addr);
+    expect(addr).to.deep.equal(copy);
+    expect(result).to.deep.equal({ ...addr, streetCombined: '123 Main' });
+  });
+
+  it('should correctly handle undefined address object', () => {
+    const result = concatStreets(undefined);
+    expect(result).to.deep.equal({ streetCombined: '' });
+  });
+
+  it('should correctly handle omitted options', () => {
+    const addr = { street: '123 Main', street2: 'Apt 4B' };
+    const result = concatStreets(addr);
+    expect(result.streetCombined).to.equal('123 Main Apt 4B');
+  });
+
+  it('should avoid trailing space or newline', () => {
+    const addr = { street: '123 Main', street2: '' };
+    const withSpace = concatStreets(addr);
+    expect(withSpace.streetCombined).to.equal('123 Main');
+
+    const withNewline = concatStreets(addr, { newLines: true });
+    expect(withNewline.streetCombined).to.equal('123 Main');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates a method used to concat street address values into a single string to correctly filter out `null` / `undefined` / empty values when creating the string. This fixes an issue where we had PDFs stamped with something like "123 main streeet undefined".

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118201

## Testing done

- Created unit test suite for the updated util

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Street values contain only populated values and not values like `undefined`

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
