### PR TITLE
Pension | Remove intro page focus

### DIFF
--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
@@ -13,13 +12,6 @@ const IntroductionPage = props => {
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const pbbFormsRequireLoa3 = useToggleValue(TOGGLE_NAMES.pbbFormsRequireLoa3);
-
-  useEffect(
-    () => {
-      focusElement('va-breadcrumbs');
-    },
-    [props],
-  );
 
   return (
     <article className="schemaform-intro">

--- a/src/applications/pensions/tests/e2e/helpers/keyboardOnlyHelpers.js
+++ b/src/applications/pensions/tests/e2e/helpers/keyboardOnlyHelpers.js
@@ -379,13 +379,6 @@ export const keyboardTestPage = (page, data) => {
   return [page.path];
 };
 
-export const startForm = () => {
-  cy.url().should('include', '/introduction');
-
-  cy.tabToElement('va-link-action');
-  cy.realPress('Enter');
-};
-
 export const fillReviewPage = data => {
   cy.url().should('include', '/review-and-submit');
   cy.tabToElement('[name="veteran-signature"]');

--- a/src/applications/pensions/tests/e2e/pensions-itf.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions-itf.cypress.spec.js
@@ -8,7 +8,6 @@ import mockPrefill from '../fixtures/mocks/prefill.json';
 import inProgressForms from '../fixtures/mocks/in-progress-forms.json';
 
 import { cypressBeforeAllSetup } from './cypress.setup';
-import { startForm } from './helpers/keyboardOnlyHelpers';
 import { mockItf, errorItf, postItf } from './helpers/itfHelpers';
 
 const FORM_ID = '21P-527EZ';
@@ -64,7 +63,7 @@ describe('Pensions ITF', () => {
     cy.intercept('GET', '/v0/intent_to_file/pension', mockItf());
 
     cypressSetup(cy);
-    startForm();
+    cy.clickStartForm();
 
     cy.get('va-alert[status="success"]')
       .should('be.visible')
@@ -82,7 +81,7 @@ describe('Pensions ITF', () => {
     cy.intercept('POST', '/v0/intent_to_file/pension', postItf());
 
     cypressSetup(cy);
-    startForm();
+    cy.clickStartForm();
 
     cy.get('va-alert[status="success"]')
       .should('be.visible')
@@ -105,7 +104,7 @@ describe('Pensions ITF', () => {
     cy.intercept('POST', '/v0/intent_to_file/pension', postItf());
 
     cypressSetup(cy);
-    startForm();
+    cy.clickStartForm();
 
     cy.get('va-alert[status="success"]')
       .should('be.visible')
@@ -123,7 +122,7 @@ describe('Pensions ITF', () => {
     cy.intercept('POST', '/v0/intent_to_file/pension', errorItf());
 
     cypressSetup(cy);
-    startForm();
+    cy.clickStartForm();
 
     cy.get('va-alert[status="warning"]')
       .should('be.visible')
@@ -142,7 +141,7 @@ describe('Pensions ITF', () => {
     cy.intercept('POST', '/v0/intent_to_file/pension', errorItf());
 
     cypressSetup(cy);
-    startForm();
+    cy.clickStartForm();
 
     cy.get('va-alert[status="warning"]')
       .should('be.visible')

--- a/src/applications/pensions/tests/e2e/pensions-keyboard-only.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions-keyboard-only.cypress.spec.js
@@ -7,7 +7,6 @@ import cypressSetup, { cypressBeforeAllSetup } from './cypress.setup';
 import {
   keyboardTestArrayPages,
   keyboardTestPage,
-  startForm,
   fillReviewPage,
   fillSchema,
   fillField,
@@ -23,7 +22,7 @@ const skipInCI = (testKey, callback) =>
 const testForm = (data, pageHooks = {}) => {
   const { chapters } = formConfig;
 
-  startForm();
+  cy.clickStartForm();
 
   let pathsVisited = [];
   Object.values(chapters).forEach(chapter => {


### PR DESCRIPTION
## Summary

Removes the **auto focus behavior** on the **Introduction page** of the **Pension Benefits form (VA Form 21P-527EZ)**.  
This change improves accessibility by allowing screen readers and keyboard users to follow the **natural DOM order** instead of forcing focus to a specific element when the page loads.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118328  

## Related issue(s)

- General a11y improvements for Pension Benefits form introduction and progress bar components  

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Navigate to:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
4. Refresh or load the **Introduction page**

## How to verify

1. On the **Introduction page**, confirm there is **no automatic focus shift** on page load.  
2. Use a screen reader (e.g., NVDA, VoiceOver, or JAWS) to verify that reading order follows the **top-to-bottom structure** naturally.  
4. Ensure form navigation and focus handling remain unchanged on subsequent pages.  
5. Confirm no console warnings or accessibility regressions.  

## What areas of the site does it impact?

- **Pension Benefits form (21P-527EZ)**  
- Introduction page accessibility behavior  

## Screenshots

| Before | After |
|--------|-------|
| Page auto-focused on progress bar | Focus follows natural DOM order |

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- Accessibility improvement for 21P-527EZ Introduction page  
- Aligns with VA Design System best practices for focus management  

## Requested Feedback

(OPTIONAL) Please confirm this focus update aligns with VA a11y guidance and that no regressions are observed on other introductory or progress-bar-enabled pages.