### PR TITLE
DR 112754: Add clickToClose to remaining VaModals in DR flows

### DIFF
--- a/src/applications/appeals/995/components/EvidenceSummary.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummary.jsx
@@ -186,6 +186,7 @@ const EvidenceSummary = ({
         </va-alert>
 
         <VaModal
+          clickToClose
           status="warning"
           visible={showModal}
           modalTitle={modalTitle}

--- a/src/applications/appeals/shared/components/MaxSelectionsAlert.jsx
+++ b/src/applications/appeals/shared/components/MaxSelectionsAlert.jsx
@@ -7,6 +7,7 @@ import { MAX_LENGTH, MAX_SELECTED_ERROR } from '../constants';
 // higher level
 export const MaxSelectionsAlert = ({ closeModal, appName }) => (
   <VaModal
+    clickToClose
     modalTitle={MAX_SELECTED_ERROR}
     status="warning"
     onCloseEvent={closeModal}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Back when we were updating the 4142 Authorization page, we enabled the Privacy Act modal to be closed when a user clicks outside of the modal. This was an accessibility finding that Tracy asked us to address. We discovered this behavior is not consistent for all modals in Decision Review applications.

This PR addresses all of the modals that we control the code for. On the introduction page of all 3 DR flows, there is the `<va-omb-info>` component that has a nested privacy modal. We can't control the code for this modal because it is nested inside of the web component. I have a [Design System ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5014) open to ask them to allow us to add that prop to the web component so it can be applied to the modal, but that ticket hasn't been addressed yet.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/112754

## Testing done & screenshots

The `EvidenceSummary` component (in Supplemental Claims) has a modal that was updated:

https://github.com/user-attachments/assets/dd7b5e82-9ff8-4e03-8dad-dc888109a986

The `MaxSelections` component is shared between all 3 DR flows and can be best tested through Cypress. Otherwise, I'd have to manually add 100 issues in the browser flow 😓 

https://github.com/user-attachments/assets/b39e5c4a-1f63-4d44-a33c-192ce04dd91d