### PR TITLE
0969 | Post MVP - Update annuities pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
@@ -234,7 +234,7 @@ const informationPage = {
     }),
     establishedDate: currentOrPastDateUI('When was the annuity created?'),
     marketValueAtEstablishment: currencyUI(
-      'What was the fair market value of the asset when the annui ty was purchased?',
+      'What was the fair market value of the asset when the annuity was purchased?',
     ),
   },
   schema: {

--- a/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
@@ -20,6 +20,7 @@ import {
   generateDeleteDescription,
   isDefined,
   surrenderValueRequired,
+  sharedYesNoOptionsBase,
   showUpdatedContent,
   requireExpandedArrayField,
 } from '../../../helpers';
@@ -43,6 +44,7 @@ export const options = {
     typeof item.receivingIncomeFromAnnuity !== 'boolean' ||
     typeof item.canBeLiquidated !== 'boolean', // include all required fields here
   text: {
+    summaryTitle: 'Review annuities',
     getItemName: item =>
       isDefined(item?.establishedDate) &&
       `Annuity established on ${formatDateLong(item.establishedDate)}`,
@@ -56,7 +58,7 @@ export const options = {
             </span>
           </li>
           <li>
-            Market value when established:{' '}
+            Fair market value when created:{' '}
             <span className="vads-u-font-weight--bold">
               {formatCurrency(item.marketValueAtEstablishment)}
             </span>
@@ -81,6 +83,19 @@ export const options = {
   },
 };
 
+// We support multiple summary pages (one per claimant type).
+// These constants centralize shared text so each summary page stays consistent.
+// Important: only one summary page should ever be displayed at a time.
+
+// Shared summary page text
+const updatedTitleNoItems = 'Do you or your dependents have an annuity?';
+const updatedTitleWithItems = 'Do you have another annuity to report?';
+const summaryPageTitle = 'Annuities summary';
+const yesNoOptionLabels = {
+  Y: 'Yes, I have an annuity to report',
+  N: 'No, I don’t have an annuity to report',
+};
+
 /**
  * Cards are populated on this page above the uiSchema if items are present
  *
@@ -91,9 +106,7 @@ const summaryPage = {
     'view:isAddingAnnuities': arrayBuilderYesNoUI(
       options,
       {
-        title: showUpdatedContent()
-          ? 'Do you or your dependents have an annuity?'
-          : 'Have you or your dependents established an annuity?',
+        title: 'Have you or your dependents established an annuity?',
         hint: 'If yes, you’ll need to report at least one annuity',
         labels: {
           Y: 'Yes',
@@ -101,13 +114,8 @@ const summaryPage = {
         },
       },
       {
-        title: showUpdatedContent()
-          ? 'Do you have another annuity to report?'
-          : 'Do you have more annuities to report?',
-        labels: {
-          Y: 'Yes',
-          N: 'No',
-        },
+        title: updatedTitleWithItems,
+        ...sharedYesNoOptionsBase,
       },
     ),
   },
@@ -121,15 +129,112 @@ const summaryPage = {
 };
 
 /** @returns {PageSchema} */
+const veteranSummaryPage = {
+  uiSchema: {
+    'view:isAddingAnnuities': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint:
+          'Your dependents include your spouse, including a same-sex and common-law partner and children who you financially support.',
+        ...sharedYesNoOptionsBase,
+        labels: yesNoOptionLabels,
+      },
+      {
+        title: updatedTitleWithItems,
+        ...sharedYesNoOptionsBase,
+      },
+    ),
+  },
+};
+
+/** @returns {PageSchema} */
+const spouseSummaryPage = {
+  uiSchema: {
+    'view:isAddingAnnuities': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint: 'Your dependents include children who you financially support. ',
+        ...sharedYesNoOptionsBase,
+        labels: yesNoOptionLabels,
+      },
+      {
+        title: updatedTitleWithItems,
+        ...sharedYesNoOptionsBase,
+      },
+    ),
+  },
+};
+
+/** @returns {PageSchema} */
+const childSummaryPage = {
+  uiSchema: {
+    'view:isAddingAnnuities': arrayBuilderYesNoUI(
+      options,
+      {
+        title: 'Do you have an annuity?',
+        hint: null,
+        ...sharedYesNoOptionsBase,
+        labels: yesNoOptionLabels,
+      },
+      {
+        title: updatedTitleWithItems,
+        ...sharedYesNoOptionsBase,
+      },
+    ),
+  },
+};
+
+const parentSummaryPage = {
+  uiSchema: {
+    'view:isAddingAnnuities': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint:
+          'Your dependents include your spouse, including a same-sex and common-law partner.',
+        ...sharedYesNoOptionsBase,
+        labels: yesNoOptionLabels,
+      },
+      {
+        title: updatedTitleWithItems,
+        ...sharedYesNoOptionsBase,
+      },
+    ),
+  },
+};
+
+/** @returns {PageSchema} */
+const custodianSummaryPage = {
+  uiSchema: {
+    'view:isAddingAnnuities': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint:
+          'Your dependents include your spouse, including a same-sex and common-law partner and the Veteran’s children who you financially support.',
+        ...sharedYesNoOptionsBase,
+        labels: yesNoOptionLabels,
+      },
+      {
+        title: updatedTitleWithItems,
+        ...sharedYesNoOptionsBase,
+      },
+    ),
+  },
+};
+
+/** @returns {PageSchema} */
 const informationPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Annuity establishment',
+      title: 'Annuity creation',
       nounSingular: options.nounSingular,
     }),
-    establishedDate: currentOrPastDateUI('When was the annuity established?'),
+    establishedDate: currentOrPastDateUI('When was the annuity created?'),
     marketValueAtEstablishment: currencyUI(
-      'What was the market value of the asset at the time of purchase?',
+      'What was the fair market value of the asset when the annui ty was purchased?',
     ),
   },
   schema: {
@@ -147,11 +252,12 @@ const revocablePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Type of annuity'),
     revocable: yesNoUI({
-      title: 'Is the annuity revocable or irrevocable?',
+      title: 'What type of annuity is it?',
       labels: {
         Y: 'Revocable',
         N: 'Irrevocable',
       },
+      ...sharedYesNoOptionsBase,
     }),
   },
   schema: {
@@ -167,14 +273,13 @@ const revocablePage = {
 const incomePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Income from annuity'),
-    receivingIncomeFromAnnuity: showUpdatedContent()
-      ? yesNoUI('Does this annuity generate income?')
-      : yesNoUI('Do you receive income from the annuity?'),
+    receivingIncomeFromAnnuity: yesNoUI({
+      title: 'Did you receive income from this annuity?',
+      ...sharedYesNoOptionsBase,
+    }),
     annualReceivedIncome: {
       ...currencyUI({
-        title: showUpdatedContent()
-          ? 'How much income does this annuity generate yearly?'
-          : 'How much is the annual amount received?',
+        title: 'How much annual income do you receive from this annuity?',
         expandUnder: 'receivingIncomeFromAnnuity',
         expandUnderCondition: true,
       }),
@@ -198,10 +303,13 @@ const incomePage = {
 const liquidationPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Annuity liquidation'),
-    canBeLiquidated: yesNoUI('Can the annuity be liquidated?'),
+    canBeLiquidated: yesNoUI({
+      title: 'Can this annuity be liquidated?',
+      ...sharedYesNoOptionsBase,
+    }),
     surrenderValue: {
       ...currencyUI({
-        title: 'What is the surrender value?',
+        title: 'What’s the surrender value?',
         expandUnder: 'canBeLiquidated',
         expandUnderCondition: true,
       }),
@@ -224,14 +332,12 @@ const liquidationPage = {
 /** @returns {PageSchema} */
 const hasAddedFundsPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Funds added to annuity'),
-    addedFundsAfterEstablishment: showUpdatedContent()
-      ? yesNoUI(
-          'Was money added to this annuity this year or in the last 3 years?',
-        )
-      : yesNoUI(
-          'Have you added funds to the annuity in the current or prior three years?',
-        ),
+    ...arrayBuilderItemSubsequentPageTitleUI('Money added to annuity'),
+    addedFundsAfterEstablishment: yesNoUI({
+      title:
+        'Was money added to this annuity this year or in the last 3 years?',
+      ...sharedYesNoOptionsBase,
+    }),
   },
   schema: {
     type: 'object',
@@ -246,12 +352,8 @@ const hasAddedFundsPage = {
 const addedFundsPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Amount added to annuity'),
-    addedFundsDate: showUpdatedContent()
-      ? currentOrPastDateUI('When was money added?')
-      : currentOrPastDateUI('When did you add funds?'),
-    addedFundsAmount: showUpdatedContent()
-      ? currencyUI('How much was added?')
-      : currencyUI('How much did you add?'),
+    addedFundsDate: currentOrPastDateUI('When was money added?'),
+    addedFundsAmount: currencyUI('How much was added?'),
   },
   schema: {
     type: 'object',
@@ -264,12 +366,54 @@ const addedFundsPage = {
 };
 
 export const annuityPages = arrayBuilderPages(options, pageBuilder => ({
+  annuityPagesVeteranSummary: pageBuilder.summaryPage({
+    title: summaryPageTitle,
+    path: 'annuities-summary-veteran',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'VETERAN',
+    uiSchema: veteranSummaryPage.uiSchema,
+    schema: summaryPage.schema,
+  }),
+  annuityPagesUpdatedSpouseSummary: pageBuilder.summaryPage({
+    title: summaryPageTitle,
+    path: 'annuities-summary-spouse',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'SPOUSE',
+    uiSchema: spouseSummaryPage.uiSchema,
+    schema: summaryPage.schema,
+  }),
+  annuityPagesUpdatedChildSummary: pageBuilder.summaryPage({
+    title: summaryPageTitle,
+    path: 'annuities-summary-child',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'CHILD',
+    uiSchema: childSummaryPage.uiSchema,
+    schema: summaryPage.schema,
+  }),
+  annuityPagesUpdatedCustodianSummary: pageBuilder.summaryPage({
+    title: summaryPageTitle,
+    path: 'annuities-summary-custodian',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+    uiSchema: custodianSummaryPage.uiSchema,
+    schema: summaryPage.schema,
+  }),
+  annuityPagesUpdatedParentSummary: pageBuilder.summaryPage({
+    title: summaryPageTitle,
+    path: 'annuities-summary-parent',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'PARENT',
+    uiSchema: parentSummaryPage.uiSchema,
+    schema: summaryPage.schema,
+  }),
+  // Ensure MVP summary page is listed last so it’s not accidentally overridden by claimantType-specific summary pages
   annuityPagesSummary: pageBuilder.summaryPage({
     ContentBeforeButtons: showUpdatedContent()
       ? customDependentDescription
       : null,
     title: 'Annuities summary',
     path: 'annuities-summary',
+    depends: () => !showUpdatedContent(),
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,
   }),

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/09-annuities/annuityPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/09-annuities/annuityPages.unit.spec.jsx
@@ -138,8 +138,8 @@ describe('annuity list and loop pages', () => {
       schema,
       uiSchema,
       [
-        'va-memorable-date[label="When was the annuity established?"]',
-        'va-text-input[label="What was the market value of the asset at the time of purchase?"]',
+        'va-memorable-date[label="When was the annuity created?"]',
+        'va-text-input[label="What was the fair market value of the asset when the annuity was purchased?"]',
       ],
       'information',
     );
@@ -169,7 +169,7 @@ describe('annuity list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-radio[label="Is the annuity revocable or irrevocable?"]'],
+      ['va-radio[label="What type of annuity is it?"]'],
       'revocable',
     );
     testSubmitsWithoutErrors(
@@ -198,7 +198,7 @@ describe('annuity list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-radio[label="Do you receive income from the annuity?"]'],
+      ['va-radio[label="Did you receive income from this annuity?"]'],
       'income',
     );
     testSubmitsWithoutErrors(
@@ -237,7 +237,7 @@ describe('annuity list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-radio[label="Can the annuity be liquidated?"]'],
+      ['va-radio[label="Can this annuity be liquidated?"]'],
       'liquidation',
     );
     testSubmitsWithoutErrors(
@@ -277,7 +277,7 @@ describe('annuity list and loop pages', () => {
       schema,
       uiSchema,
       [
-        'va-radio[label="Have you added funds to the annuity in the current or prior three years?"]',
+        'va-radio[label="Was money added to this annuity this year or in the last 3 years?"]',
       ],
       'funds',
     );
@@ -309,8 +309,8 @@ describe('annuity list and loop pages', () => {
       schema,
       uiSchema,
       [
-        'va-memorable-date[label="When did you add funds?"]',
-        'va-text-input[label="How much did you add?"]',
+        'va-memorable-date[label="When was money added?"]',
+        'va-text-input[label="How much was added?"]',
       ],
       'added funds',
     );


### PR DESCRIPTION
## Summary

This PR updates the **Annuities** chapter in the **Income and Asset Statement form (VA Form 21P-0969)** for **Post-MVP** implementation.  
Changes include revised **information** and **summary** pages to align with Design QA feedback, improve plain language clarity, and ensure consistency with other Post-MVP list-and-loop chapters such as **Trusts** and **Royalties**.  
These updates enhance user comprehension and follow VA Design System (VADS) patterns for headings, spacing, and summary presentation.

## Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123018  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123019  

## Related issue(s)

- Builds on Post-MVP chapter updates for 0969 (Trusts, Financial Accounts, Royalties, etc.)  
- Uses shared helper utilities for consistent title, summary, and empty-state behavior  

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the 0969 form at:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Progress to the **Annuities** chapter  

## How to verify

1. Navigate to the **Annuities** chapter.  
2. Confirm the **information** and **summary** pages display updated Post-MVP content, including:  
   - Revised headings, body copy, and hint text  
   - Updated labels for key input fields  
   - Proper use of shared helper utilities for summary title and empty-state text  
3. Add, edit, and remove annuity entries to verify list-and-loop navigation and validation.  
4. Validate that the summary page:  
   - Displays all entered items correctly  
   - Shows correct empty-state message when no items are present  
   - Maintains correct heading levels and accessible DOM order  
5. Confirm no console errors or broken behavior in Review & Submit.  

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- **Annuities** chapter — information and summary pages  

## Screenshots

| Before | After |
|--------|-------|
| Outdated titles and inconsistent content | Updated Post-MVP content with VADS-compliant headings and layout |

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- Post-MVP content updates for the **Annuities** chapter  
- **Behind** `income_and_assets_content_updates` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm that the updated Annuities chapter content aligns with Design QA expectations, and that the summary and information pages behave consistently with other Post-MVP list-and-loop chapters.