### PR TITLE
Removed Unique User Metrics from Medical Records

### DIFF
--- a/src/applications/mhv-medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv-medical-records/containers/LandingPage.jsx
@@ -5,8 +5,6 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import {
   renderMHVDowntime,
   updatePageTitle,
-  logUniqueUserMetricsEvents,
-  EVENT_REGISTRY,
   useAcceleratedData,
 } from '@department-of-veterans-affairs/mhv/exports';
 import {
@@ -86,9 +84,6 @@ const LandingPage = () => {
       createSession();
 
       updatePageTitle(pageTitles.MEDICAL_RECORDS_PAGE_TITLE);
-
-      // Log unique user metrics for medical records access
-      logUniqueUserMetricsEvents(EVENT_REGISTRY.MEDICAL_RECORDS_ACCESSED);
     },
     [dispatch],
   );
@@ -159,9 +154,6 @@ const LandingPage = () => {
                 history.push('/labs-and-tests');
                 sendAalViewList('Lab and test results');
                 sendDataDogAction(LAB_TEST_RESULTS_LABEL);
-                logUniqueUserMetricsEvents(
-                  EVENT_REGISTRY.MEDICAL_RECORDS_LABS_ACCESSED,
-                );
               }}
             />
           </section>
@@ -185,9 +177,6 @@ const LandingPage = () => {
                   history.push('/summaries-and-notes');
                   sendAalViewList('Care Summaries and Notes');
                   sendDataDogAction(CARE_SUMMARIES_AND_NOTES_LABEL);
-                  logUniqueUserMetricsEvents(
-                    EVENT_REGISTRY.MEDICAL_RECORDS_NOTES_ACCESSED,
-                  );
                 }}
               />
             </>
@@ -210,9 +199,6 @@ const LandingPage = () => {
                 history.push('/vaccines');
                 sendAalViewList('Vaccines');
                 sendDataDogAction(VACCINES_LABEL);
-                logUniqueUserMetricsEvents(
-                  EVENT_REGISTRY.MEDICAL_RECORDS_VACCINES_ACCESSED,
-                );
               }}
             />
           </section>
@@ -235,9 +221,6 @@ const LandingPage = () => {
                 history.push('/allergies');
                 sendAalViewList('Allergy and Reactions');
                 sendDataDogAction(ALLERGIES_AND_REACTIONS_LABEL);
-                logUniqueUserMetricsEvents(
-                  EVENT_REGISTRY.MEDICAL_RECORDS_ALLERGIES_ACCESSED,
-                );
               }}
             />
           </section>
@@ -259,9 +242,6 @@ const LandingPage = () => {
                 history.push('/conditions');
                 sendAalViewList('Health Conditions');
                 sendDataDogAction(HEALTH_CONDITIONS_LABEL);
-                logUniqueUserMetricsEvents(
-                  EVENT_REGISTRY.MEDICAL_RECORDS_CONDITIONS_ACCESSED,
-                );
               }}
             />
           </section>
@@ -289,9 +269,6 @@ const LandingPage = () => {
                 history.push('/vitals');
                 sendAalViewList('Vitals');
                 sendDataDogAction(VITALS_LABEL);
-                logUniqueUserMetricsEvents(
-                  EVENT_REGISTRY.MEDICAL_RECORDS_VITALS_ACCESSED,
-                );
               }}
             />
           </section>

--- a/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
@@ -5,7 +5,6 @@ import { fireEvent } from '@testing-library/react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
 import { addHours, format } from 'date-fns';
-import * as uniqueUserMetrics from '~/platform/mhv/unique_user_metrics';
 import LandingPage, {
   ALLERGIES_AND_REACTIONS_LABEL,
   CARE_SUMMARIES_AND_NOTES_LABEL,
@@ -98,7 +97,6 @@ describe('Landing Page', () => {
 
   describe('Landing Page without downtime', () => {
     let postCreateAALStub;
-    let logUniqueUserMetricsEventsStub;
     let sandbox;
     let getByTestId;
     let screen;
@@ -130,10 +128,6 @@ describe('Landing Page', () => {
       sandbox = sinon.createSandbox();
       // stub out postCreateAAL so it doesn't actually fire network requests
       postCreateAALStub = sandbox.stub(MrApi, 'postCreateAAL');
-      logUniqueUserMetricsEventsStub = sandbox.stub(
-        uniqueUserMetrics,
-        'logUniqueUserMetricsEvents',
-      );
       renderPage();
     });
 
@@ -299,64 +293,6 @@ describe('Landing Page', () => {
     linkTests.forEach(({ testId, activityType }) => {
       it(`calls postCreateAAL when ${activityType} link is clicked`, () => {
         clickAndAssert(testId, activityType);
-      });
-    });
-
-    it('should log medical records accessed event when landing page loads', () => {
-      expect(
-        logUniqueUserMetricsEventsStub.calledWith(
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_ACCESSED,
-        ),
-      ).to.be.true;
-    });
-
-    const uniqueUserMetricsLinkTests = [
-      {
-        testId: 'labs-and-tests-landing-page-link',
-        eventType:
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_LABS_ACCESSED,
-        description: 'labs and tests',
-      },
-      {
-        testId: 'notes-landing-page-link',
-        eventType:
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_NOTES_ACCESSED,
-        description: 'care summaries and notes',
-      },
-      {
-        testId: 'vaccines-landing-page-link',
-        eventType:
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_VACCINES_ACCESSED,
-        description: 'vaccines',
-      },
-      {
-        testId: 'allergies-landing-page-link',
-        eventType:
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_ALLERGIES_ACCESSED,
-        description: 'allergies and reactions',
-      },
-      {
-        testId: 'conditions-landing-page-link',
-        eventType:
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_CONDITIONS_ACCESSED,
-        description: 'health conditions',
-      },
-      {
-        testId: 'vitals-landing-page-link',
-        eventType:
-          uniqueUserMetrics.EVENT_REGISTRY.MEDICAL_RECORDS_VITALS_ACCESSED,
-        description: 'vitals',
-      },
-    ];
-
-    uniqueUserMetricsLinkTests.forEach(({ testId, eventType, description }) => {
-      it(`should log unique user metrics event when ${description} link is clicked`, () => {
-        // Reset the stub to clear previous calls
-        logUniqueUserMetricsEventsStub.resetHistory();
-
-        fireEvent.click(getByTestId(testId));
-
-        expect(logUniqueUserMetricsEventsStub.calledWith(eventType)).to.be.true;
       });
     });
   });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Allergies.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Allergies.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session/default.json';
-import MedicalRecordsLandingPage from '../../pages/MedicalRecordsLandingPage';
 import vamc from '../../fixtures/facilities/vamc-ehr.json';
 
 class Allergies {
@@ -27,8 +26,6 @@ class Allergies {
     cy.intercept('GET', '/my_health/v2/medical_records/allergies*', req => {
       req.reply(allergiesData);
     }).as('allergies-list');
-
-    MedicalRecordsLandingPage.uumIntercept();
   };
 
   goToAllergiesPage = () => {

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/CareSummaryAndNotes.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/CareSummaryAndNotes.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session/default.json';
-import MedicalRecordsLandingPage from '../../pages/MedicalRecordsLandingPage';
 
 class CareSummaryAndNotes {
   setIntercepts = ({ careSummaryAndNotesData }) => {
@@ -32,7 +31,6 @@ class CareSummaryAndNotes {
         req.reply(careSummaryAndNotesData);
       },
     ).as('clinical_notes-list');
-    MedicalRecordsLandingPage.uumIntercept();
   };
 
   checkLandingPageLinks = () => {

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Conditions.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Conditions.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session/default.json';
-import MedicalRecordsLandingPage from '../../pages/MedicalRecordsLandingPage';
 
 class Conditions {
   setIntercepts = ({ conditionsData }) => {
@@ -13,7 +12,6 @@ class Conditions {
     cy.intercept('GET', '/my_health/v2/medical_records/conditions*', req => {
       req.reply(conditionsData);
     }).as('conditions-list');
-    MedicalRecordsLandingPage.uumIntercept();
   };
 
   goToConditionsPage = () => {

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session/default.json';
-import MedicalRecordsLandingPage from '../../pages/MedicalRecordsLandingPage';
 
 class LabsAndTests {
   setIntercepts = ({ labsAndTestData, useOhData = true }) => {
@@ -39,7 +38,6 @@ class LabsAndTests {
       }
       req.reply(labsAndTestData);
     }).as('labs-and-test-list');
-    MedicalRecordsLandingPage.uumIntercept();
   };
 
   checkLandingPageLinks = () => {

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vaccines.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vaccines.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session/default.json';
-import MedicalRecordsLandingPage from '../../pages/MedicalRecordsLandingPage';
 
 class Vaccines {
   setIntercepts = ({ vaccinesData }) => {
@@ -13,7 +12,6 @@ class Vaccines {
     cy.intercept('GET', '/my_health/v2/medical_records/immunization*', req => {
       req.reply(vaccinesData);
     }).as('vaccines-list');
-    MedicalRecordsLandingPage.uumIntercept();
   };
 
   setDetailIntercepts = ({ vaccineDetailData, vaccineId }) => {

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session/default.json';
-import MedicalRecordsLandingPage from '../../pages/MedicalRecordsLandingPage';
 
 class Vitals {
   setIntercepts = ({ vitalData, useOhData = true }) => {
@@ -21,7 +20,6 @@ class Vitals {
       }
       req.reply(vitalData);
     }).as('vitals-list');
-    MedicalRecordsLandingPage.uumIntercept();
   };
 
   goToVitalPage = () => {

--- a/src/applications/mhv-medical-records/tests/e2e/fixtures/unique-user-metrics-response.json
+++ b/src/applications/mhv-medical-records/tests/e2e/fixtures/unique-user-metrics-response.json
@@ -1,9 +1,0 @@
-{
-  "results": [
-      {
-          "event_name": "mhv_mr_accessed",
-          "status": "exists",
-          "new_event": false
-      }
-  ]
-}

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-chem-hem-detail-page.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-chem-hem-detail-page.cypress.spec.js
@@ -3,7 +3,6 @@ import LabsAndTestsListPage from './pages/LabsAndTestsListPage';
 import ChemHemDetailsPage from './pages/ChemHemDetailsPage';
 import labsAndTests from './fixtures/labs-and-tests/labsAndTests.json';
 import sessionStatus from './fixtures/session-status.json';
-import MedicalRecordsLandingPage from './pages/MedicalRecordsLandingPage';
 
 describe('Medical Records Understanding Your Results Detail Page', () => {
   const site = new MedicalRecordsSite();
@@ -19,7 +18,6 @@ describe('Medical Records Understanding Your Results Detail Page', () => {
       statusCode: 200,
       body: sessionStatus, // status response copied from staging
     }).as('status');
-    MedicalRecordsLandingPage.uumIntercept();
     LabsAndTestsListPage.goToLabsAndTests();
   });
 

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-microbiology-detail-page.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-microbiology-detail-page.cypress.spec.js
@@ -3,7 +3,6 @@ import LabsAndTestsListPage from './pages/LabsAndTestsListPage';
 import MicrobiologyPage from './pages/MicrobiologyDetailsPage';
 import labsAndTests from './fixtures/labs-and-tests/labsAndTests.json';
 import sessionStatus from './fixtures/session-status.json';
-import MedicalRecordsLandingPage from './pages/MedicalRecordsLandingPage';
 
 describe('Medical Records Understanding Your Results Microbiology Detail Page', () => {
   const site = new MedicalRecordsSite();
@@ -19,7 +18,6 @@ describe('Medical Records Understanding Your Results Microbiology Detail Page', 
       statusCode: 200,
       body: sessionStatus, // status response copied from staging
     }).as('status');
-    MedicalRecordsLandingPage.uumIntercept();
     LabsAndTestsListPage.goToLabsAndTests();
   });
 

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-pathology-detail-page.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-pathology-detail-page.cypress.spec.js
@@ -3,7 +3,6 @@ import PathologyDetailsPage from './pages/PathologyDetailsPage';
 import LabsAndTestsListPage from './pages/LabsAndTestsListPage';
 import labsAndTests from './fixtures/labs-and-tests/labsAndTests.json';
 import sessionStatus from './fixtures/session-status.json';
-import MedicalRecordsLandingPage from './pages/MedicalRecordsLandingPage';
 
 describe.skip('Medical Records Understanding Your Results Pathology Detail Page', () => {
   const site = new MedicalRecordsSite();
@@ -19,7 +18,6 @@ describe.skip('Medical Records Understanding Your Results Pathology Detail Page'
       statusCode: 200,
       body: sessionStatus, // status response copied from staging
     }).as('status');
-    MedicalRecordsLandingPage.uumIntercept();
     LabsAndTestsListPage.goToLabsAndTests();
   });
 

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-radiology-detail-page.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-understanding-your-results-radiology-detail-page.cypress.spec.js
@@ -2,7 +2,6 @@ import MedicalRecordsSite from './mr_site/MedicalRecordsSite';
 import RadiologyDetailsPage from './pages/RadiologyDetailsPage';
 import LabsAndTestsListPage from './pages/LabsAndTestsListPage';
 import sessionStatus from './fixtures/session-status.json';
-import MedicalRecordsLandingPage from './pages/MedicalRecordsLandingPage';
 // import labsAndTests from '../fixtures/labsAndTests.json';
 // import radiologyRecordsMhv from '../fixtures/radiologyRecordsMhv.json';
 
@@ -20,7 +19,6 @@ describe('Medical Records Understanding Your Results Detail Page', () => {
       body: sessionStatus, // status response copied from staging
     }).as('status');
     // cy.visit('my-health/medical-records/labs-and-tests');
-    MedicalRecordsLandingPage.uumIntercept();
     LabsAndTestsListPage.goToLabsAndTests();
   });
 

--- a/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
+++ b/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
@@ -2,7 +2,6 @@ import mockUser from '../fixtures/user.json';
 import vamc from '../fixtures/facilities/vamc-ehr.json';
 import sessionStatus from '../fixtures/session-status.json';
 import createAal from '../fixtures/create-aal.json';
-import MedicalRecordsLandingPage from '../pages/MedicalRecordsLandingPage';
 
 class MedicalRecordsSite {
   login = (userFixture = mockUser, useDefaultFeatureToggles = true) => {
@@ -24,7 +23,6 @@ class MedicalRecordsSite {
       body: createAal,
     }).as('aal');
     cy.intercept('POST', '/v0/datadog_action', {}).as('datadogAction');
-    MedicalRecordsLandingPage.uumIntercept();
     cy.login(userFixture);
   };
 

--- a/src/applications/mhv-medical-records/tests/e2e/pages/MedicalRecordsLandingPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/MedicalRecordsLandingPage.js
@@ -1,5 +1,4 @@
 import sessionStatus from '../fixtures/session-status.json';
-import mockUumResponse from '../fixtures/unique-user-metrics-response.json';
 
 class MedicalRecordsLandingPage {
   handleSession = () => {
@@ -11,16 +10,6 @@ class MedicalRecordsLandingPage {
       statusCode: 200,
       body: sessionStatus, // status response copied from staging
     }).as('status');
-    this.uumIntercept();
-  };
-
-  uumIntercept = () => {
-    // Note that we don't need specific event names in the response
-    cy.intercept(
-      'POST',
-      '/my_health/v1/unique_user_metrics',
-      mockUumResponse,
-    ).as('uum');
   };
 
   clickExpandAllAccordionButton = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed Unique User Metrics from Medical Records. These metrics are now being recorded in the backend.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/119996

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
