### PR TITLE
fix: heading in private medical records page

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -71,6 +71,13 @@ export const recordsConfirmAlertBanner = () => {
 export const patientAcknowledgmentTitle = (
   <h3 className="vads-u-margin-top--0">Authorize us to get your records</h3>
 );
+
+export const privateRecordsChoiceHelpTitle = (
+  <h4 className="vads-u-margin-top--0">
+    What else to know about these options
+  </h4>
+);
+
 export const patientAcknowledgmentError = (
   <p>
     You must select “I acknowledge and authorize this release of information”

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -10,6 +10,7 @@ import {
   patientAcknowledgmentError,
   recordsConfirmAlertBanner,
   authorizationNotes,
+  privateRecordsChoiceHelpTitle,
 } from '../content/privateMedicalRecords';
 import { standardTitle } from '../content/form0781';
 import { isCompletingModern4142 } from '../utils';
@@ -34,7 +35,7 @@ export const uiSchema = {
       'ui:description': authorizationNotes,
     },
     'view:privateRecordsChoiceHelp': {
-      'ui:title': 'What else to know about these options',
+      'ui:title': privateRecordsChoiceHelpTitle,
       'ui:description': privateRecordsChoiceHelp,
     },
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fixed the header in the private medical records page. It was visually a heading, but is not a heading programmatically. Updated the code to make this text an `H4`, which fits within the heading hierarchy of the page

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/122458
## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/122458

## Testing done

Use `HeadingMaps` tool (Chrome) to ensure that heading does show up as a `H4` header. 
Ran unit test for this particular page.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Private Medical Records |<img width="750" height="839" alt="Screenshot 2025-10-23 at 9 05 46 PM" src="https://github.com/user-attachments/assets/33dbc06b-9252-489c-87eb-27b2bd0ec634" />|<img width="750" height="839" alt="Screenshot 2025-10-23 at 9 02 36 PM" src="https://github.com/user-attachments/assets/c4e1f7ae-2371-479f-b863-67cb54b93647" />|
| `HeadingsMap` Preview |<img width="339" height="449" alt="Screenshot 2025-10-23 at 9 06 10 PM" src="https://github.com/user-attachments/assets/5e44e02b-b922-423c-a1ac-5966675044f6" />|<img width="347" height="471" alt="Screenshot 2025-10-23 at 9 03 11 PM" src="https://github.com/user-attachments/assets/917e84ee-ece0-4f3d-bb96-31f1bf1315b2" />|

## What areas of the site does it impact?
Impacts the `/supporting-evidence/private-medical-records` within the 526 workflow 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
