### PR TITLE
Persist chatbot auth code to prevent re-auth prompt after reload

### DIFF
--- a/src/applications/virtual-agent/hooks/useChatbotToken.js
+++ b/src/applications/virtual-agent/hooks/useChatbotToken.js
@@ -10,6 +10,8 @@ import {
   getTokenKey,
   setConversationIdKey,
   setTokenKey,
+  getCodeKey,
+  setCodeKey,
 } from '../utils/sessionStorage';
 
 async function getToken(setToken, setCode, setLoadingStatus, forceNew = false) {
@@ -31,6 +33,7 @@ async function getToken(setToken, setCode, setLoadingStatus, forceNew = false) {
       setToken(existingToken);
     }
     setCode(response.code);
+    setCodeKey(response.code);
     setLoadingStatus(COMPLETE);
   } catch (ex) {
     const error = new Error('Could not retrieve chatbot token');
@@ -63,8 +66,15 @@ export default function useChatbotToken() {
       const existingConversationId = getConversationIdKey();
       const existingToken = getTokenKey();
       if (existingConversationId && existingToken) {
-        setToken(existingToken);
-        setLoadingStatus(COMPLETE);
+        const existingCode = getCodeKey();
+        if (existingCode) {
+          setToken(existingToken);
+          setCode(existingCode);
+          setLoadingStatus(COMPLETE);
+          return;
+        }
+        // If code is missing, fetch to obtain a new code while preserving existing conversation
+        getToken(setToken, setCode, setLoadingStatus);
         return;
       }
 

--- a/src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx
@@ -9,12 +9,14 @@ import {
   getLoggedInFlow,
   getRecentUtterances,
   getTokenKey,
+  getCodeKey,
   setConversationIdKey,
   setInAuthExp,
   setIsTrackingUtterances,
   setLoggedInFlow,
   setRecentUtterances,
   setTokenKey,
+  setCodeKey,
   storeUtterances,
 } from '../../utils/sessionStorage';
 
@@ -107,6 +109,18 @@ describe('sessionStorage', () => {
       expect(result).to.equal('def');
     });
   });
+  describe('codeKey', () => {
+    it('should get code key', () => {
+      sessionStorage.setItem('va-bot.code', 'ghi');
+      const result = getCodeKey();
+      expect(result).to.equal('ghi');
+    });
+    it('should set code key', () => {
+      setCodeKey('ghi');
+      const result = sessionStorage.getItem('va-bot.code');
+      expect(result).to.equal('ghi');
+    });
+  });
   describe('clearBotSessionStorage', () => {
     it('should clear bot session storage items with prefixed keys when forceClear is true', () => {
       // Set up the sessionStorage mock with the desired values
@@ -158,7 +172,7 @@ describe('sessionStorage', () => {
       expect(itemToNotClear).to.be.equal('strawberry');
     });
 
-    it('should preserve firstConnection (raw), conversationId and token by default and clear other keys', () => {
+    it('should preserve firstConnection (raw), conversationId, token, and code by default and clear other keys', () => {
       // Ensure default clearing path triggers (both not 'true')
       sessionStorage.removeItem('va-bot.loggedInFlow');
       sessionStorage.removeItem('va-bot.inAuthExperience');
@@ -167,6 +181,7 @@ describe('sessionStorage', () => {
       sessionStorage.setItem('va-bot.firstConnection', 'false');
       setConversationIdKey('abc');
       setTokenKey('def');
+      setCodeKey('ghi');
 
       // Set other bot-prefixed keys (should be cleared)
       sessionStorage.setItem('va-bot.itemToClear', 'banana');
@@ -180,6 +195,7 @@ describe('sessionStorage', () => {
       );
       expect(getConversationIdKey()).to.equal('abc');
       expect(getTokenKey()).to.equal('def');
+      expect(getCodeKey()).to.equal('ghi');
 
       // Others cleared
       expect(sessionStorage.getItem('va-bot.itemToClear')).to.be.null;


### PR DESCRIPTION
# Summary
- Fixes an issue where authenticated users are prompted to sign in again after a page reload when asking “Claims Status”.
- Persists and reuses the chatbot `code` in sessionStorage so the bot can re-establish authenticated context on `startConversation`.
- If `token`/`conversationId` exist but `code` is missing, fetches a fresh `code` while preserving the existing session.

Closes: [#2683](https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/2683)

# Root Cause
- On reload, the client reused `token` and `conversationId` but did not persist or resend the one-time `code` to the bot.
- Backend [WelcomeDialog.setup()](cci:1://file:///Users/mattkerns/dev/projects/va-virtual-agent/skills/va-root-bot/dialogs/welcomeDialog.js:33:2-47:3) expects `value.code` on the `startConversation` event to resolve the user. Without it, [MainDialog.decideRouter()](cci:1://file:///Users/mattkerns/dev/projects/va-virtual-agent/skills/va-root-bot/dialogs/mainDialog.js:257:2-320:3) routes to `SIGNIN` for authenticated skills like “Claim Status”.

# Changes
- **useChatbotToken.js**
  - Persist `code` via [setCodeKey](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:86:0-88:1) and read via [getCodeKey](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:82:0-84:1).
  - With session persistence:
    - If `token`/`conversationId`/`code` exist: reuse all, no fetch.
    - If `token`/`conversationId` exist but `code` missing: call `/chatbot/token` to obtain a new `code` and keep existing `token`/`conversationId`.
  - When persistence is off: force a fresh token/conversation.
- No changes to [actions.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/actions.js:0:0-0:0) payload shape (still sends `value.code` on `startConversation`).
- [sessionStorage.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:0:0-0:0) already excludes `CODE_KEY` from lifecycle clears.

# Files Touched
- vets-website
  - src/applications/virtual-agent/hooks/useChatbotToken.js
  - Tests:
    - src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
    - src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx

# Tests
- **Updated**
  - useChatbotToken
    - Stores `va-bot.code` on fresh session.
    - Reuses `token/conversationId/code` without network fetch when persistence is ON.
    - Fetches to obtain `code` if missing while preserving existing `token/conversationId`.
  - sessionStorage
    - Added [getCodeKey](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:82:0-84:1)/[setCodeKey](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:86:0-88:1) tests.
    - Ensures `CODE_KEY` is preserved by default in [clearBotSessionStorage](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:92:0-135:1).

# Feature Toggles
- Requires `virtualAgentChatbotSessionPersistenceEnabled` to reuse session state across reloads.
- Compatible with `virtualAgentUseStsAuthentication`.

# QA Steps
- **Happy path**
  - Log in (Dev).
  - Open chatbot, ask “Claims Status” → no sign-in prompt.
  - Reload the page.
  - Ask “Claims Status” again → still no sign-in prompt.
- **Edge**
  - Start a session, clear only `va-bot.code`.
  - Reload → client fetches fresh `code` and proceeds authenticated.
- Validate top nav shows logged-in state (sitewide session). Note: Nav login state is independent of chatbot; this change fixes the chatbot flow.

# Risk & Mitigations
- **Risk**: `code` expires between reloads.
  - **Mitigation**: If `code` missing/invalid, the hook requests a new `code`.
- **Risk**: Session clear removes critical keys.
  - **Mitigation**: [clearBotSessionStorage](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:92:0-135:1) excludes `TOKEN_KEY`, `CONVERSATION_ID_KEY`, and `CODE_KEY` by default.
- **Scope**: Frontend-only; no backend changes.

# Performance/Telemetry
- No additional calls in steady state. Only one extra token request if `code` is missing on reload.
- Errors still reported via `logErrorToDatadog`.

# Rollback Plan
- Revert [useChatbotToken.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useChatbotToken.js:0:0-0:0) and test changes.
- No data migrations required.

# Screenshots
- N/A

# Acceptance Criteria
- Authenticated users remain authenticated after reload.
- “Claims Status” does not prompt to sign in again when already logged in.
- Unit tests pass for updated code persistence behavior.