### PR TITLE
Removed Unique User Metrics from Secure Messaging

### DIFF
--- a/src/applications/mhv-secure-messaging/actions/messages.js
+++ b/src/applications/mhv-secure-messaging/actions/messages.js
@@ -1,8 +1,4 @@
 import moment from 'moment-timezone';
-import {
-  logUniqueUserMetricsEvents,
-  EVENT_REGISTRY,
-} from '@department-of-veterans-affairs/mhv/exports';
 import { Actions } from '../util/actionTypes';
 import {
   getMessage,
@@ -212,9 +208,6 @@ export const sendMessage = (
         ),
       );
     throw e;
-  } finally {
-    // Log message sending even if failed for analytics
-    logUniqueUserMetricsEvents(EVENT_REGISTRY.SECURE_MESSAGING_MESSAGE_SENT);
   }
 };
 
@@ -280,8 +273,5 @@ export const sendReply = ({
       );
     }
     throw e;
-  } finally {
-    // Log message sending even if failed for analytics
-    logUniqueUserMetricsEvents(EVENT_REGISTRY.SECURE_MESSAGING_MESSAGE_SENT);
   }
 };

--- a/src/applications/mhv-secure-messaging/containers/FolderThreadListView.jsx
+++ b/src/applications/mhv-secure-messaging/containers/FolderThreadListView.jsx
@@ -5,11 +5,7 @@ import {
   focusElement,
   waitForRenderThenFocus,
 } from '@department-of-veterans-affairs/platform-utilities/ui';
-import {
-  updatePageTitle,
-  logUniqueUserMetricsEvents,
-  EVENT_REGISTRY,
-} from '@department-of-veterans-affairs/mhv/exports';
+import { updatePageTitle } from '@department-of-veterans-affairs/mhv/exports';
 import {
   DefaultFolders as Folders,
   Alerts,
@@ -137,16 +133,6 @@ const FolderThreadListView = () => {
 
   useEffect(
     () => {
-      // Log inbox access for analytics
-      const normalizedPath = location.pathname.endsWith('/')
-        ? location.pathname
-        : `${location.pathname}/`;
-      if (normalizedPath === Paths.INBOX) {
-        logUniqueUserMetricsEvents(
-          EVENT_REGISTRY.SECURE_MESSAGING_INBOX_ACCESSED,
-        );
-      }
-
       dispatch(retrieveFolder(currentFolderId));
 
       return () => {

--- a/src/applications/mhv-secure-messaging/tests/actions/messages.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/actions/messages.unit.spec.jsx
@@ -3,11 +3,9 @@ import {
   mockFetch,
   mockMultipleApiRequests,
 } from '@department-of-veterans-affairs/platform-testing/helpers';
-import * as mhvExports from '~/platform/mhv/unique_user_metrics';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { Actions } from '../../util/actionTypes';
 import * as Constants from '../../util/constants';
 import {
@@ -227,10 +225,6 @@ describe('messages actions', () => {
   });
 
   it('should dispatch action on sendMessage', async () => {
-    const logUniqueUserMetricsEventsStub = sinon.stub(
-      mhvExports,
-      'logUniqueUserMetricsEvents',
-    );
     const store = mockStore();
     mockApiRequest(messageResponse);
     await store
@@ -263,11 +257,6 @@ describe('messages actions', () => {
         expect(actions).to.deep.include({
           type: Actions.AllRecipients.RESET_RECENT,
         });
-        expect(logUniqueUserMetricsEventsStub.calledOnce).to.be.true;
-        expect(logUniqueUserMetricsEventsStub.firstCall.args[0]).to.equal(
-          mhvExports.EVENT_REGISTRY.SECURE_MESSAGING_MESSAGE_SENT,
-        );
-        logUniqueUserMetricsEventsStub.restore();
       });
   });
 
@@ -339,10 +328,6 @@ describe('messages actions', () => {
   });
 
   it('should dispatch action on sendReply', async () => {
-    const logUniqueUserMetricsEventsStub = sinon.stub(
-      mhvExports,
-      'logUniqueUserMetricsEvents',
-    );
     const store = mockStore();
     mockApiRequest(messageResponse);
     await store
@@ -376,11 +361,6 @@ describe('messages actions', () => {
         expect(actions).to.deep.include({
           type: Actions.AllRecipients.RESET_RECENT,
         });
-        expect(logUniqueUserMetricsEventsStub.calledOnce).to.be.true;
-        expect(logUniqueUserMetricsEventsStub.firstCall.args[0]).to.equal(
-          mhvExports.EVENT_REGISTRY.SECURE_MESSAGING_MESSAGE_SENT,
-        );
-        logUniqueUserMetricsEventsStub.restore();
       });
   });
 

--- a/src/applications/mhv-secure-messaging/tests/containers/FolderThreadListView.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/FolderThreadListView.unit.spec.jsx
@@ -7,7 +7,6 @@ import {
 import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import sinon from 'sinon';
-import * as mhvExports from '~/platform/mhv/unique_user_metrics';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import {
   inbox,
@@ -99,32 +98,6 @@ describe('Folder Thread List View container', () => {
     expect(startANewMessageLink).to.exist;
     expect(startANewMessageLink).to.have.text('Start a new message');
     expect(startANewMessageLink).to.have.attr('href', Paths.COMPOSE);
-  });
-
-  it('logs unique user metrics when inbox is accessed', async () => {
-    const logUniqueUserMetricsEventsStub = sinon.stub(
-      mhvExports,
-      'logUniqueUserMetricsEvents',
-    );
-
-    setup({
-      ...initialState,
-      user: {
-        profile: {
-          facilities: userProfileFacilities,
-        },
-      },
-    });
-
-    await waitFor(() => {
-      // Verify unique user metrics logging for inbox access
-      expect(logUniqueUserMetricsEventsStub.calledOnce).to.be.true;
-      expect(logUniqueUserMetricsEventsStub.firstCall.args[0]).to.equal(
-        mhvExports.EVENT_REGISTRY.SECURE_MESSAGING_INBOX_ACCESSED,
-      );
-
-      logUniqueUserMetricsEventsStub.restore();
-    });
   });
 
   it(`verifies page title tag for 'Sent' FolderThreadListView page`, async () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/unique-user-metrics-response.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/unique-user-metrics-response.json
@@ -1,9 +1,0 @@
-{
-  "results": [
-      {
-          "event_name": "mhv_secure_messaging_accessed",
-          "status": "exists",
-          "new_event": false
-      }
-  ]
-}

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
@@ -5,7 +5,6 @@ import mockSignature from '../fixtures/signature-response.json';
 import { Locators, Paths, Data, Alerts } from '../utils/constants';
 import mockDraftResponse from '../fixtures/message-compose-draft-response.json';
 import mockRecipients from '../fixtures/recipientsResponse/recipients-response.json';
-import mockUumResponse from '../fixtures/unique-user-metrics-response.json';
 import newDraft from '../fixtures/draftsResponse/drafts-single-message-response.json';
 import SharedComponents from './SharedComponents';
 
@@ -18,8 +17,6 @@ class PatientComposePage {
     cy.intercept('POST', `${Paths.SM_API_EXTENDED}*`, mockResponse).as(
       'message',
     );
-    // Note that we don't need specific event names in the response
-    cy.intercept('POST', Paths.UUM_API_BASE, mockUumResponse).as('uum');
     cy.get(Locators.BUTTONS.SEND)
       .contains('Send')
       .click({ force: true });

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientReplyPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientReplyPage.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import mockMessage from '../fixtures/message-response.json';
 import { Locators, Paths, Data } from '../utils/constants';
-import mockUumResponse from '../fixtures/unique-user-metrics-response.json';
 
 class PatientReplyPage {
   clickReplyButton = mockResponse => {
@@ -23,8 +22,6 @@ class PatientReplyPage {
       }/reply`,
       mockReplyMessage,
     ).as('replyMessage');
-    // Note that we don't need specific event names in the response
-    cy.intercept('POST', Paths.UUM_API_BASE, mockUumResponse).as('uum');
     cy.get(Locators.BUTTONS.SEND).click();
   };
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -7,7 +7,6 @@ export const Paths = {
   UI_MAIN: '/my-health/secure-messages',
   SM_API_BASE: '/my_health/v1/messaging',
   SM_API_EXTENDED: '/my_health/v1/messaging/messages',
-  UUM_API_BASE: '/my_health/v1/unique_user_metrics',
   INBOX: '/inbox/',
   SENT: '/sent/',
   DRAFTS: '/drafts/',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed Unique User Metrics from Secure Messaging. These metrics are now being recorded in the backend.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/119996

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
MHV Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
