### PR TITLE
21P-8416 mileage expenses content and unit test updates

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
@@ -28,19 +28,19 @@ function introDescription() {
   return (
     <div>
       <p className="vads-u-margin-top--0">
-        In the next few questions, we’ll ask you about mileage that wasn’t
-        reimbursed. You’ll need to add at least one mileage.
+        Next we’ll ask you about unreimbursed mileage that you, your spouse, or
+        your dependents paid for.
       </p>
       <p>
-        Report miles traveled for medical purposes in a privately owned vehicle
-        such as a car, truck or motorcycle.
+        You can report miles that you traveled for medical purposes in a
+        privately owned vehicle such as a car, truck, or motorcycle.
       </p>
     </div>
   );
 }
 
 /** @type {ArrayBuilderOptions} */
-const options = {
+export const options = {
   arrayPath: 'mileageExpenses',
   nounSingular: 'mileage expense',
   nounPlural: 'mileage expenses',
@@ -57,7 +57,7 @@ const options = {
 const introPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Add mileage expenses',
+      title: 'Mileage expenses',
       nounSingular: options.nounSingular,
       nounPlural: options.nounPlural,
     }),
@@ -128,7 +128,7 @@ const destinationPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Expense destination and date'),
     travelLocation: radioUI({
-      title: 'Who is the expense for?',
+      title: 'What was the destination?',
       labels: travelLocationLabels,
       descriptions: {
         CLINIC:
@@ -136,7 +136,7 @@ const destinationPage = {
       },
     }),
     travelLocationOther: textUI({
-      title: 'Tell us where you traveled',
+      title: 'Describe the destination',
       expandUnder: 'travelLocation',
       expandUnderCondition: field => field === 'OTHER',
       required: (formData, index, fullData) => {
@@ -146,9 +146,9 @@ const destinationPage = {
         return mileageExpense?.travelLocation === 'OTHER';
       },
     }),
-    travelMilesTraveled: numberUI('How many miles did you travel?'),
+    travelMilesTraveled: numberUI('How many miles were travelled?'),
     travelDate: currentOrPastDateUI({
-      title: 'What’s the date of your travel?',
+      title: 'What was the date of travel?',
       monthSelect: false,
     }),
   },
@@ -168,11 +168,14 @@ const destinationPage = {
 const reimbursementPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Expense reimbursement'),
-    travelReimbursed: yesNoUI('Were you reimbursed from another source?'),
+    travelReimbursed: yesNoUI({
+      title: 'Has this mileage been reimbursed by any other source?',
+      hint: 'For example: a VA Medical Center',
+    }),
     // Required doesn't seem to work set directly on currencyUI.
     travelReimbursementAmount: {
       ...currencyUI({
-        title: 'How much were you reimbursed?',
+        title: 'How much money was reimbursed?',
         expandUnder: 'travelReimbursed',
         expandUnderCondition: field => field === true,
       }),
@@ -202,7 +205,7 @@ export const mileageExpensesPages = arrayBuilderPages(options, pageBuilder => ({
     schema: introPage.schema,
   }),
   mileageExpensesSummary: pageBuilder.summaryPage({
-    title: 'Mileage expenses',
+    title: 'Do you have a mileage expense to add?',
     path: 'expenses/mileage/add',
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/mileageExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/mileageExpensesPage.unit.spec.jsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+import {
+  mileageExpensesPages,
+  options,
+} from '../../../../config/chapters/02-expenses/mileageExpensesPage';
+import {
+  recipientTypeLabels,
+  travelLocationLabels,
+} from '../../../../utils/labels';
+
+const arrayPath = 'mileageExpenses';
+
+describe('Mileage Expense Pages', () => {
+  it('renders the mileage expenses intro', async () => {
+    const { mileageExpensesIntro } = mileageExpensesPages;
+
+    const form = render(
+      <DefinitionTester
+        schema={mileageExpensesIntro.schema}
+        uiSchema={mileageExpensesIntro.uiSchema}
+        data={{}}
+      />,
+    );
+    expect(form.getByRole('heading')).to.have.text(mileageExpensesIntro.title);
+  });
+  it('renders the mileage expenses summary', async () => {
+    const { mileageExpensesSummary } = mileageExpensesPages;
+
+    const form = render(
+      <DefinitionTester
+        schema={mileageExpensesSummary.schema}
+        uiSchema={mileageExpensesSummary.uiSchema}
+        data={{}}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaRadio = $('va-radio', formDOM);
+    const vaRadioOptions = $$('va-radio-option', formDOM);
+
+    expect(vaRadio.getAttribute('label-header-level')).to.equal('3');
+    expect(vaRadio.getAttribute('label')).to.equal(
+      'Do you have a mileage expense to add?',
+    );
+    expect(vaRadioOptions.length).to.equal(2);
+    expect(vaRadioOptions[0].getAttribute('label')).to.equal('Yes');
+    expect(vaRadioOptions[1].getAttribute('label')).to.equal('No');
+  });
+  it('renders the mileage page destination', async () => {
+    const { mileageExpensesTravelerPage } = mileageExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={mileageExpensesTravelerPage.schema}
+        uiSchema={mileageExpensesTravelerPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaTraveler = $('va-radio[label*="Who needed to travel?"]', formDOM);
+    expect(vaTraveler.getAttribute('required')).to.equal('true');
+    const vaTravelerOtherSelector =
+      'va-text-input[label*="Full name of the person who traveled"]';
+    const vaTravelerOptions = $$('va-radio-option', formDOM);
+    expect(vaTravelerOptions.length).to.equal(4);
+    Object.keys(recipientTypeLabels).forEach((key, index) => {
+      expect(vaTravelerOptions[index].getAttribute('label')).to.equal(
+        recipientTypeLabels[key],
+      );
+    });
+
+    vaTraveler.__events.vaValueChange({
+      detail: { value: 'OTHER' },
+    });
+    expect($(vaTravelerOtherSelector, formDOM)).to.exist;
+    vaTraveler.__events.vaValueChange({
+      detail: { value: 'DEPENDENT' },
+    });
+    expect($(vaTravelerOtherSelector, formDOM)).to.exist;
+    vaTraveler.__events.vaValueChange({
+      detail: { value: 'SPOUSE' },
+    });
+    expect($(vaTravelerOtherSelector, formDOM)).to.not.exist;
+  });
+  it('renders the mileage page destination', async () => {
+    const { mileageExpensesDestinationPage } = mileageExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={mileageExpensesDestinationPage.schema}
+        uiSchema={mileageExpensesDestinationPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaDestination = $(
+      'va-radio[label*="What was the destination?"]',
+      formDOM,
+    );
+    expect(vaDestination.getAttribute('required')).to.equal('true');
+    const vaDestinationOtherSelector =
+      'va-text-input[label*="Describe the destination"]';
+    const vaDestinationOptions = $$('va-radio-option', formDOM);
+    expect(vaDestinationOptions.length).to.equal(4);
+    Object.keys(travelLocationLabels).forEach((key, index) => {
+      expect(vaDestinationOptions[index].getAttribute('label')).to.equal(
+        travelLocationLabels[key],
+      );
+      if (key === 'CLINIC') {
+        expect(
+          vaDestinationOptions[index].getAttribute('description'),
+        ).to.equal(
+          'This would be a doctor’s office, dentist, or other outpatient medical provider.',
+        );
+      }
+    });
+
+    vaDestination.__events.vaValueChange({
+      detail: { value: 'OTHER' },
+    });
+    expect($(vaDestinationOtherSelector, formDOM)).to.exist;
+    expect(
+      $(vaDestinationOtherSelector, formDOM).getAttribute('required'),
+    ).to.equal('true');
+    vaDestination.__events.vaValueChange({
+      detail: { value: 'HOSPITAL' },
+    });
+    expect($(vaDestinationOtherSelector, formDOM)).to.not.exist;
+    const vaMilesTravelled = $(
+      'va-text-input[label*="How many miles were travelled?"]',
+      formDOM,
+    );
+    expect(vaMilesTravelled.getAttribute('required')).to.equal('true');
+    const vaTravelDate = $(
+      'va-memorable-date[label*="What was the date of travel?"]',
+      formDOM,
+    );
+    expect(vaTravelDate.getAttribute('required')).to.equal('true');
+  });
+  it('renders the mileage page reimbursement', async () => {
+    const { mileageExpensesReimbursementPage } = mileageExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={mileageExpensesReimbursementPage.schema}
+        uiSchema={mileageExpensesReimbursementPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaMileageReimbursedRadio = $(
+      'va-radio[label*="Has this mileage been reimbursed by any other source?"]',
+      formDOM,
+    );
+    expect(vaMileageReimbursedRadio.getAttribute('required')).to.equal('true');
+    vaMileageReimbursedRadio.__events.vaValueChange({
+      detail: { value: 'Y' },
+    });
+    const vaMileageReimbursedInput = $(
+      'va-text-input[label*="How much money was reimbursed?"]',
+      formDOM,
+    );
+    expect(vaMileageReimbursedInput.getAttribute('required')).to.equal('true');
+  });
+  it('should return the correct card title with travelLocation', () => {
+    const item = {
+      travelLocation: 'PHARMACY',
+    };
+    const { getByText } = render(options.text.getItemName(item));
+    expect(getByText('Pharmacy')).to.exist;
+  });
+  it('should return the correct card description with travelDate', () => {
+    const item = {
+      travelDate: '2004-04-04',
+    };
+    const { getByText } = render(options.text.cardDescription(item));
+    expect(getByText('04/04/2004')).to.exist;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update content on the mileage expenses pages of the form
- Add unit tests for the section

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122583
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123065
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123066

## Testing done

- Manual testing
- Added unit tests for the form pages and helper functions

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="654" height="317" alt="Screenshot 2025-10-24 at 12 03 53 PM" src="https://github.com/user-attachments/assets/c731bd6c-6ca9-4cb1-b013-9e1cac3f5308" /> <img width="593" height="272" alt="Screenshot 2025-10-24 at 12 00 25 PM" src="https://github.com/user-attachments/assets/4012c655-d7ba-4b15-8868-7cd8dc9adc0e" /> <img width="638" height="535" alt="Screenshot 2025-10-24 at 12 00 30 PM" src="https://github.com/user-attachments/assets/5f23a302-b7af-4a1d-97ee-4eead8278064" /> <img width="673" height="850" alt="Screenshot 2025-10-24 at 12 00 38 PM" src="https://github.com/user-attachments/assets/030a29b5-b41c-43f5-99bd-b14232621033" /> <img width="614" height="485" alt="Screenshot 2025-10-24 at 12 00 52 PM" src="https://github.com/user-attachments/assets/c6b225b7-e584-443c-9dce-1d9a77e9e7fb" /> <img width="622" height="474" alt="Screenshot 2025-10-24 at 12 00 58 PM" src="https://github.com/user-attachments/assets/a8e64c07-e899-4fc4-9c1f-16879bbe6e58" /> | <img width="585" height="335" alt="Screenshot 2025-10-24 at 12 04 00 PM" src="https://github.com/user-attachments/assets/37f2c726-5fd4-422d-85be-2d995bba2e2c" /> <img width="643" height="272" alt="Screenshot 2025-10-24 at 11 45 35 AM" src="https://github.com/user-attachments/assets/1b95d233-bb32-4540-bf0f-1d210cb7671b" /> <img width="677" height="506" alt="Screenshot 2025-10-24 at 11 45 43 AM" src="https://github.com/user-attachments/assets/f8140064-6b05-46c4-8276-ba3bfcd6950d" /> <img width="610" height="862" alt="Screenshot 2025-10-24 at 11 45 55 AM" src="https://github.com/user-attachments/assets/a9c05eb2-3af2-46ad-83c0-dcd621699f8d" /> <img width="635" height="506" alt="Screenshot 2025-10-24 at 11 46 06 AM" src="https://github.com/user-attachments/assets/229502a7-2c71-40a4-9073-fe64c2d471aa" /> <img width="655" height="478" alt="Screenshot 2025-10-24 at 11 46 13 AM" src="https://github.com/user-attachments/assets/73f7d227-a09f-4ce9-9dd4-286a6abb84dc" /> |





## What areas of the site does it impact?

Just the mileage expenses section of the 21P-8416 form.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
