### PR TITLE
[123306] Add missing checkboxes for conditions on POW page

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -21,6 +21,7 @@ import { standardTitle } from '../content/form0781';
 
 import {
   capitalizeEachWord,
+  claimingNew,
   getPageTitle,
   hasGuardOrReservePeriod,
   hasNewPtsdDisability,
@@ -28,7 +29,6 @@ import {
   hasPrivateEvidence,
   hasRatedDisabilities,
   hasVAEvidence,
-  increaseOnly,
   isAnswering781aQuestions,
   isAnswering781Questions,
   isBDD,
@@ -485,7 +485,7 @@ const formConfig = {
         prisonerOfWar: {
           title: 'Prisoner of war (POW)',
           path: 'pow',
-          depends: formData => !increaseOnly(formData) && !isBDD(formData),
+          depends: formData => !isBDD(formData) && claimingNew(formData),
           uiSchema: prisonerOfWar.uiSchema,
           schema: prisonerOfWar.schema,
           appStateSelector: state => ({

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -54,12 +54,22 @@ const createCheckboxSchema = (schema, disabilityName) => {
  * New claim type
  */
 export const makeSchemaForNewDisabilities = createSelector(
-  formData => (isClaimingNew(formData) ? formData.newDisabilities : []),
-  (newDisabilities = []) => ({
-    properties: newDisabilities
-      .map(disability => disability.condition)
-      .reduce(createCheckboxSchema, {}),
-  }),
+  formData =>
+    isClaimingNew(formData) && Array.isArray(formData?.newDisabilities)
+      ? formData.newDisabilities
+      : [],
+
+  (newDisabilities = []) => {
+    const raw = newDisabilities
+      .map(d => (typeof d?.condition === 'string' ? d.condition.trim() : ''))
+      .filter(s => s.length > 0);
+
+    const normalized = raw.map(s => s[0].toUpperCase() + s.slice(1));
+    const unique = [...new Set(normalized)];
+    const properties = unique.reduce(createCheckboxSchema, {});
+
+    return { properties };
+  },
 );
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

On the POW page, when the “Yes” radio button is selected, a series of conditional fields appears. One of the questions is “Which of your conditions is connected to your POW experience?”

However, the expected checkbox group listing the available conditions does not appear in the new conditions workflow when it should do so.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/123306.

## Steps to Reproduce

1. Log in as user 229.
2. Navigate to the Conditions section.
3. Add a rated disability and/or new conditions.
4. Proceed to the POW page.
5. Select “Yes” for the POW question.

**Expected behavior:**
When the feature flag is enabled, the checkbox group should display only the new conditions.

**Actual behavior:**
The checkbox group does not appear when the feature flag is enabled, but it does appear when the feature flag is disabled as expected.

## Root Cause

The current disability benefits workflow does not add rated disabilities to the newDisabilities object, whereas the new conditions workflow does.

The shape of the newDisabilities array is as follows:

```
[
    {
        "conditionDate": "1995-03-01",
        "ratedDisability": "Tinnitus",
        "cause": "WORSENED"
    },
    {
        "primaryDescription": "asfadgdsgfshfdhgfdhggdf",
        "cause": "NEW",
        "conditionDate": "1990-02-01",
        "condition": "lung cancer",
        "ratedDisability": "A condition I haven't claimed before"
    },
    {
        "causedByDisability": "Lung cancer",
        "causedByDisabilityDescription": "klfjkdslajfkladjfkldajfklda;jflk;da",
        "cause": "SECONDARY",
        "condition": "asthma",
        "ratedDisability": "A condition I haven't claimed before"
    }
]
```

The presence of the rated disability object causes the function that generates the checkbox list to return undefined or null, which prevents the list from rendering on the POW page.

### Code change required

The problematic function is `makeSchemaForNewDisabilities` in `vets-website/src/applications/disability-benefits/all-claims/utils/schemas.js`. 

**Current implementation:**

```
export const makeSchemaForNewDisabilities = createSelector(
  formData => (isClaimingNew(formData) ? formData.newDisabilities : []),
  (newDisabilities = []) => ({
    properties: newDisabilities
      .map(disability => disability.condition)
      .reduce(createCheckboxSchema, {}),
  }),
);
```

**Proposed fix:**

```
export const makeSchemaForNewDisabilities = createSelector(
  formData =>
    isClaimingNew(formData) && Array.isArray(formData?.newDisabilities)
      ? formData.newDisabilities
      : [],

  (newDisabilities = []) => {
    const raw = newDisabilities
      .map(d => (typeof d?.condition === 'string' ? d.condition.trim() : ''))
      .filter(s => s.length > 0);

    const normalized = raw.map(s => s[0].toUpperCase() + s.slice(1));
    const unique = [...new Set(normalized)];
    const properties = unique.reduce(createCheckboxSchema, {});

    return { properties };
  },
);
```

This change ensures the schema only includes valid condition strings and prevents rated disabilities from breaking the checkbox rendering logic.

## Screenshots

### Add conditions and rated disabilities

<img width="694" height="834" alt="Image" src="https://github.com/user-attachments/assets/394785a4-a0be-44b3-ba1c-2e581dbd2283" />

### Before

<img width="629" height="872" alt="Image" src="https://github.com/user-attachments/assets/321c57ab-e9c7-4d05-9c47-bac5d9b397d3" />

### After

<img width="609" height="906" alt="Image" src="https://github.com/user-attachments/assets/121b6c8b-3dfc-41cc-b801-0fdce096da47" />

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#123306
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#120746
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/123214

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

When the flag is enabled or disabled:

- Application skips the POW section when only rated disabilities are added.
- Application does not skip the POW section when only new conditions are added. Selecting "Yes" on the POW page should display the list of new conditions.
- Application does not skip the POW section when both rated disabilities and new conditions are added. In this case, only the new conditions should appear when "Yes" is selected.
