### PR TITLE
add pagination info

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -50,7 +50,7 @@ const FilesWeCouldntReceive = () => {
 
   const handlePageSelect = page => {
     onPageSelect(page);
-    setPageFocus('#files-not-received-section');
+    setPageFocus('#pagination-info');
   };
 
   useEffect(
@@ -121,6 +121,18 @@ const FilesWeCouldntReceive = () => {
                     by mail or in person, by you or by others, don’t appear in
                     this tool.
                   </p>
+
+                  {shouldPaginate &&
+                    (() => {
+                      const start = (currentPage - 1) * 10 + 1;
+                      const end = Math.min(
+                        currentPage * 10,
+                        sortedFailedFiles.length,
+                      );
+                      const listLen = sortedFailedFiles.length;
+                      const txt = `Showing ${start} \u2012 ${end} of ${listLen} items`;
+                      return <p id="pagination-info">{txt}</p>;
+                    })()}
 
                   {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
                   <ul

--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -13,6 +13,7 @@ import { usePagination } from '../hooks/usePagination';
 import { fetchFailedUploads } from '../actions';
 import { buildDateFormatter } from '../utils/helpers';
 import { setPageFocus } from '../utils/page';
+import { ITEMS_PER_PAGE } from '../constants';
 import NeedHelp from './NeedHelp';
 
 const FilesWeCouldntReceive = () => {
@@ -124,12 +125,12 @@ const FilesWeCouldntReceive = () => {
 
                   {shouldPaginate &&
                     (() => {
-                      const start = (currentPage - 1) * 10 + 1;
-                      const end = Math.min(
-                        currentPage * 10,
-                        sortedFailedFiles.length,
-                      );
                       const listLen = sortedFailedFiles.length;
+                      const start = (currentPage - 1) * ITEMS_PER_PAGE + 1;
+                      const end = Math.min(
+                        currentPage * ITEMS_PER_PAGE,
+                        listLen,
+                      );
                       const txt = `Showing ${start} \u2012 ${end} of ${listLen} items`;
                       return <p id="pagination-info">{txt}</p>;
                     })()}

--- a/src/applications/claims-status/components/Type1UnknownUploadError.jsx
+++ b/src/applications/claims-status/components/Type1UnknownUploadError.jsx
@@ -20,7 +20,7 @@ export default function Type1UnknownUploadError({ errorFiles }) {
     const isOnFilesPage = location.pathname.endsWith('/files');
 
     if (!isOnFilesPage) navigate('../files#other-ways-to-send');
-
+    // setTimeout needed for cross-tab navigation to allow target page content to render
     setTimeout(() => {
       scrollAndFocus('#other-ways-to-send');
     }, 100);

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -310,12 +310,33 @@ describe('<FilesWeCouldntReceive>', () => {
       const pagination = container.querySelector('va-pagination');
       expect(pagination).to.not.exist;
 
+      // Test that pagination info text is NOT rendered
+      const paginationInfo = container.querySelector('#pagination-info');
+      expect(paginationInfo).to.not.exist;
+
       // Test that all 5 items are shown
       const failedFileCards = getAllByTestId(/failed-file-/);
       expect(failedFileCards).to.have.length(5);
     });
 
-    it('should focus on files section when pagination is clicked', () => {
+    it('should display pagination info text with correct format when pagination is shown', () => {
+      // Create 15 mock failed files to trigger pagination
+      const mockFailedFiles = createMockFailedFiles(15);
+      const store = createMockStore(mockFailedFiles);
+      const { container, getByText } = renderWithCustomStore(
+        <FilesWeCouldntReceive />,
+        store,
+      );
+
+      // Test that pagination info text is rendered with correct format
+      const paginationInfo = container.querySelector('#pagination-info');
+      expect(paginationInfo).to.exist;
+
+      // Test that the text shows the correct range for first page
+      expect(getByText('Showing 1 ‒ 10 of 15 items')).to.exist;
+    });
+
+    it('should focus on pagination info when pagination is clicked', () => {
       // Create 15 mock failed files to trigger pagination
       const mockFailedFiles = createMockFailedFiles(15);
       const store = createMockStore(mockFailedFiles);
@@ -343,8 +364,7 @@ describe('<FilesWeCouldntReceive>', () => {
 
       // Verify that setPageFocus was called with the correct selector
       expect(mockSetPageFocus.calledOnce).to.be.true;
-      expect(mockSetPageFocus.calledWith('#files-not-received-section')).to.be
-        .true;
+      expect(mockSetPageFocus.calledWith('#pagination-info')).to.be.true;
 
       // Restore the original function
       require('../../utils/page').setPageFocus = originalSetPageFocus;


### PR DESCRIPTION
## Summary

This PR implements **pagination focus management and accessibility improvements** for the `Files we couldn't receive` page. The changes ensure that when users navigate between pagination pages, focus moves to the pagination info text.

### Changes

- Updated `handlePageSelect` function to focus on `#pagination-info` instead of `#files-not-received-section`
- Ensured pagination info only appears when there are more than 10 failed files
- **Accessibility:** Verified focus management respects `prefers-reduced-motion` settings through existing `scrollAndFocus` utility
- Added unit tests for pagination text display and focus management

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#121811

## How to Test Locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```

3. **Test the pagination focus behavior:**
   - Navigate to the `track-claims/your-claims/files-we-couldnt-receive` page
   - Ensure you have more than 10 failed files to trigger pagination
   - Click on pagination buttons (page 2, 3, etc.)
   - Verify focus moves to the "Showing X–Y of Z items" text
   - Test with reduced motion preferences enabled in browser dev tools

4. **Test pagination visibility:**
   - With ≤10 failed files: Verify no pagination info text is displayed
   - With >10 failed files: Verify pagination info text appears above the file cards

## Testing Done

- Added tests for pagination text display and focus management
- Verified focus moves to pagination info when pagination is clicked
- **Manual Testing:** Confirmed pagination text format matches design specifications

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Scenario | Pagination Info Display |
| ------- | ------ |
| With Pagination (>10 files) | <img width="483" height="346" alt="Screenshot 2025-10-28 at 12 32 27 PM" src="https://github.com/user-attachments/assets/a75fe1a3-cd78-475d-988c-59814bf680e7" /> |
| Without Pagination (≤10 files) | <img width="505" height="905" alt="Screenshot 2025-10-28 at 12 32 55 PM" src="https://github.com/user-attachments/assets/43c1abd2-8e4e-4f61-b9e4-f4a33ef6b6a5" /> |

## What areas of the site does it impact?

- `track-claims/your-claims/files-we-couldnt-receive` page

## Acceptance Criteria

- [x] Pagination info text only appears when there are more than 10 failed files
- [x] Focus moves to pagination info text when pagination buttons are clicked
- [x] Text format matches design specification: "Showing X–Y of Z items"
- [x] Behavior matches track-claims/your-claims pagination pattern
- [x] Respects `prefers-reduced-motion` settings for accessibility
- [x] Updated unit tests cover new pagination focus behavior

## Quality Assurance & Testing

- [x] I updated unit tests for pagination text display and focus management
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors
- [x] Proper fallback behavior when pagination elements are not found
- [x] Focus management works correctly with reduced motion preferences
- [x] Pagination text displays correctly for all page ranges

### Authentication

- [x] Did you log in to a local build and verify all authenticated routes work as expected with a test user?