### PR TITLE
10-10d extended | Fix missing stepper on OHI intro pages

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
@@ -331,8 +331,8 @@ export const healthInsurancePages = arrayBuilderPages(
   healthInsuranceOptions,
   pageBuilder => ({
     healthInsuranceSummary: pageBuilder.summaryPage({
-      path: 'review-your-health-insurance-plans',
-      title: 'Report other health insurance',
+      path: 'other-health-insurance-plans',
+      title: 'Other health insurance plans',
       uiSchema: healthInsuranceSummaryPage.uiSchema,
       schema: healthInsuranceSummaryPage.schema,
     }),

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -774,8 +774,8 @@ export const medicarePages = arrayBuilderPages(
   medicareOptions,
   pageBuilder => ({
     medicareSummary: pageBuilder.summaryPage({
-      path: 'report-medicare-plans',
-      title: 'Report Medicare plans',
+      path: 'medicare-plans',
+      title: 'Medicare plans',
       uiSchema: medicareSummaryPage.uiSchema,
       schema: medicareSummaryPage.schema,
     }),

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -232,7 +232,7 @@ const formConfig = {
           schema: blankSchema,
         },
         medicareIntro: {
-          path: 'medicare-introduction',
+          path: 'report-medicare',
           title: 'Report Medicare',
           CustomPage: MedicareIntroduction,
           CustomPageReview: null,
@@ -249,7 +249,7 @@ const formConfig = {
         'Other Health Insurance Certification: Health insurance information',
       pages: {
         healthInsuranceIntro: {
-          path: 'other-health-insurance-introduction',
+          path: 'report-other-health-insurance',
           title: 'Report other health insurance',
           CustomPage: OtherHealthInsuranceInformation,
           CustomPageReview: null,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the page routing to avoid using reserved words like `introduction` in the page route. `Introduction` is one of the reserved pathname words and causes things like the progress indicator to not render.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#122645

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="519" height="446" alt="Screenshot 2025-10-21 at 11 31 50" src="https://github.com/user-attachments/assets/d083eddd-1c0d-4c9b-a858-2b3d3c36ff08" /> | <img width="680" height="555" alt="Screenshot 2025-10-21 at 11 30 56" src="https://github.com/user-attachments/assets/96176c86-5d47-4200-ae89-e726f04013f2" /> |

## Acceptance criteria

- All form elements correctly render

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
