### PR TITLE
adds context to sign-in modal close button label

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -34,6 +34,7 @@ export default function SignInModal() {
       visible={visible}
       onCloseEvent={onClose}
       id="signin-signup-modal"
+      label="sign-in"
     >
       <LoginContainer />
     </VaModal>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- UX reseach pointed out that the `sign-in modal` close button ("x") has a generic `close modal` label
- That doesn't inform screenreader users that it's the sign-in modal that they're closing
- `Va-Modal` provides the functionality to add context between `close` and `modal` on the close button ("x")
- By adding `label='sign-in'` the close button ("x") on the modal will now read `close sign-in modal` to screenreader users

## Related issue(s)

A11y change to sign-in modal close button [#827](https://github.com/department-of-veterans-affairs/identity-documentation/issues/827)
[Slack thread](https://dsva.slack.com/archives/C8E985R32/p1761248028372679)

## Testing done

- all unit tests pass. no updates needed.

## Acceptance criteria

- sign-in modal label reads `close sign-in modal`


