### PR TITLE
21P-8416 Care Expense updates

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -94,7 +94,7 @@ function introDescription() {
 }
 
 /** @type {ArrayBuilderOptions} */
-const options = {
+export const options = {
   arrayPath: 'careExpenses',
   nounSingular: 'care expense',
   nounPlural: 'care expenses',

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -87,10 +87,7 @@ function introDescription() {
             </span>
           </li>
         </ul>
-        <p>
-          We’ll ask you to upload these documents at the end of this
-          application.
-        </p>
+        <p>We’ll ask you to upload these documents at the end of this form.</p>
       </va-additional-info>
     </div>
   );
@@ -180,11 +177,9 @@ const typeOfCarePage = {
 /** @returns {PageSchema} */
 const recipientPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI(
-      'Care recipient and provider name',
-    ),
+    ...arrayBuilderItemSubsequentPageTitleUI('Care recipient'),
     recipient: radioUI({
-      title: 'Who is the expense for?',
+      title: 'Who’s the expense for?',
       labels: recipientTypeLabels,
     }),
     recipientName: textUI({
@@ -199,22 +194,23 @@ const recipientPage = {
         return ['DEPENDENT', 'OTHER'].includes(careExpense?.recipient);
       },
     }),
-    provider: textUI('What’s the name of the care provider?'),
   },
   schema: {
     type: 'object',
     properties: {
       recipient: radioSchema(Object.keys(recipientTypeLabels)),
       recipientName: textSchema,
-      provider: textSchema,
     },
-    required: ['recipient', 'provider'],
+    required: ['recipient'],
   },
 };
 /** @returns {PageSchema} */
 const datePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Dates of care'),
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      'Care provider’s name and dates of care',
+    ),
+    provider: textUI('What’s the name of the care provider?'),
     careDate: currentOrPastDateRangeUI(
       {
         title: 'Care start date',
@@ -230,21 +226,25 @@ const datePage = {
   schema: {
     type: 'object',
     properties: {
+      provider: textSchema,
       careDate: {
         ...currentOrPastDateRangeSchema,
         required: ['from'],
       },
       noEndDate: checkboxSchema,
     },
-    required: ['typeOfCare'],
+    required: ['typeOfCare', 'provider'],
   },
 };
 
 /** @returns {PageSchema} */
 const costPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Cost of care'),
-    monthlyAmount: currencyUI('How much is each monthly payment?'),
+    ...arrayBuilderItemSubsequentPageTitleUI(({ formData }) => {
+      const provider = formData?.provider ?? '';
+      return provider ? `Cost of care for ${provider}` : 'Cost of care';
+    }),
+    monthlyAmount: currencyUI('What’s the monthly cost of this care?'),
     hourlyRate: {
       ...currencyUI({
         title: 'What is the care provider’s hourly rate?',
@@ -307,19 +307,22 @@ export const careExpensesPages = arrayBuilderPages(options, pageBuilder => ({
     schema: typeOfCarePage.schema,
   }),
   careExpensesRecipientPage: pageBuilder.itemPage({
-    title: 'Care recipient and provider',
-    path: 'expenses/care/:index/recipient-provider',
+    title: 'Care recipient',
+    path: 'expenses/care/:index/recipient',
     uiSchema: recipientPage.uiSchema,
     schema: recipientPage.schema,
   }),
   careExpensesDatesPage: pageBuilder.itemPage({
-    title: 'Dates of care',
+    title: 'Care provider’s name and dates of care',
     path: 'expenses/care/:index/dates',
     uiSchema: datePage.uiSchema,
     schema: datePage.schema,
   }),
   careExpensesCostPage: pageBuilder.itemPage({
-    title: 'Cost of care',
+    title: ({ formData }) => {
+      const provider = formData?.provider ?? '';
+      return provider ? `Cost of care for ${provider}` : 'Cost of care';
+    },
     path: 'expenses/care/:index/cost',
     uiSchema: costPage.uiSchema,
     schema: costPage.schema,

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/careExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/careExpensesPage.unit.spec.jsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+import {
+  careExpensesPages,
+  options,
+} from '../../../../config/chapters/02-expenses/careExpensesPages';
+import { recipientTypeLabels } from '../../../../utils/labels';
+
+const arrayPath = 'careExpenses';
+
+describe('Care Expenses Pages', () => {
+  it('renders the care expenses intro', async () => {
+    const { careExpensesIntro } = careExpensesPages;
+
+    const form = render(
+      <DefinitionTester
+        schema={careExpensesIntro.schema}
+        uiSchema={careExpensesIntro.uiSchema}
+        data={{}}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaLinks = $$('va-link', formDOM);
+    expect(form.getByRole('heading')).to.have.text(careExpensesIntro.title);
+    expect(vaLinks.length).to.equal(4);
+  });
+  it('renders the care expenses summary', async () => {
+    const { careExpensesSummary } = careExpensesPages;
+
+    const form = render(
+      <DefinitionTester
+        schema={careExpensesSummary.schema}
+        uiSchema={careExpensesSummary.uiSchema}
+        data={{}}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaRadio = $('va-radio', formDOM);
+    const vaRadioOptions = $$('va-radio-option', formDOM);
+
+    expect(vaRadio.getAttribute('label-header-level')).to.equal('3');
+    expect(vaRadio.getAttribute('label')).to.equal(
+      'Do you have a care expense to add?',
+    );
+    expect(vaRadioOptions.length).to.equal(2);
+    expect(vaRadioOptions[0].getAttribute('label')).to.equal('Yes');
+    expect(vaRadioOptions[1].getAttribute('label')).to.equal('No');
+  });
+  it('renders the care expenses type of care page', async () => {
+    const { careExpensesTypePage } = careExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={careExpensesTypePage.schema}
+        uiSchema={careExpensesTypePage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaRadio = $('va-radio', formDOM);
+    const vaRadioOptions = $$('va-radio-option', formDOM);
+
+    expect(form.getByRole('heading')).to.have.text('Type of care');
+
+    expect(vaRadio.getAttribute('label')).to.equal('Select the type of care.');
+    expect(vaRadioOptions.length).to.equal(2);
+    expect(vaRadioOptions[0].getAttribute('label')).to.equal(
+      'Residential care facility',
+    );
+    expect(vaRadioOptions[1].getAttribute('label')).to.equal(
+      'In-home care attendant',
+    );
+  });
+  it('renders the care expenses recipient page', async () => {
+    const { careExpensesRecipientPage } = careExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={careExpensesRecipientPage.schema}
+        uiSchema={careExpensesRecipientPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaRecipient = $('va-radio[label*="Who’s the expense for?"]', formDOM);
+    expect(vaRecipient.getAttribute('required')).to.equal('true');
+    const vaRecipientOtherSelector =
+      'va-text-input[label*="Full name of the person who received care"]';
+    const vaRecipientOptions = $$('va-radio-option', formDOM);
+    expect(form.getByRole('heading')).to.have.text('Care recipient');
+    expect(vaRecipientOptions.length).to.equal(4);
+    Object.keys(recipientTypeLabels).forEach((key, index) => {
+      expect(vaRecipientOptions[index].getAttribute('label')).to.equal(
+        recipientTypeLabels[key],
+      );
+    });
+
+    vaRecipient.__events.vaValueChange({
+      detail: { value: 'OTHER' },
+    });
+    expect($(vaRecipientOtherSelector, formDOM)).to.exist;
+    vaRecipient.__events.vaValueChange({
+      detail: { value: 'DEPENDENT' },
+    });
+    expect($(vaRecipientOtherSelector, formDOM)).to.exist;
+    vaRecipient.__events.vaValueChange({
+      detail: { value: 'SPOUSE' },
+    });
+    expect($(vaRecipientOtherSelector, formDOM)).to.not.exist;
+  });
+  it('renders the care expenses provider and care dates', async () => {
+    const { careExpensesDatesPage } = careExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={careExpensesDatesPage.schema}
+        uiSchema={careExpensesDatesPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    expect(form.getByRole('heading')).to.have.text(
+      'Care provider’s name and dates of care',
+    );
+    const vaTextInputs = $$('va-text-input', formDOM);
+    expect(vaTextInputs.length).to.equal(1);
+    const vaProviderInput = $(
+      'va-text-input[label*="What’s the name of the care provider?"]',
+      formDOM,
+    );
+    expect(vaProviderInput.getAttribute('required')).to.equal('true');
+
+    const vaMemorableDates = $$('va-memorable-date', formDOM);
+    expect(vaMemorableDates.length).to.equal(2);
+    const vaMemorableDateStart = $(
+      'va-memorable-date[label*="Care start date"]',
+      formDOM,
+    );
+    expect(vaMemorableDateStart.getAttribute('required')).to.equal('true');
+    const vaMemorableDateEnd = $(
+      'va-memorable-date[label*="Care end date"]',
+      formDOM,
+    );
+    expect(vaMemorableDateEnd.getAttribute('required')).to.equal('false');
+
+    const vaCheckboxes = $$('va-checkbox', formDOM);
+    expect(vaCheckboxes.length).to.equal(1);
+    const vaCheckbox = $('va-checkbox[label*="No end date"]', formDOM);
+    expect(vaCheckbox.getAttribute('required')).to.equal('false');
+  });
+  it('renders the cost of care page with no provider', async () => {
+    const { careExpensesCostPage } = careExpensesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={careExpensesCostPage.schema}
+        uiSchema={careExpensesCostPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    expect(form.getByRole('heading')).to.have.text('Cost of care');
+  });
+  it('renders the cost of care page for in-home care', async () => {
+    const { careExpensesCostPage } = careExpensesPages;
+    const formData = {
+      provider: 'Test Provider',
+      typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+    };
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={careExpensesCostPage.schema}
+        uiSchema={careExpensesCostPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    expect(form.getByRole('heading')).to.have.text(
+      'Cost of care for Test Provider',
+    );
+    const vaTextInputs = $$('va-text-input', formDOM);
+    expect(vaTextInputs.length).to.equal(3);
+    const vaMonthlyInput = $(
+      'va-text-input[label*="What’s the monthly cost of this care?"]',
+      formDOM,
+    );
+    expect(vaMonthlyInput.getAttribute('required')).to.equal('true');
+    const vaHourlyInput = $(
+      'va-text-input[label*="What is the care provider’s hourly rate?"]',
+      formDOM,
+    );
+    expect(vaHourlyInput.getAttribute('required')).to.equal('true');
+    const vaHoursPerWeekInput = $(
+      'va-text-input[label*="How many hours per week does the care provider work?"]',
+      formDOM,
+    );
+    expect(vaHoursPerWeekInput.getAttribute('required')).to.equal('true');
+  });
+  it('renders the cost of care page for residential care', async () => {
+    const { careExpensesCostPage } = careExpensesPages;
+    const formData = {
+      provider: 'New Provider',
+      typeOfCare: 'RESIDENTIAL',
+    };
+    const form = render(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        schema={careExpensesCostPage.schema}
+        uiSchema={careExpensesCostPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ [arrayPath]: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    expect(form.getByRole('heading')).to.have.text(
+      'Cost of care for New Provider',
+    );
+    const vaTextInputs = $$('va-text-input', formDOM);
+    expect(vaTextInputs.length).to.equal(1);
+    const vaMonthlyInput = $(
+      'va-text-input[label*="What’s the monthly cost of this care?"]',
+      formDOM,
+    );
+    expect(vaMonthlyInput.getAttribute('required')).to.equal('true');
+    const vaHourlyInput = $(
+      'va-text-input[label*="What is the care provider’s hourly rate?"]',
+      formDOM,
+    );
+    expect(vaHourlyInput).to.not.exist;
+    const vaHoursPerWeekInput = $(
+      'va-text-input[label*="How many hours per week does the care provider work?"]',
+      formDOM,
+    );
+    expect(vaHoursPerWeekInput).to.not.exist;
+  });
+  it('should return the correct card description with paymentDate', () => {
+    const item = {
+      careDate: {
+        from: '2004-04-04',
+      },
+      typeOfCare: 'RESIDENTIAL',
+    };
+    const { getByText: nameText } = render(options.text.getItemName(item));
+    const { getByText: descriptionText } = render(
+      options.text.cardDescription(item),
+    );
+    expect(nameText('Residential care facility')).to.exist;
+    expect(descriptionText('04/04/2004')).to.exist;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update field labels and hints from staging review and content team
- Update title on cost page to include provider name
- Add unit test coverage for care expenses

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122549
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122552

## Testing done

- Manual testing and review of changes
- Created unit tests to cover all the updates

## Screenshots

| Before | After |
| ------- | ------ |
| <img width="655" height="880" alt="Screenshot 2025-10-27 at 3 01 08 PM" src="https://github.com/user-attachments/assets/6ce84e63-1633-422e-98bb-9cc75cef1803" /> <img width="511" height="350" alt="Screenshot 2025-10-27 at 3 01 12 PM" src="https://github.com/user-attachments/assets/024fd08c-539c-46e0-b24c-2a68e9fbbdbe" /> <img width="557" height="490" alt="Screenshot 2025-10-27 at 3 01 18 PM" src="https://github.com/user-attachments/assets/f05728cb-b82c-47e4-ab09-ab3219223355" /> <img width="740" height="733" alt="Screenshot 2025-10-27 at 3 01 25 PM" src="https://github.com/user-attachments/assets/fa5f14eb-5e66-4dda-a677-1ad4e79f90b7" /> <img width="593" height="689" alt="Screenshot 2025-10-27 at 3 01 34 PM" src="https://github.com/user-attachments/assets/2589f59e-83e7-4675-87f5-f97d79bf4bdb" /> <img width="631" height="628" alt="Screenshot 2025-10-27 at 3 01 45 PM" src="https://github.com/user-attachments/assets/1a59d513-f3cb-4697-b5a6-09c979c829b9" /> <img width="670" height="519" alt="Screenshot 2025-10-27 at 3 01 52 PM" src="https://github.com/user-attachments/assets/17382f0d-f22d-4aed-b724-a2ca7483fe9f" /> | <img width="743" height="968" alt="Screenshot 2025-10-27 at 3 02 10 PM" src="https://github.com/user-attachments/assets/6740f623-acee-4695-bf81-6e204cad3ab4" /> <img width="545" height="373" alt="Screenshot 2025-10-27 at 3 02 14 PM" src="https://github.com/user-attachments/assets/fcbdd0ca-7e0f-4ce7-8997-627b08059b59" /> <img width="632" height="582" alt="Screenshot 2025-10-27 at 3 02 20 PM" src="https://github.com/user-attachments/assets/4340c50a-8c7e-4706-b4cc-14f766170931" /> <img width="701" height="771" alt="Screenshot 2025-10-27 at 3 02 30 PM" src="https://github.com/user-attachments/assets/fc61b433-5408-4011-b8d4-b2eb8ee20ac4" /> <img width="733" height="901" alt="Screenshot 2025-10-27 at 3 02 36 PM" src="https://github.com/user-attachments/assets/764f0ea5-d672-4193-98c6-4e03e2da4813" /> <img width="666" height="709" alt="Screenshot 2025-10-27 at 3 02 51 PM" src="https://github.com/user-attachments/assets/7280c074-5c98-4f2b-b5bd-e70e6b25b76a" /> <img width="710" height="615" alt="Screenshot 2025-10-27 at 3 02 57 PM" src="https://github.com/user-attachments/assets/dd655b38-e568-4af0-97b0-2db778630b5b" /> |

## What areas of the site does it impact?

The expense care array builder part of the 8416 form.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
