### PR TITLE
[5047] Form Upload: Alerts on first two pages are not using the correct alert type and content

### DIFF
--- a/src/applications/simple-forms/form-upload/config/constants.js
+++ b/src/applications/simple-forms/form-upload/config/constants.js
@@ -28,14 +28,12 @@ export const MUST_MATCH_ALERT = (variant, onCloseEvent, formData) => {
       closeable
       onCloseEvent={onCloseEvent}
     >
-      {variant === 'name-and-zip-code' ? (
+      {variant === 'nameAndZipCodePage' ? (
         <h3 slot="headline">
           Veteran’s name and postal code must match your PDF
         </h3>
       ) : (
-        <h3 slot="headline">
-          Veteran’s identification information must match your PDF
-        </h3>
+        <h3 slot="headline">This information must match your form</h3>
       )}
       {isLoa3 ? (
         <p>
@@ -43,15 +41,16 @@ export const MUST_MATCH_ALERT = (variant, onCloseEvent, formData) => {
           application based on your account details.
         </p>
       ) : null}
-      {variant === 'name-and-zip-code' ? (
+      {variant === 'nameAndZipCodePage' ? (
         <p>
-          If the Veteran’s name and postal code here don’t match your uploaded
-          PDF, it will cause processing delays.
+          Since you’re signed in to your account, we prefilled this page based
+          on your account details.
         </p>
       ) : (
         <p>
-          If the Veteran’s identification information you enter here doesn’t
-          match your uploaded PDF, it will cause processing delays.
+          Since you’re signed in, we prefilled this information based on your VA
+          profile. <br /> If this information doesn’t match what’s on your form,
+          it’ll cause processing delays.
         </p>
       )}
     </VaAlert>

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -5,6 +5,7 @@ import {
   FORM_UPLOAD_FILE_UPLOADING_ALERT,
   FORM_UPLOAD_INSTRUCTION_ALERT,
   FORM_UPLOAD_OCR_ALERT,
+  MUST_MATCH_ALERT,
 } from '../config/constants';
 
 export const formMappings = {
@@ -218,8 +219,11 @@ export const onClickContinue = (props, setContinueClicked) => {
 };
 
 export const getAlert = (props, continueClicked) => {
-  const warnings = props.data?.uploadedFile?.warnings;
-  const fileUploading = props.data?.uploadedFile?.name === 'uploading';
+  const warnings = props?.data?.uploadedFile?.warnings;
+  const fileUploading = props?.data?.uploadedFile?.name === 'uploading';
+  const veteranInformation =
+    props?.name === 'nameAndZipCodePage' ||
+    props?.name === 'veteranIdentificationInformationPage';
   const formNumber = getFormNumber();
 
   if (warnings?.length > 0) {
@@ -233,6 +237,10 @@ export const getAlert = (props, continueClicked) => {
 
   if (fileUploading && continueClicked) {
     return FORM_UPLOAD_FILE_UPLOADING_ALERT(onCloseAlert);
+  }
+
+  if (veteranInformation) {
+    return MUST_MATCH_ALERT(props?.name, onCloseAlert, props?.data);
   }
 
   return FORM_UPLOAD_INSTRUCTION_ALERT(onCloseAlert);

--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -45,7 +45,7 @@ export const CustomAlertPage = props => {
 
   return (
     <div className="form-panel">
-      {getAlert(props, continueClicked)}
+      {props.name === 'uploadPage' && getAlert(props, continueClicked)}
       <SchemaForm {...props}>
         <>
           {props.contentBeforeButtons}
@@ -66,5 +66,6 @@ CustomAlertPage.propTypes = {
   contentAfterButtons: PropTypes.element,
   contentBeforeButtons: PropTypes.element,
   goBack: PropTypes.func,
+  name: PropTypes.string,
   onContinue: PropTypes.func,
 };

--- a/src/applications/simple-forms/form-upload/pages/nameAndZipCode.jsx
+++ b/src/applications/simple-forms/form-upload/pages/nameAndZipCode.jsx
@@ -7,14 +7,18 @@ import {
   firstNameLastNameNoSuffixUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { MUST_MATCH_ALERT } from '../config/constants';
-import { onCloseAlert } from '../helpers';
 import { CustomAlertPage } from './helpers';
+import { getAlert } from '../helpers';
 
 /** @type {PageSchema} */
 export const nameAndZipCodePage = {
   uiSchema: {
-    ...titleUI('Veteran’s name and postal code'),
+    ...titleUI(
+      'Veteran’s name and postal code',
+      <div className="vads-u-margin-top--3">
+        {getAlert({ name: 'nameAndZipCodePage' }, false)}
+      </div>,
+    ),
     fullName: firstNameLastNameNoSuffixUI(),
     address: addressUI({
       labels: {
@@ -53,8 +57,7 @@ export const nameAndZipCodePage = {
 
 /** @type {CustomPageType} */
 export function NameAndZipCodePage(props) {
-  const alert = MUST_MATCH_ALERT('name-and-zip-code', onCloseAlert, props.data);
-  return <CustomAlertPage {...props} alert={alert} />;
+  return <CustomAlertPage {...props} />;
 }
 
 NameAndZipCodePage.propTypes = {

--- a/src/applications/simple-forms/form-upload/pages/veteranIdentificationInformation.jsx
+++ b/src/applications/simple-forms/form-upload/pages/veteranIdentificationInformation.jsx
@@ -5,16 +5,20 @@ import {
   ssnOrVaFileNumberUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { MUST_MATCH_ALERT } from '../config/constants';
-import { onCloseAlert } from '../helpers';
 import { CustomAlertPage } from './helpers';
+import { getAlert } from '../helpers';
 
 /** @type {PageSchema} */
 export const veteranIdentificationInformationPage = {
   uiSchema: {
     ...titleUI(
       'Veteran identification information',
-      'You must enter either a Social Security number or a VA File number.',
+      <>
+        You must enter either a Social Security number or a VA File number.
+        <div className="vads-u-margin-top--3">
+          {getAlert({ name: 'veteranIdentificationInformationPage' }, false)}
+        </div>
+      </>,
     ),
     idNumber: ssnOrVaFileNumberUI(),
   },
@@ -28,12 +32,7 @@ export const veteranIdentificationInformationPage = {
 
 /** @type {CustomPageType} */
 export function VeteranIdentificationInformationPage(props) {
-  const alert = MUST_MATCH_ALERT(
-    'veteran-identification',
-    onCloseAlert,
-    props.data,
-  );
-  return <CustomAlertPage {...props} alert={alert} />;
+  return <CustomAlertPage {...props} />;
 }
 
 VeteranIdentificationInformationPage.propTypes = {

--- a/src/applications/simple-forms/form-upload/tests/unit/pages/helpers.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/pages/helpers.unit.spec.jsx
@@ -4,7 +4,7 @@ import { render, cleanup } from '@testing-library/react';
 import { expect } from 'chai';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import formConfig from '../../../config/form';
-import { CustomTopContent } from '../../../pages/helpers';
+import { CustomTopContent, CustomAlertPage } from '../../../pages/helpers';
 
 const TEST_URL = 'https://dev.va.gov/form-upload/21-0779/test-page';
 const config = formConfig(TEST_URL);
@@ -86,5 +86,37 @@ describe('CustomTopContent', () => {
       'breadcrumb-list',
       '[{"href":"/","label":"VA.gov home"},{"href":"/find-forms","label":"Find a VA form"},{"href":"/find-forms/upload/21-0779/introduction","label":"Upload form 21-0779"}]',
     );
+  });
+});
+
+describe('CustomAlertPage', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const mockProps = {
+    name: 'uploadPage',
+    contentBeforeButtons: <div>Before Buttons</div>,
+    contentAfterButtons: <div>After Buttons</div>,
+    goBack: () => {},
+    onContinue: () => {},
+  };
+
+  const subject = (props = mockProps) =>
+    render(
+      <Provider store={mockStore}>
+        <CustomAlertPage {...props} />
+      </Provider>,
+    );
+
+  it('renders successfully', () => {
+    const { container } = subject();
+    expect(container).to.exist;
+  });
+
+  it('renders content before and after buttons', () => {
+    const { container } = subject();
+    expect(container.textContent).to.include('Before Buttons');
+    expect(container.textContent).to.include('After Buttons');
   });
 });


### PR DESCRIPTION
## Summary

This PR places the alerts for Personal Info and Veteran ID Info into their respective schemas to fix an issue where the Alert is placed above the page header instead of below it.  It also updates the contents of some of the alerts to match the new design.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5047

## Testing done

local testing, unit testing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Personal Info | <img width="1178" height="1294" alt="image" src="https://github.com/user-attachments/assets/b9d1c845-8d04-4e02-873a-1cd88ac2c677" /> | <img width="1178" height="1294" alt="image" src="https://github.com/user-attachments/assets/6df08c29-b76d-4b90-8f38-899a8e942ce7" /> |
| Veteran ID Info | <img width="1178" height="1294" alt="image" src="https://github.com/user-attachments/assets/04b65552-5248-47f7-b524-568cd7643132" /> | <img width="1178" height="1294" alt="image" src="https://github.com/user-attachments/assets/48ea3271-851a-4247-a5b0-02ce37939d7f" /> |
