### PR TITLE
[123314] Update confirmation page not to show "unknown condition"

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ClaimConfirmationInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ClaimConfirmationInfo.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { capitalizeEachWord, formatFullName } from '../utils';
+import { formatFullName } from '../utils';
 import { formatDate } from '../utils/dates/formatting';
-import { NULL_CONDITION_STRING } from '../constants';
 
 export function ClaimConfirmationInfo({
   fullName,
@@ -28,13 +27,20 @@ export function ClaimConfirmationInfo({
           <li>
             <strong>Conditions claimed</strong>
             <ul className="disability-list vads-u-margin-top--0">
-              {conditions.map((disability, i) => (
-                <li key={i} className="vads-u-margin-bottom--0">
-                  {typeof disability === 'string'
-                    ? capitalizeEachWord(disability)
-                    : NULL_CONDITION_STRING}
+              {conditions.length > 0 ? (
+                conditions.map((cond, idx) => (
+                  <li
+                    key={`${idx}-${cond}`}
+                    className="vads-u-margin-bottom--0"
+                  >
+                    {cond}
+                  </li>
+                ))
+              ) : (
+                <li className="vads-u-margin-bottom--0">
+                  No new conditions claimed
                 </li>
-              ))}
+              )}
             </ul>
           </li>
           {claimId && (

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -17,48 +17,69 @@ import {
 import { alertBody } from '../content/confirmation-poll';
 import { ClaimConfirmationInfo } from '../components/ClaimConfirmationInfo';
 import { BddConfirmationAlert } from '../content/bddConfirmationAlert';
+import { capitalizeEachWord } from '../utils';
+
+export const getNewConditionsNames = (disabilities = []) => {
+  const allowed = new Set(['NEW', 'SECONDARY']);
+
+  const names = disabilities
+    .map(item => {
+      if (typeof item === 'string') return item;
+      const cause = String(item?.cause || '').toUpperCase();
+      if (!allowed.has(cause)) return null;
+      return item?.condition ?? null;
+    })
+    .filter(s => typeof s === 'string' && s.trim() !== '')
+    .map(s => capitalizeEachWord(s.trim().toLowerCase()));
+
+  return [...new Set(names)];
+};
 
 export default class ConfirmationPage extends React.Component {
   componentDidMount() {
     setTimeout(() => focusElement('va-alert h2'), 100);
   }
 
-  ConfirmationPageContent = props => (
-    <ConfirmationView
-      submitDate={props.submittedAt}
-      formConfig={props.route?.formConfig}
-    >
-      <ConfirmationView.SubmissionAlert actions={<></>} content={alertBody} />
-      {props.isSubmittingBDD && <BddConfirmationAlert />}
-      <ClaimConfirmationInfo
-        claimId={props.claimId}
-        conditions={props.disabilities}
-        dateSubmitted={props.submittedAt}
-        fullName={props.fullName}
-        isSubmittingBDD={props.isSubmittingBDD}
-      />
-      <Toggler
-        toggleName={Toggler.TOGGLE_NAMES.disability526ShowConfirmationReview}
+  ConfirmationPageContent = props => {
+    const newConditionsNames = getNewConditionsNames(props.disabilities);
+
+    return (
+      <ConfirmationView
+        submitDate={props.submittedAt}
+        formConfig={props.route?.formConfig}
       >
-        <Toggler.Enabled>
-          <ConfirmationView.ChapterSectionCollection showPageTitles />
-        </Toggler.Enabled>
-      </Toggler>
-      <ConfirmationView.PrintThisPage />
-      <ConfirmationView.WhatsNextProcessList
-        item1Header="We’ll send you an email to confirm your submission"
-        item1Content={<></>}
-        item1Actions={<></>}
-        item2Header="Next we’ll send you a letter to let you know we have your claim"
-        item2Content="You should get this letter in about 1 week, plus mailing time, after we receive your claim."
-      />
-      <ConfirmationView.HowToContact />
-      {howLongForDecision}
-      {dependentsAdditionalBenefits}
-      <ConfirmationView.GoBackLink />
-      <ConfirmationView.NeedHelp />
-    </ConfirmationView>
-  );
+        <ConfirmationView.SubmissionAlert actions={<></>} content={alertBody} />
+        {props.isSubmittingBDD && <BddConfirmationAlert />}
+        <ClaimConfirmationInfo
+          claimId={props.claimId}
+          conditions={newConditionsNames}
+          dateSubmitted={props.submittedAt}
+          fullName={props.fullName}
+          isSubmittingBDD={props.isSubmittingBDD}
+        />
+        <Toggler
+          toggleName={Toggler.TOGGLE_NAMES.disability526ShowConfirmationReview}
+        >
+          <Toggler.Enabled>
+            <ConfirmationView.ChapterSectionCollection showPageTitles />
+          </Toggler.Enabled>
+        </Toggler>
+        <ConfirmationView.PrintThisPage />
+        <ConfirmationView.WhatsNextProcessList
+          item1Header="We’ll send you an email to confirm your submission"
+          item1Content={<></>}
+          item1Actions={<></>}
+          item2Header="Next we’ll send you a letter to let you know we have your claim"
+          item2Content="You should get this letter in about 1 week, plus mailing time, after we receive your claim."
+        />
+        <ConfirmationView.HowToContact />
+        {howLongForDecision}
+        {dependentsAdditionalBenefits}
+        <ConfirmationView.GoBackLink />
+        <ConfirmationView.NeedHelp />
+      </ConfirmationView>
+    );
+  };
 
   render() {
     // Reset everything

--- a/src/applications/disability-benefits/all-claims/tests/components/ClaimConfirmationInfo.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ClaimConfirmationInfo.unit.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { ClaimConfirmationInfo } from '../../components/ClaimConfirmationInfo';
+
+describe('ClaimConfirmationInfo', () => {
+  const baseProps = {
+    fullName: { first: 'Hector', middle: 'Lee', last: 'Brooks', suffix: 'Sr.' },
+    dateSubmitted: new Date('November 7, 2024'),
+    conditions: [],
+    claimId: undefined,
+    isSubmittingBDD: false,
+  };
+
+  it('renders the section headers and formatted name/date', () => {
+    const { getByText } = render(<ClaimConfirmationInfo {...baseProps} />);
+
+    getByText('Disability Compensation Claim');
+    getByText('(Form 21-526EZ)');
+    getByText('For Hector Lee Brooks Sr.');
+    getByText('Date submitted');
+    getByText('November 7, 2024');
+    getByText('Conditions claimed');
+  });
+
+  it('renders each condition when the list is non-empty', () => {
+    const props = { ...baseProps, conditions: ['Knee Pain', 'Tinnitus'] };
+    const { getByText, queryByText } = render(
+      <ClaimConfirmationInfo {...props} />,
+    );
+
+    getByText('Knee Pain');
+    getByText('Tinnitus');
+    expect(queryByText('No new conditions claimed')).to.be.null;
+  });
+
+  it('renders the fallback when there are no new conditions', () => {
+    const props = { ...baseProps, conditions: [] };
+    const { getByText, queryByText } = render(
+      <ClaimConfirmationInfo {...props} />,
+    );
+
+    getByText('No new conditions claimed');
+    expect(queryByText('Knee Pain')).to.be.null;
+  });
+
+  it('conditionally renders the Claim ID when provided', () => {
+    const withId = { ...baseProps, claimId: 12345678 };
+    const { getByText, rerender, queryByText } = render(
+      <ClaimConfirmationInfo {...withId} />,
+    );
+
+    getByText('Claim ID number');
+    getByText('12345678');
+
+    rerender(<ClaimConfirmationInfo {...baseProps} />);
+    expect(queryByText('Claim ID number')).to.be.null;
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -5,7 +5,9 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { Toggler } from '~/platform/utilities/feature-toggles';
-import ConfirmationPage from '../../containers/ConfirmationPage';
+import ConfirmationPage, {
+  getNewConditionsNames,
+} from '../../containers/ConfirmationPage';
 import { submissionStatuses } from '../../constants';
 import { bddConfirmationHeadline } from '../../content/bddConfirmationAlert';
 import formConfig from '../../config/form';
@@ -119,7 +121,6 @@ describe('ConfirmationPage', () => {
     getByText('November 7, 2024');
     getByText('Conditions claimed');
     getByText('Something Something');
-    getByText('Unknown Condition');
 
     if (claimId) {
       getByText('Claim ID number');
@@ -178,5 +179,33 @@ describe('ConfirmationPage', () => {
       submissionStatuses.succeeded,
       true, // disability526ShowConfirmationReview toggle
     );
+  });
+});
+
+describe('getNewConditionsNames', () => {
+  it('keeps strings and capitalizes them', () => {
+    expect(
+      getNewConditionsNames(['low back pain', '  knee PAIN  ']),
+    ).to.deep.equal(['Low Back Pain', 'Knee Pain']);
+  });
+
+  it('includes only NEW/SECONDARY objects, ignores others and blanks', () => {
+    const input = [
+      { condition: 'tinnitus', cause: 'secondary' },
+      { condition: 'sleep apnea', cause: 'NEW' },
+      { condition: 'flu', cause: 'primary' },
+      { condition: ' ', cause: 'NEW' },
+      { condition: 'tinnitus', cause: 'SECONDARY' },
+      undefined,
+    ];
+    expect(getNewConditionsNames(input)).to.deep.equal([
+      'Tinnitus',
+      'Sleep Apnea',
+    ]);
+  });
+
+  it('returns empty list for empty/invalid inputs', () => {
+    expect(getNewConditionsNames([])).to.deep.equal([]);
+    expect(getNewConditionsNames()).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder
- [ ] 
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

After form submission, the confirmation page displays items labeled as "Unknown condition" in the blue summary box. Conditions shown should be limited to new conditions only and exclude rated disabilities.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/123314
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/123210

## Steps to Reproduce

1. Log in as user 229 with the feature flag enabled in the **staging** environment
2. Navigate to the Conditions section
3. Add both rated disabilities and new conditions
4. Go to the Review and Submit page
5. Expand the Conditions accordion and verify that all entries appear
6. Scroll to the Claim and Certification section
7. Enter your signature and select the checkbox
8. On the confirmation page, note that:
   - New conditions display correctly
   - Rated disabilities appear as "Unknown condition"

**Expected behavior:**

When the feature flag is enabled, the confirmation page should only display new conditions.

**Actual behavior:**

The confirmation page correctly lists new conditions but incorrectly includes rated disabilities labeled as "Unknown condition."

## Root Cause

In the disability benefits workflow:

- Rated disabilities are not added to the newDisabilities object.
- New conditions are added properly.

Example structure of newDisabilities:

```
[
    {
        "conditionDate": "1995-03-01",
        "ratedDisability": "Allergies due to Hearing Loss",
        "cause": "WORSENED"
    },
    {
        "primaryDescription": "kldfjakldjfkaljgfkldajgkladjgklad;gj;",
        "cause": "NEW",
        "conditionDate": "1990-02-01",
        "condition": "lung cancer",
        "ratedDisability": "A condition I haven't claimed before"
    },
    {
        "causedByDisability": "Lung cancer",
        "causedByDisabilityDescription": "aserastdsgsysuysyw",
        "cause": "SECONDARY",
        "conditionDate": "1991-01-01",
        "condition": "asthma",
        "ratedDisability": "A condition I haven't claimed before"
    },
    {
        "conditionDate": "2020-11-01",
        "ratedDisability": "Sarcoma Soft-Tissue",
        "cause": "WORSENED"
    }
]
```

Rated disability entries lack a condition key/value, which causes "Unknown condition" to appear on the confirmation page.

### Code change required

File: `vets-website/src/applications/disability-benefits/all-claims/components/ClaimConfirmationInfo.jsx`. 

**Current implementation:**

```
<ul className="disability-list vads-u-margin-top--0">
              {conditions.map((disability, i) => (
                <li key={i} className="vads-u-margin-bottom--0">
                  {typeof disability === 'string'
                    ? capitalizeEachWord(disability)
                    : NULL_CONDITION_STRING}
                </li>
              ))}
</ul>
```

**Proposed fix:**

Filter out rated disabilities before passing data to the ClaimConfirmationInfo component.

In ConfirmationPage.jsx, apply this helper:

```
export const getNewConditionsNames = (disabilities = []) => {
  const allowed = new Set(['NEW', 'SECONDARY']);

  const names = disabilities
    .map(item => {
      if (typeof item === 'string') return item;
      const cause = String(item?.cause || '').toUpperCase();
      if (!allowed.has(cause)) return null;
      return item?.condition ?? null;
    })
    .filter(s => typeof s === 'string' && s.trim() !== '')
    .map(s => capitalizeEachWord(s.trim().toLowerCase()));

  return [...new Set(names)];
};
```

Then update the ConfirmationPageContent:

```
ConfirmationPageContent = props => {
   _// Add this line below_
    const newConditionsNames = getNewConditionsNames(props.disabilities);

    return (
      <ConfirmationView
        submitDate={props.submittedAt}
        formConfig={props.route?.formConfig}
      >
        <ConfirmationView.SubmissionAlert actions={<></>} content={alertBody} />
        {props.isSubmittingBDD && <BddConfirmationAlert />}

        <ClaimConfirmationInfo
          claimId={props.claimId}
          _// Pass the already-sanitized list_
          conditions={newConditionsNames}
          dateSubmitted={props.submittedAt}
          fullName={props.fullName}
          isSubmittingBDD={props.isSubmittingBDD}
        /> 
     
       ...rest of code
}
```

This change ensures **only** the new conditions are rendered on the claim confirmation information page.

Unit tests were added due to this change.

## Screenshots

### Review and Submit Page

_(Conditions and Rated Disabilities)_

<img width="690" height="920" alt="Image" src="https://github.com/user-attachments/assets/78ea77e1-9639-4cbf-81c4-a0874817f0c3" />

### Before

<img width="665" height="822" alt="Image" src="https://github.com/user-attachments/assets/dc6df517-8b30-468a-b4d1-d23cdb619baf" />

### After

<img width="512" height="323" alt="Image" src="https://github.com/user-attachments/assets/f32c45ff-a123-4116-aeb6-ff4c67f27378" />

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#123314
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#120746

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

Since it is not possible to submit the form and obtain a response via the confirmation page in a **local** environment, a workaround is needed in order to ensure that the list of names is limited to new conditions. One approach is to modify the Summary of evidence page: `vets-website-con/src/applications/disability-benefits/all-claims/pages/summaryOfEvidence.js`.

On the Summary of evidence page, comment out or delete the existing code:

```
import { summaryOfEvidenceDescription } from '../content/summaryOfEvidence';
import { standardTitle } from '../content/form0781';

export const uiSchema = {
  'ui:title': standardTitle('Summary of evidence'),
  'ui:description': summaryOfEvidenceDescription,
};

export const schema = {
  type: 'object',
  properties: {},
};
```

Add the code from this [gist](https://gist.github.com/sdbars/191abaf1ed9a043f52a247de6bc755d6) to the Summary of evidence file.

Run the application locally and add new conditions / rated disabilities. Navigate to the Summary of evidence page whose URL ends with `supporting-evidence/summary`.  This page should render the list of conditions as they would appear on the Confirmation Page.