### PR TITLE
Fix checkbox activation when using TalkBack

### DIFF
--- a/src/applications/personalization/profile/components/paperless-delivery/Document.jsx
+++ b/src/applications/personalization/profile/components/paperless-delivery/Document.jsx
@@ -76,7 +76,6 @@ export const Document = ({ document }) => {
       <VaCheckbox
         checked={checked}
         className={checkboxClassName}
-        disabled={loading}
         id={`paperless-checkbox-${item.name}`}
         label={item.name}
         onVaChange={handleChange}

--- a/src/applications/personalization/profile/tests/components/paperless-delivery/Document.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/paperless-delivery/Document.unit.spec.jsx
@@ -83,7 +83,6 @@ describe('Document', () => {
       'va-checkbox[label="1095-B Proof of Health Care"]',
     );
     expect(checkbox.className).to.include('vads-u-display--none');
-    expect(checkbox.disabled).to.be.true;
   });
 
   it('renders alert when updateStatus has error', () => {


### PR DESCRIPTION
## Summary

- _This change fixes a bug to allow TalkBack users to activate checkbox_

## Related issue(s)

- _https://github.com/department-of-veterans-affairs/va.gov-team/issues/119434_


## Testing done

- _BrowserStack_

https://github.com/user-attachments/assets/e31bd676-c536-4427-939c-9ed194732755




## Screenshots

See attached video under Testing Done

## What areas of the site does it impact?

Paperless Delivery in Profile

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
