### PR TITLE
[120643] BlueButton report: Add null guards for graceful fallback

### DIFF
--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -387,7 +387,9 @@ const DownloadFileType = props => {
         }
       } catch (error) {
         logAal(0);
-        datadogRum.addError(error, 'Download Report Error - PDF');
+        datadogRum.addError(error, {
+          feature: 'Blue Button report - download_report_pdf',
+        });
         dispatch(addAlert(ALERT_TYPE_BB_ERROR, error));
       }
     },
@@ -437,7 +439,9 @@ const DownloadFileType = props => {
         }
       } catch (error) {
         logAal(0);
-        datadogRum.addError(error, 'Download Report Error - TXT');
+        datadogRum.addError(error, {
+          feature: 'Blue Button report - download_report_txt',
+        });
         dispatch(addAlert(ALERT_TYPE_BB_ERROR, error));
       }
     },

--- a/src/applications/mhv-medical-records/tests/reducers/vitals.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/reducers/vitals.unit.spec.jsx
@@ -284,4 +284,59 @@ describe('getMeasurement', () => {
     const measurement = getMeasurement(record, type);
     expect(measurement).to.equal('84%');
   });
+
+  it('should return EMPTY_FIELD for blood pressure when component is missing or empty', () => {
+    const type = 'BLOOD_PRESSURE';
+
+    expect(getMeasurement({}, type)).to.eq(EMPTY_FIELD);
+    expect(getMeasurement({ component: null }, type)).to.eq(EMPTY_FIELD);
+    expect(getMeasurement({ component: [] }, type)).to.eq(EMPTY_FIELD);
+  });
+
+  it('should return EMPTY_FIELD for blood pressure when systolic or diastolic is missing', () => {
+    const type = 'BLOOD_PRESSURE';
+
+    const onlyDiastolic = {
+      component: [
+        {
+          code: { coding: [{ code: '8462-4' }] },
+          valueQuantity: { value: 79 },
+        },
+      ],
+    };
+    expect(getMeasurement(onlyDiastolic, type)).to.eq(EMPTY_FIELD);
+
+    const onlySystolic = {
+      component: [
+        {
+          code: { coding: [{ code: '8480-6' }] },
+          valueQuantity: { value: 125 },
+        },
+      ],
+    };
+    expect(getMeasurement(onlySystolic, type)).to.eq(EMPTY_FIELD);
+  });
+
+  it('should return EMPTY_FIELD for blood pressure when component items are malformed', () => {
+    const type = 'BLOOD_PRESSURE';
+
+    const missingValueQuantity = {
+      component: [
+        { code: { coding: [{ code: '8480-6' }] } },
+        {
+          code: { coding: [{ code: '8462-4' }] },
+          valueQuantity: { value: 79 },
+        },
+      ],
+    };
+    expect(getMeasurement(missingValueQuantity, type)).to.eq(EMPTY_FIELD);
+
+    const missingCoding = {
+      component: [
+        { valueQuantity: { value: 125 } },
+        { code: {}, valueQuantity: { value: 79 } },
+      ],
+    };
+    expect(getMeasurement(missingCoding, type)).to.eq(EMPTY_FIELD);
+  });
 });

--- a/src/applications/mhv-medical-records/tests/util/pdfHelpers/demographics.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/pdfHelpers/demographics.unit.spec.jsx
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import { generateDemographicsContent } from '../../../util/pdfHelpers/demographics';
+import { NONE_RECORDED, NO_INFO_REPORTED } from '../../../util/constants';
+
+describe('generateDemographicsContent', () => {
+  it('should replace sections with all empty values with NO_INFO_REPORTED', () => {
+    const record = {
+      firstName: 'John',
+      // Missing nested object (undefined)
+      eligibility: {}, // Empty object (all values undefined)
+      employment: {
+        occupation: null,
+        meansTestStatus: null,
+        employerName: null,
+      },
+      civilGuardian: {
+        name: undefined,
+        homePhone: null,
+        workPhone: NONE_RECORDED,
+        address: {
+          street: '',
+          city: undefined,
+          state: null,
+          zipcode: NONE_RECORDED,
+        },
+      },
+    };
+
+    const result = generateDemographicsContent(record);
+
+    // Missing nested object
+    const addressSection = result.results.items.find(
+      item => item.header === 'Permanent address and contact information',
+    );
+    expect(addressSection.items).to.have.lengthOf(1);
+    expect(addressSection.items[0].value).to.equal(NO_INFO_REPORTED);
+
+    // Empty object
+    const eligibilitySection = result.results.items.find(
+      item => item.header === 'Eligibility',
+    );
+    expect(eligibilitySection.items).to.have.lengthOf(1);
+    expect(eligibilitySection.items[0].value).to.equal(NO_INFO_REPORTED);
+
+    // All null
+    const employmentSection = result.results.items.find(
+      item => item.header === 'Employment',
+    );
+    expect(employmentSection.items).to.have.lengthOf(1);
+    expect(employmentSection.items[0].value).to.equal(NO_INFO_REPORTED);
+
+    // Mixed empty values
+    const civilGuardianSection = result.results.items.find(
+      item => item.header === 'Civil guardian',
+    );
+    expect(civilGuardianSection.items).to.have.lengthOf(1);
+    expect(civilGuardianSection.items[0].value).to.equal(NO_INFO_REPORTED);
+  });
+
+  it('should keep sections with at least one valid value', () => {
+    const record = {
+      firstName: 'John',
+      permanentAddress: {
+        street: '123 Main St',
+        city: undefined,
+        state: null,
+        zipcode: NONE_RECORDED,
+      },
+      primaryNextOfKin: {
+        name: 'Jane Doe',
+        // address missing entirely
+        homePhone: undefined,
+      },
+    };
+
+    const result = generateDemographicsContent(record);
+
+    const addressSection = result.results.items.find(
+      item => item.header === 'Permanent address and contact information',
+    );
+    expect(addressSection.items.length).to.be.greaterThan(1);
+    expect(addressSection.items[0].value).to.equal('123 Main St');
+
+    const nextOfKinSection = result.results.items.find(
+      item => item.header === 'Primary next of kin',
+    );
+    expect(nextOfKinSection.items.length).to.be.greaterThan(1);
+    const nameItem = nextOfKinSection.items.find(item => item.title === 'Name');
+    expect(nameItem.value).to.equal('Jane Doe');
+  });
+});

--- a/src/applications/mhv-medical-records/tests/util/pdfHelpers/demographics.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/pdfHelpers/demographics.unit.spec.jsx
@@ -18,7 +18,7 @@ describe('generateDemographicsContent', () => {
         homePhone: null,
         workPhone: NONE_RECORDED,
         address: {
-          street: '',
+          street: undefined,
           city: undefined,
           state: null,
           zipcode: NONE_RECORDED,

--- a/src/applications/mhv-medical-records/util/pdfHelpers/accountSummary.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/accountSummary.js
@@ -1,5 +1,5 @@
 export const generateAccountSummaryContent = record => {
-  const { authenticationSummary, vaTreatmentFacilities } = record;
+  const { authenticationSummary = {}, vaTreatmentFacilities = [] } = record;
 
   return {
     details: {

--- a/src/applications/mhv-medical-records/util/pdfHelpers/allergies.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/allergies.js
@@ -5,13 +5,13 @@ export const generateAllergiesIntro = (records, lastUpdated) => {
     subtitles: [
       'This list includes all allergies, reactions, and side effects in your VA medical records. If you have allergies or reactions that are missing from this list, tell your care team at your next appointment.',
       lastUpdated,
-      `Showing ${records.length} records from newest to oldest`,
+      `Showing ${records?.length} records from newest to oldest`,
     ],
   };
 };
 
 export const generateAllergyItem = record => {
-  const multipleReactions = record.reaction.length > 1;
+  const multipleReactions = record.reaction?.length > 1;
 
   if (record.isOracleHealthData) {
     return {

--- a/src/applications/mhv-medical-records/util/pdfHelpers/appointments.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/appointments.js
@@ -1,6 +1,6 @@
 export const generateAppointmentsContent = records => ({
   results: {
-    preface: `Showing ${records.length} appointments, sorted by date`,
+    preface: `Showing ${records?.length} appointments, sorted by date`,
     sectionSeparators: false,
     items: records.map(item => ({
       header: item.date,

--- a/src/applications/mhv-medical-records/util/pdfHelpers/blueButton.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/blueButton.js
@@ -53,27 +53,26 @@ export const generateBlueButtonData = (
       `Showing ${labsAndTests?.length} records from newest to oldest`,
     ],
     selected: recordFilter.includes('labTests'),
-    records:
-      isArrayAndHasItems(labsAndTests) && labsAndTests.length > 0
-        ? labsAndTests.map(record => {
-            const title = record.name;
-            let content;
+    records: isArrayAndHasItems(labsAndTests)
+      ? labsAndTests.map(record => {
+          const title = record.name;
+          let content;
 
-            if (record.type === labTypes.CHEM_HEM) {
-              content = generateChemHemContent(record);
-            }
-            if (record.type === labTypes.MICROBIOLOGY) {
-              content = generateMicrobioContent(record);
-            }
-            if (record.type === labTypes.PATHOLOGY) {
-              content = generatePathologyContent(record);
-            }
-            if (record.type === labTypes.RADIOLOGY) {
-              content = generateRadiologyContent(record);
-            }
-            return { title, ...content };
-          })
-        : [],
+          if (record.type === labTypes.CHEM_HEM) {
+            content = generateChemHemContent(record);
+          }
+          if (record.type === labTypes.MICROBIOLOGY) {
+            content = generateMicrobioContent(record);
+          }
+          if (record.type === labTypes.PATHOLOGY) {
+            content = generatePathologyContent(record);
+          }
+          if (record.type === labTypes.RADIOLOGY) {
+            content = generateRadiologyContent(record);
+          }
+          return { title, ...content };
+        })
+      : [],
   });
 
   data.push({
@@ -85,7 +84,7 @@ export const generateBlueButtonData = (
       `Showing ${notes?.length} records from newest to oldest`,
     ],
     selected: recordFilter.includes('careSummaries'),
-    records: notes?.length
+    records: isArrayAndHasItems(notes)
       ? notes.map(record => {
           const title = record.name;
           let content;
@@ -112,7 +111,9 @@ export const generateBlueButtonData = (
       `Showing ${vaccines?.length} records from newest to oldest`,
     ],
     selected: recordFilter.includes('vaccines'),
-    records: vaccines?.length ? generateVaccinesContent(vaccines) : [],
+    records: isArrayAndHasItems(vaccines)
+      ? generateVaccinesContent(vaccines)
+      : [],
   });
 
   data.push({
@@ -124,8 +125,10 @@ export const generateBlueButtonData = (
     ],
     selected:
       recordFilter.includes('allergies') ||
-      (recordFilter.includes('medications') && medications?.length > 0),
-    records: allergies?.length ? generateAllergiesContent(allergies) : [],
+      (recordFilter.includes('medications') && isArrayAndHasItems(medications)),
+    records: isArrayAndHasItems(allergies)
+      ? generateAllergiesContent(allergies)
+      : [],
   });
 
   data.push({
@@ -136,7 +139,7 @@ export const generateBlueButtonData = (
       `Showing ${conditions?.length} records from newest to oldest`,
     ],
     selected: recordFilter.includes('conditions'),
-    records: conditions?.length
+    records: isArrayAndHasItems(conditions)
       ? conditions.map(record => {
           const title = record.name;
           const content = generateConditionContent(record);
@@ -152,7 +155,9 @@ export const generateBlueButtonData = (
       'Vitals are basic health numbers your providers check at your appointments.',
     ],
     selected: recordFilter.includes('vitals'),
-    records: vitals?.length ? generateVitalsContentByType(vitals) : [],
+    records: isArrayAndHasItems(vitals)
+      ? generateVitalsContentByType(vitals)
+      : [],
   });
 
   data.push({
@@ -164,7 +169,7 @@ export const generateBlueButtonData = (
       `Showing ${medications?.length} medications, alphabetically by name`,
     ],
     selected: recordFilter.includes('medications'),
-    records: medications?.length
+    records: isArrayAndHasItems(medications)
       ? medications.map(record => {
           const title = record.prescriptionName;
           const content = generateMedicationsContent(record);
@@ -174,12 +179,12 @@ export const generateBlueButtonData = (
   });
 
   const upcoming =
-    appointments?.length && recordFilter.includes('upcomingAppts')
+    isArrayAndHasItems(appointments) && recordFilter.includes('upcomingAppts')
       ? appointments.filter(appt => appt.isUpcoming)
       : [];
 
   const past =
-    appointments?.length && recordFilter.includes('pastAppts')
+    isArrayAndHasItems(appointments) && recordFilter.includes('pastAppts')
       ? appointments.filter(appt => !appt.isUpcoming)
       : [];
 
@@ -216,7 +221,7 @@ export const generateBlueButtonData = (
       'Each of your VA facilities may have different demographic information for you. If you need update your information, contact your facility.',
     ],
     selected: recordFilter.includes('demographics'),
-    records: demographics?.length
+    records: isArrayAndHasItems(demographics)
       ? demographics.map(record => ({
           title: `VA facility: ${record.facility}`,
           titleMoveDownAmount: 0.5,
@@ -225,7 +230,7 @@ export const generateBlueButtonData = (
       : [],
   });
 
-  const militaryServiceContent = militaryService?.length
+  const militaryServiceContent = isArrayAndHasItems(militaryService)
     ? generateMilitaryServiceContent(militaryService)
     : {};
   data.push({

--- a/src/applications/mhv-medical-records/util/pdfHelpers/blueButton.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/blueButton.js
@@ -125,7 +125,7 @@ export const generateBlueButtonData = (
     ],
     selected:
       recordFilter.includes('allergies') ||
-      (recordFilter.includes('medications') && isArrayAndHasItems(medications)),
+      (recordFilter.includes('medications') && medications?.length > 0),
     records: isArrayAndHasItems(allergies)
       ? generateAllergiesContent(allergies)
       : [],
@@ -230,7 +230,7 @@ export const generateBlueButtonData = (
       : [],
   });
 
-  const militaryServiceContent = isArrayAndHasItems(militaryService)
+  const militaryServiceContent = militaryService?.length
     ? generateMilitaryServiceContent(militaryService)
     : {};
   data.push({

--- a/src/applications/mhv-medical-records/util/pdfHelpers/demographics.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/demographics.js
@@ -65,52 +65,52 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Street address',
-              value: record.permanentAddress.street,
+              value: record.permanentAddress?.street,
               inline: true,
             },
             {
               title: 'City',
-              value: record.permanentAddress.city,
+              value: record.permanentAddress?.city,
               inline: true,
             },
             {
               title: 'State',
-              value: record.permanentAddress.state,
+              value: record.permanentAddress?.state,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.permanentAddress.zipcode,
+              value: record.permanentAddress?.zipcode,
               inline: true,
             },
             {
               title: 'County',
-              value: record.permanentAddress.county,
+              value: record.permanentAddress?.county,
               inline: true,
             },
             {
               title: 'Country',
-              value: record.permanentAddress.country,
+              value: record.permanentAddress?.country,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.contactInfo.homePhone,
+              value: record.contactInfo?.homePhone,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.contactInfo.workPhone,
+              value: record.contactInfo?.workPhone,
               inline: true,
             },
             {
               title: 'Cell phone number',
-              value: record.contactInfo.cellPhone,
+              value: record.contactInfo?.cellPhone,
               inline: true,
             },
             {
               title: 'Email address',
-              value: record.contactInfo.emailAddress,
+              value: record.contactInfo?.emailAddress,
               inline: true,
             },
           ],
@@ -121,17 +121,17 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Service connected percentage',
-              value: record.eligibility.serviceConnectedPercentage,
+              value: record.eligibility?.serviceConnectedPercentage,
               inline: true,
             },
             {
               title: 'Means test status',
-              value: record.eligibility.meansTestStatus,
+              value: record.eligibility?.meansTestStatus,
               inline: true,
             },
             {
               title: 'Primary eligibility code',
-              value: record.eligibility.primaryEligibilityCode,
+              value: record.eligibility?.primaryEligibilityCode,
               inline: true,
             },
           ],
@@ -142,17 +142,17 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Occupation',
-              value: record.employment.occupation,
+              value: record.employment?.occupation,
               inline: true,
             },
             {
               title: 'Means test status',
-              value: record.employment.meansTestStatus,
+              value: record.employment?.meansTestStatus,
               inline: true,
             },
             {
               title: 'Employer name',
-              value: record.employment.employerName,
+              value: record.employment?.employerName,
               inline: true,
             },
           ],
@@ -163,37 +163,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.primaryNextOfKin.name,
+              value: record.primaryNextOfKin?.name,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.primaryNextOfKin.address.street,
+              value: record.primaryNextOfKin?.address?.street,
               inline: true,
             },
             {
               title: 'City',
-              value: record.primaryNextOfKin.address.city,
+              value: record.primaryNextOfKin?.address?.city,
               inline: true,
             },
             {
               title: 'State',
-              value: record.primaryNextOfKin.address.state,
+              value: record.primaryNextOfKin?.address?.state,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.primaryNextOfKin.address.zipcode,
+              value: record.primaryNextOfKin?.address?.zipcode,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.primaryNextOfKin.homePhone,
+              value: record.primaryNextOfKin?.homePhone,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.primaryNextOfKin.workPhone,
+              value: record.primaryNextOfKin?.workPhone,
               inline: true,
             },
           ],
@@ -204,37 +204,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.emergencyContact.name,
+              value: record.emergencyContact?.name,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.emergencyContact.address.street,
+              value: record.emergencyContact?.address?.street,
               inline: true,
             },
             {
               title: 'City',
-              value: record.emergencyContact.address.city,
+              value: record.emergencyContact?.address?.city,
               inline: true,
             },
             {
               title: 'State',
-              value: record.emergencyContact.address.state,
+              value: record.emergencyContact?.address?.state,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.emergencyContact.address.zipcode,
+              value: record.emergencyContact?.address?.zipcode,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.emergencyContact.homePhone,
+              value: record.emergencyContact?.homePhone,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.emergencyContact.workPhone,
+              value: record.emergencyContact?.workPhone,
               inline: true,
             },
           ],
@@ -245,37 +245,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.vaGuardian.name,
+              value: record.vaGuardian?.name,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.vaGuardian.address.street,
+              value: record.vaGuardian?.address?.street,
               inline: true,
             },
             {
               title: 'City',
-              value: record.vaGuardian.address.city,
+              value: record.vaGuardian?.address?.city,
               inline: true,
             },
             {
               title: 'State',
-              value: record.vaGuardian.address.state,
+              value: record.vaGuardian?.address?.state,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.vaGuardian.address.zipcode,
+              value: record.vaGuardian?.address?.zipcode,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.vaGuardian.homePhone,
+              value: record.vaGuardian?.homePhone,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.vaGuardian.workPhone,
+              value: record.vaGuardian?.workPhone,
               inline: true,
             },
           ],
@@ -286,37 +286,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.civilGuardian.name,
+              value: record.civilGuardian?.name,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.civilGuardian.address.street,
+              value: record.civilGuardian?.address?.street,
               inline: true,
             },
             {
               title: 'City',
-              value: record.civilGuardian.address.city,
+              value: record.civilGuardian?.address?.city,
               inline: true,
             },
             {
               title: 'State',
-              value: record.civilGuardian.address.state,
+              value: record.civilGuardian?.address?.state,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.civilGuardian.address.zipcode,
+              value: record.civilGuardian?.address?.zipcode,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.civilGuardian.homePhone,
+              value: record.civilGuardian?.homePhone,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.civilGuardian.workPhone,
+              value: record.civilGuardian?.workPhone,
               inline: true,
             },
           ],
@@ -327,42 +327,42 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Insurance company',
-              value: record.activeInsurance.company,
+              value: record.activeInsurance?.company,
               inline: true,
             },
             {
               title: 'Effective date',
-              value: record.activeInsurance.effectiveDate,
+              value: record.activeInsurance?.effectiveDate,
               inline: true,
             },
             {
               title: 'Expiration date',
-              value: record.activeInsurance.expirationDate,
+              value: record.activeInsurance?.expirationDate,
               inline: true,
             },
             {
               title: 'Group name',
-              value: record.activeInsurance.groupName,
+              value: record.activeInsurance?.groupName,
               inline: true,
             },
             {
               title: 'Group number',
-              value: record.activeInsurance.groupNumber,
+              value: record.activeInsurance?.groupNumber,
               inline: true,
             },
             {
               title: 'Subscriber ID',
-              value: record.activeInsurance.subscriberId,
+              value: record.activeInsurance?.subscriberId,
               inline: true,
             },
             {
               title: 'Subscriber name',
-              value: record.activeInsurance.subscriberName,
+              value: record.activeInsurance?.subscriberName,
               inline: true,
             },
             {
               title: 'Subscriber relationship',
-              value: record.activeInsurance.relationship,
+              value: record.activeInsurance?.relationship,
               inline: true,
             },
           ],
@@ -372,7 +372,7 @@ export const generateDemographicsContent = record => {
   };
 
   results.results.items = results.results.items.map(item => {
-    if (item.items.every(i => i.value === NONE_RECORDED)) {
+    if (item.items.every(i => !i.value || i.value === NONE_RECORDED)) {
       return {
         ...item,
         items: [

--- a/src/applications/mhv-medical-records/util/pdfHelpers/demographics.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/demographics.js
@@ -65,52 +65,52 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Street address',
-              value: record.permanentAddress?.street,
+              value: record.permanentAddress?.street ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'City',
-              value: record.permanentAddress?.city,
+              value: record.permanentAddress?.city ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'State',
-              value: record.permanentAddress?.state,
+              value: record.permanentAddress?.state ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.permanentAddress?.zipcode,
+              value: record.permanentAddress?.zipcode ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'County',
-              value: record.permanentAddress?.county,
+              value: record.permanentAddress?.county ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Country',
-              value: record.permanentAddress?.country,
+              value: record.permanentAddress?.country ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.contactInfo?.homePhone,
+              value: record.contactInfo?.homePhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.contactInfo?.workPhone,
+              value: record.contactInfo?.workPhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Cell phone number',
-              value: record.contactInfo?.cellPhone,
+              value: record.contactInfo?.cellPhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Email address',
-              value: record.contactInfo?.emailAddress,
+              value: record.contactInfo?.emailAddress ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -121,17 +121,19 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Service connected percentage',
-              value: record.eligibility?.serviceConnectedPercentage,
+              value:
+                record.eligibility?.serviceConnectedPercentage ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Means test status',
-              value: record.eligibility?.meansTestStatus,
+              value: record.eligibility?.meansTestStatus ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Primary eligibility code',
-              value: record.eligibility?.primaryEligibilityCode,
+              value:
+                record.eligibility?.primaryEligibilityCode ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -142,17 +144,17 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Occupation',
-              value: record.employment?.occupation,
+              value: record.employment?.occupation ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Means test status',
-              value: record.employment?.meansTestStatus,
+              value: record.employment?.meansTestStatus ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Employer name',
-              value: record.employment?.employerName,
+              value: record.employment?.employerName ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -163,37 +165,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.primaryNextOfKin?.name,
+              value: record.primaryNextOfKin?.name ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.primaryNextOfKin?.address?.street,
+              value: record.primaryNextOfKin?.address?.street ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'City',
-              value: record.primaryNextOfKin?.address?.city,
+              value: record.primaryNextOfKin?.address?.city ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'State',
-              value: record.primaryNextOfKin?.address?.state,
+              value: record.primaryNextOfKin?.address?.state ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.primaryNextOfKin?.address?.zipcode,
+              value: record.primaryNextOfKin?.address?.zipcode ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.primaryNextOfKin?.homePhone,
+              value: record.primaryNextOfKin?.homePhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.primaryNextOfKin?.workPhone,
+              value: record.primaryNextOfKin?.workPhone ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -204,37 +206,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.emergencyContact?.name,
+              value: record.emergencyContact?.name ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.emergencyContact?.address?.street,
+              value: record.emergencyContact?.address?.street ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'City',
-              value: record.emergencyContact?.address?.city,
+              value: record.emergencyContact?.address?.city ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'State',
-              value: record.emergencyContact?.address?.state,
+              value: record.emergencyContact?.address?.state ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.emergencyContact?.address?.zipcode,
+              value: record.emergencyContact?.address?.zipcode ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.emergencyContact?.homePhone,
+              value: record.emergencyContact?.homePhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.emergencyContact?.workPhone,
+              value: record.emergencyContact?.workPhone ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -245,37 +247,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.vaGuardian?.name,
+              value: record.vaGuardian?.name ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.vaGuardian?.address?.street,
+              value: record.vaGuardian?.address?.street ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'City',
-              value: record.vaGuardian?.address?.city,
+              value: record.vaGuardian?.address?.city ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'State',
-              value: record.vaGuardian?.address?.state,
+              value: record.vaGuardian?.address?.state ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.vaGuardian?.address?.zipcode,
+              value: record.vaGuardian?.address?.zipcode ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.vaGuardian?.homePhone,
+              value: record.vaGuardian?.homePhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.vaGuardian?.workPhone,
+              value: record.vaGuardian?.workPhone ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -286,37 +288,37 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Name',
-              value: record.civilGuardian?.name,
+              value: record.civilGuardian?.name ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Street address',
-              value: record.civilGuardian?.address?.street,
+              value: record.civilGuardian?.address?.street ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'City',
-              value: record.civilGuardian?.address?.city,
+              value: record.civilGuardian?.address?.city ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'State',
-              value: record.civilGuardian?.address?.state,
+              value: record.civilGuardian?.address?.state ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Zip code',
-              value: record.civilGuardian?.address?.zipcode,
+              value: record.civilGuardian?.address?.zipcode ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Home phone number',
-              value: record.civilGuardian?.homePhone,
+              value: record.civilGuardian?.homePhone ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Work phone number',
-              value: record.civilGuardian?.workPhone,
+              value: record.civilGuardian?.workPhone ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -327,42 +329,42 @@ export const generateDemographicsContent = record => {
           items: [
             {
               title: 'Insurance company',
-              value: record.activeInsurance?.company,
+              value: record.activeInsurance?.company ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Effective date',
-              value: record.activeInsurance?.effectiveDate,
+              value: record.activeInsurance?.effectiveDate ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Expiration date',
-              value: record.activeInsurance?.expirationDate,
+              value: record.activeInsurance?.expirationDate ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Group name',
-              value: record.activeInsurance?.groupName,
+              value: record.activeInsurance?.groupName ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Group number',
-              value: record.activeInsurance?.groupNumber,
+              value: record.activeInsurance?.groupNumber ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Subscriber ID',
-              value: record.activeInsurance?.subscriberId,
+              value: record.activeInsurance?.subscriberId ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Subscriber name',
-              value: record.activeInsurance?.subscriberName,
+              value: record.activeInsurance?.subscriberName ?? NONE_RECORDED,
               inline: true,
             },
             {
               title: 'Subscriber relationship',
-              value: record.activeInsurance?.relationship,
+              value: record.activeInsurance?.relationship ?? NONE_RECORDED,
               inline: true,
             },
           ],
@@ -372,7 +374,7 @@ export const generateDemographicsContent = record => {
   };
 
   results.results.items = results.results.items.map(item => {
-    if (item.items.every(i => !i.value || i.value === NONE_RECORDED)) {
+    if (item.items.every(i => i.value === NONE_RECORDED)) {
       return {
         ...item,
         items: [

--- a/src/applications/mhv-medical-records/util/pdfHelpers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/labsAndTests.js
@@ -39,7 +39,7 @@ export const generateGenericContent = record => {
     details,
   };
 
-  if (record.observations) {
+  if (Array.isArray(record.observations) && record.observations.length) {
     const observationKeys = [
       'referenceRange',
       'status',
@@ -67,7 +67,7 @@ export const generateGenericContent = record => {
         items: [
           {
             title: 'Result',
-            value: item.value.text,
+            value: item.value?.text,
             inline: true,
           },
           ...observationKeys.filter(key => item[key]).map(key => {
@@ -137,31 +137,33 @@ export const generateChemHemContent = record => ({
       },
     ],
     sectionSeparators: false,
-    items: record.results.map(item => ({
-      header: item.name,
-      items: [
-        {
-          title: 'Result',
-          value: item.result,
-          inline: true,
-        },
-        {
-          title: 'Reference range',
-          value: item.standardRange,
-          inline: true,
-        },
-        {
-          title: 'Status',
-          value: item.status,
-          inline: true,
-        },
-        {
-          title: 'Lab comments',
-          value: item.labComments,
-          inline: true,
-        },
-      ],
-    })),
+    items: Array.isArray(record.results)
+      ? record.results.map(item => ({
+          header: item.name,
+          items: [
+            {
+              title: 'Result',
+              value: item.result,
+              inline: true,
+            },
+            {
+              title: 'Reference range',
+              value: item.standardRange,
+              inline: true,
+            },
+            {
+              title: 'Status',
+              value: item.status,
+              inline: true,
+            },
+            {
+              title: 'Lab comments',
+              value: item.labComments,
+              inline: true,
+            },
+          ],
+        }))
+      : [],
   },
 });
 
@@ -224,7 +226,7 @@ export const generateMicrobioContent = record => {
     },
   };
 
-  if (record.name !== 'Microbiology' && record.labType) {
+  if (record?.name !== 'Microbiology' && record?.labType) {
     content.details.items.unshift({
       title: 'Lab type',
       value: record.labType,

--- a/src/applications/mhv-medical-records/util/pdfHelpers/vaccines.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/vaccines.js
@@ -5,7 +5,7 @@ export const generateVaccinesIntro = (records, lastUpdated) => {
     subtitles: [
       'This list includes all vaccines (immunizations) in your VA medical records. For a list of your allergies and reactions (including any reactions to vaccines), download your allergy records. ',
       lastUpdated,
-      `Showing ${records.length} records from newest to oldest`,
+      `Showing ${records?.length} records from newest to oldest`,
     ],
   };
 };

--- a/src/applications/mhv-medical-records/util/pdfHelpers/vitals.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/vitals.js
@@ -7,7 +7,7 @@ export const generateVitalsIntro = (records, lastUpdated) => {
     subtitles: [
       'Vitals are basic health numbers your providers check at your appointments.',
       lastUpdated,
-      `Showing ${records.length} records from newest to oldest`,
+      `Showing ${records?.length} records from newest to oldest`,
     ],
   };
 };
@@ -48,7 +48,7 @@ export const generateVitalsContent = records => ({
     header: records[0].name,
     headerType: 'H3',
     headerIndent: 30,
-    preface: `Showing ${records.length} records, from newest to oldest`,
+    preface: `Showing ${records?.length} records, from newest to oldest`,
     prefaceIndent: 30,
     sectionSeparators: false,
     items: records.map(record => ({

--- a/src/applications/mhv-medical-records/util/txtHelpers/blueButton.js
+++ b/src/applications/mhv-medical-records/util/txtHelpers/blueButton.js
@@ -96,9 +96,9 @@ export const getTxtContent = (data, user, dateRange, failedDomains) => {
   ];
 
   // ––– appointment counts & expander helper ––––––––––––––––––––––––––––––––––––
-  const apptData = data?.appointments ?? [];
-  const pastCount = apptData.filter(a => !a.isUpcoming).length;
-  const upcomingCount = apptData.filter(a => a.isUpcoming).length;
+  const apptData = Array.isArray(data?.appointments) ? data.appointments : [];
+  const pastCount = apptData.filter(a => !a?.isUpcoming).length;
+  const upcomingCount = apptData.filter(a => a?.isUpcoming).length;
 
   /**
    * Expand “Appointments” or “VA appointments” into Past/Upcoming
@@ -161,13 +161,14 @@ export const getTxtContent = (data, user, dateRange, failedDomains) => {
     .map(l => `  • ${l}`)
     .join('\n');
 
-  // build “failed” list
-  const failedList = failedDomains.length
-    ? failedDomains
-        .flatMap(d => expandAppt(d, 'failed'))
-        .map(l => `  • ${l}`)
-        .join('\n')
-    : '';
+  // build "failed" list
+  const failedList =
+    Array.isArray(failedDomains) && failedDomains.length
+      ? failedDomains
+          .flatMap(d => expandAppt(d, 'failed'))
+          .map(l => `  • ${l}`)
+          .join('\n')
+      : '';
 
   // assemble the records section
   const recordsParts = [
@@ -222,7 +223,7 @@ export const getTxtContent = (data, user, dateRange, failedDomains) => {
 VA Blue Button® report
 
 This report includes key information from your VA medical records.
-${userFullName.first} ${userFullName.last}
+${userFullName?.first} ${userFullName?.last}
 
 Date of birth: ${formatUserDob(user)}
 

--- a/src/applications/mhv-medical-records/util/txtHelpers/blueButton.js
+++ b/src/applications/mhv-medical-records/util/txtHelpers/blueButton.js
@@ -96,9 +96,9 @@ export const getTxtContent = (data, user, dateRange, failedDomains) => {
   ];
 
   // ––– appointment counts & expander helper ––––––––––––––––––––––––––––––––––––
-  const apptData = Array.isArray(data?.appointments) ? data.appointments : [];
-  const pastCount = apptData.filter(a => !a?.isUpcoming).length;
-  const upcomingCount = apptData.filter(a => a?.isUpcoming).length;
+  const apptData = data?.appointments ?? [];
+  const pastCount = apptData.filter(a => !a.isUpcoming).length;
+  const upcomingCount = apptData.filter(a => a.isUpcoming).length;
 
   /**
    * Expand “Appointments” or “VA appointments” into Past/Upcoming

--- a/src/platform/mhv/util/helpers.js
+++ b/src/platform/mhv/util/helpers.js
@@ -252,7 +252,7 @@ export const makePdf = async (
   } catch (error) {
     // Reset the pdfModulePromise so subsequent calls can try again
     pdfModulePromise = null;
-    datadogRum.addError(error, sentryErrorLabel);
+    datadogRum.addError(error, { feature: sentryErrorLabel });
     sendErrorToSentry(error, sentryErrorLabel);
   }
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds defensive null checks to prevent runtime crashes when data or components are undefined, which can block users from downloading their Blue Button reports - as seen in the two cases described below

**VA Blue Button download flow**
Start page → Step 1 (Date Range) → Step 2 (Record Type) → Step 3 (File Type) → Returns to Start page.

- Users have reported a spinner getting stuck on Step 3 (File Type).
  - This occurs when the state isDataFetched remains false, causing the spinner to render indefinitely.

- Users have also reported the “Can’t download medical records” error.
  - The Blue Button Report AccessTroubleAlertBox appears on DownloadReportPage.jsx when the ALERT_TYPE_BB_ERROR state is set.
  - This happens when an error is thrown in DownloadFileType.jsx during the generatePdf or generateTxt callbacks.
  - The error is caught in the catch block, which dispatches an action to set ALERT_TYPE_BB_ERROR, triggering the alert on DownloadReportPage.jsx.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#120643
- department-of-veterans-affairs/va.gov-team#120528

## Testing done

- Added test specs
- Local testing

## Screenshots
Vitals Domain presently crashes with some undefined/null data. This fix will default missing blood pressure data to 'None recorded"
<img width="1455" height="816" alt="Screenshot 2025-10-28 at 1 41 36 PM" src="https://github.com/user-attachments/assets/4cb5799a-8ef6-4769-bed4-7b90a80dd9ae" />


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
