### PR TITLE
112968 Profile - Update success/error alert focus management

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
@@ -105,14 +105,15 @@ const CopyAddressModal = props => {
     },
     onCloseModal() {
       updateCopyAddressModalAction(null);
+      focusElement('#home-address [data-testid=update-success-alert]');
     },
     onCloseSuccessModal() {
-      handlers.onCloseModal();
+      updateCopyAddressModalAction(null);
       focusElement('#mailing-address [data-testid=update-success-alert]');
     },
     onCloseFailureModal() {
-      handlers.onCloseModal();
-      focusElement('#mailing-address .usa-input-error-message');
+      updateCopyAddressModalAction(null);
+      focusElement('#mailing-address [data-testid=generic-error-alert]');
     },
   };
 

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalFailure.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalFailure.jsx
@@ -7,12 +7,11 @@ const CopyAddressModalFailure = ({ visible, onClose }) => (
   <VaModal
     modalTitle="We can't update your mailing address"
     visible={visible}
-    onClose={onClose}
+    onCloseEvent={onClose}
     status="error"
     primaryButtonText="Close"
     onPrimaryButtonClick={onClose}
     data-testid="copy-address-failure"
-    uswds
   >
     <>
       <div data-testid="modal-content">

--- a/src/applications/personalization/profile/tests/e2e/address-validation/no-changes-made.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/no-changes-made.cypress.spec.js
@@ -13,11 +13,6 @@ describe('Personal and contact information', () => {
       addressPage.loadPage('no-change');
       addressPage.updateWithoutChanges();
       addressPage.validateSavedForm(formFields, false);
-      addressPage.validateFocusedElement({
-        tag: 'va-button',
-        name: 'Edit Mailing address',
-        innerTag: 'button',
-      });
       cy.injectAxeThenAxeCheck();
     });
   });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -25,15 +25,10 @@ const validateSavedForm = (
   });
   fields.military && cy.findByTestId('mailingAddress').should('contain', 'FPO');
   if (saved) {
-    cy.findByTestId('update-success-alert', { timeout: 10000 }).should('exist');
+    cy.findByTestId('update-success-alert', { timeout: 10000 }).should(
+      'be.focused',
+    );
     cy.get('#edit-mailing-address').should('exist');
-
-    // this linting warning is actually a bug in cypress
-    // https://github.com/cypress-io/eslint-plugin-cypress/issues/140
-    cy.focused().then($focused => {
-      expect($focused).to.have.attr('aria-label', 'Edit Mailing address');
-      expect($focused).to.have.text('Edit');
-    });
   }
 
   altText && cy.findByText(altText).should('exist');
@@ -146,20 +141,6 @@ const updateWithoutChanges = () => {
   cy.findByTestId('save-edit-button', { timeout: 10000 }).should('not.exist');
 };
 
-const validateFocusedElement = element => {
-  // If the element is a web component, assert focus is on the
-  // native element inside the shadow DOM
-  if (element.innerTag) {
-    cy.get(`${element.tag}[label="${element.name}"]`)
-      .shadow()
-      .find(element.innerTag)
-      .should('be.focused');
-  } else {
-    // Otherwise, use the standard role-based query
-    cy.findByRole(element.tag, { name: element.name }).should('be.focused');
-  }
-};
-
 class AddressPage {
   loadPage = (config, toggles = {}) => {
     setUp(config, toggles);
@@ -254,7 +235,7 @@ class AddressPage {
     if (saved) {
       cy.wait('@mockUser');
       cy.findByTestId('update-success-alert', { timeout: 10000 }).should(
-        'exist',
+        'be.focused',
       );
       cy.get('#edit-mailing-address').should('exist');
     }
@@ -316,20 +297,6 @@ class AddressPage {
     cy.findByTestId('save-edit-button').click({ force: true });
     cy.findByTestId('save-edit-button', { timeout: 10000 }).should('not.exist');
   };
-
-  validateFocusedElement = element => {
-    // If the element is a web component, assert focus is on the
-    // native element inside the shadow DOM
-    if (element.innerTag) {
-      cy.get(`${element.tag}[label="${element.name}"]`)
-        .shadow()
-        .find(element.innerTag)
-        .should('be.focused');
-    } else {
-      // Otherwise, use the standard role-based query
-      cy.findByRole(element.tag, { name: element.name }).should('be.focused');
-    }
-  };
 }
 
 export {
@@ -341,7 +308,6 @@ export {
   confirmAddressFields,
   editAddress,
   updateWithoutChanges,
-  validateFocusedElement,
 };
 
 export default AddressPage;

--- a/src/applications/personalization/profile/tests/e2e/contact-information/delete-email-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/delete-email-address.cypress.spec.js
@@ -32,8 +32,11 @@ const removeEmailAddress = () => {
     .find('va-button[text="Remove"]')
     .click();
 
+  // Confirm modal appears with focus
+  cy.get('va-modal').should('be.focused');
+
   // Confirm delete in modal
-  cy.get('va-button[data-testid="confirm-remove-button"]').click();
+  cy.get('[data-testid="confirm-remove-button"]').click();
 };
 
 describe('Delete email address', () => {
@@ -46,7 +49,7 @@ describe('Delete email address', () => {
     cy.get('[data-field-name="email"]')
       .find('va-button[text="Remove"]')
       .click();
-    cy.get('va-button[data-testid="cancel-remove-button"]').click();
+    cy.get('[data-testid="cancel-remove-button"]').click();
     // Confirm modal closes & focus is on the Remove button
     cy.get('va-modal').should('not.exist');
     cy.get('[data-field-name="email"]')

--- a/src/applications/personalization/profile/tests/e2e/contact-information/delete-email-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/delete-email-address.cypress.spec.js
@@ -124,7 +124,7 @@ describe('Delete email address', () => {
     removeEmailAddress();
     // Confirm modal closes & success alert appears
     cy.get('va-modal').should('not.exist');
-    cy.get('[data-testid="update-success-alert"]').should('be.visible');
+    cy.get('[data-testid="update-success-alert"]').should('be.focused');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/profile/tests/e2e/contact-information/edit-email-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/edit-email-address.cypress.spec.js
@@ -118,11 +118,11 @@ describe('Edit email address', () => {
     editEmailAddress(newEmail);
     // Confirm the Save button is in a loading state while the transaction is pending
     cy.get('[data-testid="save-edit-button"]').should('have.attr', 'loading');
-    // Confirm edit view exits & update success alert appears
+    // Confirm edit view exits & update success alert appears with focus
     cy.get('[data-field-name="email"]')
       .find('va-button[text="Edit"]')
       .should('exist');
-    cy.get('[data-testid="update-success-alert"]').should('be.visible');
+    cy.get('[data-testid="update-success-alert"]').should('be.focused');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/profile/tests/e2e/contact-information/focus.after.edit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/focus.after.edit.cypress.spec.js
@@ -26,7 +26,7 @@ describe('focus after editing fields', () => {
       cy.intercept('GET', '/v0/user*', loa3User72);
     });
 
-    it('should focus on mailing address button when editing is complete', () => {
+    it('should focus on mailing address update success alert when editing is complete', () => {
       cy.visit(PROFILE_PATHS.CONTACT_INFORMATION);
       // should show a loading indicator
       cy.get('va-loading-indicator')
@@ -48,7 +48,7 @@ describe('focus after editing fields', () => {
       cy.get('[data-testid="confirm-address-button"]').click({
         waitForAnimations: true,
       });
-      cy.get('va-alert[status="success"]').should('be.focused');
+      cy.get('[data-testid="update-success-alert"]').should('be.focused');
     });
   });
   describe('Phone number fields with SCHEMA form system', () => {
@@ -64,7 +64,7 @@ describe('focus after editing fields', () => {
         req.reply(200, phoneNumber.transactions.successful);
       });
     });
-    it('should focus on edit phone number button when editing is complete', () => {
+    it('should focus on phone number update success alert when editing is complete', () => {
       cy.visit(PROFILE_PATHS.CONTACT_INFORMATION);
       // should show a loading indicator
       cy.get('va-loading-indicator')
@@ -84,8 +84,7 @@ describe('focus after editing fields', () => {
       cy.get('[data-testid="save-edit-button"]').click({
         waitForAnimations: true,
       });
-      cy.get('[data-testid="update-success-alert"]').should('exist');
-      cy.get('va-alert[status="success"]').should('be.focused');
+      cy.get('[data-testid="update-success-alert"]').should('be.focused');
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/contact-information/home-address-modal-failure.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/home-address-modal-failure.cypress.spec.js
@@ -23,6 +23,7 @@ describe('Home address update modal - api failure', () => {
     addressPage.fillAddressForm(formFields);
     addressPage.saveForm();
 
+    cy.findByTestId('copy-address-prompt').should('be.focused');
     cy.findByTestId('copy-address-prompt')
       .shadow()
       .findByText(`We've updated your home address`)
@@ -32,6 +33,7 @@ describe('Home address update modal - api failure', () => {
       force: true,
     });
 
+    cy.findByTestId('copy-address-failure').should('be.focused');
     cy.findByTestId('copy-address-failure')
       .shadow()
       .findByText(`We can't update your mailing address`)
@@ -47,7 +49,7 @@ describe('Home address update modal - api failure', () => {
 
     cy.findByTestId('mailingAddress')
       .findByTestId('generic-error-alert')
-      .should('exist');
+      .should('be.focused');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/profile/tests/e2e/contact-information/home-address-modal.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/home-address-modal.cypress.spec.js
@@ -42,6 +42,7 @@ describe('Home address update modal', () => {
     addressPage.fillAddressForm(formFields);
     addressPage.saveForm();
 
+    cy.findByTestId('copy-address-prompt').should('be.focused');
     cy.findByTestId('copy-address-prompt')
       .shadow()
       .findByText(`We've updated your home address`)
@@ -52,6 +53,7 @@ describe('Home address update modal', () => {
       waitForAnimations: true,
     });
 
+    cy.findByTestId('copy-address-success').should('be.focused');
     cy.findByTestId('copy-address-success')
       .shadow()
       .findByText(`We've updated your mailing address`)
@@ -68,7 +70,7 @@ describe('Home address update modal', () => {
 
     cy.findByTestId('mailingAddress')
       .findByTestId('update-success-alert')
-      .should('exist');
+      .should('be.focused');
 
     cy.findByTestId('residentialAddress')
       .findByTestId('update-success-alert')

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ContactInformationUpdateSuccessAlert.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ContactInformationUpdateSuccessAlert.jsx
@@ -1,24 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-
-import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 const ContactInformationUpdateSuccessAlert = ({ fieldName }) => {
   const id = `${fieldName}-alert`;
-
-  useEffect(
-    () => {
-      if (fieldName) {
-        // Focus on the va-alert element itself
-        waitForRenderThenFocus(
-          `[data-field-name=${fieldName}] va-alert`,
-          document,
-          50,
-        );
-      }
-    },
-    [fieldName],
-  );
 
   return (
     <>
@@ -31,9 +15,9 @@ const ContactInformationUpdateSuccessAlert = ({ fieldName }) => {
         visible="true"
         full-width
         slim
-        uswds
         role="alert"
         data-testid="update-success-alert"
+        tabindex="-1"
       >
         <p className="vads-u-margin-y--0" id={id}>
           Update saved.

--- a/src/platform/user/profile/vap-svc/components/GenericErrorAlert.jsx
+++ b/src/platform/user/profile/vap-svc/components/GenericErrorAlert.jsx
@@ -17,9 +17,9 @@ const GenericErrorAlert = ({ fieldName }) => {
         visible="true"
         full-width
         slim
-        uswds
         role="alert"
         data-testid="generic-error-alert"
+        tabindex="-1"
       >
         <p className="vads-u-margin-y--0" id={id}>
           {DEFAULT_ERROR_MESSAGE}

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 // platform level imports
 import recordEvent from '../../../../monitoring/record-event';
 import { isVAPatient } from '../../../selectors';
-import { focusElement, waitForRenderThenFocus } from '../../../../utilities/ui';
+import { waitForRenderThenFocus } from '../../../../utilities/ui';
 import prefixUtilityClasses from '../../../../utilities/prefix-utility-classes';
 
 // local level imports
@@ -93,6 +93,7 @@ class ProfileInformationFieldController extends React.Component {
       forceEditView,
       successCallback,
       showUpdateSuccessAlert,
+      showErrorAlert,
     } = this.props;
     // Exit the edit view if it takes more than 5 seconds for the update/save
     // transaction to resolve. If the transaction has not resolved after 5
@@ -134,40 +135,32 @@ class ProfileInformationFieldController extends React.Component {
 
     if (this.justClosedModal(prevProps, this.props)) {
       clearTimeout(this.closeModalTimeoutID);
-      if (this.props.transaction) {
-        focusElement(`div#${fieldName}-transaction-status`);
-      } else if (showUpdateSuccessAlert) {
-        // Success check after confirming suggested address
-        if (forceEditView && typeof successCallback === 'function') {
-          successCallback();
-        }
-        // Focus on the edit button after the update success alert is shown
+      if (showErrorAlert || showUpdateSuccessAlert) {
+        // Focus on whichever alert is showing for the current field (success or error)
         waitForRenderThenFocus(
-          `#${getEditButtonId(fieldName)}`,
+          `[data-field-name="${fieldName}"] va-alert`,
           document,
           50,
-          'button',
         );
+        // Handle success callback for success alerts
+        if (
+          forceEditView &&
+          typeof successCallback === 'function' &&
+          showUpdateSuccessAlert
+        ) {
+          successCallback();
+        }
       } else if (!forceEditView) {
         if (prevProps.showRemoveModal && !this.props.showRemoveModal) {
-          // Focus on the remove button if it exists, otherwise focus on the edit button
-          if (document.querySelector(`#${getRemoveButtonId(fieldName)}`)) {
-            waitForRenderThenFocus(
-              `#${getRemoveButtonId(fieldName)}`,
-              document,
-              50,
-              'button',
-            );
-          } else {
-            waitForRenderThenFocus(
-              `#${getEditButtonId(fieldName)}`,
-              document,
-              50,
-              'button',
-            );
-          }
+          // Focus on the remove button after exiting the remove modal
+          waitForRenderThenFocus(
+            `#${getRemoveButtonId(fieldName)}`,
+            document,
+            50,
+            'button',
+          );
         } else {
-          // forcesEditView will result in now standard edit button being rendered, so we don't want to focus on it
+          // Focus on the edit button after exiting the edit or validation modal
           // focusElement did not work here on iphone or safari, so using waitForRenderThenFocus
           waitForRenderThenFocus(
             `#${getEditButtonId(fieldName)}`,
@@ -183,8 +176,21 @@ class ProfileInformationFieldController extends React.Component {
       prevProps.transactionRequest &&
       !this.props.transactionRequest
     ) {
+      // forceEditView will result in now standard edit button being rendered, so we don't want to focus on it
       // Success callback (non-address) after updating a field
       successCallback();
+    } else if (
+      ((!prevProps.showUpdateSuccessAlert && showUpdateSuccessAlert) ||
+        (!prevProps.showErrorAlert && showErrorAlert)) &&
+      !this.props.showEditView &&
+      !this.props.showRemoveModal
+    ) {
+      // Success or error alert just appeared after modal was already closed
+      waitForRenderThenFocus(
+        `[data-field-name="${fieldName}"] va-alert`,
+        document,
+        50,
+      );
     }
   }
 
@@ -423,6 +429,7 @@ class ProfileInformationFieldController extends React.Component {
       CustomConfirmCancelModal,
       showUpdateSuccessAlert,
       showErrorAlert,
+      showCopyAddressModal,
     } = this.props;
 
     const activeSection = VAP_SERVICE.FIELD_TITLES[
@@ -439,7 +446,8 @@ class ProfileInformationFieldController extends React.Component {
             showEditView ||
             showValidationView ||
             showRemoveModal ||
-            forceEditView
+            forceEditView ||
+            showCopyAddressModal
           }
           id={`${fieldName}-transaction-status`}
           title={title}
@@ -642,6 +650,7 @@ ProfileInformationFieldController.propTypes = {
   refreshTransactionRequest: PropTypes.func,
   saveButtonText: PropTypes.string,
   shouldFocusCancelButton: PropTypes.bool,
+  showCopyAddressModal: PropTypes.bool,
   showErrorAlert: PropTypes.bool,
   showRemoveModal: PropTypes.bool,
   showUpdateSuccessAlert: PropTypes.bool,
@@ -712,6 +721,12 @@ export const mapStateToProps = (state, ownProps) => {
   }
 
   const hasUnsavedEdits = state.vapService?.hasUnsavedEdits;
+
+  const showCopyAddressModal =
+    fieldName === VAP_SERVICE.FIELD_NAMES.MAILING_ADDRESS
+      ? !!state.vapService?.copyAddressModal
+      : false;
+
   return {
     hasUnsavedEdits,
     analyticsSectionName: VAP_SERVICE.ANALYTICS_FIELD_MAP[fieldName],
@@ -744,6 +759,7 @@ export const mapStateToProps = (state, ownProps) => {
     isEnrolledInVAHealthCare,
     showUpdateSuccessAlert: shouldShowUpdateSuccessAlert(state, fieldName),
     showErrorAlert: shouldShowErrorAlert(state, fieldName),
+    showCopyAddressModal,
   };
 };
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This is a followup to https://github.com/department-of-veterans-affairs/vets-website/pull/39400, which updated our contact info update success, failure, and loading indicators to use VADS components. This PR ensures focus is set on an open modal, or on the most relevant profile field alert when no modals are open. This PR does NOT update focus within the address validation view.

- Changes
  - Remove focus management from `ContactInformationUpdateSuccessAlert`
  - Use `tabindex="-1"` in the `ContactInformationUpdateSuccessAlert` and `GenericErrorAlert`
  - Explicitly set focus on the relevant alerts within the copy address flow in `CopyAddressModalController`
  - In `ProfileInformationFieldController`
    - Hide the `VAPServiceTransaction ` loading indicator when the copy address modal is open
    - Consolidate focus management logic by first checking for any open modals, then setting focus on the error or success alert for the most recently updated field if present
  - Add/update focus assertions in tests
  - Fix minor close button bug in `CopyAddressModalFailure`
- Team: Authenticated Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112968

## Testing done

Updated tests

### Local testing steps
You may need to increase/add a delay for success and error responses in [personalization/profile/mocks/server.js](https://github.com/department-of-veterans-affairs/vets-website/pull/39400/files#diff-34d70f93f012b74bf9ec47f57994c0085287f4fab19e0270461e42e13548e9b5) for the `email_address`, `telephones`, and `addresses` endpoints in order to verify focus behavior
```javascript
// Example: returning a DELETE email address error response with a 5 second delay
'DELETE /v0/profile/email_addresses': (_req, res) => {
    const secondsOfDelay = 5;
    delaySingleResponse(
      // () => res.status(200).json(emailAddress.transactions.received),
      () => res.status(500).json(genericErrors.error500),
      secondsOfDelay,
    );
  },
```
1. Start the mock server
2. Navigate to http://127.0.0.1:3001/profile/contact-information
3. DELETE w/ error response
  a. Mock an error response for the DELETE email_address endpoint & increase the delay (see example), refresh the page
  b. Click Remove on the contact email section
  c. In the browser console, enter `document.activeElement` to assert focus is on the modal
  d. Click to confirm
  e. Exit the modal before the transaction completes to verify the loading indicator appears in the email section & is focused
  f. Verify the generic error alert appears when the transaction finishes & is focused
  g. Repeat for telephones, addresses
4. PUT addresses w/ success response (copy address flow)
  a. Click Edit on the home address section
  b. Click to save (no need to update fields)
  c. Click to use suggested address
  d. In the browser console, enter `document.activeElement` to assert focus is on the modal
  d. Click Yes to update mailing address with the new home address
  e. Confirm the success modal is focused when the transaction finishes
  f. Exit the modal and verify the update success alert appears & is focused

## Screenshots

| Before | After |
| ---- | ---- |
| <img width="441" height="728" alt="Screenshot 2025-10-21 at 3 39 40 PM" src="https://github.com/user-attachments/assets/b16dd858-53c0-496d-b970-a27060aa0376" /> | <img width="451" height="733" alt="Screenshot 2025-10-21 at 3 40 22 PM" src="https://github.com/user-attachments/assets/1cfff005-935b-4fde-8459-35dcd6cd63d9" /> |
| <img width="362" height="689" alt="Screenshot 2025-10-21 at 3 50 05 PM" src="https://github.com/user-attachments/assets/ae838297-dc92-4e25-b142-74f2d11367eb" /> | <img width="363" height="694" alt="Screenshot 2025-10-21 at 3 49 32 PM" src="https://github.com/user-attachments/assets/b79de589-bb20-48f0-9e84-cb958002ff1e" /> |
| <img width="438" height="352" alt="Screenshot 2025-10-21 at 3 39 54 PM" src="https://github.com/user-attachments/assets/6cdf1a45-8928-47d1-94e6-6c8d2b38228c" /> | <img width="446" height="359" alt="Screenshot 2025-10-21 at 3 40 31 PM" src="https://github.com/user-attachments/assets/ef7db543-de1a-4a2d-a5c3-f37aeb488885" /> |
| <img width="709" height="307" alt="Screenshot 2025-10-21 at 3 46 23 PM" src="https://github.com/user-attachments/assets/9e1eeaba-dac7-483e-8c35-02436f2af58b" /> | <img width="782" height="310" alt="Screenshot 2025-10-21 at 3 45 19 PM" src="https://github.com/user-attachments/assets/8eaf6394-7af3-44e2-aac7-cfdbed1059cd" /> |
| <img width="375" height="335" alt="Screenshot 2025-10-21 at 3 52 45 PM" src="https://github.com/user-attachments/assets/cf927cf5-ad76-47b6-a039-df69557aae2a" /> | <img width="375" height="337" alt="Screenshot 2025-10-21 at 3 53 15 PM" src="https://github.com/user-attachments/assets/a4a6a9c0-a7b7-458e-aaea-4d9e38138e60" /> |

## What areas of the site does it impact?

Profile > Contact Information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
