### PR TITLE
10-10d extended | Apply bugfix for Medicare Part A denial titles 

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -444,11 +444,15 @@ const medicarePartBCardUploadPage = {
 };
 
 const medicarePartADenialPage = dataKey => {
-  const PageTitle = ({ formData: localData }) => {
+  const PageTitle = ({ formContext }) => {
     const formData = useSelector(state => state.form.data);
-    if (localData.medicareParticipant) {
+    const n = Number(formContext.pagePerItemIndex);
+    const itemIndex = Number.isFinite(n) && n >= 0 ? n : null;
+    if (formData?.medicare?.[itemIndex]?.medicareParticipant) {
       return privWrapper(
-        `${generateParticipantName(localData)} Medicare status`,
+        `${generateParticipantName(
+          formData?.medicare?.[itemIndex],
+        )} Medicare status`,
       );
     }
     const apps = getEligibleApplicantsWithoutMedicare(formData) ?? [];

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -96,7 +96,7 @@ export const generateParticipantName = item => {
       app => item?.medicareParticipant === toHashMemoized(app.applicantSSN),
     );
     const name = applicantWording(match, false, false, false);
-    return name.length > 0 ? `${name}'s` : 'applicant';
+    return name.length > 0 ? `${name}’s` : 'Applicant';
   }
   return 'No participant';
 };

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { memoize } from 'lodash';
 import set from 'platform/utilities/data/set';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
@@ -443,11 +444,13 @@ const medicarePartBCardUploadPage = {
 };
 
 const medicarePartADenialPage = dataKey => {
-  const pageTitle = ({ formData }) => {
-    if (formData?.medicareParticipant)
+  const PageTitle = ({ formData: localData }) => {
+    const formData = useSelector(state => state.form.data);
+    if (localData.medicareParticipant) {
       return privWrapper(
-        `${generateParticipantName(formData)} Medicare status`,
+        `${generateParticipantName(localData)} Medicare status`,
       );
+    }
     const apps = getEligibleApplicantsWithoutMedicare(formData) ?? [];
     const item = apps.find(a => getAgeInYears(a.applicantDob) >= 65);
     return privWrapper(
@@ -458,7 +461,7 @@ const medicarePartADenialPage = dataKey => {
     uiSchema: {
       'view:addtlInfo': { ...descriptionUI(ProofOfMedicareAlert) },
       [`view:${dataKey}`]: {
-        ...arrayBuilderItemSubsequentPageTitleUI(pageTitle),
+        ...arrayBuilderItemSubsequentPageTitleUI(PageTitle),
         [dataKey]: {
           ...yesNoUI({
             title:

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
@@ -274,9 +274,9 @@ describe('generateParticipantName', () => {
           },
         ],
       }),
-    ).to.eq("App1 Jones's");
+    ).to.eq('App1 Jones’s');
   });
-  it('should return "applicant" if no participant SSN hash matches', () => {
+  it('should return `Applicant` if no participant SSN hash matches', () => {
     expect(
       generateParticipantName({
         medicareParticipant: '000000000000',
@@ -287,9 +287,9 @@ describe('generateParticipantName', () => {
           },
         ],
       }),
-    ).to.eq('applicant');
+    ).to.eq('Applicant');
   });
-  it('should return "No participant" if no participant selected', () => {
+  it('should return `No participant` if no participant selected', () => {
     expect(generateParticipantName(undefined)).to.eq('No participant');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR applies a couple fixes for title formatting for the Medicare Part A Denial Notice pages. Some of the formatting issues are related to capitalization, while others are bugfixing getting the appropriate name to render.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#122648

## Testing done

- n/a

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Titles are appropriately rendered

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user