### PR TITLE
Bug fix to separate hasMatchingClinics execution from flipper conditions

### DIFF
--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -344,6 +344,7 @@ export async function fetchFlowEligibilityAndClinics({
   };
 
   // Call not added above if removeFacilityConfigCheck is true, but requires resolved eligibility status to determine if needed
+  // When removing feature toggle, remove just the removeFacilityConfigCheck variable, not the other booleans.
   if (
     typeOfCareRequiresPastHistory &&
     removeFacilityConfigCheck &&
@@ -430,15 +431,15 @@ export async function fetchFlowEligibilityAndClinics({
       );
     }
     // When removeFacilityConfigCheck is removed, remove the entire condition inside the parens (2nd set of nested parens) with
-    // keepFacilityConfigCheck because we no longer will no longer be doing determination off the server (eligibility endpoint)
+    // keepFacilityConfigCheck because we no longer will no longer be doing determination on the client side.
     if (
       !isCerner &&
       typeOfCare.id !== TYPE_OF_CARE_IDS.PRIMARY_CARE &&
       (typeOfCare.id !== TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID ||
         featurePastVisitMHFilter) &&
       (keepFacilityConfigCheck &&
-        directTypeOfCareSettings.patientHistoryRequired &&
-        !hasMatchingClinics(results.clinics, results.pastAppointments))
+        directTypeOfCareSettings.patientHistoryRequired) &&
+      !hasMatchingClinics(results.clinics, results.pastAppointments)
     ) {
       eligibility.direct = false;
       eligibility.directReasons.push(ELIGIBILITY_REASONS.noMatchingClinics);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Makes execution of hasMatchingClinics separate (out of parenthesis from flipper condition)
- Logically makes separation of flipper conditions so that we can make a separate source for flipper context.
- Unified Appointments Experience Orion (Appointments) team - owners of this code

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122982

## Testing done

- Tested locally

## Screenshots

No visible change (because logically it was always producing the same values in almost every condition)

## What areas of the site does it impact?

Appointments scheduling flow

## Acceptance criteria

Having matching clinics are still required for being able to direct schedule. If no past appointments at clinics, no clinics should show.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added (N/A)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check to see what happens when no appointments at any matching clinics and direct scheduling is allowed by facility.

To reproduce this, might need to modify mocks or use source overrides in chrome.

1. Make sure flipper is on (Default state in local mocks)
2. Schedule a new appt. Pick a service type
3. Pick a facility with direct scheduling enabled by eligibility response (Cheyenne usually)
4. Alter responses so no appointments at any of the available clinics (override appointments api/mock response)
5. See that if no appointments or no appointments at available clinics, that it transitions you to request flow.


Reason for modifying responses in overrides in chrome: you can make responses for appointments empty but keep eligibility for direct true for the facility.