### PR TITLE
changed recent care H1 and copy for radio label below it. updated uni…

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -14,7 +14,8 @@ import { focusOnErrorField } from '../util/formHelpers';
 import { updateDraftInProgress } from '../actions/threadDetails';
 import useFeatureToggles from '../hooks/useFeatureToggles';
 
-const RADIO_BUTTON_SET_LABEL = `Select a team from those you've sent messages to in the past 6 months. Or select "A different care team" to find another team.`;
+const RECENT_RECIPIENTS_LABEL = `Select a team you want to message. This list only includes teams that you've sent messages to in the last 6 months. If you want to contact another team, select "A different care team."`;
+
 const OTHER_VALUE = 'other';
 const { Paths } = Constants;
 
@@ -129,13 +130,13 @@ const RecentCareTeams = () => {
   return (
     <>
       <h1 className="vads-u-margin-bottom--3" tabIndex="-1" ref={h1Ref}>
-        Recent care teams
+        Care teams you recently sent messages to
       </h1>
       <EmergencyNote dropDownFlag />
       <VaRadio
         class="vads-u-margin-bottom--3"
         error={error}
-        label={RADIO_BUTTON_SET_LABEL}
+        label={RECENT_RECIPIENTS_LABEL}
         required
         onVaValueChange={handleRadioChange}
         data-testid="recent-care-teams-radio-group"

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -14,7 +14,7 @@ import { focusOnErrorField } from '../util/formHelpers';
 import { updateDraftInProgress } from '../actions/threadDetails';
 import useFeatureToggles from '../hooks/useFeatureToggles';
 
-const RECENT_RECIPIENTS_LABEL = `Select a team you want to message. This list only includes teams that you've sent messages to in the last 6 months. If you want to contact another team, select "A different care team."`;
+const RECENT_RECIPIENTS_LABEL = `Select a team you want to message. This list only includes teams that you’ve sent messages to in the last 6 months. If you want to contact another team, select “A different care team.”`;
 
 const OTHER_VALUE = 'other';
 const { Paths } = Constants;

--- a/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
@@ -11,7 +11,7 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import App from '../../containers/App';
 import * as SmApi from '../../api/SmApi';
 import reducer from '../../reducers';
-import { Paths } from '../../util/constants';
+import { PageHeaders, Paths } from '../../util/constants';
 
 describe('App', () => {
   const initialState = {
@@ -440,7 +440,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Care teams you recently sent messages to', {
+        screen.getByText(PageHeaders.RECENT_RECIPIENTS, {
           selector: 'h1',
         }),
       ).to.exist;

--- a/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
@@ -439,8 +439,11 @@ describe('App', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Recent care teams', { selector: 'h1' })).to
-        .exist;
+      expect(
+        screen.getByText('Care teams you recently sent messages to', {
+          selector: 'h1',
+        }),
+      ).to.exist;
     });
   });
 

--- a/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
@@ -90,7 +90,7 @@ describe('RecentCareTeams component', () => {
       const screen = renderComponent();
 
       expect(
-        screen.getByText('Care teams you recently sent messages to', {
+        screen.getByText(Constants.PageHeaders.RECENT_RECIPIENTS, {
           selector: 'h1',
         }),
       ).to.exist;
@@ -160,7 +160,7 @@ describe('RecentCareTeams component', () => {
       const screen = renderComponent();
 
       expect(
-        screen.getByText('Care teams you recently sent messages to', {
+        screen.getByText(Constants.PageHeaders.RECENT_RECIPIENTS, {
           selector: 'h1',
         }),
       ).to.exist;
@@ -180,7 +180,7 @@ describe('RecentCareTeams component', () => {
       const screen = renderComponent(state);
 
       expect(
-        screen.getByText('Care teams you recently sent messages to', {
+        screen.getByText(Constants.PageHeaders.RECENT_RECIPIENTS, {
           selector: 'h1',
         }),
       ).to.exist;
@@ -215,7 +215,7 @@ describe('RecentCareTeams component', () => {
 
       // Component should still render
       expect(
-        screen.getByText('Care teams you recently sent messages to', {
+        screen.getByText(Constants.PageHeaders.RECENT_RECIPIENTS, {
           selector: 'h1',
         }),
       ).to.exist;
@@ -252,7 +252,7 @@ describe('RecentCareTeams component', () => {
       );
       const screen = renderComponent(customState);
       expect(
-        screen.getByText('Care teams you recently sent messages to', {
+        screen.getByText(Constants.PageHeaders.RECENT_RECIPIENTS, {
           selector: 'h1',
         }),
       ).to.exist;
@@ -566,7 +566,7 @@ describe('RecentCareTeams component', () => {
 
       await waitFor(() => {
         const h1Element = screen.getByText(
-          'Care teams you recently sent messages to',
+          Constants.PageHeaders.RECENT_RECIPIENTS,
           { selector: 'h1' },
         );
         expect(document.activeElement).to.equal(h1Element);
@@ -577,7 +577,7 @@ describe('RecentCareTeams component', () => {
       const screen = renderComponent();
 
       const h1Element = screen.getByText(
-        'Care teams you recently sent messages to',
+        Constants.PageHeaders.RECENT_RECIPIENTS,
         { selector: 'h1' },
       );
       expect(h1Element.getAttribute('tabIndex')).to.equal('-1');

--- a/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
@@ -89,13 +89,17 @@ describe('RecentCareTeams component', () => {
     it('should render the component with heading and radio options', () => {
       const screen = renderComponent();
 
-      expect(screen.getByText('Recent care teams')).to.exist;
+      expect(
+        screen.getByText('Care teams you recently sent messages to', {
+          selector: 'h1',
+        }),
+      ).to.exist;
 
       // Check for va-radio element with the label attribute
       const radioGroup = document.querySelector('va-radio');
       expect(radioGroup).to.exist;
       expect(radioGroup.getAttribute('label')).to.include(
-        "Select a team from those you've sent messages to in the past 6 months",
+        'Select a team you want to message',
       );
 
       // Check for va-radio-option elements with label attributes
@@ -155,7 +159,11 @@ describe('RecentCareTeams component', () => {
       // This test verifies the component renders with the expected state
       const screen = renderComponent();
 
-      expect(screen.getByText('Recent care teams')).to.exist;
+      expect(
+        screen.getByText('Care teams you recently sent messages to', {
+          selector: 'h1',
+        }),
+      ).to.exist;
     });
 
     it('should not dispatch getRecentRecipients when allRecipients is empty', () => {
@@ -171,8 +179,11 @@ describe('RecentCareTeams component', () => {
       };
       const screen = renderComponent(state);
 
-      expect(screen.getByText('Recent care teams', { selector: 'h1' })).to
-        .exist;
+      expect(
+        screen.getByText('Care teams you recently sent messages to', {
+          selector: 'h1',
+        }),
+      ).to.exist;
     });
   });
 
@@ -203,7 +214,11 @@ describe('RecentCareTeams component', () => {
       const screen = renderComponent(state);
 
       // Component should still render
-      expect(screen.getByText('Recent care teams')).to.exist;
+      expect(
+        screen.getByText('Care teams you recently sent messages to', {
+          selector: 'h1',
+        }),
+      ).to.exist;
     });
 
     it('should dispatch ohTriageGroup attribute for care system', async () => {
@@ -236,7 +251,11 @@ describe('RecentCareTeams component', () => {
         'updateDraftInProgress',
       );
       const screen = renderComponent(customState);
-      expect(screen.getByText('Recent care teams')).to.exist;
+      expect(
+        screen.getByText('Care teams you recently sent messages to', {
+          selector: 'h1',
+        }),
+      ).to.exist;
       selectVaRadio(screen.container, 123);
       await waitFor(() => {
         const callArgs = updateDraftInProgressStub.lastCall.args[0];
@@ -546,7 +565,10 @@ describe('RecentCareTeams component', () => {
       const screen = renderComponent();
 
       await waitFor(() => {
-        const h1Element = screen.getByText('Recent care teams');
+        const h1Element = screen.getByText(
+          'Care teams you recently sent messages to',
+          { selector: 'h1' },
+        );
         expect(document.activeElement).to.equal(h1Element);
       });
     });
@@ -554,7 +576,10 @@ describe('RecentCareTeams component', () => {
     it('should have proper tabIndex on h1 element', () => {
       const screen = renderComponent();
 
-      const h1Element = screen.getByText('Recent care teams');
+      const h1Element = screen.getByText(
+        'Care teams you recently sent messages to',
+        { selector: 'h1' },
+      );
       expect(h1Element.getAttribute('tabIndex')).to.equal('-1');
     });
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js
@@ -241,7 +241,7 @@ describe('SM CURATED LIST BREADCRUMBS', () => {
       PatientInterstitialPage.continueToRecentRecipients(
         searchSentFolderResponse,
       );
-      GeneralFunctionsPage.verifyPageHeader('Recent care teams');
+      GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
       // Navigate forward to select care team
       cy.findByLabelText('A different care team').click();
@@ -250,7 +250,7 @@ describe('SM CURATED LIST BREADCRUMBS', () => {
 
       // Navigate back through the flow
       SharedComponents.clickBackBreadcrumb();
-      GeneralFunctionsPage.verifyPageHeader('Recent care teams');
+      GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
       SharedComponents.clickBackBreadcrumb();
       GeneralFunctionsPage.verifyPageHeader(
@@ -283,7 +283,7 @@ describe('SM CURATED LIST BREADCRUMBS', () => {
       PatientInterstitialPage.continueToRecentRecipients(
         searchSentFolderResponse,
       );
-      GeneralFunctionsPage.verifyPageHeader('Recent care teams');
+      GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
       cy.location('pathname').should(
         'equal',
         `${Paths.UI_MAIN}${Paths.COMPOSE}${Paths.RECENT_CARE_TEAMS}`,
@@ -319,7 +319,7 @@ describe('SM CURATED LIST BREADCRUMBS', () => {
 
       // Backward: Select care team → Recent care teams
       SharedComponents.clickBackBreadcrumb();
-      GeneralFunctionsPage.verifyPageHeader('Recent care teams');
+      GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
       cy.location('pathname').should(
         'equal',
         `${Paths.UI_MAIN}${Paths.COMPOSE}${Paths.RECENT_CARE_TEAMS}`,

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
@@ -33,7 +33,7 @@ describe('SM CURATED LIST MAIN FLOW', () => {
     PatientInboxPage.clickCreateNewMessage();
     // cy.wait(100000); // wait for recent recipients to load
     PatientInterstitialPage.continueToRecentRecipients();
-    GeneralFunctionsPage.verifyPageHeader(`Recent care teams`);
+    GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
     cy.findByTestId(Locators.EMERGENCY_USE_EXPANDABLE_DATA_TEST_ID).should(
       `exist`,
@@ -64,7 +64,7 @@ describe('SM CURATED LIST MAIN FLOW', () => {
     );
     PatientInboxPage.clickCreateNewMessage();
     PatientInterstitialPage.continueToRecentRecipients(modifiedSearchResponse);
-    GeneralFunctionsPage.verifyPageHeader(`Recent care teams`);
+    GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
     cy.findByTestId(Locators.EMERGENCY_USE_EXPANDABLE_DATA_TEST_ID).should(
       `exist`,
@@ -91,7 +91,7 @@ describe('SM CURATED LIST MAIN FLOW', () => {
   it('validate selection error', () => {
     PatientInboxPage.clickCreateNewMessage();
     PatientInterstitialPage.continueToRecentRecipients();
-    GeneralFunctionsPage.verifyPageHeader(`Recent care teams`);
+    GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
     cy.findByTestId(
       Locators.RECENT_CARE_TEAMS_CONTINUE_BUTTON_DATA_TEST_ID,
@@ -112,7 +112,7 @@ describe('SM CURATED LIST MAIN FLOW', () => {
   it('validate selecting different care team option', () => {
     PatientInboxPage.clickCreateNewMessage();
     PatientInterstitialPage.continueToRecentRecipients();
-    GeneralFunctionsPage.verifyPageHeader(`Recent care teams`);
+    GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
     cy.findByLabelText('A different care team').click();
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
@@ -31,7 +31,6 @@ describe('SM CURATED LIST MAIN FLOW', () => {
 
   it('verify recent recipients list with maximum recipients', () => {
     PatientInboxPage.clickCreateNewMessage();
-    // cy.wait(100000); // wait for recent recipients to load
     PatientInterstitialPage.continueToRecentRecipients();
     GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
@@ -97,10 +97,11 @@ describe('SM CURATED LIST MAIN FLOW', () => {
       Locators.RECENT_CARE_TEAMS_CONTINUE_BUTTON_DATA_TEST_ID,
     ).click();
 
+    // Wait for error message to appear and be visible
     cy.findByTestId(Locators.RECENT_CARE_TEAMS_RADIO_GROUP_TEST_ID)
       .shadow()
       .findByText('Select a care team')
-      .should('exist');
+      .should('be.visible');
 
     // validate the first va-radio-option is focused
     cy.findByLabelText(`${recentCareTeams[0]}VA Madison health care`).should(

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -411,6 +411,7 @@ export const Data = {
   CANNOT_REMOVE_FOLDER: `You can't remove a folder with messages in it. Move all the messages to another folder. Then try removing it again.`,
   HCS_SELECT: `Select care team`,
   REPLY_HEADER: `Only use messages for non-urgent needs`,
+  RECENT_RECIPIENTS_HEADER: 'Care teams you recently sent messages to',
   RECENT_RECIPIENTS_LABEL: `Select a team you want to message. This list only includes teams that you've sent messages to in the last 6 months. If you want to contact another team, select "A different care team."`,
   ATTACH_INFO: [
     'You may attach up to 4 files to each message',

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -411,7 +411,7 @@ export const Data = {
   CANNOT_REMOVE_FOLDER: `You can't remove a folder with messages in it. Move all the messages to another folder. Then try removing it again.`,
   HCS_SELECT: `Select care team`,
   REPLY_HEADER: `Only use messages for non-urgent needs`,
-  RECENT_RECIPIENTS_LABEL: `Select a team from those you've sent messages to in the past 6 months. Or select "A different care team" to find another team.`,
+  RECENT_RECIPIENTS_LABEL: `Select a team you want to message. This list only includes teams that you've sent messages to in the last 6 months. If you want to contact another team, select "A different care team."`,
   ATTACH_INFO: [
     'You may attach up to 4 files to each message',
     'You can attach only these file types: doc, docx, gif, jpg, pdf, png, rtf, txt, xls, xlsx, jpeg, jfif, pjpeg, pjp',

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -412,7 +412,7 @@ export const Data = {
   HCS_SELECT: `Select care team`,
   REPLY_HEADER: `Only use messages for non-urgent needs`,
   RECENT_RECIPIENTS_HEADER: 'Care teams you recently sent messages to',
-  RECENT_RECIPIENTS_LABEL: `Select a team you want to message. This list only includes teams that you've sent messages to in the last 6 months. If you want to contact another team, select "A different care team."`,
+  RECENT_RECIPIENTS_LABEL: `Select a team you want to message. This list only includes teams that you’ve sent messages to in the last 6 months. If you want to contact another team, select “A different care team.”`,
   ATTACH_INFO: [
     'You may attach up to 4 files to each message',
     'You can attach only these file types: doc, docx, gif, jpg, pdf, png, rtf, txt, xls, xlsx, jpeg, jfif, pjpeg, pjp',

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -479,6 +479,10 @@ export const PageTitles = {
     'Can’t find your care team? - Messages | Veterans Affairs',
 };
 
+export const PageHeaders = {
+  RECENT_RECIPIENTS: 'Care teams you recently sent messages to',
+};
+
 export const Recipients = {
   CARE_TEAM: 'Care Team',
   FACILITY: 'Facility',


### PR DESCRIPTION
## Summary
This pull request updates the heading and radio group label for the "Recent Care Teams" feature in secure messaging to use more user-friendly language. It also ensures that all related unit and e2e tests reflect these updated labels and headings for consistency.

**UI copy updates:**

* Changed the heading in `RecentCareTeams.jsx` from "Recent care teams" to "Care teams you recently sent messages to".
* Updated the radio group label to: "Select a team you want to message. This list only includes teams that you've sent messages to in the last 6 months. If you want to contact another team, select 'A different care team.'"

**Test updates:**

* Updated all unit tests in `RecentCareTeams.unit.spec.jsx` to expect the new heading and label text, ensuring correct selector usage and improved test reliability.
* Updated the relevant e2e test constant to match the new radio group label.
* Modified the `App.unit.spec.jsx` test to expect the updated heading.


## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Related issue(s)

- This PR addresses 2 separate issues: 
  - https://github.com/department-of-veterans-affairs/va.gov-team/issues/121758
  - https://github.com/department-of-veterans-affairs/va.gov-team/issues/120578

## Testing done

Unit tests and E2E tests were updated and all passing. This container currently has 100% unit test coverage.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="393" height="788" alt="Screenshot 2025-10-22 at 9 51 01 AM" src="https://github.com/user-attachments/assets/f755e198-fec2-402c-974a-a2f9c720af0b" />   |   <img width="414" height="795" alt="Screenshot 2025-10-22 at 9 50 23 AM" src="https://github.com/user-attachments/assets/1f811fde-5747-442d-8dc6-1a531950ab83" />    |
| Desktop | <img width="1220" height="1177" alt="Screenshot 2025-10-22 at 9 51 15 AM" src="https://github.com/user-attachments/assets/5904f03d-fa52-410c-9237-4b96b1f7109b" />     |    <img width="1243" height="1206" alt="Screenshot 2025-10-22 at 9 49 25 AM" src="https://github.com/user-attachments/assets/1d322410-989b-4f85-b525-1e7342eecfd0" />   |

## What areas of the site does it impact?
Secure Messaging

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
