### PR TITLE
Adding flipper for 526 DD RUM

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -68,6 +68,7 @@
   "disabilityCompensationToxicExposureDestructionModal": "disability_compensation_toxic_exposure_destruction_modal",
   "disability526ToxicExposureOptOutDataPurge": "disability_526_toxic_exposure_opt_out_data_purge",
   "disability526ToxicExposureOptOutDataPurgeByUser": "disability_526_toxic_exposure_opt_out_data_purge_by_user",
+  "disability526BrowserMonitoringEnabled": "disability_526_browser_monitoring_enabled",
   "disablityBenefitsBrowserMonitoringEnabled": "disablity_benefits_browser_monitoring_enabled",
   "disabilityCompNewConditionsWorkflow": "disability_compensation_new_conditions_workflow",
   "dischargeWizardFeatures": "discharge_wizard_features",


### PR DESCRIPTION
> NOTE: [Someone already took ](https://github.com/department-of-veterans-affairs/vets-website/blame/c6c402761f95a7f9811aa0fb995df551d6c48f09/src/platform/utilities/feature-toggles/featureFlagNames.json#L71C26-L71C26) `disablityBenefitsBrowserMonitoringEnabled` which is what we would have used... so I have to make it something else.

## Summary

- *This work is behind a feature toggle (flipper): YES
  - `disability526BrowserMonitoringEnabled`(FE)/`disability_526_browser_monitoring_enabled`(BE)
- *(Summarize the changes that have been made to the platform)*
  - Adding a a flipper for DD RUM for 526
- *(If bug, how to reproduce)*: N/A
- *(What is the solution, why is this the solution?)*: N/A
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits and Claim Core Form Team, yes we will own it.
- *(If introducing a flipper, what is the success criteria being targeted?)*
  - Will enable in staging, test and check RUM sessions showing up in DD, and confirming there is no PII leaks

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/123020


