### PR TITLE
DR 111690 Move GA event on start pages to onContinue click instead

### DIFF
--- a/src/applications/appeals/995/actions/index.js
+++ b/src/applications/appeals/995/actions/index.js
@@ -1,8 +1,7 @@
 import environment from 'platform/utilities/environment';
-
 import { apiRequest } from 'platform/utilities/api';
-
-import { SUPPORTED_BENEFIT_TYPES, DEFAULT_BENEFIT_TYPE } from '../constants';
+import { DEFAULT_BENEFIT_TYPE } from '../../shared/constants';
+import { SUPPORTED_BENEFIT_TYPES } from '../constants';
 import { CONTESTABLE_ISSUES_API, ITF_API } from '../constants/apis';
 
 import {

--- a/src/applications/appeals/995/constants/index.js
+++ b/src/applications/appeals/995/constants/index.js
@@ -47,11 +47,6 @@ export const EVIDENCE_OTHER = 'view:hasOtherEvidence';
 export const LIMITED_CONSENT_RESPONSE = 'view:hasPrivateLimitation';
 export const MST_OPTION = 'mstOption';
 
-// Including a default until we determine how to get around the user restarting
-// the application after using the "Finish this application later" link
-// See https://dsva.slack.com/archives/C0113MPTGH5/p1600725048027200
-export const DEFAULT_BENEFIT_TYPE = 'compensation';
-
 export const errorMessages = {
   evidence: {
     // VA evidence

--- a/src/applications/appeals/995/subtask/pages/other.jsx
+++ b/src/applications/appeals/995/subtask/pages/other.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-
 import { focusElement } from 'platform/utilities/ui';
-import recordEvent from 'platform/monitoring/record-event';
-
-import pageNames from './pageNames';
+import {
+  PAGE_NAMES,
+  recordBenefitOfficeClickEvent,
+} from '../../../shared/utils/start-page';
 import DownloadLink from '../../content/DownloadLink';
 import { BENEFIT_OFFICES_URL } from '../../constants';
 import { title995 } from '../../content/title';
@@ -15,22 +15,14 @@ const DecisionReviewPage = () => {
     });
   }, []);
 
-  recordEvent({
-    event: 'howToWizard-alert-displayed',
-    'reason-for-alert': 'veteran wants to submit an unsupported claim type',
-  });
-
   const handlers = {
     officeLinkClick: () => {
-      recordEvent({
-        event: 'howToWizard-alert-link-click',
-        'howToWizard-alert-link-click-label': 'benefit office',
-      });
+      recordBenefitOfficeClickEvent();
     },
   };
 
   return (
-    <div id={pageNames.other} className="vads-u-padding-bottom--2">
+    <div id={PAGE_NAMES.other} className="vads-u-padding-bottom--2">
       <h1 className="vads-u-margin-bottom--0">{title995}</h1>
       <div className="schemaform-subtitle vads-u-font-size--lg">
         VA Form 20-0995
@@ -70,8 +62,8 @@ const DecisionReviewPage = () => {
 };
 
 export default {
-  name: pageNames.other,
+  name: PAGE_NAMES.other,
   component: DecisionReviewPage,
   next: null,
-  back: pageNames.start,
+  back: PAGE_NAMES.start,
 };

--- a/src/applications/appeals/995/subtask/pages/pageNames.js
+++ b/src/applications/appeals/995/subtask/pages/pageNames.js
@@ -1,4 +1,0 @@
-export default {
-  start: 'start',
-  other: 'other',
-};

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -111,6 +111,6 @@ export default {
   validate: ({ benefitType } = {}) => validateBenefitType(benefitType),
   back: null,
   next: data => getNextPage(BASE_URL, data),
-  onContinue: benefitType =>
+  onContinue: ({ benefitType }) =>
     recordBenefitTypeEvent(benefitType, content.groupLabel),
 };

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -4,39 +4,21 @@ import {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-
 import { focusElement } from 'platform/utilities/ui';
-import recordEvent from 'platform/monitoring/record-event';
-
-import { BASE_URL, DEFAULT_BENEFIT_TYPE } from '../../constants';
-import pageNames from './pageNames';
-
+import { BASE_URL } from '../../constants';
 import { title995, subTitle995 } from '../../content/title';
+import {
+  getNextPage,
+  options,
+  PAGE_NAMES,
+  recordBenefitTypeEvent,
+  validateBenefitType,
+} from '../../../shared/utils/start-page';
 
 const content = {
   groupLabel: 'What type of claim are you filing a Supplemental Claim for?',
   errorMessage: 'You must choose a claim type.',
 };
-
-const options = [
-  {
-    value: DEFAULT_BENEFIT_TYPE,
-    label: 'Disability compensation claim',
-  },
-  {
-    value: pageNames.other,
-    label: 'Another type of claim (not a disability claim)',
-  },
-];
-
-const optionValues = options.map(option => option.value);
-
-const getNextPage = data =>
-  data?.benefitType === optionValues[0]
-    ? `${BASE_URL}/introduction` // valid benefit type, go to intro page
-    : pageNames.other; // benefit type not supported
-
-const validate = ({ benefitType } = {}) => optionValues.includes(benefitType);
 
 /**
  * Benefit type page
@@ -51,18 +33,11 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
       focusElement('#main h2');
     });
   }, []);
+
   const handlers = {
     setBenefitType: event => {
       const { value } = event.detail;
       setPageData({ benefitType: value || null });
-
-      recordEvent({
-        event: 'howToWizard-formChange',
-        'form-field-type': 'form-radio-buttons',
-        'form-field-label':
-          'What type of claim are you filing a Supplemental Claim for?',
-        'form-field-value': value,
-      });
     },
   };
 
@@ -131,9 +106,11 @@ BenefitType.propTypes = {
 };
 
 export default {
-  name: pageNames.start,
+  name: PAGE_NAMES.start,
   component: BenefitType,
-  validate,
+  validate: ({ benefitType } = {}) => validateBenefitType(benefitType),
   back: null,
-  next: getNextPage,
+  next: data => getNextPage(BASE_URL, data),
+  onContinue: benefitType =>
+    recordBenefitTypeEvent(benefitType, content.groupLabel),
 };

--- a/src/applications/appeals/996/actions/index.js
+++ b/src/applications/appeals/996/actions/index.js
@@ -1,7 +1,7 @@
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
-
-import { SUPPORTED_BENEFIT_TYPES, DEFAULT_BENEFIT_TYPE } from '../constants';
+import { DEFAULT_BENEFIT_TYPE } from '../../shared/constants';
+import { SUPPORTED_BENEFIT_TYPES } from '../constants';
 import { CONTESTABLE_ISSUES_API } from '../constants/apis';
 
 import {

--- a/src/applications/appeals/996/config/submit-transformer.js
+++ b/src/applications/appeals/996/config/submit-transformer.js
@@ -1,4 +1,4 @@
-import { DEFAULT_BENEFIT_TYPE } from '../constants';
+import { DEFAULT_BENEFIT_TYPE } from '../../shared/constants';
 
 import {
   getAddress,

--- a/src/applications/appeals/996/constants/index.js
+++ b/src/applications/appeals/996/constants/index.js
@@ -27,11 +27,6 @@ export const PROFILE_URL = '/profile';
 // anchor (not an accordion)
 export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#file-by-mail-in-person-or-with`;
 
-// Including a default until we determine how to get around the user restarting
-// the application after using the "Finish this application later" link
-// See https://dsva.slack.com/archives/C0113MPTGH5/p1600725048027200
-export const DEFAULT_BENEFIT_TYPE = 'compensation';
-
 export const errorMessages = {
   savedFormNotFound: 'Please start over to request a Higher-Level Review',
   savedFormNoAuth:

--- a/src/applications/appeals/996/subtask/pages/other.jsx
+++ b/src/applications/appeals/996/subtask/pages/other.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-
 import { focusElement } from 'platform/utilities/ui';
-import recordEvent from 'platform/monitoring/record-event';
-
-import pageNames from './pageNames';
+import {
+  PAGE_NAMES,
+  recordBenefitOfficeClickEvent,
+} from '../../../shared/utils/start-page';
 import DownloadLink from '../../content/DownloadLink';
 import { PageTitle } from '../../content/title';
 import { BENEFIT_OFFICES_URL } from '../../constants';
@@ -15,22 +15,14 @@ const DecisionReviewPage = () => {
     });
   }, []);
 
-  recordEvent({
-    event: 'howToWizard-alert-displayed',
-    'reason-for-alert': 'veteran wants to submit an unsupported claim type',
-  });
-
   const handlers = {
     officeLinkClick: () => {
-      recordEvent({
-        event: 'howToWizard-alert-link-click',
-        'howToWizard-alert-link-click-label': 'benefit office',
-      });
+      recordBenefitOfficeClickEvent();
     },
   };
 
   return (
-    <div id={pageNames.other} className="vads-u-padding-bottom--2">
+    <div id={PAGE_NAMES.other} className="vads-u-padding-bottom--2">
       <PageTitle />
       <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0">
         Requesting a Higher-Level Review if it isn’t for a disability
@@ -68,8 +60,8 @@ const DecisionReviewPage = () => {
 };
 
 export default {
-  name: pageNames.other,
+  name: PAGE_NAMES.other,
   component: DecisionReviewPage,
   next: null,
-  back: pageNames.start,
+  back: PAGE_NAMES.start,
 };

--- a/src/applications/appeals/996/subtask/pages/pageNames.js
+++ b/src/applications/appeals/996/subtask/pages/pageNames.js
@@ -1,4 +1,0 @@
-export default {
-  start: 'start',
-  other: 'other',
-};

--- a/src/applications/appeals/996/subtask/pages/start.jsx
+++ b/src/applications/appeals/996/subtask/pages/start.jsx
@@ -101,6 +101,6 @@ export default {
   validate: ({ benefitType } = {}) => validateBenefitType(benefitType),
   back: null,
   next: data => getNextPage(BASE_URL, data),
-  onContinue: benefitType =>
+  onContinue: ({ benefitType }) =>
     recordBenefitTypeEvent(benefitType, content.groupLabel),
 };

--- a/src/applications/appeals/996/subtask/pages/start.jsx
+++ b/src/applications/appeals/996/subtask/pages/start.jsx
@@ -4,40 +4,22 @@ import {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-
 import { focusElement } from '~/platform/utilities/ui';
-import recordEvent from '~/platform/monitoring/record-event';
-
 import { BASE_URL } from '../../constants';
 import { PageTitle } from '../../content/title';
-
-import pageNames from './pageNames';
+import {
+  getNextPage,
+  options,
+  PAGE_NAMES,
+  recordBenefitTypeEvent,
+  validateBenefitType,
+} from '../../../shared/utils/start-page';
 
 const content = {
   groupLabel:
     'What type of claim are you requesting a Higher-Level Review for?',
   errorMessage: 'You must choose a claim type.',
 };
-
-const options = [
-  {
-    value: 'compensation',
-    label: 'Disability compensation claim',
-  },
-  {
-    value: pageNames.other,
-    label: 'A claim other than disability compensation',
-  },
-];
-
-const optionValues = options.map(option => option.value);
-
-const getNextPage = data =>
-  data?.benefitType === optionValues[0]
-    ? `${BASE_URL}/introduction` // valid benefit type, go to intro page
-    : pageNames.other; // benefit type not supported
-
-const validate = ({ benefitType } = {}) => optionValues.includes(benefitType);
 
 /**
  * Benefit type page
@@ -52,17 +34,11 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
       focusElement('#main h2');
     });
   }, []);
+
   const handlers = {
     setBenefitType: event => {
       const { value } = event.detail;
       setPageData({ benefitType: value || null });
-
-      recordEvent({
-        event: 'howToWizard-formChange',
-        'form-field-type': 'form-radio-buttons',
-        'form-field-label': content.groupLabel,
-        'form-field-value': value,
-      });
     },
   };
 
@@ -120,9 +96,11 @@ BenefitType.propTypes = {
 };
 
 export default {
-  name: pageNames.start,
+  name: PAGE_NAMES.start,
   component: BenefitType,
-  validate,
+  validate: ({ benefitType } = {}) => validateBenefitType(benefitType),
   back: null,
-  next: getNextPage,
+  next: data => getNextPage(BASE_URL, data),
+  onContinue: benefitType =>
+    recordBenefitTypeEvent(benefitType, content.groupLabel),
 };

--- a/src/applications/appeals/996/tests/subtask/subtask.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/subtask/subtask.unit.spec.jsx
@@ -30,9 +30,18 @@ const mockStore = ({ data = {} } = {}) => {
       },
     }),
     subscribe: () => {},
-    dispatch: () => ({
-      setFormData: () => {},
-    }),
+    dispatch: action => {
+      if (action && typeof action === 'function') {
+        return action(mockStore.dispatch, mockStore.getState);
+      }
+
+      // Handle SET_DATA action to update storeData
+      if (action && action.type === 'SET_DATA') {
+        Object.assign(data, action.data);
+      }
+
+      return action;
+    },
   };
 };
 
@@ -48,111 +57,139 @@ describe('the HLR Sub-task', () => {
       </Provider>,
     );
     const form = $('form[data-page="start"]', container);
+
     expect(form).to.exist;
     expect($('va-radio-option[value="compensation"]', form)).to.exist;
     expect($('va-radio-option[value="other"]', form)).to.exist;
     expect($('va-button[continue]', container)).to.exist;
   });
 
-  it('should go to the "other" SubTask page and back to "start"', () => {
-    const { container } = render(
-      <Provider store={mockStore({ data: { benefitType: 'other' } })}>
-        <SubTaskContainer />
-      </Provider>,
-    );
+  describe('when "disability compensation" is selected for type of claim', () => {
+    it('should go to the Introduction page when complete', () => {
+      global.window.dataLayer = [];
+      const router = { push: sinon.spy() };
+      // using SubTask here since SubTaskContainer isn't passing the router to the
+      // SubTask component
+      const { container } = render(
+        <Provider store={mockStore({ data: {} })}>
+          <SubTask pages={pages} router={router} />
+        </Provider>,
+      );
 
-    expect($('form[data-page="start"]', container)).to.exist;
+      $('va-radio', container).__events.vaValueChange({
+        detail: { value: 'compensation' },
+      });
 
-    fireEvent.click($('va-button[continue]', container));
-    expect($('form[data-page="other"]', container)).to.exist;
-    expect($('va-link[download]', container)).to.exist;
-
-    fireEvent.click($('va-button[back]', container));
-    expect($('form[data-page="start"]', container)).to.exist;
-  });
-
-  it('should show an error when no selection is made', async () => {
-    const { container } = render(
-      <Provider store={mockStore()}>
-        <SubTaskContainer />
-      </Provider>,
-    );
-
-    expect($('form[data-page="start"]', container)).to.exist;
-    const vaRadio = $('va-radio', container);
-    expect(vaRadio).to.exist;
-    expect(vaRadio.error).to.be.null;
-
-    // testing empty value branch
-    $('va-radio', container).__events.vaValueChange({ detail: {} });
-
-    fireEvent.click($('va-button[continue]', container));
-
-    await waitFor(() => {
       expect($('form[data-page="start"]', container)).to.exist;
-      expect(vaRadio.error).to.contain('choose a claim type');
+      fireEvent.click($('va-button[continue]', container));
+
+      const event = global.window.dataLayer[0];
+
+      expect(event).to.deep.equal({
+        event: 'howToWizard-formChange',
+        'form-field-type': 'form-radio-buttons',
+        'form-field-label':
+          'What type of claim are you requesting a Higher-Level Review for?',
+        'form-field-value': 'compensation',
+      });
+
+      expect(router.push.args[0][0]).to.include('/introduction');
     });
   });
-  it('should go to the Introduction page when complete', () => {
-    global.window.dataLayer = [];
-    const router = { push: sinon.spy() };
-    // using SubTask here since SubTaskContainer isn't passing the router to the
-    // SubTask component
-    const { container } = render(
-      <Provider store={mockStore({ data: {} })}>
-        <SubTask pages={pages} router={router} />
-      </Provider>,
-    );
 
-    $('va-radio', container).__events.vaValueChange({
-      detail: { value: 'compensation' },
+  describe('when "other" is selected for type of claim', () => {
+    it('should go to the "other" SubTask page and back to "start"', () => {
+      const { container } = render(
+        <Provider store={mockStore({ data: { benefitType: 'other' } })}>
+          <SubTaskContainer />
+        </Provider>,
+      );
+
+      expect($('form[data-page="start"]', container)).to.exist;
+
+      fireEvent.click($('va-button[continue]', container));
+
+      const firstEvent = global.window.dataLayer[0];
+
+      expect(firstEvent).to.deep.equal({
+        event: 'howToWizard-formChange',
+        'form-field-type': 'form-radio-buttons',
+        'form-field-label':
+          'What type of claim are you requesting a Higher-Level Review for?',
+        'form-field-value': 'other',
+      });
+
+      const secondEvent = global.window.dataLayer[1];
+
+      expect(secondEvent).to.deep.equal({
+        event: 'howToWizard-alert-displayed',
+        'reason-for-alert': 'veteran wants to submit an unsupported claim type',
+      });
+
+      expect($('form[data-page="other"]', container)).to.exist;
+      expect($('va-link[download]', container)).to.exist;
+
+      fireEvent.click($('va-button[back]', container));
+      expect($('form[data-page="start"]', container)).to.exist;
     });
 
-    expect($('form[data-page="start"]', container)).to.exist;
+    it('should record "other" page find benefit office link click', () => {
+      global.window.dataLayer = [];
+      const router = { push: () => {} };
+      // using SubTask here since SubTaskContainer isn't passing the router to the
+      // SubTask component
+      const { container } = render(
+        <Provider store={mockStore({ data: {} })}>
+          <SubTask pages={pages} router={router} />
+        </Provider>,
+      );
 
-    const event = global.window.dataLayer.slice(-1)[0];
-    expect(event).to.deep.equal({
-      event: 'howToWizard-formChange',
-      'form-field-type': 'form-radio-buttons',
-      'form-field-label':
-        'What type of claim are you requesting a Higher-Level Review for?',
-      'form-field-value': 'compensation',
+      $('va-radio', container).__events.vaValueChange({
+        detail: { value: 'other' },
+      });
+
+      fireEvent.click($('va-button[continue]', container));
+      expect($('va-button[back]', container)).to.exist;
+
+      fireEvent.click($('[href*="file-by-mail-in-person"]', container));
+
+      const event = global.window.dataLayer.slice(-1)[0];
+      expect(event).to.deep.equal({
+        event: 'howToWizard-alert-link-click',
+        'howToWizard-alert-link-click-label': 'benefit office',
+      });
     });
-
-    fireEvent.click($('va-button[continue]', container));
-    expect(router.push.args[0][0]).to.include('/introduction');
   });
 
-  it('should record "other" page find benefit office link click', () => {
-    global.window.dataLayer = [];
-    const router = { push: () => {} };
-    // using SubTask here since SubTaskContainer isn't passing the router to the
-    // SubTask component
-    const { container } = render(
-      <Provider store={mockStore({ data: {} })}>
-        <SubTask pages={pages} router={router} />
-      </Provider>,
-    );
+  describe('when no selection is made', () => {
+    it('should show an error', async () => {
+      const { container } = render(
+        <Provider store={mockStore()}>
+          <SubTaskContainer />
+        </Provider>,
+      );
 
-    $('va-radio', container).__events.vaValueChange({
-      detail: { value: 'other' },
-    });
+      expect($('form[data-page="start"]', container)).to.exist;
+      const vaRadio = $('va-radio', container);
+      expect(vaRadio).to.exist;
+      expect(vaRadio.error).to.be.null;
 
-    fireEvent.click($('va-button[continue]', container));
-    expect($('va-button[back]', container)).to.exist;
+      // testing empty value branch
+      $('va-radio', container).__events.vaValueChange({ detail: {} });
 
-    fireEvent.click($('[href*="file-by-mail-in-person"]', container));
+      fireEvent.click($('va-button[continue]', container));
 
-    const event = global.window.dataLayer.slice(-1)[0];
-    expect(event).to.deep.equal({
-      event: 'howToWizard-alert-link-click',
-      'howToWizard-alert-link-click-label': 'benefit office',
+      await waitFor(() => {
+        expect($('form[data-page="start"]', container)).to.exist;
+        expect(vaRadio.error).to.contain('choose a claim type');
+      });
     });
   });
 
   it('should check validate fallback to default (checking branches)', () => {
     expect(pages[0].validate()).to.eq(false);
   });
+
   it('should check setBenefitType fallback', () => {
     const setPageDataSpy = sinon.spy();
     const StartPage = pages[0].component;

--- a/src/applications/appeals/shared/components/SubTaskWrap.jsx
+++ b/src/applications/appeals/shared/components/SubTaskWrap.jsx
@@ -1,20 +1,34 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import SubTask from '~/platform/forms/sub-task';
 
 import GetFormHelp from '../content/GetFormHelp';
 
-const SubTaskWrap = ({ pages }) => (
-  <>
-    <div className="vads-u-margin-bottom--4">
-      <SubTask pages={pages} focusOnAlertRole />
-    </div>
-    <va-need-help>
-      <div slot="content">
-        <GetFormHelp />
+const SubTaskWrap = ({ pages }) => {
+  return (
+    <>
+      <div className="vads-u-margin-bottom--4">
+        <SubTask pages={pages} focusOnAlertRole />
       </div>
-    </va-need-help>
-  </>
-);
+      <va-need-help>
+        <div slot="content">
+          <GetFormHelp />
+        </div>
+      </va-need-help>
+    </>
+  );
+};
+
+SubTaskWrap.propTypes = {
+  pages: PropTypes.arrayOf(
+    PropTypes.shape({
+      back: PropTypes.string,
+      component: PropTypes.component,
+      name: PropTypes.string,
+      next: PropTypes.func,
+      validate: PropTypes.func,
+    }),
+  ),
+};
 
 export default SubTaskWrap;

--- a/src/applications/appeals/shared/components/SubTaskWrap.jsx
+++ b/src/applications/appeals/shared/components/SubTaskWrap.jsx
@@ -4,20 +4,18 @@ import SubTask from '~/platform/forms/sub-task';
 
 import GetFormHelp from '../content/GetFormHelp';
 
-const SubTaskWrap = ({ pages }) => {
-  return (
-    <>
-      <div className="vads-u-margin-bottom--4">
-        <SubTask pages={pages} focusOnAlertRole />
+const SubTaskWrap = ({ pages }) => (
+  <>
+    <div className="vads-u-margin-bottom--4">
+      <SubTask pages={pages} focusOnAlertRole />
+    </div>
+    <va-need-help>
+      <div slot="content">
+        <GetFormHelp />
       </div>
-      <va-need-help>
-        <div slot="content">
-          <GetFormHelp />
-        </div>
-      </va-need-help>
-    </>
-  );
-};
+    </va-need-help>
+  </>
+);
 
 SubTaskWrap.propTypes = {
   pages: PropTypes.arrayOf(

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -1,4 +1,12 @@
 /**
+ **** BENEFIT TYPES ****
+ */
+// Including a default until we determine how to get around the user restarting
+// the application after using the "Finish this application later" link
+// See https://dsva.slack.com/archives/C0113MPTGH5/p1600725048027200
+export const DEFAULT_BENEFIT_TYPE = 'compensation';
+
+/**
  **** KEYS ****
  */
 // key for contestableIssues to indicate that the user selected the issue

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -1,9 +1,6 @@
 /**
  **** BENEFIT TYPES ****
  */
-// Including a default until we determine how to get around the user restarting
-// the application after using the "Finish this application later" link
-// See https://dsva.slack.com/archives/C0113MPTGH5/p1600725048027200
 export const DEFAULT_BENEFIT_TYPE = 'compensation';
 
 /**

--- a/src/applications/appeals/shared/utils/start-page.js
+++ b/src/applications/appeals/shared/utils/start-page.js
@@ -1,0 +1,56 @@
+// These utilities are used for Supplemental Claims and Higher-Level Review /start pages
+// where we ask about whether the user is filing for a disability compensation claim or
+// a claim other than disability compensation. If you select "a claim other than disability
+// compensation", you are seeing the "other" page rather than the "start" page (although the
+// URL remains the same)
+import recordEvent from 'platform/monitoring/record-event';
+import { DEFAULT_BENEFIT_TYPE } from '../constants';
+
+export const PAGE_NAMES = {
+  start: 'start',
+  other: 'other',
+};
+
+export const recordBenefitTypeEvent = (benefitType, label) => {
+  recordEvent({
+    event: 'howToWizard-formChange',
+    'form-field-type': 'form-radio-buttons',
+    'form-field-label': label,
+    'form-field-value': benefitType,
+  });
+
+  if (benefitType !== DEFAULT_BENEFIT_TYPE) {
+    recordEvent({
+      event: 'howToWizard-alert-displayed',
+      'reason-for-alert': 'veteran wants to submit an unsupported claim type',
+    });
+  }
+};
+
+export const options = [
+  {
+    value: DEFAULT_BENEFIT_TYPE,
+    label: 'Disability compensation claim',
+  },
+  {
+    value: PAGE_NAMES.other,
+    label: 'A claim other than disability compensation',
+  },
+];
+
+export const optionValues = options.map(option => option.value);
+
+export const getNextPage = (baseUrl, data) =>
+  data?.benefitType === optionValues[0]
+    ? `${baseUrl}/introduction` // valid benefit type, go to intro page
+    : PAGE_NAMES.other; // benefit type not supported
+
+export const validateBenefitType = benefitType =>
+  optionValues.includes(benefitType);
+
+export const recordBenefitOfficeClickEvent = () => {
+  recordEvent({
+    event: 'howToWizard-alert-link-click',
+    'howToWizard-alert-link-click-label': 'benefit office',
+  });
+};

--- a/src/platform/forms/sub-task/index.js
+++ b/src/platform/forms/sub-task/index.js
@@ -149,7 +149,16 @@ export const SubTask = props => {
 
   const continueButton =
     getDestinationPage(currentPage.next) !== null ? (
-      <va-button continue onClick={() => pageCheck('next')}>
+      <va-button
+        continue
+        onClick={() => {
+          pageCheck('next');
+
+          if (currentPage.onContinue) {
+            currentPage.onContinue(formData);
+          }
+        }}
+      >
         Continue
       </va-button>
     ) : null;
@@ -209,6 +218,7 @@ SubTask.propTypes = {
   setFormData: PropTypes.func.isRequired,
   focusOnAlertRole: PropTypes.bool,
   formData: PropTypes.shape({}),
+  onContinue: PropTypes.func,
 };
 
 export default withRouter(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Problem: On the start screens of Supplemental Claims and Higher Level Review, there is a question about the type of claim the user is trying to submit (disability or other). When a radio button is chosen from this group, the same Google Analytics event is fired twice. If the user clicks again on a different radio button, the same Google Analytics event may be fired another one or two times.

[Per Amy's guidance](https://dsva.slack.com/archives/C5AGLBNRK/p1761685757989529), we moved the analytics event to only happen when the **Continue** button is clicked. The event has the same contents, and should only be fired one time.

While I was making updates I noticed we had another event that logged only when you reach the "A claim other than disability compensation" page. That one was firing twice as well so I moved it so that it only fires one time.

I discovered that there was a lot of duplicated functionality between the two `/start` pages for SC & HLR, so there is some refactor in here for that as well.

A reminder about how to log analytics events in the browser:
1. Add a Chrome extension called `Adswerve - dataLayer Inspector+`
2. Enable the extension and reload your browser
3. Open the console and click away!

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111690

## Testing done

Screen recording of the events happening when clicking on both filing options for Supplemental Claims and Higher-Level Review.

https://github.com/user-attachments/assets/5ed71f36-48e7-4dba-9c0a-561c4e92b759