### PR TITLE
Update ConfirmationNewDisabilities component to pass axe check

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationNewDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationNewDisabilities.jsx
@@ -6,7 +6,7 @@ const ConfirmationNewDisabilities = ({ formData }) => {
   const { newDisabilities = [] } = formData || {};
 
   return (
-    <div>
+    <>
       {newDisabilities.map(dis => {
         // guard is necessary for legacy 0781 conditions that do not have a cause
         const cause = dis?.cause || 'Claimed';
@@ -15,7 +15,7 @@ const ConfirmationNewDisabilities = ({ formData }) => {
             ? 'VA'
             : cause.charAt(0).toUpperCase() + cause.slice(1).toLowerCase();
         return (
-          <div key={dis.condition}>
+          <li key={dis.condition}>
             <h4>{capitalizeEachWord(dis.condition)} </h4>
             <div className="vads-u-color--gray">Description </div>
             {capitalizedCause} condition; {dis.primaryDescription}
@@ -47,10 +47,10 @@ const ConfirmationNewDisabilities = ({ formData }) => {
                   {dis['view:vaFollowUp'].vaMistreatmentDescription}
                 </>
               )}
-          </div>
+          </li>
         );
       })}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
I restructured the HTML in the ConfirmationNewDisabilities component to pass the axe validation scan. The issue was caused by a [div] as a direct child of a [ul].

- _(If bug, how to reproduce)_
Run an axe scan on the confirmation page in staging or main to see the existing bug

- _(What is the solution, why is this the solution)_
I replaced the offending divs so that the scan would pass and the content of the page would remain the same.

- _(Which team do you work for, does your team own the maintenance of this component?)_
VADBC Core team

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
This is gated behind flipper `disability_526_show_confirmation_review`  
Dates TBD

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122820

## Testing done

- _Describe what the old behavior was prior to the change_
The confirmation page axe scan found a [div] as a direct child of a [ul], causing the scan to fail.

- _Describe the steps required to verify your changes are working as expected_
1. Set up
    - New confirmation page flipper on: `disability_526_show_confirmation_review`  
    - New conditions flow off: `disability_compensation_new_conditions_workflow`. 
2. Complete and submit the form to reach the `/confirmation` page. The new copy of submission accordion should now display for all paths and users.
3. Expand the accordion and run a scan with the axe dev tool to make sure there are no issues. Note: the accordion needs to be expanded to scan all the elements
    - Axe testing instructions here: https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review#Prepareforanaccessibilitystagingreview-Stepstotest(web)
 4. Verify:
    - no axe issues are reported from the scan
    - the accordion content renders as expected

- _Describe the tests completed and the results_
Existing tests pass
Axe scan passes

- Proof of local submission
<img width="768" height="955" alt="Screenshot 2025-10-29 at 4 31 54 PM" src="https://github.com/user-attachments/assets/e40cefff-e170-400b-8a65-8a7a897095f1" />

## Screenshots

| Before - with 1 axe scan issue| 
| ------ | 
| <img width="1488" height="795" alt="Screenshot 2025-10-29 at 4 28 45 PM" src="https://github.com/user-attachments/assets/a0c88a27-0505-4256-92c2-5da281c18259" /> |  

| After - with 0 axe scan issues | 
| ------ | 
| <img width="1396" height="818" alt="Screenshot 2025-10-29 at 4 20 21 PM" src="https://github.com/user-attachments/assets/438abb3e-b661-4f32-9eab-1b0a9082d60d" /> |

## What areas of the site does it impact?
This only affects the accordion within the 526 confirmation page

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
