### PR TITLE
21P-8416 update text and config for chapter 2 array builder pages

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -19,7 +19,12 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import { recipientTypeLabels, careTypeLabels } from '../../../utils/labels';
-import { transformDate } from './helpers';
+import {
+  transformDate,
+  hideIfInHomeCare,
+  requiredIfInHomeCare,
+  getCostPageTitle,
+} from './helpers';
 
 function introDescription() {
   return (
@@ -93,27 +98,40 @@ function introDescription() {
   );
 }
 
+function checkIsItemIncomplete(item) {
+  return (
+    !item?.typeOfCare ||
+    !item?.recipient ||
+    ((item.recipient === 'DEPENDENT' || item.recipient === 'OTHER') &&
+      !item?.recipientName) ||
+    !item?.provider ||
+    !item?.careDateRange?.from ||
+    !item?.monthlyAmount ||
+    (item?.typeOfCare === 'IN_HOME_CARE_ATTENDANT' &&
+      (!item?.hourlyRate || !item?.weeklyHours))
+  );
+}
+
 /** @type {ArrayBuilderOptions} */
 export const options = {
   arrayPath: 'careExpenses',
   nounSingular: 'care expense',
   nounPlural: 'care expenses',
   required: false,
-  isItemIncomplete: item =>
-    !item?.typeOfCare ||
-    !item?.recipient ||
-    ((item.recipient === 'DEPENDENT' || item.recipient === 'OTHER') &&
-      !item?.recipientName) ||
-    !item?.provider ||
-    !item?.careDate?.from ||
-    !item?.monthlyAmount ||
-    (item?.typeOfCare === 'IN_HOME_CARE_ATTENDANT' &&
-      (!item?.hourlyRate || !item?.weeklyHours)),
-  maxItems: 5,
+  isItemIncomplete: item => checkIsItemIncomplete(item),
+  maxItems: 8,
   text: {
     getItemName: item =>
       careTypeLabels[(item?.typeOfCare)] || 'New care expense',
-    cardDescription: item => transformDate(item?.careDate?.from) || '',
+    cardDescription: item => transformDate(item?.careDateRange?.from) || '',
+    cancelAddTitle: 'Cancel adding this care expense?',
+    cancelEditTitle: 'Cancel editing this care expense?',
+    cancelAddDescription:
+      'If you cancel, we won’t add this expense to your list of care expenses. You’ll return to a page where you can add a new care expense.',
+    cancelAddYes: 'Yes, cancel adding',
+    cancelAddNo: 'No, continue adding',
+    cancelEditYes: 'Yes, cancel editing',
+    cancelEditNo: 'No, continue editing',
   },
 };
 
@@ -211,7 +229,7 @@ const datePage = {
       'Care provider’s name and dates of care',
     ),
     provider: textUI('What’s the name of the care provider?'),
-    careDate: currentOrPastDateRangeUI(
+    careDateRange: currentOrPastDateRangeUI(
       {
         title: 'Care start date',
         monthSelect: false,
@@ -227,7 +245,7 @@ const datePage = {
     type: 'object',
     properties: {
       provider: textSchema,
-      careDate: {
+      careDateRange: {
         ...currentOrPastDateRangeSchema,
         required: ['from'],
       },
@@ -248,32 +266,20 @@ const costPage = {
     hourlyRate: {
       ...currencyUI({
         title: 'What is the care provider’s hourly rate?',
-        hideIf: (formData, index, fullData) => {
-          const careExpenses = formData?.careExpenses ?? fullData?.careExpenses;
-          const careExpense = careExpenses?.[index];
-          return careExpense?.typeOfCare !== 'IN_HOME_CARE_ATTENDANT';
-        },
+        hideIf: (formData, index, fullData) =>
+          hideIfInHomeCare(formData, index, fullData),
       }),
-      'ui:required': (formData, index, fullData) => {
-        const careExpenses = formData?.careExpenses ?? fullData?.careExpenses;
-        const careExpense = careExpenses?.[index];
-        return careExpense?.typeOfCare === 'IN_HOME_CARE_ATTENDANT';
-      },
+      'ui:required': (formData, index, fullData) =>
+        requiredIfInHomeCare(formData, index, fullData),
     },
     weeklyHours: {
       ...numberUI({
         title: 'How many hours per week does the care provider work?',
-        hideIf: (formData, index, fullData) => {
-          const careExpenses = formData?.careExpenses ?? fullData?.careExpenses;
-          const careExpense = careExpenses?.[index];
-          return careExpense?.typeOfCare !== 'IN_HOME_CARE_ATTENDANT';
-        },
+        hideIf: (formData, index, fullData) =>
+          hideIfInHomeCare(formData, index, fullData),
       }),
-      'ui:required': (formData, index, fullData) => {
-        const careExpenses = formData?.careExpenses ?? fullData?.careExpenses;
-        const careExpense = careExpenses?.[index];
-        return careExpense?.typeOfCare === 'IN_HOME_CARE_ATTENDANT';
-      },
+      'ui:required': (formData, index, fullData) =>
+        requiredIfInHomeCare(formData, index, fullData),
     },
   },
   schema: {
@@ -319,10 +325,7 @@ export const careExpensesPages = arrayBuilderPages(options, pageBuilder => ({
     schema: datePage.schema,
   }),
   careExpensesCostPage: pageBuilder.itemPage({
-    title: ({ formData }) => {
-      const provider = formData?.provider ?? '';
-      return provider ? `Cost of care for ${provider}` : 'Cost of care';
-    },
+    title: ({ formData }) => getCostPageTitle(formData),
     path: 'expenses/care/:index/cost',
     uiSchema: costPage.uiSchema,
     schema: costPage.schema,

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -18,6 +18,7 @@ import {
   arrayBuilderYesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { getArrayUrlSearchParams } from '~/platform/forms-system/src/js/patterns/array-builder/helpers';
 import { recipientTypeLabels, careTypeLabels } from '../../../utils/labels';
 import {
   transformDate,
@@ -177,7 +178,14 @@ const summaryPage = {
 /** @returns {PageSchema} */
 const typeOfCarePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Type of care'),
+    ...arrayBuilderItemSubsequentPageTitleUI('Type of care', () => {
+      const search = getArrayUrlSearchParams();
+      const isEdit = search.get('edit');
+      if (isEdit) {
+        return 'We’ll take you through each of the sections of this care expense for you to review and edit.';
+      }
+      return null;
+    }),
     typeOfCare: radioUI({
       title: 'Select the type of care.',
       labels: careTypeLabels,

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/helpers.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/helpers.js
@@ -29,3 +29,62 @@ export const hasCareExpenses = formData => {
   const careExpenses = formData.careExpenses || [];
   return careExpenses.length > 0;
 };
+
+/**
+ * @param formData
+ * @param index
+ * @param fullData
+ * @returns boolean - false if in home attendant, true otherwise.
+ */
+export const hideIfInHomeCare = (formData, index, fullData) => {
+  const careExpenses = formData?.careExpenses ?? fullData?.careExpenses;
+  const careExpense = careExpenses?.[index];
+  return careExpense?.typeOfCare !== 'IN_HOME_CARE_ATTENDANT';
+};
+
+/**
+ * @param formData
+ * @param index
+ * @param fullData
+ * @returns boolean - true if in home attendant, true otherwise.
+ */
+export const requiredIfInHomeCare = (formData, index, fullData) => {
+  const careExpenses = formData?.careExpenses ?? fullData?.careExpenses;
+  const careExpense = careExpenses?.[index];
+  return careExpense?.typeOfCare === 'IN_HOME_CARE_ATTENDANT';
+};
+
+/**
+ * @param formData
+ * @returns string - cost page title.
+ */
+export const getCostPageTitle = formData => {
+  const provider = formData?.provider ?? '';
+  return provider ? `Cost of care for ${provider}` : 'Cost of care';
+};
+
+/**
+ * @param formData
+ * @param index
+ * @param fullData
+ * @returns boolean - true if in home attendant, true otherwise.
+ */
+export const requiredIfMileageReimbursed = (formData, index, fullData) => {
+  const mileageExpenses =
+    formData?.mileageExpenses ?? fullData?.mileageExpenses;
+  const mileageExpense = mileageExpenses?.[index];
+  return mileageExpense?.travelReimbursed === true;
+};
+
+/**
+ * @param formData
+ * @param index
+ * @param fullData
+ * @returns boolean - true if in home attendant, true otherwise.
+ */
+export const requiredIfMileageLocationOther = (formData, index, fullData) => {
+  const mileageExpenses =
+    formData?.mileageExpenses ?? fullData?.mileageExpenses;
+  const mileageExpense = mileageExpenses?.[index];
+  return mileageExpense?.travelLocation === 'OTHER';
+};

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/medicalExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/medicalExpensesPage.js
@@ -52,17 +52,37 @@ function introDescription() {
   );
 }
 
+function checkIsItemIncomplete(item) {
+  return (
+    !item?.recipient ||
+    ((item.recipient === 'DEPENDENT' || item.recipient === 'OTHER') &&
+      !item?.recipientName) ||
+    !item?.paymentDate ||
+    !item?.purpose ||
+    !item?.paymentFrequency ||
+    !item?.paymentAmount
+  );
+}
+
 /** @type {ArrayBuilderOptions} */
 export const options = {
   arrayPath: 'medicalExpenses',
   nounSingular: 'medical expense',
   nounPlural: 'medical expenses',
   required: false,
-  isItemIncomplete: item => !item?.recipient || !item?.paymentDate,
-  maxItems: 5,
+  isItemIncomplete: item => checkIsItemIncomplete(item),
+  maxItems: 14,
   text: {
     getItemName: item => item?.provider || 'Provider',
     cardDescription: item => ItemDescription(item),
+    cancelAddTitle: 'Cancel adding this medical expense?',
+    cancelEditTitle: 'Cancel editing this medical expense?',
+    cancelAddDescription:
+      'If you cancel, we won’t add this expense to your list of medical expenses. You’ll return to a page where you can add a new medical expense.',
+    cancelAddYes: 'Yes, cancel adding',
+    cancelAddNo: 'No, continue adding',
+    cancelEditYes: 'Yes, cancel editing',
+    cancelEditNo: 'No, continue editing',
   },
 };
 
@@ -134,7 +154,7 @@ const recipientPage = {
       recipient: radioSchema(Object.keys(recipientTypeLabels)),
       recipientName: textSchema,
     },
-    required: ['recipient', 'recipientName'],
+    required: ['recipient'],
   },
 };
 

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/medicalExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/medicalExpensesPage.js
@@ -14,6 +14,7 @@ import {
   arrayBuilderYesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { getArrayUrlSearchParams } from '~/platform/forms-system/src/js/patterns/array-builder/helpers';
 import {
   careFrequencyLabels,
   recipientTypeLabels,
@@ -128,7 +129,14 @@ const summaryPage = {
 /** @returns {PageSchema} */
 const recipientPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Medical recipient'),
+    ...arrayBuilderItemSubsequentPageTitleUI('Medical recipient', () => {
+      const search = getArrayUrlSearchParams();
+      const isEdit = search.get('edit');
+      if (isEdit) {
+        return 'We’ll take you through each of the sections of this medical expense for you to review and edit.';
+      }
+      return null;
+    }),
     recipient: radioUI({
       title: 'Who’s the expense for?',
       labels: recipientTypeLabels,

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
@@ -18,6 +18,7 @@ import {
   arrayBuilderYesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { getArrayUrlSearchParams } from '~/platform/forms-system/src/js/patterns/array-builder/helpers';
 import {
   recipientTypeLabels,
   travelLocationLabels,
@@ -52,7 +53,8 @@ function checkIsItemIncomplete(item) {
     (item.travelLocation === 'OTHER' && !item?.travelLocationOther) ||
     !item?.travelDate ||
     !item?.travelMilesTraveled ||
-    !item?.travelReimbursed
+    (item?.travelReimbursed !== false &&
+      (item.travelReimbursed === true && !item?.travelReimbursementAmount))
   );
 }
 
@@ -120,7 +122,14 @@ const summaryPage = {
 /** @returns {PageSchema} */
 const travelerPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Traveler information'),
+    ...arrayBuilderItemSubsequentPageTitleUI('Traveler information', () => {
+      const search = getArrayUrlSearchParams();
+      const isEdit = search.get('edit');
+      if (isEdit) {
+        return 'We’ll take you through each of the sections of this mileage expense for you to review and edit.';
+      }
+      return null;
+    }),
     traveler: radioUI({
       title: 'Who needed to travel?',
       labels: recipientTypeLabels,

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/careExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/careExpensesPage.unit.spec.jsx
@@ -250,7 +250,7 @@ describe('Care Expenses Pages', () => {
   });
   it('should return the correct card description with paymentDate', () => {
     const item = {
-      careDate: {
+      careDateRange: {
         from: '2004-04-04',
       },
       typeOfCare: 'RESIDENTIAL',
@@ -261,5 +261,42 @@ describe('Care Expenses Pages', () => {
     );
     expect(nameText('Residential care facility')).to.exist;
     expect(descriptionText('04/04/2004')).to.exist;
+  });
+  it('should return default card description', () => {
+    const item = {
+      typeOfCare: 'BLAH',
+    };
+    const { getByText: nameText } = render(options.text.getItemName(item));
+    expect(nameText('New care expense')).to.exist;
+  });
+  it('should check if the item is incomplete', () => {
+    const completeItem = {
+      typeOfCare: 'RESIDENTIAL',
+      recipient: 'SPOUSE',
+      provider: 'Provider Name',
+      careDateRange: { from: '2004-04-04' },
+      monthlyAmount: 1200,
+    };
+    const incompleteNoHourlyItem = {
+      typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+      recipient: 'DEPENDENT',
+      recipientName: 'John Doe',
+      provider: 'Provider Name',
+      careDateRange: { from: '2004-04-04' },
+      monthlyAmount: 800,
+      weeklyHours: 20,
+    };
+    const incompleteNoWeeklyItem = {
+      typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+      recipient: 'DEPENDENT',
+      recipientName: 'John Doe',
+      provider: 'Provider Name',
+      careDateRange: { from: '2004-04-04' },
+      monthlyAmount: 800,
+      hourlyRate: 20,
+    };
+    expect(options.isItemIncomplete(completeItem)).to.be.false;
+    expect(options.isItemIncomplete(incompleteNoHourlyItem)).to.be.true;
+    expect(options.isItemIncomplete(incompleteNoWeeklyItem)).to.be.true;
   });
 });

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/helpers.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/helpers.unit.spec.jsx
@@ -1,0 +1,170 @@
+import { expect } from 'chai';
+import {
+  hideIfInHomeCare,
+  requiredIfInHomeCare,
+  getCostPageTitle,
+  requiredIfMileageLocationOther,
+} from '../../../../config/chapters/02-expenses/helpers';
+
+describe('Chapter 2 helpers', () => {
+  describe('hideIfInHomeCare', () => {
+    it('should return false if typeOfCare is IN_HOME_CARE_ATTENDANT', () => {
+      const formData = {
+        careExpenses: [
+          {
+            typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+          },
+        ],
+      };
+      const result = hideIfInHomeCare(formData, 0);
+      expect(result).to.be.false;
+    });
+
+    it('should return true if typeOfCare is not IN_HOME_CARE_ATTENDANT', () => {
+      const formData = {
+        careExpenses: [
+          {
+            typeOfCare: 'OTHER',
+          },
+        ],
+      };
+      const result = hideIfInHomeCare(formData, 0);
+      expect(result).to.be.true;
+    });
+
+    it('should return false if fullData has typeOfCare as IN_HOME_CARE_ATTENDANT', () => {
+      const fullData = {
+        careExpenses: [
+          {
+            typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+          },
+        ],
+      };
+      const result = hideIfInHomeCare({}, 0, fullData);
+      expect(result).to.be.false;
+    });
+
+    it('should return true if fullData has typeOfCare not IN_HOME_CARE_ATTENDANT', () => {
+      const fullData = {
+        careExpenses: [
+          {
+            typeOfCare: 'OTHER',
+          },
+        ],
+      };
+      const result = hideIfInHomeCare({}, 0, fullData);
+      expect(result).to.be.true;
+    });
+  });
+  describe('requiredIfInHomeCare', () => {
+    it('should return true if typeOfCare is IN_HOME_CARE_ATTENDANT', () => {
+      const formData = {
+        careExpenses: [
+          {
+            typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+          },
+        ],
+      };
+      const result = requiredIfInHomeCare(formData, 0);
+      expect(result).to.be.true;
+    });
+
+    it('should return false if typeOfCare is not IN_HOME_CARE_ATTENDANT', () => {
+      const formData = {
+        careExpenses: [
+          {
+            typeOfCare: 'OTHER',
+          },
+        ],
+      };
+      const result = requiredIfInHomeCare(formData, 0);
+      expect(result).to.be.false;
+    });
+
+    it('should return true if fullData has typeOfCare as IN_HOME_CARE_ATTENDANT', () => {
+      const fullData = {
+        careExpenses: [
+          {
+            typeOfCare: 'IN_HOME_CARE_ATTENDANT',
+          },
+        ],
+      };
+      const result = requiredIfInHomeCare({}, 0, fullData);
+      expect(result).to.be.true;
+    });
+
+    it('should return false if fullData has typeOfCare not IN_HOME_CARE_ATTENDANT', () => {
+      const fullData = {
+        careExpenses: [
+          {
+            typeOfCare: 'OTHER',
+          },
+        ],
+      };
+      const result = requiredIfInHomeCare({}, 0, fullData);
+      expect(result).to.be.false;
+    });
+  });
+  describe('requiredIfMileageLocationOther', () => {
+    it('should return true if travelLocation is OTHER', () => {
+      const formData = {
+        mileageExpenses: [
+          {
+            travelLocation: 'OTHER',
+          },
+        ],
+      };
+      const result = requiredIfMileageLocationOther(formData, 0);
+      expect(result).to.be.true;
+    });
+
+    it('should return false if travelLocation is not OTHER', () => {
+      const formData = {
+        mileageExpenses: [
+          {
+            travelLocation: 'CLINIC',
+          },
+        ],
+      };
+      const result = requiredIfMileageLocationOther(formData, 0);
+      expect(result).to.be.false;
+    });
+
+    it('should return true if fullData has travelLocation as OTHER', () => {
+      const fullData = {
+        mileageExpenses: [
+          {
+            travelLocation: 'OTHER',
+          },
+        ],
+      };
+      const result = requiredIfMileageLocationOther({}, 0, fullData);
+      expect(result).to.be.true;
+    });
+
+    it('should return false if fullData travelLocation is not OTHER', () => {
+      const fullData = {
+        mileageExpenses: [
+          {
+            travelLocation: 'CLINIC',
+          },
+        ],
+      };
+      const result = requiredIfMileageLocationOther({}, 0, fullData);
+      expect(result).to.be.false;
+    });
+  });
+  describe('getCostPageTitle', () => {
+    it('should return "Cost of care" when provider is not specified', () => {
+      const formData = {};
+      const result = getCostPageTitle(formData);
+      expect(result).to.equal('Cost of care');
+    });
+
+    it('should return "Cost of care for [provider]" when provider is specified', () => {
+      const formData = { provider: 'Dr Doe' };
+      const result = getCostPageTitle(formData);
+      expect(result).to.equal('Cost of care for Dr Doe');
+    });
+  });
+});

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/medicalExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/medicalExpensesPage.unit.spec.jsx
@@ -198,4 +198,22 @@ describe('Medical Expenses Pages', () => {
     expect(queryByText('04/04/2004')).to.not.exist;
     expect(queryByText('Once a month')).to.not.exist;
   });
+  it('should check if the item is incomplete', () => {
+    const completeItem = {
+      recipient: 'SPOUSE',
+      paymentDate: '2004-04-04',
+      purpose: 'Medical supplies',
+      paymentFrequency: 'ONCE_MONTH',
+      paymentAmount: 200,
+    };
+    const incompleteItem = {
+      recipient: 'DEPENDENT',
+      paymentDate: '2004-04-04',
+      purpose: 'Medical supplies',
+      paymentFrequency: 'ONCE_MONTH',
+      paymentAmount: 200,
+    };
+    expect(options.isItemIncomplete(completeItem)).to.be.false;
+    expect(options.isItemIncomplete(incompleteItem)).to.be.true;
+  });
 });

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/mileageExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/mileageExpensesPage.unit.spec.jsx
@@ -197,6 +197,7 @@ describe('Mileage Expense Pages', () => {
       travelDate: '2004-04-04',
       travelMilesTraveled: 100,
       travelReimbursed: true,
+      travelReimbursementAmount: 50,
     };
     const completeItem2 = {
       traveler: 'OTHER',
@@ -205,7 +206,7 @@ describe('Mileage Expense Pages', () => {
       travelLocationOther: 'Some other place',
       travelDate: '2004-04-04',
       travelMilesTraveled: 100,
-      travelReimbursed: true,
+      travelReimbursed: false,
     };
     const incompleteNoTravelLocation = {
       traveler: 'DEPENDENT',
@@ -220,7 +221,7 @@ describe('Mileage Expense Pages', () => {
       travelLocation: 'PHARMACY',
       travelDate: '2004-04-04',
       travelMilesTraveled: 100,
-      travelReimbursed: true,
+      travelReimbursed: false,
     };
     expect(options.isItemIncomplete(completeItem)).to.be.false;
     expect(options.isItemIncomplete(completeItem2)).to.be.false;

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/mileageExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/mileageExpensesPage.unit.spec.jsx
@@ -188,4 +188,43 @@ describe('Mileage Expense Pages', () => {
     const { getByText } = render(options.text.cardDescription(item));
     expect(getByText('04/04/2004')).to.exist;
   });
+  it('should check if the item is incomplete', () => {
+    const completeItem = {
+      traveler: 'DEPENDENT',
+      travelerName: 'John Doe',
+      travelLocation: 'OTHER',
+      travelLocationOther: 'Some other place',
+      travelDate: '2004-04-04',
+      travelMilesTraveled: 100,
+      travelReimbursed: true,
+    };
+    const completeItem2 = {
+      traveler: 'OTHER',
+      travelerName: 'John Doe',
+      travelLocation: 'OTHER',
+      travelLocationOther: 'Some other place',
+      travelDate: '2004-04-04',
+      travelMilesTraveled: 100,
+      travelReimbursed: true,
+    };
+    const incompleteNoTravelLocation = {
+      traveler: 'DEPENDENT',
+      travelerName: 'John Doe',
+      travelLocation: 'OTHER',
+      travelDate: '2004-04-04',
+      travelMilesTraveled: 100,
+      travelReimbursed: true,
+    };
+    const incompleteNoTravelerName = {
+      traveler: 'DEPENDENT',
+      travelLocation: 'PHARMACY',
+      travelDate: '2004-04-04',
+      travelMilesTraveled: 100,
+      travelReimbursed: true,
+    };
+    expect(options.isItemIncomplete(completeItem)).to.be.false;
+    expect(options.isItemIncomplete(completeItem2)).to.be.false;
+    expect(options.isItemIncomplete(incompleteNoTravelLocation)).to.be.true;
+    expect(options.isItemIncomplete(incompleteNoTravelerName)).to.be.true;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add hint text on first page during edit mode.
- Set correct max number of items per list section
- Update careDate to careDateRange to match new schema
- Add custom modal text for each of the array builder pages
- Update `isItemIncomplete` functions for each page
- Break out some reused functions into helpers
- Add more unit tests to cover the above changes 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122364
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122363
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122365

## Testing done

- Manual testing 
- Added unit more unit tests to cover custom non config code changes

## Screenshots

<img width="504" height="381" alt="Screenshot 2025-10-30 at 10 09 47 AM" src="https://github.com/user-attachments/assets/0c2c0737-ac08-41e8-aca7-2d29f867168e" /> <img width="519" height="399" alt="Screenshot 2025-10-30 at 10 09 26 AM" src="https://github.com/user-attachments/assets/c18e29c6-3456-440a-8c7f-a97a6b3628a3" /> <img width="505" height="382" alt="Screenshot 2025-10-30 at 10 09 09 AM" src="https://github.com/user-attachments/assets/df6ae4f6-44c3-43f8-acd8-0d9912c329b2" /> <img width="507" height="388" alt="Screenshot 2025-10-30 at 10 08 48 AM" src="https://github.com/user-attachments/assets/1397d52f-1ae7-4234-a28b-a6155dcc4b5e" /> <img width="523" height="352" alt="Screenshot 2025-10-30 at 10 08 28 AM" src="https://github.com/user-attachments/assets/3f8b8890-9e71-4b66-9adb-784b12ea2119" /> <img width="522" height="381" alt="Screenshot 2025-10-30 at 10 08 09 AM" src="https://github.com/user-attachments/assets/627520b9-a5a1-41bf-b810-9c490225288f" />



## What areas of the site does it impact?

Chapter 2 of the 21P-8416

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
