### PR TITLE
534EZ Household Information Chapter - Marriage To Veteran Page

### DIFF
--- a/src/applications/survivors-benefits/components/FormAlerts/index.jsx
+++ b/src/applications/survivors-benefits/components/FormAlerts/index.jsx
@@ -53,3 +53,14 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
     advisory="A licensed medical professional must complete this form."
   />
 );
+
+export const CourtOrderSeparationAlert = () => (
+  <va-alert-expandable
+    status="warning"
+    trigger="You'll need to submit a copy of the court order."
+    disable-border="true"
+  >
+    We’ll ask you to upload this document at the end of this application. Or you
+    can send it to us by mail.
+  </va-alert-expandable>
+);

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/index.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/index.js
@@ -1,0 +1,10 @@
+import marriageToVeteran from './marriageToVeteran';
+import legalStatusOfMarriage from './legalStatusOfMarriage';
+
+export default {
+  title: 'Household information',
+  pages: {
+    marriageToVeteran,
+    legalStatusOfMarriage,
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/legalStatusOfMarriage.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/legalStatusOfMarriage.js
@@ -1,0 +1,38 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  titleUI,
+  textUI,
+  textSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Legal status of marriage',
+  path: 'household/legal-status-of-marriage',
+  uiSchema: {
+    ...titleUI('Legal status of marriage'),
+    awareOfLegalIssues: yesNoUI({
+      title:
+        'At the time of your marriage to the Veteran, were you aware of any reason the marriage might not be legally valid?',
+    }),
+    legalIssueExplanation: {
+      ...textUI({
+        title: 'Tell us why your marriage might not be legally valid',
+        required: formData => formData.awareOfLegalIssues === true,
+      }),
+      'ui:options': {
+        expandUnder: 'awareOfLegalIssues',
+        expandUnderCondition: true,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['awareOfLegalIssues'],
+    properties: {
+      awareOfLegalIssues: yesNoSchema,
+      legalIssueExplanation: textSchema,
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageStatus.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageStatus.js
@@ -1,0 +1,25 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Marriage status',
+  path: 'household/marriage-status',
+  uiSchema: {
+    ...titleUI('Marriage status'),
+    livedContinuouslyWithVeteran: yesNoUI({
+      title:
+        'Did you live continuously with the Veteran from the date of marriage to the date of their death?',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['livedContinuouslyWithVeteran'],
+    properties: {
+      livedContinuouslyWithVeteran: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteran.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteran.js
@@ -1,0 +1,107 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  radioUI,
+  radioSchema,
+  textUI,
+  textSchema,
+  titleUI,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { marriageEndOptions, marriageTypeOptions } from '../../../utils/labels';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Marriage to Veteran',
+  path: 'household/marriage-to-veteran',
+  uiSchema: {
+    ...titleUI('Marriage to Veteran'),
+    marriedAtDeath: yesNoUI({
+      title: 'Were you married to the Veteran at the time of their death?',
+    }),
+    marriageEndDetails: {
+      'ui:field': 'ObjectField',
+      'ui:options': {
+        expandUnder: 'marriedAtDeath',
+        expandUnderCondition: false,
+        hideIf: formData => formData.marriedAtDeath !== false,
+      },
+      marriageEndReason: {
+        ...radioUI({
+          title: 'How did the marriage end?',
+          labels: marriageEndOptions,
+          required: formData => formData.marriedAtDeath === false,
+        }),
+      },
+      marriageEndOtherReason: {
+        ...textUI({
+          title: 'Tell us how the marriage ended?',
+          required: formData =>
+            formData?.marriageEndDetails?.marriageEndReason === 'OTHER',
+        }),
+        'ui:options': {
+          expandUnder: 'marriageEndReason',
+          expandUnderCondition: 'OTHER',
+        },
+      },
+    },
+    marriageDate: currentOrPastDateUI({
+      title: 'Date of marriage',
+      monthSelect: false,
+    }),
+    marriageEndDate: currentOrPastDateUI({
+      title: 'Date marriage ended',
+      monthSelect: false,
+    }),
+    placeOfMarriage: textUI({
+      title: 'Place of marriage',
+      hint: 'City, state or foreign country',
+    }),
+    placeMarriageEnded: textUI({
+      title: 'Place marriage ended',
+      hint: 'City, state or foreign country',
+    }),
+    marriageType: radioUI({
+      title: 'How did you get married?',
+      labels: marriageTypeOptions,
+    }),
+    marriageTypeOther: {
+      ...textUI({
+        title: 'Tell us how you got married.',
+        required: formData => formData?.marriageType === 'OTHER_WAY',
+      }),
+      'ui:options': {
+        hint:
+          'You can enter common law, proxy (someone else represented you or your spouse at your marriage ceremony), tribal ceremony, or another way.',
+        expandUnder: 'marriageType',
+        expandUnderCondition: 'OTHER_WAY',
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: [
+      'marriedAtDeath',
+      'marriageDate',
+      'placeOfMarriage',
+      'marriageType',
+    ],
+    properties: {
+      marriedAtDeath: yesNoSchema,
+      marriageEndDetails: {
+        type: 'object',
+        properties: {
+          marriageEndReason: radioSchema(Object.keys(marriageEndOptions)),
+          marriageEndOtherReason: textSchema,
+        },
+      },
+      marriageDate: currentOrPastDateSchema,
+      marriageEndDate: currentOrPastDateSchema,
+      placeOfMarriage: textSchema,
+      placeMarriageEnded: textSchema,
+      marriageType: radioSchema(Object.keys(marriageTypeOptions)),
+      marriageTypeOther: textSchema,
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/reasonForSeparation.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/reasonForSeparation.js
@@ -1,0 +1,27 @@
+import {
+  radioSchema,
+  radioUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { separationReasonOptions } from '../../../utils/labels';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Reason for separation',
+  path: 'household/reason-for-separation',
+  depends: formData => formData.livedContinuouslyWithVeteran === false,
+  uiSchema: {
+    ...titleUI('Reason for separation'),
+    separationReason: radioUI({
+      title: 'What was the reason for separation?',
+      labels: separationReasonOptions,
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['separationReason'],
+    properties: {
+      separationReason: radioSchema(Object.keys(separationReasonOptions)),
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/separationDetails.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/separationDetails.js
@@ -1,0 +1,63 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  textUI,
+  textSchema,
+  titleUI,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { isYes } from '../05-claim-information/helpers';
+import { CourtOrderSeparationAlert } from '../../../components/FormAlerts';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Separation details',
+  path: 'household/separation-details',
+  depends: formData =>
+    formData.separationReason === 'RELATIONSHIP_DIFFERENCES' ||
+    formData.separationReason === 'OTHER',
+  uiSchema: {
+    ...titleUI('Separation details'),
+    separationReasonExplanation: textUI({
+      title: 'Tell us the reason for the separation',
+    }),
+    separationStartDate: currentOrPastDateUI({
+      title: 'Start date of separation',
+      monthSelect: false,
+    }),
+    separationEndDate: currentOrPastDateUI({
+      title: 'End date of separation',
+      monthSelect: false,
+    }),
+    courtOrderedSeparation: yesNoUI({
+      title: 'Was the separation due to a court order?',
+    }),
+    courtOrderAlert: {
+      'ui:description': CourtOrderSeparationAlert,
+      'ui:options': {
+        hideIf: formData => !isYes(formData?.courtOrderedSeparation),
+        displayEmptyObjectOnReview: true,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: [
+      'separationReasonExplanation',
+      'separationStartDate',
+      'separationEndDate',
+      'courtOrderedSeparation',
+    ],
+    properties: {
+      separationReasonExplanation: textSchema,
+      separationStartDate: currentOrPastDateSchema,
+      separationEndDate: currentOrPastDateSchema,
+      courtOrderedSeparation: yesNoSchema,
+      courtOrderAlert: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -30,6 +30,11 @@ import nationalGuardUnitAddress from './chapters/03-military-history/nationalGua
 import { otherServiceNamesPages } from './chapters/03-military-history/serviceNames';
 import prisonerOfWarPage from './chapters/03-military-history/prisonerOfWar';
 import powPeriodOfTimePage from './chapters/03-military-history/powPeriodOfTime';
+import marriageToVeteran from './chapters/04-household-information/marriageToVeteran';
+import legalStatusOfMarriage from './chapters/04-household-information/legalStatusOfMarriage';
+import marriageStatus from './chapters/04-household-information/marriageStatus';
+import reasonForSeparation from './chapters/04-household-information/reasonForSeparation';
+import separationDetails from './chapters/04-household-information/separationDetails';
 import dicBenefits from './chapters/05-claim-information/dicBenefits';
 import nursingHome from './chapters/05-claim-information/nursingHome';
 import { treatmentPages } from './chapters/05-claim-information/treatmentPages';
@@ -201,6 +206,52 @@ const formConfig = {
           depends: formData => formData?.prisonerOfWar === true,
           uiSchema: powPeriodOfTimePage.uiSchema,
           schema: powPeriodOfTimePage.schema,
+        },
+      },
+    },
+    // Chapter 4 - Household Information
+    householdInformation: {
+      title: 'Household information',
+      pages: {
+        marriageToVeteran: {
+          path: 'household/marriage-to-veteran',
+          title: 'Marriage to Veteran',
+          depends: formData => formData.claimantRelationship === 'SPOUSE',
+          uiSchema: marriageToVeteran.uiSchema,
+          schema: marriageToVeteran.schema,
+        },
+        legalStatusOfMarriage: {
+          path: 'household/legal-status-of-marriage',
+          title: 'Legal status of marriage',
+          depends: formData => formData.claimantRelationship === 'SPOUSE',
+          uiSchema: legalStatusOfMarriage.uiSchema,
+          schema: legalStatusOfMarriage.schema,
+        },
+        marriageStatus: {
+          path: 'household/marriage-status',
+          title: 'Marriage status',
+          depends: formData => formData.claimantRelationship === 'SPOUSE',
+          uiSchema: marriageStatus.uiSchema,
+          schema: marriageStatus.schema,
+        },
+        reasonForSeparation: {
+          path: 'household/reason-for-separation',
+          title: 'Reason for separation',
+          depends: formData =>
+            formData.claimantRelationship === 'SPOUSE' &&
+            formData.livedContinuouslyWithVeteran === false,
+          uiSchema: reasonForSeparation.uiSchema,
+          schema: reasonForSeparation.schema,
+        },
+        separationDetails: {
+          path: 'household/separation-details',
+          title: 'Separation details',
+          depends: formData =>
+            formData.claimantRelationship === 'SPOUSE' &&
+            (formData.separationReason === 'RELATIONSHIP_DIFFERENCES' ||
+              formData.separationReason === 'OTHER'),
+          uiSchema: separationDetails.uiSchema,
+          schema: separationDetails.schema,
         },
       },
     },

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -28,6 +28,24 @@ export const claimantRelationshipOptions = {
   ADULT_CHILD_SERIOUSLY_DISABLED: 'Adult child who is seriously disabled',
 };
 
+export const marriageEndOptions = {
+  SPOUSE_DEATH: "Spouse's death",
+  DIVORCE: 'Divorce',
+  OTHER: 'Other',
+};
+
+export const marriageTypeOptions = {
+  CIVIL_RELIGIOUS:
+    'In a civil or religious ceremony with an officiant who signed me marriage license',
+  OTHER_WAY: 'Some other way',
+};
+
+export const separationReasonOptions = {
+  MEDICAL_FINANCIAL: 'Medical or financial reasons',
+  RELATIONSHIP_DIFFERENCES: 'Relationship differences or problems',
+  OTHER: 'Other',
+};
+
 export const bankAccountTypeOptions = {
   CHECKING: 'Checking',
   SAVINGS: 'Savings',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request adds a comprehensive "Household Information" chapter to the survivors benefits application, introducing several new pages and supporting logic for collecting detailed marriage and separation information from applicants. The changes include new form schemas, UI components, conditional logic, and label definitions to support these pages.

**New Household Information Chapter and Pages:**

* Added a new `householdInformation` chapter to the main form configuration, including pages for marriage to veteran, legal status of marriage, marriage status, reason for separation, and separation details, with appropriate conditional display logic for each page. [[1]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364R212-R257) [[2]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364R33-R37) [[3]](diffhunk://#diff-f63abad1dfadb17e9a5b241ac5f96ec086b3d4cac7233ffb064a8318d34cfde6R1-R10)

**Form Page Implementations:**

* Implemented the `marriageToVeteran`, `legalStatusOfMarriage`, and `marriageStatus` pages, each collecting specific details about the applicant's marriage to the veteran, including type, status, and legal validity. [[1]](diffhunk://#diff-411cf40d36415f2d3ae3b10bbaf1453e9567e884f92907be1c193f22ade99d91R1-R107) [[2]](diffhunk://#diff-cdf8630372ab4122d120cb54af157921b2bb81864403fb6e0b22667e7bcb9e2aR1-R38) [[3]](diffhunk://#diff-c7dfe385b9a370b9fecd845b51c850bb680a2625abcbab184591fc1abe1aede4R1-R25)
* Added `reasonForSeparation` and `separationDetails` pages to capture information about any separation, including reason, dates, and whether it was court-ordered, with conditional rendering based on previous answers. [[1]](diffhunk://#diff-b8ca35b42a9a9f846ca80789d19e58a1b8a131ae05664bf49fcfa4f991abf4dcR1-R27) [[2]](diffhunk://#diff-ab7483db8a5bfe49ceded1ba9dd5c23a1a6206f38e683bf93f4d7366ce1dde5cR1-R63)

**UI Components and Alerts:**

* Introduced a new `CourtOrderSeparationAlert` expandable alert component to inform users about required documentation for court-ordered separations, used in the separation details page. [[1]](diffhunk://#diff-084cb62f9701371da62741ee8771f209d88ee3e0d0ca75e5b767f26c0c25e9a7R56-R66) [[2]](diffhunk://#diff-ab7483db8a5bfe49ceded1ba9dd5c23a1a6206f38e683bf93f4d7366ce1dde5cR1-R63)

**Label and Option Definitions:**

* Defined new option sets in `labels.jsx` for marriage end reasons, marriage types, and separation reasons, used across the new form pages for consistency and clarity.

These changes collectively enhance the application's ability to gather nuanced household and marital information, supporting more accurate eligibility determination and documentation requirements.

## Related issue(s)
N/A

## Testing done
Manual testing of the 534EZ Household info marriage to veteran pages.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |
<img width="527" height="1154" alt="Screenshot 2025-10-28 at 3 16 58 PM" src="https://github.com/user-attachments/assets/3f545ed1-67fc-4803-bf3c-ba3d81e91e49" />
<img width="502" height="598" alt="Screenshot 2025-10-28 at 3 17 17 PM" src="https://github.com/user-attachments/assets/dd417194-0ee3-4d65-81a7-c5b6f251efe5" />
<img width="502" height="598" alt="Screenshot 2025-10-28 at 3 17 29 PM" src="https://github.com/user-attachments/assets/39953796-4036-4df8-b010-3bcb17690495" />
<img width="502" height="598" alt="Screenshot 2025-10-28 at 3 17 41 PM" src="https://github.com/user-attachments/assets/6a7370d0-459f-45a0-9c70-59883612bcbb" />
<img width="502" height="913" alt="Screenshot 2025-10-28 at 3 18 25 PM" src="https://github.com/user-attachments/assets/171424ce-709f-459d-b3ac-b1b13bbe474c" />
|

## What areas of the site does it impact?
N/A

## Acceptance criteria
New 534EZ household information Marriage to Veteran pages exist

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
