### PR TITLE
Msaltykov 98827 spouse v2 confirmation flow spouse additional information

### DIFF
--- a/src/applications/ezr/config/chapters/householdInformation/spouseInformation.js
+++ b/src/applications/ezr/config/chapters/householdInformation/spouseInformation.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import spouseInformationSummaryPage from '../../../definitions/spouseInformationSummary';
 import spousePersonalInformationPage from '../../../definitions/spousePersonalInformation';
+import spouseAdditionalInformationPage from '../../../definitions/spouseAdditionalInformation';
 
 import content from '../../../locales/en/content.json';
 import SpouseSummaryCardDescription from '../../../components/FormDescriptions/SpouseSummaryCardDescription';
@@ -61,6 +62,15 @@ const spousePersonalInformationPageSchema = spousePersonalInformationPage(
   options,
 );
 
+/**
+ * Schemas for spouse additional information page.
+ *
+ * @returns {PageSchema}
+ */
+const spouseAdditionalInformationPageSchema = spouseAdditionalInformationPage(
+  options,
+);
+
 const spousalInformationPages = arrayBuilderPages(options, pageBuilder => ({
   spouseInformationSummaryPage: pageBuilder.summaryPage({
     title: content['household-spouse-information-summary-title'],
@@ -74,6 +84,13 @@ const spousalInformationPages = arrayBuilderPages(options, pageBuilder => ({
       'household-information/spouse-information/:index/spouse-personal-information',
     uiSchema: spousePersonalInformationPageSchema.uiSchema,
     schema: spousePersonalInformationPageSchema.schema,
+  }),
+  spouseAdditionalInformationPage: pageBuilder.itemPage({
+    title: content['household-spouse-addtl-info-title'],
+    path:
+      'household-information/spouse-information/:index/spouse-additional-information',
+    uiSchema: spouseAdditionalInformationPageSchema.uiSchema,
+    schema: spouseAdditionalInformationPageSchema.schema,
   }),
 }));
 

--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -1,4 +1,3 @@
-// platform imports
 import environment from 'platform/utilities/environment';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
@@ -9,7 +8,6 @@ import manifest from '../manifest.json';
 import content from '../locales/en/content.json';
 import { SHARED_PATHS, VIEW_FIELD_SCHEMA } from '../utils/constants';
 import {
-  includeSpousalInformation,
   includeSpousalInformationV1,
   includeSpousalInformationV2,
   includeHouseholdInformation,
@@ -381,6 +379,10 @@ const formConfig = {
           ...spousalInformationPages.spousePersonalInformationPage,
           depends: includeSpousalInformationV2,
         },
+        spouseAdditionalInformationV2: {
+          ...spousalInformationPages.spouseAdditionalInformationPage,
+          depends: includeSpousalInformationV2,
+        },
         spousePersonalInformation: {
           path: 'household-information/spouse-personal-information',
           title: 'Spouse\u2019s personal information',
@@ -393,7 +395,7 @@ const formConfig = {
           path: 'household-information/spouse-additional-information',
           title: 'Spouse\u2019s additional information',
           initialData: {},
-          depends: includeSpousalInformation,
+          depends: includeSpousalInformationV1,
           uiSchema: spouseAdditionalInformation.uiSchema,
           schema: spouseAdditionalInformation.schema,
         },

--- a/src/applications/ezr/definitions/spouseAdditionalInformation.js
+++ b/src/applications/ezr/definitions/spouseAdditionalInformation.js
@@ -1,0 +1,36 @@
+import {
+  arrayBuilderItemSubsequentPageTitleUI,
+  descriptionUI,
+  yesNoUI,
+  yesNoSchema,
+} from '~/platform/forms-system/src/js/web-component-patterns';
+import SpouseInfoDescription from '../components/FormDescriptions/SpouseInfoDescription';
+import { replaceStrValues } from '../utils/helpers/general';
+import { LAST_YEAR } from '../utils/constants';
+import content from '../locales/en/content.json';
+
+/** @returns {PageSchema} */
+const spouseAdditionalInformationPage = () => ({
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      content['household-spouse-addtl-info-title'],
+    ),
+    ...descriptionUI(SpouseInfoDescription, {
+      hideOnReview: true,
+    }),
+    cohabitedLastYear: yesNoUI(
+      replaceStrValues(content['household-spouse-cohabitate-label'], LAST_YEAR),
+    ),
+    sameAddress: yesNoUI(content['household-spouse-same-address-label']),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      cohabitedLastYear: yesNoSchema,
+      sameAddress: yesNoSchema,
+    },
+    required: ['sameAddress', 'cohabitedLastYear'],
+  },
+});
+
+export default spouseAdditionalInformationPage;

--- a/src/applications/ezr/tests/unit/definitions/spouseAdditionalInformation.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/definitions/spouseAdditionalInformation.unit.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../../config/form';
+import spouseAdditionalInformationPage from '../../../definitions/spouseAdditionalInformation';
+import { renderProviderWrappedComponent } from '../../helpers';
+
+describe('ezr spouseAdditionalInformationPage config', () => {
+  const { schema, uiSchema } = spouseAdditionalInformationPage();
+  const definitions = {
+    ...formConfig.defaultDefinitions,
+  };
+
+  it('should render', () => {
+    const mockStoreData = {
+      'view:householdEnabled': true,
+      'view:isProvidersAndDependentsPrefillEnabled': true,
+    };
+    const { container } = renderProviderWrappedComponent(
+      mockStoreData,
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(container).to.exist;
+  });
+
+  it('should have required fields', () => {
+    expect(schema.required).to.include('sameAddress');
+    expect(schema.required).to.include('cohabitedLastYear');
+  });
+
+  it('should have correct properties', () => {
+    expect(schema.properties).to.have.property('cohabitedLastYear');
+    expect(schema.properties).to.have.property('sameAddress');
+  });
+
+  it('should have yes/no schema for both fields', () => {
+    expect(schema.properties.cohabitedLastYear.type).to.equal('boolean');
+    expect(schema.properties.sameAddress.type).to.equal('boolean');
+  });
+});


### PR DESCRIPTION
This PR merges the contents of #37743 into main individually, to break up the 3500 lines of the overall #37774.
When #39335 is merged, this PR will auto-update to target main and can be merged in next. Original description follows:

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request introduces a new "Spouse Additional Information" V2 confirmation flow (ArrayBuilder/List and Loop) page to the EZR application form. The changes include adding the page schema, updating the form configuration to incorporate the new page, and creating unit tests to validate its functionality. The "new" page is equivalent to the existing V1 page in form function, but is incorporated into the V2 flow's List and Loop pattern.

This work is behind the isSpouseConfirmationFlowEnabled feature flag.

### Addition of "Spouse Additional Information" Page:

* **Page Schema Definition**: Added a new schema for the "Spouse Additional Information" page in `spouseAdditionalInformation.js`. This includes UI elements for questions about cohabitation and address sharing, along with validation requiring both fields.
* **Form Configuration Update**: Integrated the new page into the form configuration by adding it to `spousalInformationPages` and updating dependencies for conditional rendering. [[1]](diffhunk://#diff-db07d3e35d5933761d79cedc535173c717bc77a734a1b94cc34b8337bcdf7207R88-R94) [[2]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bR383-R386) [[3]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bL397-R399)

### Codebase Enhancements:

* **Import Adjustments**: Added imports for the new page schema and removed unused imports in `spouseInformation.js` and `form.js`. [[1]](diffhunk://#diff-db07d3e35d5933761d79cedc535173c717bc77a734a1b94cc34b8337bcdf7207R5) [[2]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bL1) [[3]](diffhunk://#diff-bbc025ed0a2310fdbeb4625186521ddcf736af93216a0e6caf302a68f3a1fe5bL12)

### Testing:

* **Unit Tests**: Created unit tests in `spouseAdditionalInformation.unit.spec.jsx` to ensure the page renders correctly, has required fields, and uses the correct schema properties.

## Related issue(s)
 - **department-of-veterans-affairs/va.gov-team/issues/98827**

## Testing done
With ezr_spouse_confirmation_flow_enabled feature flag **disabled**:
Old behavior - the V1 spouse additional information page is displayed which includes two yes/no questions about the living situation with the spouse in the previous year. Answers to these questions determine the next page:

Expected next page navigation for both V1 and V2:
| Did you live with your spouse for all or part of 2024? | Do you currently have the same address as your spouse? | Next Page |
|--------|--------|--------|
| Y | N | Spouse contact info |
| Y | Y | Dependents |
| N | N | Spouse financial support | 
| N | Y | Spouse financial support | 

With ezr_spouse_confirmation_flow_enabled feature flag **enabled**:
New Behavior 
- New V2 spouse additional information page is displayed which has the same form fields as V1, but presented in the ArrayBuilder/List and Loop path pattern.
- After answering questions on the page, the continue button takes the user to the V2 spouse information summary to display the review card (later, this will take the user through the rest of the V2 flow once those pages are merged in)

### Current/V1 Test Steps (no spouse prefill):

1. Login to the test site (local, RI)
2. Visit the 10-10EZR form at /my-health/update-benefits-information-form-10-10ezr
3. Start the application process
4. Proceed filling the form up to the /my-health/update-benefits-information-form-10-10ezr/household-information/marital-status-information
5. Select a Married or Separated status
6. Click continue
7. Confirm you are at the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-personal-information page.
8.  Fill required fields and click continue
9. Verify you are at the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-additional-information page.

### New V2 Test Steps:

0. Ensure the feature flag is enabled.
1. Steps 1-8 above
2. Confirm you are on the /my-health/update-benefits-information-form-10-10ezr/household-information/spouse-information/0/spouse-additional-information?add=true page.
3. Confirm there are two y/n questions: 'Did you live with your spouse for all or part of 2024?', and 'Do you currently have the same address as your spouse?'
4. Confirm the answers to these questions take you to the correct page (based on table above).

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="1067" height="901" alt="Screenshot 2025-07-15 at 10 33 48 AM" src="https://github.com/user-attachments/assets/0655de56-5bdd-4cf1-9e66-641ad94d9a50" />  |  <img width="1109" height="899" alt="Screenshot 2025-07-15 at 10 32 44 AM" src="https://github.com/user-attachments/assets/0583a6ee-a76e-433f-a679-faafe3d5a25a" /> |
| Desktop | <img width="1069" height="847" alt="Screenshot 2025-07-15 at 10 33 43 AM" src="https://github.com/user-attachments/assets/705f7496-d602-4e96-ab10-2e198ea34a78" />  |  <img width="1151" height="1061" alt="Screenshot 2025-07-15 at 10 32 38 AM" src="https://github.com/user-attachments/assets/16a9aeb4-396b-4d88-9fdd-ed265fb70585" /> |

## What areas of the site does it impact?
10-10EZR form.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
