### PR TITLE
0969 | Revert App.js redirect change (fix session storage bug)

### DIFF
--- a/src/applications/income-and-asset-statement/containers/App.jsx
+++ b/src/applications/income-and-asset-statement/containers/App.jsx
@@ -8,7 +8,6 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import environment from 'platform/utilities/environment';
 import { openReviewChapter as openReviewChapterAction } from 'platform/forms-system/src/js/actions';
 
-import manifest from '../manifest.json';
 import formConfig from '../config/form';
 import { NoFormPage } from '../components/NoFormPage';
 import { getAssetTypes } from '../components/FormAlerts/SupplementaryFormsAlert';
@@ -27,7 +26,6 @@ function App({ location, children, isLoggedIn, openReviewChapter }) {
     state => state?.featureToggles?.loading ?? false,
   );
   const assets = useSelector(state => state?.form?.data?.ownedAssets || []);
-  const isIntroPage = location.pathname === '/introduction';
 
   const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
@@ -60,13 +58,7 @@ function App({ location, children, isLoggedIn, openReviewChapter }) {
           !!incomeAndAssetsContentUpdates,
         );
       }
-
-      if (!isIntroPage) {
-        // Redirect to intro page if user tries to access any other page directly
-        window.location.replace(manifest.rootUrl);
-      }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isLoadingFeatures, incomeAndAssetsContentUpdates],
   );
 


### PR DESCRIPTION
## Summary

This PR **reverts a recent change** that added a **redirect in `App.js`** for the **Income and Asset Statement form (VA Form 21P-0969)**.  
The redirect logic unintentionally introduced a **bug affecting session storage initialization** for Post-MVP content.  
By reverting this change, session storage for form data is restored to its intended behavior, ensuring users can resume forms and persist state correctly.

## Issue

- Regression introduced in `App.js` where redirect logic interfered with session storage setup for Post-MVP content.  
- Resulted in inconsistent data persistence and potential form start failures for authenticated and unauthenticated users.

## Related issue(s)

- Post-MVP content storage reliability issues for 0969  
- Follows internal investigation into `sessionStorage` handling within form entry initialization  

## Associated Pull Request(s)

- Reverts a previously merged `App.js` redirect update related to 0969 entry routing  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the base route:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  

## How to verify

1. Start the **0969 form** and proceed through several pages.  
2. Refresh or navigate away, then return — confirm session storage correctly restores the form state.  
3. Verify no redirect occurs unexpectedly on page load or when returning from save-in-progress flows.  
4. Check browser **Application > Storage > Session Storage** tab for persisted data.  
5. Confirm:
   - Session storage keys populate correctly for Post-MVP pages  
   - No console errors related to routing or undefined storage keys  
   - Save-in-progress and resume behaviors remain functional  

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- `App.js` initialization logic and session storage handling  

## Screenshots

_N/A — code reversion and stability fix_

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- 0969 Post-MVP form stability  
- Restores session storage behavior disrupted by recent redirect logic  

## Requested Feedback

(OPTIONAL) Please confirm the session storage logic now initializes correctly when starting or resuming 0969 forms, and that the removal of the redirect does not impact expected routing or save-in-progress flows.