### PR TITLE
10-10d extended | Bugfix Medicare titles in edit mode

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -183,8 +183,9 @@ const medicareSummaryPage = {
 
 const medicarePlanTypes = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(`${generateParticipantName(formData)} Medicare plan types`),
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        `${generateParticipantName(formData)} Medicare plan types`,
     ),
     medicarePlanType: {
       ...radioUI({
@@ -209,10 +210,9 @@ const medicarePlanTypes = {
 
 const medicarePartAPartBEffectiveDatesPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(formData)} Medicare effective dates`,
-      ),
     ),
     'view:medicarePartAEffectiveDate': {
       'ui:title': <h3>Medicare Part A</h3>,
@@ -309,10 +309,9 @@ const medicareABCardUploadPage = {
 
 const medicarePartAEffectiveDatePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(formData)} Medicare Part A effective date`,
-      ),
     ),
     medicarePartAEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part A effective date',
@@ -377,10 +376,9 @@ const medicarePartACardUploadPage = {
 
 const medicarePartBEffectiveDatePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(formData)} Medicare Part B effective date`,
-      ),
     ),
     medicarePartBEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part B Effective date',
@@ -449,17 +447,13 @@ const medicarePartADenialPage = dataKey => {
     const n = Number(formContext.pagePerItemIndex);
     const itemIndex = Number.isFinite(n) && n >= 0 ? n : null;
     if (formData?.medicare?.[itemIndex]?.medicareParticipant) {
-      return privWrapper(
-        `${generateParticipantName(
-          formData?.medicare?.[itemIndex],
-        )} Medicare status`,
-      );
+      return `${generateParticipantName(
+        formData?.medicare?.[itemIndex],
+      )} Medicare status`;
     }
     const apps = getEligibleApplicantsWithoutMedicare(formData) ?? [];
     const item = apps.find(a => getAgeInYears(a.applicantDob) >= 65);
-    return privWrapper(
-      `${applicantWording(item, false, false, false)}’s Medicare status`,
-    );
+    return `${applicantWording(item, false, false, false)}’s Medicare status`;
   };
   return {
     uiSchema: {
@@ -558,12 +552,11 @@ const medicarePartADenialProofUploadPage = dataKey => {
 
 const medicarePartCCarrierEffectiveDatePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(
           formData,
         )} Medicare Part C carrier and effective date`,
-      ),
     ),
     medicarePartCCarrier: textUI({
       title: 'Name of insurance carrier',
@@ -587,10 +580,9 @@ const medicarePartCCarrierEffectiveDatePage = {
 
 const medicarePartCPharmacyBenefitsPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(formData)} Medicare pharmacy benefits`,
-      ),
     ),
     hasPharmacyBenefits: {
       ...yesNoUI({
@@ -660,10 +652,9 @@ const medicarePartCCardUploadPage = {
 
 const medicarePartDStatusPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(formData)} Medicare Part D status`,
-      ),
     ),
     hasMedicarePartD: {
       ...yesNoUI({
@@ -683,10 +674,9 @@ const medicarePartDStatusPage = {
 
 const medicarePartDCarrierEffectiveDatePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) =>
-      privWrapper(
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
         `${generateParticipantName(formData)} Medicare Part D effective date`,
-      ),
     ),
     medicarePartDEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part D effective date',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the Medicare section to remove any JSX in any of the ArrayBuilder page titles. The ArrayBuilder does not accept JSX for titles in Edit mode and will need an update for those to apply. 

## Related issue(s)

department-of-veterans-affairs/va.gov-team#122648

## Testing done

- Prior to the update, any page title with JSX would fail in edit mode
- After the update, no page titles contain JSX that would cause the failure

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- ArrayBuilder page titles are free from JSX

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
