### PR TITLE
0969 | Post MVP - Update unreported assets relationship and information pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/06-asset-transfers/assetTransferPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/06-asset-transfers/assetTransferPages.js
@@ -678,7 +678,7 @@ export const assetTransferPages = arrayBuilderPages(options, pageBuilder => ({
     schema: nonVeteranIncomeRecipientPage.schema,
   }),
   // When claimantType is 'CHILD' we skip showing the recipient page entirely
-  // To preserve required data, we auto-set recipientRelationship to 'CHILD'
+  // To preserve required data, we auto-set originalOwnerRelationship to 'CHILD'
   assetTransferInformationPage: pageBuilder.itemPage({
     title: 'Asset transfer information',
     path: 'asset-transfers/:index/information',

--- a/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
@@ -63,6 +63,24 @@ export const options = {
               {formatCurrency(item.marketValueAtEstablishment)}
             </span>
           </li>
+          {item?.receivingIncomeFromAnnuity &&
+            item?.annualReceivedIncome && (
+              <li>
+                Annual income:{' '}
+                <span className="vads-u-font-weight--bold">
+                  {formatCurrency(item.annualReceivedIncome)}
+                </span>
+              </li>
+            )}
+          {item?.addedFundsAfterEstablishment &&
+            item?.addedFundsAmount && (
+              <li>
+                Money added:{' '}
+                <span className="vads-u-font-weight--bold">
+                  {formatCurrency(item.addedFundsAmount)}
+                </span>
+              </li>
+            )}
         </ul>
       ),
     reviewAddButtonText: 'Add another annuity',
@@ -274,7 +292,7 @@ const incomePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Income from annuity'),
     receivingIncomeFromAnnuity: yesNoUI({
-      title: 'Did you receive income from this annuity?',
+      title: 'Do you receive income from this annuity?',
       ...sharedYesNoOptionsBase,
     }),
     annualReceivedIncome: {

--- a/src/applications/income-and-asset-statement/config/chapters/09-unreported-assets/unreportedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/09-unreported-assets/unreportedAssetPages.js
@@ -19,12 +19,21 @@ import {
   generateDeleteDescription,
   isDefined,
   otherAssetOwnerRelationshipExplanationRequired,
+  otherRecipientRelationshipExplanationRequired,
   requireExpandedArrayField,
+  sharedRecipientRelationshipBase,
   showUpdatedContent,
   sharedYesNoOptionsBase,
 } from '../../../helpers';
-import { relationshipLabels } from '../../../labels';
+import {
+  custodianRelationshipLabels,
+  parentRelationshipLabels,
+  relationshipLabels,
+  relationshipLabelDescriptions,
+  spouseRelationshipLabels,
+} from '../../../labels';
 import { UnreportedAssetsSummaryDescription } from '../../../components/SummaryDescriptions';
+import { DependentDescription } from '../../../components/DependentDescription';
 
 /** @type {ArrayBuilderOptions} */
 export const options = {
@@ -88,6 +97,7 @@ const updatedTitleNoItems =
   'Did you or your dependents have any assets you haven’t already reported?';
 const updatedTitleWithItems = 'Do you have more assets to report?';
 const summaryPageTitle = 'Other Assets';
+const incomeRecipientPageTitle = 'Unreported asset relationship information';
 const yesNoOptionLabels = {
   Y: 'Yes, I have an asset to report',
   N: 'No, I don’t have an asset to report',
@@ -219,8 +229,162 @@ const parentSummaryPage = {
   },
 };
 
+const updatedSharedRecipientRelationshipBase = {
+  ...sharedRecipientRelationshipBase,
+  title: 'What’s the relationship of the original asset owner to the Veteran?',
+};
+
+const otherRecipientRelationshipTypeUI = {
+  'ui:title':
+    'Describe who owned the asset and how are they related to the Veteran',
+  'ui:webComponentField': VaTextInputField,
+  'ui:options': {
+    expandUnder: 'assetOwnerRelationship',
+    expandUnderCondition: 'OTHER',
+    expandedContentFocus: true,
+  },
+  'ui:required': (formData, index) =>
+    otherRecipientRelationshipExplanationRequired(
+      formData,
+      index,
+      'unreportedAssets',
+    ),
+};
+
 /** @returns {PageSchema} */
-const relationshipPage = {
+const veteranIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Asset owner relationship',
+      nounSingular: options.nounSingular,
+    }),
+    assetOwnerRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: Object.fromEntries(
+        Object.entries(relationshipLabels).filter(
+          ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      descriptions: relationshipLabelDescriptions,
+    }),
+    otherAssetOwnerRelationshipType: otherRecipientRelationshipTypeUI,
+    'ui:options': {
+      ...requireExpandedArrayField('otherAssetOwnerRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      assetOwnerRelationship: radioSchema(
+        Object.keys(relationshipLabels).filter(
+          key => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      otherAssetOwnerRelationshipType: { type: 'string' },
+    },
+    required: ['assetOwnerRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const spouseIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Asset owner relationship',
+      nounSingular: options.nounSingular,
+    }),
+    assetOwnerRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: spouseRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key === 'CHILD',
+        ),
+      ),
+    }),
+    otherAssetOwnerRelationshipType: otherRecipientRelationshipTypeUI,
+    'ui:options': {
+      ...requireExpandedArrayField('otherAssetOwnerRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      assetOwnerRelationship: radioSchema(
+        Object.keys(spouseRelationshipLabels),
+      ),
+      otherAssetOwnerRelationshipType: { type: 'string' },
+    },
+    required: ['assetOwnerRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const custodianIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Asset owner relationship',
+      nounSingular: options.nounSingular,
+    }),
+    assetOwnerRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: custodianRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key !== 'CHILD',
+        ),
+      ),
+    }),
+    otherAssetOwnerRelationshipType: otherRecipientRelationshipTypeUI,
+    'ui:options': {
+      ...requireExpandedArrayField('otherAssetOwnerRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      assetOwnerRelationship: radioSchema(
+        Object.keys(custodianRelationshipLabels),
+      ),
+      otherAssetOwnerRelationshipType: { type: 'string' },
+    },
+    required: ['assetOwnerRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const parentIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Asset owner relationship',
+      nounSingular: options.nounSingular,
+    }),
+    assetOwnerRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: parentRelationshipLabels,
+      descriptions: {
+        SPOUSE: 'The Veteran’s other parent should file a separate claim',
+      },
+    }),
+    otherAssetOwnerRelationshipType: otherRecipientRelationshipTypeUI,
+    'ui:options': {
+      ...requireExpandedArrayField('otherAssetOwnerRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      assetOwnerRelationship: radioSchema(
+        Object.keys(parentRelationshipLabels),
+      ),
+      otherAssetOwnerRelationshipType: { type: 'string' },
+    },
+    required: ['assetOwnerRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const nonVeteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Unreported asset owner relationship',
@@ -256,19 +420,20 @@ const relationshipPage = {
 };
 
 /** @returns {PageSchema} */
-const assetTypePage = {
+const informationPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Unreported asset type'),
+    ...arrayBuilderItemSubsequentPageTitleUI('Asset information'),
     assetType: textUI({
-      title: 'What is the type of asset?',
-      hint: 'Cash, art, etc',
+      title: 'What type of asset is it?',
+      hint: 'Examples: Cash, art',
     }),
     ownedPortionValue: currencyUI(
-      'What is the value of your portion of the property?',
+      'How much is your portion of this asset worth?',
     ),
     assetLocation: textUI({
-      title: 'Where is the asset located?',
-      hint: 'Financial institution, property address, etc.',
+      title: 'Asset’s location?',
+      hint:
+        'Name of the financial institution or the property address of the asset location',
     }),
   },
   schema: {
@@ -331,16 +496,77 @@ export const unreportedAssetPages = arrayBuilderPages(options, pageBuilder => ({
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,
   }),
-  unreportedAssetRelationshipPage: pageBuilder.itemPage({
-    title: 'Unreported asset owner relationship',
-    path: 'unreported-assets/:index/relationship',
-    uiSchema: relationshipPage.uiSchema,
-    schema: relationshipPage.schema,
+  unreportedAssetVeteranRecipientPage: pageBuilder.itemPage({
+    ContentBeforeButtons: showUpdatedContent() ? (
+      <DependentDescription claimantType="VETERAN" />
+    ) : null,
+    title: incomeRecipientPageTitle,
+    path: 'unreported-assets/:index/veteran-income-recipient',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'VETERAN',
+    uiSchema: veteranIncomeRecipientPage.uiSchema,
+    schema: veteranIncomeRecipientPage.schema,
   }),
-  unreportedAssetTypePage: pageBuilder.itemPage({
-    title: 'Unreported asset type',
-    path: 'unreported-assets/:index/asset-type',
-    uiSchema: assetTypePage.uiSchema,
-    schema: assetTypePage.schema,
+  unreportedAssetSpouseRecipientPage: pageBuilder.itemPage({
+    ContentBeforeButtons: showUpdatedContent() ? (
+      <DependentDescription claimantType="SPOUSE" />
+    ) : null,
+    title: incomeRecipientPageTitle,
+    path: 'unreported-assets/:index/spouse-income-recipient',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'SPOUSE',
+    uiSchema: spouseIncomeRecipientPage.uiSchema,
+    schema: spouseIncomeRecipientPage.schema,
+  }),
+  unreportedAssetCustodianRecipientPage: pageBuilder.itemPage({
+    ContentBeforeButtons: showUpdatedContent() ? (
+      <DependentDescription claimantType="CUSTODIAN" />
+    ) : null,
+    title: incomeRecipientPageTitle,
+    path: 'unreported-assets/:index/custodian-income-recipient',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+    uiSchema: custodianIncomeRecipientPage.uiSchema,
+    schema: custodianIncomeRecipientPage.schema,
+  }),
+  unreportedAssetParentRecipientPage: pageBuilder.itemPage({
+    ContentBeforeButtons: showUpdatedContent() ? (
+      <DependentDescription claimantType="PARENT" />
+    ) : null,
+    title: incomeRecipientPageTitle,
+    path: 'unreported-assets/:index/parent-income-recipient',
+    depends: formData =>
+      showUpdatedContent() && formData.claimantType === 'PARENT',
+    uiSchema: parentIncomeRecipientPage.uiSchema,
+    schema: parentIncomeRecipientPage.schema,
+  }),
+  unreportedAssetNonVeteranRecipientPage: pageBuilder.itemPage({
+    title: incomeRecipientPageTitle,
+    path: 'unreported-assets/:index/income-recipient',
+    depends: () => !showUpdatedContent(),
+    uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
+    schema: nonVeteranIncomeRecipientPage.schema,
+  }),
+  // When claimantType is 'CHILD' we skip showing the recipient page entirely
+  // To preserve required data, we auto-set assetOwnerRelationship to 'CHILD'
+  unreportedAssetInformationPage: pageBuilder.itemPage({
+    title: 'Unreported asset information',
+    path: 'unreported-assets/:index/information',
+    uiSchema: {
+      ...informationPage.uiSchema,
+      'ui:options': {
+        updateSchema: (formData, formSchema, _uiSchema, index) => {
+          const arrayData = formData?.unreportedAssets || [];
+          const item = arrayData[index];
+          if (formData.claimantType === 'CHILD' && item) {
+            item.assetOwnerRelationship = 'CHILD';
+          }
+          return {
+            ...formSchema,
+          };
+        },
+      },
+    },
+    schema: informationPage.schema,
   }),
 }));

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/09-annuities/annuityPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/09-annuities/annuityPages.unit.spec.jsx
@@ -198,7 +198,7 @@ describe('annuity list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-radio[label="Did you receive income from this annuity?"]'],
+      ['va-radio[label="Do you receive income from this annuity?"]'],
       'income',
     );
     testSubmitsWithoutErrors(

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/10-unreported-assets/unreportedAssetPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/10-unreported-assets/unreportedAssetPages.unit.spec.jsx
@@ -91,10 +91,10 @@ describe('unreported asset list and loop pages', () => {
 
   describe('relationship page', () => {
     const schema =
-      unreportedAssetPages.unreportedAssetRelationshipPage.schema.properties
-        .unreportedAssets.items;
+      unreportedAssetPages.unreportedAssetNonVeteranRecipientPage.schema
+        .properties.unreportedAssets.items;
     const uiSchema =
-      unreportedAssetPages.unreportedAssetRelationshipPage.uiSchema
+      unreportedAssetPages.unreportedAssetNonVeteranRecipientPage.uiSchema
         .unreportedAssets.items;
 
     testNumberOfFieldsByType(
@@ -132,11 +132,11 @@ describe('unreported asset list and loop pages', () => {
 
   describe('type page', () => {
     const schema =
-      unreportedAssetPages.unreportedAssetTypePage.schema.properties
+      unreportedAssetPages.unreportedAssetInformationPage.schema.properties
         .unreportedAssets.items;
     const uiSchema =
-      unreportedAssetPages.unreportedAssetTypePage.uiSchema.unreportedAssets
-        .items;
+      unreportedAssetPages.unreportedAssetInformationPage.uiSchema
+        .unreportedAssets.items;
 
     testNumberOfFieldsByType(
       formConfig,
@@ -150,9 +150,9 @@ describe('unreported asset list and loop pages', () => {
       schema,
       uiSchema,
       [
-        'va-text-input[label="What is the type of asset?"]',
-        'va-text-input[label="What is the value of your portion of the property?"]',
-        'va-text-input[label="Where is the asset located?"]',
+        'va-text-input[label="What type of asset is it?"]',
+        'va-text-input[label="How much is your portion of this asset worth?"]',
+        'va-text-input[label="Asset’s location?"]',
       ],
       'type',
     );


### PR DESCRIPTION
## Summary

This PR updates the **Unreported Assets** chapter in the **Income and Asset Statement form (VA Form 21P-0969)** as part of the **Post-MVP content and design QA alignment**.  
The changes apply to both the **Relationship to Veteran** and **Information** pages, refining page titles, question phrasing, and hint text to follow VA Design System (VADS) content patterns and ensure clarity across claimant types.

## Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111728  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111729  

## Related issue(s)

- Complements prior Post-MVP updates to **Unreported Assets summary pages** (issues #111727 and #111730)  
- Follows the same content alignment and list-and-loop consistency patterns used in **Trusts**, **Annuities**, and **Royalties** chapters  

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the form:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Progress to the **Unreported Assets** chapter  

## How to verify

1. Navigate to the **Unreported Assets** chapter and add a new item.  
2. Review updated content on:
   - **Relationship to Veteran** page  
   - **Information** page  
3. Confirm:
   - Titles, body text, and hint content match Post-MVP copy guidance  
   - Label and input field ordering follow VADS recommendations  
   - Updated plain language phrasing improves readability and comprehension  
   - Conditional logic still correctly displays fields based on claimant type  
4. Add and remove entries to verify list-and-loop flow remains consistent.  
5. Confirm summary pages reflect new data fields and that Review & Submit displays the entered data accurately.  
6. Verify accessibility:
   - Heading hierarchy and ARIA structure are valid  
   - No console errors or validation regressions  

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- **Unreported Assets** chapter  
  - Relationship to Veteran page  
  - Information page  

## Screenshots

| Before | After |
|--------|-------|
| Legacy content  | Updated Post-MVP titles, copy, and VADS-aligned patterns |

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- 0969 Post-MVP Unreported Assets chapter enhancements  
- **Behind** `income_and_assets_content_updates` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm that the updated Relationship to Veteran and Information pages match Design QA copy, maintain correct conditional behavior, and follow Post-MVP list-and-loop standards across claimant types.