### PR TITLE
fix: acknowledgement statement background width

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/Authorization.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Authorization.jsx
@@ -239,7 +239,7 @@ const PrivateRecordsAuthorization = ({
           </p>
         </va-accordion-item>
       </va-accordion>
-      <div className="hipaa-privacy-agreement vads-u-padding-x--3 vads-u-padding-top--3 vads-u-padding-bottom--2 vads-u-margin-top--3">
+      <div className="hipaa-privacy-agreement">
         <form onSubmit={handlers.onGoForward}>
           <va-card background>
             <h3 className="vads-u-margin-top--0" id="acknowledgement">


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Previously, the `Acknowledgement and HIPAA compliance` had padding around the card which made background smaller than the accordion.

Removed padding from the `Acknowledgement and HIPAA compliance` card to make the width the same as the accordions above. 

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/122460

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/122460

## Testing done

Tested it locally by going through the form and checking the page `/supporting-evidence/private-medical-records-authorize-release`


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| `private-medical-records-authorize-release`  |<img width="562" height="1021" alt="Screenshot 2025-10-24 at 11 17 55 AM" src="https://github.com/user-attachments/assets/e2e27ac6-4cb4-4485-a751-9b8c66dd13b6" />|<img width="562" height="934" alt="image" src="https://github.com/user-attachments/assets/b26ba79b-97fa-4cab-952d-984bb3103b63" />|

## What areas of the site does it impact?
It impacts the form 526 at `/supporting-evidence/private-medical-records-authorize-release`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
