### PR TITLE
silence all front-end requests from platform/monitoring/sentry.js with sentry_key=faker@

### DIFF
--- a/src/platform/monitoring/sentry.js
+++ b/src/platform/monitoring/sentry.js
@@ -12,6 +12,7 @@ const trackErrors = environment.BASE_URL.indexOf('localhost') < 0;
 if (trackErrors) {
   const url = `${environment.BASE_URL}/js-report/0`.replace('//', '//faker@');
   Sentry.init({
+    enabled: !url.includes('//faker@'),
     autoSessionTracking: false,
     dsn: url,
     environment: environment.vspEnvironment(),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Since mid-June we have received approximately 9.7 million requests to /js-report/api/0/envelope/?sentry_key=faker&sentry_version=7, which returns a 400 (Bad Request) response code.
- _This PR allows Sentry to initialize but adds a conditional check to ensure no requests with the faker DSN are generated and sent._
- _This is essentially a soft-silencing of the function in order to avoid any complications from the removal of the script file altogether._


## Related issue(s)

- _https://github.com/department-of-veterans-affairs/va.gov-team/issues/119705_


## What areas of the site does it impact?

*This should only remove the high volume of Bad Requests being fielded by vets-api.*
