### PR TITLE
fix(526): Fix flaky utils failing timezones in unit tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils/dates/formatting.js
+++ b/src/applications/disability-benefits/all-claims/utils/dates/formatting.js
@@ -300,6 +300,15 @@ export const isWithinServicePeriod = (date, servicePeriods = []) => {
 };
 
 /**
+ * Get current date/time as a moment object
+ * Uses local timezone, with time stripped to start of day for date-only comparisons
+ * @returns {moment.Moment} Current date at start of day (00:00:00)
+ */
+export const getCurrentDate = () => {
+  return moment().startOf('day');
+};
+
+/**
  * Parse a date string
  * @param {string} dateString - Date to parse
  * @param {string} format - Optional format

--- a/src/applications/disability-benefits/all-claims/utils/dates/index.js
+++ b/src/applications/disability-benefits/all-claims/utils/dates/index.js
@@ -26,6 +26,7 @@ export {
   isWithinRange,
   isWithinServicePeriod,
   // Parsing functions
+  getCurrentDate,
   parseDate,
   parseDateWithTemplate,
   // BDD-specific functions

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -1,8 +1,8 @@
 import _ from 'platform/utilities/data';
 import some from 'lodash/some';
-import moment from 'moment';
 
 import {
+  getCurrentDate,
   parseDate,
   isTreatmentBeforeService,
   findEarliestServiceDate,
@@ -276,7 +276,7 @@ export const isInFuture = (err, fieldData) => {
 export const isLessThan180DaysInFuture = (errors, fieldData) => {
   const enteredDate = parseDate(fieldData);
   if (enteredDate && enteredDate.isValid()) {
-    const today = moment().startOf('day');
+    const today = getCurrentDate();
     const in180Days = today.clone().add(180, 'days');
 
     if (enteredDate.isBefore(today)) {
@@ -640,8 +640,8 @@ export const validateSeparationDate = (
     return;
   }
 
-  // Get today using local timezone (not UTC)
-  const today = moment().startOf('day');
+  // Get today using centralized date utility (local timezone)
+  const today = getCurrentDate();
 
   // If a reservist is activated, they are considered to be active duty.
   // Inactive or active reserves may have a future separation date.
@@ -703,7 +703,7 @@ export const validateTitle10StartDate = (
       return b > a ? -1 : 1;
     });
   const activationDate = parseDate(dateString);
-  const today = moment().startOf('day');
+  const today = getCurrentDate();
   if (activationDate && activationDate.isAfter(today)) {
     errors.addError('Enter an activation date in the past');
   } else if (!startTimes[0] || dateString < startTimes[0]) {

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -1,5 +1,6 @@
 import _ from 'platform/utilities/data';
 import some from 'lodash/some';
+import moment from 'moment';
 
 import {
   parseDate,
@@ -275,7 +276,7 @@ export const isInFuture = (err, fieldData) => {
 export const isLessThan180DaysInFuture = (errors, fieldData) => {
   const enteredDate = parseDate(fieldData);
   if (enteredDate && enteredDate.isValid()) {
-    const today = parseDate(new Date().toISOString().split('T')[0]);
+    const today = moment().startOf('day');
     const in180Days = today.clone().add(180, 'days');
 
     if (enteredDate.isBefore(today)) {
@@ -639,8 +640,8 @@ export const validateSeparationDate = (
     return;
   }
 
-  // Get today as a moment object by parsing the current date
-  const today = parseDate(new Date().toISOString().split('T')[0]);
+  // Get today using local timezone (not UTC)
+  const today = moment().startOf('day');
 
   // If a reservist is activated, they are considered to be active duty.
   // Inactive or active reserves may have a future separation date.
@@ -702,7 +703,7 @@ export const validateTitle10StartDate = (
       return b > a ? -1 : 1;
     });
   const activationDate = parseDate(dateString);
-  const today = parseDate(new Date().toISOString().split('T')[0]);
+  const today = moment().startOf('day');
   if (activationDate && activationDate.isAfter(today)) {
     errors.addError('Enter an activation date in the past');
   } else if (!startTimes[0] || dateString < startTimes[0]) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders

### TeamSites

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

**Bug Fix: Timezone-dependent test failures in Form 526EZ date validation**

### The Bug

Three unit tests failed in Pacific timezone but passed in UTC due to timezone handling in date validation:

- `validateSeparationDate` - "should not allow future end service dates > 180 days"
- `validateSeparationDate` - "should set error for reservist with separation date > 180 days"
- `validateTitle10StartDate` - "should show an error for an activation date in the future"

<img width="853" alt="Failing tests" src="https://github.com/user-attachments/assets/7fc90a9e-1ced-466a-bb8c-bcb848f7828e" />

### Root Cause

PR #38966 refactored to use centralized date utilities but incorrectly used `parseDate(new Date().toISOString().split('T')[0])` to get "today":

- `.toISOString()` converts to UTC time (not local)
- Misused `parseDate()` which is for parsing user input strings, not getting current time
- Created off-by-one day error: Pacific 5pm Oct 29 → UTC midnight Oct 30

### Solution

Added `getCurrentDate()` utility to centralized date utils and replaced buggy usage:

```javascript
// Before (buggy - uses UTC):
const today = parseDate(new Date().toISOString().split('T')[0]);

// After (fixed - uses local time):
const today = getCurrentDate();  // Returns moment().startOf('day')
````

Changes:

* Added getCurrentDate() to `utils/dates/formatting.js`
* Exported from `utils/dates/index.js`
* Updated 3 validation functions to use centralized utility
* No moment.js added to `validations.js` - maintains centralization

Team: Disability Benefits Pathways
No feature flipper required

### Related issue(s)

* Original refactor: department-of-veterans-affairs/vets-website#38966

### Testing done

#### How to Reproduce

Run in Pacific timezone:
`yarn test:unit src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx`

#### Tests Verified

* All 3 previously failing tests now pass
* All other validation tests still pass (regression check)
* Verified all 3 buggy instances fixed (lines 279, 643, 706)

### Known Gaps

* No E2E testing (validation logic only, no UI changes)
* Low production impact: edge case affects users in specific timezones entering dates exactly 180/90 days in future

### Screenshots

N/A - Backend validation logic only, no UI changes

### What areas of the site does it impact?

Form 526EZ date validation:

* Separation date validation (BDD: 90-180 days future; non-BDD active duty: ≤90 days)
* Title 10 activation dates (Reserve/National Guard must be in past)
* Anticipated separation dates

### Acceptance criteria

#### Quality Assurance & Testing

* Unit tests pass without failures
* No sensitive information in logging/hardcoded/specs
* Linting warnings addressed
* Documentation updated (inline comments)
* No UI changes - screenshots N/A
* No a11y changes - testing N/A

