### PR TITLE
122091-update-medications-details-pdf-txt-files

### DIFF
--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -164,7 +164,7 @@ const PrescriptionDetails = () => {
             list: prescriptionPdfList,
           },
           {
-            header: 'Allergies',
+            header: 'Allergies and reactions',
             ...(allergiesPdfList &&
               allergiesPdfList.length > 0 && {
                 preface: [

--- a/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
@@ -164,6 +164,57 @@ describe('VA prescription Config', () => {
     const txt = buildVAPrescriptionTXT(rxDetails);
     expect(txt).to.match(/Status: This is a renewal you requested/);
   });
+
+  it('should include previous prescriptions section when grouped medications exist', () => {
+    const rxDetails = { ...prescriptionDetails.data.attributes };
+    rxDetails.groupedMedications = [
+      {
+        prescriptionNumber: '44444',
+        sortedDispensedDate: '2023-12-01',
+        quantity: 90,
+        orderedDate: '2023-10-15',
+      },
+      {
+        prescriptionNumber: '55555',
+        sortedDispensedDate: '2023-09-01',
+        quantity: 60,
+        orderedDate: '2023-08-01',
+      },
+    ];
+
+    const txt = buildVAPrescriptionTXT(rxDetails);
+
+    expect(txt).to.include('Previous prescriptions');
+    expect(txt).to.include('Showing 2 prescriptions, from newest to oldest');
+    expect(txt).to.include('Prescription number: 44444');
+    expect(txt).to.include('Prescription number: 55555');
+  });
+
+  it('should handle single previous prescription without plural wording', () => {
+    const rxDetails = { ...prescriptionDetails.data.attributes };
+    rxDetails.groupedMedications = [
+      {
+        prescriptionNumber: '10101',
+        sortedDispensedDate: '2024-07-01',
+        quantity: 30,
+        orderedDate: '2024-06-01',
+      },
+    ];
+
+    const txt = buildVAPrescriptionTXT(rxDetails);
+
+    expect(txt).to.include('Showing 1 prescription');
+    expect(txt).to.not.include('prescriptions, from newest to oldest');
+  });
+
+  it('should handle empty groupedMedications array', () => {
+    const rxDetails = { ...prescriptionDetails.data.attributes };
+    rxDetails.groupedMedications = [];
+
+    const txt = buildVAPrescriptionTXT(rxDetails);
+
+    expect(txt).to.not.include('Previous prescriptions');
+  });
 });
 
 describe('Non VA prescription Config', () => {

--- a/src/applications/mhv-medications/util/pdfConfigs.js
+++ b/src/applications/mhv-medications/util/pdfConfigs.js
@@ -507,9 +507,9 @@ export const buildVAPrescriptionPDFList = prescription => {
                     ? `* Shape: ${shape[0].toUpperCase()}${shape
                         .slice(1)
                         .toLowerCase()}
-    * Color: ${color[0].toUpperCase()}${color.slice(1).toLowerCase()}
-    * Front marking: ${frontImprint}
-    ${backImprint ? `* Back marking: ${backImprint}` : ''}`
+* Color: ${color[0].toUpperCase()}${color.slice(1).toLowerCase()}
+* Front marking: ${frontImprint}
+${backImprint ? `* Back marking: ${backImprint}` : ''}`
                     : createNoDescriptionText(phone);
                   return {
                     header: `${refillLabel}: ${dateFormat(

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -215,7 +215,7 @@ export const buildVAPrescriptionTXT = prescription => {
   const showRefillHistory = getShowRefillHistory(refillHistory);
   if (showRefillHistory) {
     const refillHistoryHeader = joinLines(
-      'Refill History',
+      'Refill history',
       `Showing ${refillHistory.length} fill${
         refillHistory.length > 1 ? 's, from newest to oldest' : ''
       }`,

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -25,16 +25,57 @@ const fieldLine = (label, value) =>
   `${label}: ${validateIfAvailable(label, value)}`;
 const SEPARATOR =
   '---------------------------------------------------------------------------------';
+const getLastFilledAndRxNumberBlock = rx => {
+  const pendingMed =
+    rx?.prescriptionSource === 'PD' && rx?.dispStatus === 'NewOrder';
+  const pendingRenewal =
+    rx?.prescriptionSource === 'PD' && rx?.dispStatus === 'Renew';
+  const isRxPending = pendingMed || pendingRenewal;
+
+  return !isRxPending
+    ? joinLines(
+        `Last filled on: ${dateFormat(
+          rx.sortedDispensedDate,
+          'MMMM D, YYYY',
+          'Date not available',
+        )}`,
+        `Prescription number: ${rx.prescriptionNumber}`,
+      )
+    : '';
+};
+const getAttributes = rx =>
+  joinLines(
+    `Status: ${prescriptionMedAndRenewalStatus(rx, medStatusDisplayTypes.TXT)}`,
+    fieldLine('Refills left', rx.refillRemaining),
+    `Request refills by this prescription expiration date: ${dateFormat(
+      rx.expirationDate,
+      'MMMM D, YYYY',
+      'Date not available',
+    )}`,
+    fieldLine('Facility', rx.facilityName),
+    fieldLine('Pharmacy phone number', rx.phoneNumber),
+    fieldLine('Instructions', rx.sig),
+    fieldLine('Reason for use', rx.indicationForUse),
+    fieldLine('Quantity', rx.quantity),
+    `Prescribed on: ${dateFormat(
+      rx.orderedDate,
+      'MMMM D, YYYY',
+      'Date not available',
+    )}`,
+    `Prescribed by: ${displayProviderName(
+      rx.providerFirstName,
+      rx.providerLastName,
+    )}`,
+  );
 
 /**
  * Return Non-VA prescription TXT
  */
 export const buildNonVAPrescriptionTXT = (prescription, options) => {
   const { includeSeparators = true } = options ?? {};
-  const header = includeSeparators ? `${SEPARATOR}${newLine(2)}` : '';
-  const footer = includeSeparators
-    ? `${newLine(2)}${SEPARATOR}${newLine(2)}`
-    : newLine(2);
+  const header = includeSeparators
+    ? `${newLine()}${SEPARATOR}${newLine(3)}`
+    : '';
 
   const body = joinBlocks(
     prescription?.prescriptionName || prescription?.orderableItem,
@@ -62,7 +103,7 @@ export const buildNonVAPrescriptionTXT = (prescription, options) => {
     ),
   );
 
-  return `${header}${body}${footer}`;
+  return `${header}${body}${newLine()}`;
 };
 
 /**
@@ -93,55 +134,15 @@ export const buildPrescriptionsTXT = prescriptions => {
       }).trimEnd();
     }
 
-    const pendingMed =
-      rx?.prescriptionSource === 'PD' && rx?.dispStatus === 'NewOrder';
-    const pendingRenewal =
-      rx?.prescriptionSource === 'PD' && rx?.dispStatus === 'Renew';
-    const isPending = pendingMed || pendingRenewal;
-
     const title = rx.prescriptionName;
-
-    const fillandRxBlock = !isPending
-      ? joinLines(
-          `Last filled on: ${dateFormat(
-            rx.sortedDispensedDate,
-            'MMMM D, YYYY',
-            'Date not available',
-          )}`,
-          `Prescription number: ${rx.prescriptionNumber}`,
-        )
-      : '';
-
-    const attributes = joinLines(
-      `Status: ${prescriptionMedAndRenewalStatus(
-        rx,
-        medStatusDisplayTypes.TXT,
-      )}`,
-      fieldLine('Refills left', rx.refillRemaining),
-      `Request refills by this prescription expiration date: ${dateFormat(
-        rx.expirationDate,
-        'MMMM D, YYYY',
-        'Date not available',
-      )}`,
-      fieldLine('Facility', rx.facilityName),
-      fieldLine('Pharmacy phone number', rx.phoneNumber),
-      fieldLine('Instructions', rx.sig),
-      fieldLine('Reason for use', rx.indicationForUse),
-      fieldLine('Quantity', rx.quantity),
-      `Prescribed on: ${dateFormat(
-        rx.orderedDate,
-        'MMMM D, YYYY',
-        'Date not available',
-      )}`,
-      `Prescribed by: ${displayProviderName(
-        rx.providerFirstName,
-        rx.providerLastName,
-      )}`,
-    );
-
     const mostRecent = mostRecentRxRefillLine(rx);
 
-    return joinBlocks(title, fillandRxBlock, attributes, mostRecent).trimEnd();
+    return joinBlocks(
+      title,
+      getLastFilledAndRxNumberBlock(rx),
+      getAttributes(rx),
+      mostRecent,
+    ).trimEnd();
   });
 
   return `${header}${body.join(newLine(3))}${newLine(2)}`;
@@ -191,189 +192,124 @@ export const buildAllergiesTXT = allergies => {
     )
     .join(newLine());
 
-  return `${header}${body}${newLine()}${items}${footer}`;
+  return `${header}${body}${newLine()}${items}${newLine()}${footer}`;
 };
 
 /**
  * Return VA prescription TXT
  */
 export const buildVAPrescriptionTXT = prescription => {
+  const header = `${newLine()}${SEPARATOR}${newLine(3)}`;
+  const rxTitle = prescription?.prescriptionName || prescription?.orderableItem;
+  const subTitle = `Most recent prescription`;
+
+  const mostRecentRxSection = joinLines(
+    `${rxTitle}${newLine()}`,
+    `${subTitle}${newLine()}`,
+    getLastFilledAndRxNumberBlock(prescription),
+    getAttributes(prescription),
+  ).trimEnd();
+
+  let refillHistorySection = '';
   const refillHistory = getRefillHistory(prescription);
   const showRefillHistory = getShowRefillHistory(refillHistory);
-  const pendingMed =
-    prescription?.prescriptionSource === 'PD' &&
-    prescription?.dispStatus === 'NewOrder';
-  const pendingRenewal =
-    prescription?.prescriptionSource === 'PD' &&
-    prescription?.dispStatus === 'Renew';
-
-  let result = `
----------------------------------------------------------------------------------
-
-
-${prescription?.prescriptionName || prescription?.orderableItem}
-
-
-Most recent prescription
-
-${
-    pendingMed || pendingRenewal
-      ? ''
-      : `
-Last filled on: ${dateFormat(
-          prescription.sortedDispensedDate,
-          'MMMM D, YYYY',
-          'Date not available',
-        )}
-`
-  }
-
-${
-    !pendingMed && !pendingRenewal
-      ? `
-Prescription number: ${prescription.prescriptionNumber}
-`
-      : ''
-  }
-Status: ${prescriptionMedAndRenewalStatus(
-    prescription,
-    medStatusDisplayTypes.TXT,
-  )}
-Refills left: ${validateIfAvailable(
-    'Number of refills left',
-    prescription.refillRemaining,
-  )}
-
-Request refills by this prescription expiration date: ${dateFormat(
-    prescription.expirationDate,
-    'MMMM D, YYYY',
-    'Date not available',
-  )}
-
-Facility: ${validateIfAvailable('Facility', prescription.facilityName)}
-
-Pharmacy phone number: ${validateIfAvailable(
-    'Pharmacy phone number',
-    prescription.phoneNumber,
-  )}
-
-Instructions: ${validateIfAvailable('Instructions', prescription.sig)}
-
-Reason for use: ${validateIfAvailable(
-    'Reason for use',
-    prescription.indicationForUse,
-  )}
-
-Quantity: ${validateIfAvailable('Quantity', prescription.quantity)}
-
-Prescribed on: ${dateFormat(
-    prescription.orderedDate,
-    'MMMM D, YYYY',
-    'Date not available',
-  )}
-
-Prescribed by: ${displayProviderName(
-    prescription.providerFirstName,
-    prescription.providerLastName,
-  )}
-  `;
-
   if (showRefillHistory) {
-    result += `
-Refill history
+    const refillHistoryHeader = joinLines(
+      'Refill History',
+      `Showing ${refillHistory.length} fill${
+        refillHistory.length > 1 ? 's, from newest to oldest' : ''
+      }`,
+    ).trimEnd();
 
-Showing ${refillHistory.length} fill${
-      refillHistory.length > 1 ? 's, from newest to oldest' : ''
-    }
-
-`;
-
-    refillHistory.forEach((entry, i) => {
-      const phone = entry.cmopDivisionPhone || entry.dialCmopDivisionPhone;
-      const { shape, color, backImprint, frontImprint } = entry;
-      const hasValidDesc =
-        shape?.trim() && color?.trim() && frontImprint?.trim();
-      const isPartialFill = entry.prescriptionSource === 'PF';
-      const refillLabel = determineRefillLabel(isPartialFill, refillHistory, i);
-      const description = hasValidDesc
-        ? `
-Note: If the medication you’re taking doesn’t match this description, call ${createVAPharmacyText(
-            phone,
-          )}
-
+    const refillHistoryRecords = refillHistory
+      .map((record, i) => {
+        const phone = record.cmopDivisionPhone || record.dialCmopDivisionPhone;
+        const { shape, color, backImprint, frontImprint } = record;
+        const hasValidDesc =
+          shape?.trim() && color?.trim() && frontImprint?.trim();
+        const isPartialFill = record.prescriptionSource === 'PF';
+        const refillLabel = determineRefillLabel(
+          isPartialFill,
+          refillHistory,
+          i,
+        );
+        const description = hasValidDesc
+          ? `${newLine()}Note: If the medication you’re taking doesn’t match this description, call ${createVAPharmacyText(
+              phone,
+            )}
 * Shape: ${shape[0].toUpperCase()}${shape.slice(1).toLowerCase()}
 * Color: ${color[0].toUpperCase()}${color.slice(1).toLowerCase()}
 * Front marking: ${frontImprint}
-${backImprint ? `* Back marking: ${backImprint}` : ''}`
-        : createNoDescriptionText(phone);
-      result += `
-${refillLabel}: ${dateFormat(
-        entry.dispensedDate,
-        'MMMM D, YYYY',
-        'Date not available',
-      )}
-${
-        isPartialFill
-          ? `
-This fill has a smaller quantity on purpose.
+${backImprint ? `* Back marking: ${backImprint}` : ''}${newLine()}`
+          : createNoDescriptionText(phone);
 
-Quantity: ${entry.quantity}`
-          : ``
-      }
-${
-        i === 0 && !isPartialFill
-          ? `
-Shipped on: ${dateFormat(
-              prescription?.trackingList?.[0]?.completeDateTime,
-              'MMMM D, YYYY',
-              'Date not available',
-            )}
-`
-          : ``
-      }
-${!isPartialFill ? `Medication description: ${description}` : ``}
+        return joinBlocks(
+          `${refillLabel}: ${dateFormat(
+            record.dispensedDate,
+            'MMMM D, YYYY',
+            'Date not available',
+          )}`,
+          isPartialFill
+            ? joinLines(
+                'This fill has a smaller quantity on purpose',
+                `Quantity: ${record.quantity}`,
+              )
+            : '',
+          i === 0 && !isPartialFill
+            ? `Shipped on: ${dateFormat(
+                prescription?.trackingList?.[0]?.completeDateTime,
+                'MMMM D, YYYY',
+                'Date not available',
+              )}`
+            : ``,
+          !isPartialFill ? `Medication description: ${description}` : '',
+        );
+      })
+      .join(newLine(2));
 
-  `;
-    });
+    refillHistorySection = `${refillHistoryHeader}${newLine(
+      3,
+    )}${refillHistoryRecords}`;
   }
 
+  let previousRxSection = '';
   if (prescription?.groupedMedications?.length > 0) {
-    result += `
-Previous prescriptions
+    const previousRxHeader = joinBlocks(
+      'Previous prescriptions',
+      `Showing ${prescription.groupedMedications.length} prescription${
+        prescription.groupedMedications.length > 1
+          ? 's, from newest to oldest'
+          : ''
+      }`,
+    ).trimEnd();
 
-Showing ${prescription.groupedMedications.length} prescription${
-      prescription.groupedMedications.length > 1
-        ? 's, from newest to oldest'
-        : ''
-    }
-    `;
+    const previousRxs = prescription.groupedMedications
+      .map(previousRx => {
+        return joinBlocks(
+          `Prescription number: ${previousRx.prescriptionNumber}`,
+          `Last filled: ${dateFormat(
+            previousRx.sortedDispensedDate,
+            'MMMM D, YYYY',
+            'Date not available',
+          )}`,
+          fieldLine('Quantity', previousRx.quantity),
+          `Prescribed on: ${dateFormat(
+            previousRx.orderedDate,
+            'MMMM D, YYYY',
+            'Date not available',
+          )}`,
+          `Prescribed by: ${displayProviderName(
+            prescription.providerFirstName,
+            prescription.providerLastName,
+          )}`,
+        ).trimEnd();
+      })
+      .join(newLine(3));
 
-    prescription.groupedMedications.forEach(previousPrescription => {
-      result += `
-
-Prescription number: ${previousPrescription.prescriptionNumber}
-
-Last filled: ${dateFormat(
-        previousPrescription.sortedDispensedDate,
-        'MMMM D, YYYY',
-        'Date not available',
-      )}
-
-Quantity: ${validateIfAvailable('Quantity', previousPrescription.quantity)}
-
-Prescribed on: ${dateFormat(
-        previousPrescription.orderedDate,
-        'MMMM D, YYYY',
-        'Date not available',
-      )}
-
-Prescribed by: ${displayProviderName(
-        prescription.providerFirstName,
-        prescription.providerLastName,
-      )}
-      `;
-    });
+    previousRxSection = joinBlocks(previousRxHeader, previousRxs);
   }
 
-  return result;
+  return `${header}${mostRecentRxSection}${newLine(
+    3,
+  )}${refillHistorySection}${newLine(2)}${previousRxSection}${newLine()}`;
 };

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -275,6 +275,7 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}${newLine()}`
   let previousRxSection = '';
   if (prescription?.groupedMedications?.length > 0) {
     const previousRxHeader = joinBlocks(
+      newLine(),
       'Previous prescriptions',
       `Showing ${prescription.groupedMedications.length} prescription${
         prescription.groupedMedications.length > 1
@@ -311,5 +312,5 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}${newLine()}`
 
   return `${header}${mostRecentRxSection}${newLine(
     3,
-  )}${refillHistorySection}${newLine(2)}${previousRxSection}${newLine()}`;
+  )}${refillHistorySection}${previousRxSection}${newLine()}`;
 };

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -32,16 +32,16 @@ const getLastFilledAndRxNumberBlock = rx => {
     rx?.prescriptionSource === 'PD' && rx?.dispStatus === 'Renew';
   const isRxPending = pendingMed || pendingRenewal;
 
-  return !isRxPending
-    ? joinLines(
+  return isRxPending
+    ? ''
+    : joinLines(
         `Last filled on: ${dateFormat(
           rx.sortedDispensedDate,
           'MMMM D, YYYY',
           'Date not available',
         )}`,
         `Prescription number: ${rx.prescriptionNumber}`,
-      )
-    : '';
+      );
 };
 const getAttributes = rx =>
   joinLines(
@@ -251,7 +251,7 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}${newLine()}`
           )}`,
           isPartialFill
             ? joinLines(
-                'This fill has a smaller quantity on purpose',
+                'This fill has a smaller quantity on purpose.',
                 `Quantity: ${record.quantity}`,
               )
             : '',
@@ -261,7 +261,7 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}${newLine()}`
                 'MMMM D, YYYY',
                 'Date not available',
               )}`
-            : ``,
+            : '',
           !isPartialFill ? `Medication description: ${description}` : '',
         );
       })


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- updated content for Medication Details page pdf and txt files

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122091

## Testing done

- Compared new content updates to [figma file](https://www.figma.com/design/cqiuYyA1vn728D0Nde2NgS/Medications---Milestone-1---2?node-id=79-3897&p=f&t=36Hr3HZKiqCNtH78-0) associated with the ticket
- Regression tested pdf/txt files for Medications List
- Ensured old and new unit tests and e2e tests passed

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1275" height="1650" alt="4c5674e75fc91ai4 pdf-1" src="https://github.com/user-attachments/assets/62f9e6d4-ed28-4587-90c2-18bffb8e1da4" /> <img width="1275" height="1650" alt="4c5674e75fc91ai4 pdf-2" src="https://github.com/user-attachments/assets/aa38dbc3-fd3b-4d10-9832-33623ecf9ba0" /> <img width="1275" height="1650" alt="4c5674e75fc91ai4 pdf-3" src="https://github.com/user-attachments/assets/fb09a766-5e0e-4985-a819-b9a1cde79911" /> <img width="933" height="994" alt="Screenshot 2025-10-24 at 11 51 22 AM" src="https://github.com/user-attachments/assets/180c5c0b-bbf5-4a04-9ba1-61294f99b93c" /> <img width="939" height="445" alt="Screenshot 2025-10-24 at 11 51 40 AM" src="https://github.com/user-attachments/assets/3671e39c-eb82-4dfc-9e82-148140654d3e" /> <img width="936" height="844" alt="Screenshot 2025-10-24 at 11 51 50 AM" src="https://github.com/user-attachments/assets/c08fa8e4-ec63-42be-b08a-21dd83beca46" /> | <img width="1275" height="1650" alt="3d4a8c356e02aei4 pdf-1" src="https://github.com/user-attachments/assets/45ba0783-773d-434a-b8b9-2f89fc5420f7" /> <img width="1275" height="1650" alt="3d4a8c356e02aei4 pdf-2" src="https://github.com/user-attachments/assets/98ef4150-669e-44de-905e-97bc74fe06a6" /> <img width="1275" height="1650" alt="3d4a8c356e02aei4 pdf-3" src="https://github.com/user-attachments/assets/6929c641-b9bb-4c78-b2a4-528e6f05bca2" /> <img width="933" height="950" alt="Screenshot 2025-10-24 at 11 45 10 AM" src="https://github.com/user-attachments/assets/d097a238-5575-44ed-9035-51d6b244aa89" /> <img width="936" height="439" alt="Screenshot 2025-10-24 at 11 45 27 AM" src="https://github.com/user-attachments/assets/1ee74b0b-6d11-4326-b219-791af6067762" /> <img width="934" height="853" alt="Screenshot 2025-10-24 at 11 45 38 AM" src="https://github.com/user-attachments/assets/2d4861fc-8c06-42d3-802a-d196d30f05f8" /> |

## What areas of the site does it impact?

N/A

## Acceptance criteria

- Update the PDF and TXT files per the mocks.
  - AC1: Change: Non-VA Med fields
    - Content change for Non-VA status definition
    - Remove “Non-VA medications include these types” field
    - Remove “Provider notes” field
 
  - AC2: Change: Allergies section
    - Content change for “Allergies” h2 to “Allergies and reactions”
    - Remove “Date entered” field
    - Remove “Location” field
    - Remove “Provider notes” field
  
  - AC3: Change: The definition of the status will begin on the same line, a separated by a “-”.
    - This is for all definitions except for Non-VA meds
  
  - AC4: Add: 32px spacing above and below the divider
  
  - AC5: Change: PDF changes apply to .txt files

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user