### PR TITLE
534EZ Household Information - Claimant Marriages

### DIFF
--- a/src/applications/survivors-benefits/components/FormAlerts/index.jsx
+++ b/src/applications/survivors-benefits/components/FormAlerts/index.jsx
@@ -1,6 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+export const CourtOrderSeparationAlert = () => (
+  <va-alert-expandable
+    status="warning"
+    trigger="You'll need to submit a copy of the court order."
+    disable-border="true"
+  >
+    We’ll ask you to upload this document at the end of this application. Or you
+    can send it to us by mail.
+  </va-alert-expandable>
+);
+
+export const AdditionalMarriagesAlert = () => (
+  <va-alert-expandable
+    status="warning"
+    trigger="You'll need to submit VA Form 21-4138"
+    disable-border="true"
+  >
+    <p>
+      You’ll need to submit a Statement in Support of Claim (VA Form 21-4138) as
+      needed to provide the information for each additional marriage.
+    </p>
+    <p>
+      We’ll ask you to upload these documents at the end of this application. Or
+      you can send it to us by mail.
+    </p>
+    <p>
+      <va-link
+        href="/find-forms/about-form-21-4138/"
+        external
+        text="Get VA Form 21-4138 to download"
+      />
+    </p>
+  </va-alert-expandable>
+);
+
 const RequestFormAlert = ({
   title,
   formName,
@@ -52,15 +87,4 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
     formLink="https://www.va.gov/find-forms/about-form-21-2680/"
     advisory="A licensed medical professional must complete this form."
   />
-);
-
-export const CourtOrderSeparationAlert = () => (
-  <va-alert-expandable
-    status="warning"
-    trigger="You'll need to submit a copy of the court order."
-    disable-border="true"
-  >
-    We’ll ask you to upload this document at the end of this application. Or you
-    can send it to us by mail.
-  </va-alert-expandable>
 );

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/additionalMarriages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/additionalMarriages.js
@@ -1,0 +1,39 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { isYes } from '../05-claim-information/helpers';
+import { AdditionalMarriagesAlert } from '../../../components/FormAlerts';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Additional marriages',
+  path: 'household/additional-marriages',
+  depends: formData =>
+    formData.claimantRelationship === 'SPOUSE' && formData.remarried === true,
+  uiSchema: {
+    ...titleUI('Additional marriages'),
+    additionalMarriages: yesNoUI({
+      title: 'Did you have more than 1 marriage after the Veteran death?',
+    }),
+    additionalMarriagesAlert: {
+      'ui:description': AdditionalMarriagesAlert,
+      'ui:options': {
+        hideIf: formData => !isYes(formData?.additionalMarriages),
+        displayEmptyObjectOnReview: true,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['additionalMarriages'],
+    properties: {
+      additionalMarriages: yesNoSchema,
+      additionalMarriagesAlert: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriages.js
@@ -1,0 +1,30 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Previous marriages',
+  path: 'household/previous-marriage-question',
+  depends: formData => formData.claimantRelationship === 'SPOUSE',
+  uiSchema: {
+    ...titleUI('Previous marriages'),
+    recognizedAsSpouse: yesNoUI({
+      title: 'Did we recognize you as a Veteran spouse before their death?',
+    }),
+    hadPreviousMarriages: yesNoUI({
+      title:
+        'Were you or the Veteran married to anyone else before you married each other?',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['recognizedAsSpouse', 'hadPreviousMarriages'],
+    properties: {
+      recognizedAsSpouse: yesNoSchema,
+      hadPreviousMarriages: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -1,0 +1,471 @@
+import React from 'react';
+import {
+  arrayBuilderItemFirstPageTitleUI,
+  arrayBuilderYesNoSchema,
+  arrayBuilderYesNoUI,
+  fullNameSchema,
+  fullNameUI,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+  textUI,
+  selectUI,
+  radioUI,
+  radioSchema,
+  checkboxUI,
+  checkboxSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import constants from 'vets-json-schema/dist/constants.json';
+import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
+import { previousMarriageEndOptions } from '../../../utils/labels';
+
+const handleAlertMaxItems = () => (
+  <div>
+    You have added the maximum number of allowed previous marriages for this
+    application. Additional marriages can be added using VA Form 21-4138 and
+    uploaded at the end of this application.
+    <va-link
+      href="/find-forms/about-form-21-4138/"
+      external
+      text="Get VA Form 21-4138 to download"
+    />
+  </div>
+);
+
+// Helper function to determine if previous marriages section should be shown
+const shouldShowPreviousMarriages = formData => {
+  // Skip if YES recognized as spouse AND NO only ever married to each other
+  if (
+    formData.recognizedAsSpouse === true &&
+    formData.hadPreviousMarriages === false
+  ) {
+    return false;
+  }
+  // Show if NO not recognized as spouse OR YES have been married before
+  return (
+    formData.recognizedAsSpouse === false ||
+    formData.hadPreviousMarriages === true
+  );
+};
+
+// Get military states to filter them out
+const MILITARY_STATE_VALUES = constants.militaryStates.map(
+  state => state.value,
+);
+
+// Get states from the same source as the addressUI component
+const filteredStates = constants.states.USA.filter(
+  state => !MILITARY_STATE_VALUES.includes(state.value),
+);
+const STATE_VALUES = filteredStates.map(state => state.value);
+const STATE_NAMES = filteredStates.map(state => state.label);
+
+// Get countries from the same source as the addressUI component
+const COUNTRY_VALUES = constants.countries
+  .filter(country => country.value !== 'USA')
+  .map(country => country.value);
+const COUNTRY_NAMES = constants.countries
+  .filter(country => country.value !== 'USA')
+  .map(country => country.label);
+
+/** @type {ArrayBuilderOptions} */
+const options = {
+  arrayPath: 'previousMarriages',
+  nounSingular: 'previous marriage',
+  nounPlural: 'previous marriages',
+  required: false,
+  minItems: 0,
+  isItemIncomplete: item =>
+    !item?.previousSpouseName?.first ||
+    !item?.previousSpouseName?.last ||
+    !item?.marriageToVeteranDate ||
+    !item?.marriageLocation?.city ||
+    (!item?.marriedOutsideUS && !item?.marriageLocation?.state) ||
+    (item?.marriedOutsideUS && !item?.marriageLocation?.country) ||
+    !item?.marriageEndReason ||
+    (item?.marriageEndReason === 'OTHER' && !item?.marriageEndOtherExplanation),
+  maxItems: 2,
+  text: {
+    alertMaxItems: handleAlertMaxItems,
+    getItemName: item => {
+      const name = item?.previousSpouseName;
+      if (!name?.first && !name?.last) return '';
+
+      const parts = [];
+      if (name?.first) parts.push(name.first);
+      if (name?.middle) parts.push(name.middle);
+      if (name?.last) parts.push(name.last);
+      if (name?.suffix) parts.push(name.suffix);
+
+      return parts.join(' ');
+    },
+  },
+};
+
+function introDescription() {
+  return (
+    <div>
+      <p>
+        Next we'll ask you about your previous marriages before your marriage to
+        the Veteran. You may add up to 2 marriages.
+      </p>
+      <p>
+        <strong>Note:</strong> We usually don't need to contact a previous
+        spouse of a Veteran's spouse. In very rare cases where we need
+        information from this person, we'll contact you first.
+      </p>
+    </div>
+  );
+}
+
+/** @returns {PageSchema} */
+const introPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Your previous marriages',
+      nounSingular: options.nounSingular,
+      nounPlural: options.nounPlural,
+    }),
+    'ui:description': introDescription,
+  },
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+/** @returns {PageSchema} */
+const summaryPage = {
+  uiSchema: {
+    'view:hasPreviousMarriages': arrayBuilderYesNoUI(
+      options,
+      {
+        title:
+          'Do you have a marriage to add that was before your marriage to the Veteran?',
+        hint: '',
+      },
+      {
+        title: 'Do you have another previous marriage to add?',
+        hint: '',
+      },
+    ),
+  },
+  schema: {
+    type: 'object',
+    required: ['view:hasPreviousMarriages'],
+    properties: {
+      'view:hasPreviousMarriages': arrayBuilderYesNoSchema,
+    },
+  },
+};
+
+/** @returns {PageSchema} */
+const previousMarriageItemPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Previous spouse name',
+      nounSingular: options.nounSingular,
+    }),
+    previousSpouseName: fullNameUI(),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      previousSpouseName: fullNameSchema,
+    },
+    required: ['previousSpouseName'],
+  },
+};
+
+/** @returns {PageSchema} */
+const marriageDateAndLocationPage = {
+  uiSchema: {
+    marriageToVeteranDate: currentOrPastDateUI({
+      title: 'Date of marriage',
+      monthSelect: false,
+    }),
+    marriedOutsideUS: checkboxUI({
+      title: 'I got married outside the U.S.',
+    }),
+    marriageLocation: {
+      city: textUI('City'),
+      state: {
+        ...selectUI('State'),
+        'ui:required': (formData, index) => {
+          const item = formData?.previousMarriages?.[index];
+          const currentPageData = formData;
+          return !(item?.marriedOutsideUS || currentPageData?.marriedOutsideUS);
+        },
+        'ui:options': {
+          hideIf: (formData, index) => {
+            const item = formData?.previousMarriages?.[index];
+            const currentPageData = formData;
+            return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
+          },
+          labels: STATE_VALUES.reduce((acc, value, idx) => {
+            acc[value] = STATE_NAMES[idx];
+            return acc;
+          }, {}),
+        },
+        'ui:errorMessages': {
+          required: 'Please select a state',
+        },
+      },
+      country: {
+        ...selectUI('Country'),
+        'ui:required': (formData, index) => {
+          const item = formData?.previousMarriages?.[index];
+          const currentPageData = formData;
+          return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
+        },
+        'ui:options': {
+          hideIf: (formData, index) => {
+            const item = formData?.previousMarriages?.[index];
+            const currentPageData = formData;
+            return !(
+              item?.marriedOutsideUS || currentPageData?.marriedOutsideUS
+            );
+          },
+          labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
+            acc[value] = COUNTRY_NAMES[idx];
+            return acc;
+          }, {}),
+        },
+        'ui:errorMessages': {
+          required: 'Please select a country',
+        },
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['marriageToVeteranDate', 'marriageLocation'],
+    properties: {
+      marriageToVeteranDate: currentOrPastDateSchema,
+      marriedOutsideUS: checkboxSchema,
+      marriageLocation: {
+        type: 'object',
+        required: ['city'],
+        properties: {
+          city: {
+            type: 'string',
+          },
+          state: {
+            type: 'string',
+            enum: STATE_VALUES,
+            enumNames: STATE_NAMES,
+          },
+          country: {
+            type: 'string',
+            enum: COUNTRY_VALUES,
+            enumNames: COUNTRY_NAMES,
+          },
+        },
+      },
+    },
+  },
+};
+
+/** @returns {PageSchema} */
+const marriageEndDateAndLocationPage = {
+  uiSchema: {
+    marriageEndDate: currentOrPastDateUI({
+      title: 'Date marriage ended',
+      monthSelect: false,
+    }),
+    marriageEndedOutsideUS: checkboxUI({
+      title: 'My marriage ended outside the U.S.',
+    }),
+    marriageEndLocation: {
+      city: textUI('City'),
+      state: {
+        ...selectUI('State'),
+        'ui:required': (formData, index) => {
+          const item = formData?.previousMarriages?.[index];
+          const currentPageData = formData;
+          return !(
+            item?.marriageEndedOutsideUS ||
+            currentPageData?.marriageEndedOutsideUS
+          );
+        },
+        'ui:options': {
+          hideIf: (formData, index) => {
+            const item = formData?.previousMarriages?.[index];
+            const currentPageData = formData;
+            return (
+              item?.marriageEndedOutsideUS ||
+              currentPageData?.marriageEndedOutsideUS
+            );
+          },
+          labels: STATE_VALUES.reduce((acc, value, idx) => {
+            acc[value] = STATE_NAMES[idx];
+            return acc;
+          }, {}),
+        },
+        'ui:errorMessages': {
+          required: 'Please select a state',
+        },
+      },
+      country: {
+        ...selectUI('Country'),
+        'ui:required': (formData, index) => {
+          const item = formData?.previousMarriages?.[index];
+          const currentPageData = formData;
+          return (
+            item?.marriageEndedOutsideUS ||
+            currentPageData?.marriageEndedOutsideUS
+          );
+        },
+        'ui:options': {
+          hideIf: (formData, index) => {
+            const item = formData?.previousMarriages?.[index];
+            const currentPageData = formData;
+            return !(
+              item?.marriageEndedOutsideUS ||
+              currentPageData?.marriageEndedOutsideUS
+            );
+          },
+          labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
+            acc[value] = COUNTRY_NAMES[idx];
+            return acc;
+          }, {}),
+        },
+        'ui:errorMessages': {
+          required: 'Please select a country',
+        },
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['marriageEndDate', 'marriageEndLocation'],
+    properties: {
+      marriageEndDate: currentOrPastDateSchema,
+      marriageEndedOutsideUS: checkboxSchema,
+      marriageEndLocation: {
+        type: 'object',
+        required: ['city'],
+        properties: {
+          city: {
+            type: 'string',
+          },
+          state: {
+            type: 'string',
+            enum: STATE_VALUES,
+            enumNames: STATE_NAMES,
+          },
+          country: {
+            type: 'string',
+            enum: COUNTRY_VALUES,
+            enumNames: COUNTRY_NAMES,
+          },
+        },
+      },
+    },
+  },
+};
+
+/** @returns {PageSchema} */
+const marriageEndPage = {
+  uiSchema: {
+    marriageEndReason: radioUI({
+      title: 'How did the marriage end?',
+      label: previousMarriageEndOptions,
+    }),
+    marriageEndOtherExplanation: {
+      ...textUI({
+        title: 'Tell us how the marriage ended',
+        required: (formData, index) => {
+          const item = formData?.previousMarriages?.[index];
+          const currentPageData = formData;
+          return (
+            item?.marriageEndReason === 'OTHER' ||
+            currentPageData?.marriageEndReason === 'OTHER'
+          );
+        },
+      }),
+      'ui:required': (formData, index) => {
+        const item = formData?.previousMarriages?.[index];
+        const currentPageData = formData;
+        return (
+          item?.marriageEndReason === 'OTHER' ||
+          currentPageData?.marriageEndReason === 'OTHER'
+        );
+      },
+      'ui:options': {
+        expandUnder: 'marriageEndReason',
+        expandUnderCondition: 'OTHER',
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['marriageEndReason', 'marriageEndOtherExplanation'],
+    properties: {
+      marriageEndReason: radioSchema(Object.keys(previousMarriageEndOptions)),
+      marriageEndOtherExplanation: {
+        type: 'string',
+      },
+    },
+  },
+};
+
+export const previousMarriagesPages = arrayBuilderPages(
+  options,
+  pageBuilder => ({
+    previousMarriagesIntro: pageBuilder.introPage({
+      title: 'Your previous marriages',
+      path: 'household/previous-marriage-intro',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        shouldShowPreviousMarriages(formData),
+      uiSchema: introPage.uiSchema,
+      schema: introPage.schema,
+    }),
+    previousMarriagesSummary: pageBuilder.summaryPage({
+      title:
+        'Do you have a marriage to add that was before your marriage to the Veteran?',
+      path: 'household/previous-marriage',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        shouldShowPreviousMarriages(formData),
+      uiSchema: summaryPage.uiSchema,
+      schema: summaryPage.schema,
+    }),
+    previousMarriageItemPage: pageBuilder.itemPage({
+      title: 'Previous spouse name',
+      path: 'household/previous-marriage/:index/name',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        shouldShowPreviousMarriages(formData),
+      uiSchema: previousMarriageItemPage.uiSchema,
+      schema: previousMarriageItemPage.schema,
+    }),
+    previousMarriageDateAndLocationPage: pageBuilder.itemPage({
+      title: 'When and where did you get married?',
+      path: 'household/previous-marriage/:index/date-and-location',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        shouldShowPreviousMarriages(formData),
+      uiSchema: marriageDateAndLocationPage.uiSchema,
+      schema: marriageDateAndLocationPage.schema,
+    }),
+    previousMarriageEndPage: pageBuilder.itemPage({
+      title: 'How did the marriage end?',
+      path: 'household/previous-marriage/:index/end',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        shouldShowPreviousMarriages(formData),
+      uiSchema: marriageEndPage.uiSchema,
+      schema: marriageEndPage.schema,
+    }),
+    previousMarriageEndDateAndLocationPage: pageBuilder.itemPage({
+      title: 'When and where did your marriage end?',
+      path: 'household/previous-marriage/:index/end-date-and-location',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        shouldShowPreviousMarriages(formData),
+      uiSchema: marriageEndDateAndLocationPage.uiSchema,
+      schema: marriageEndDateAndLocationPage.schema,
+    }),
+  }),
+);

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/remarriage.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/remarriage.js
@@ -1,0 +1,24 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Remarriage',
+  path: 'household/remarriage',
+  uiSchema: {
+    ...titleUI('Remarriage'),
+    remarried: yesNoUI({
+      title: 'Have you remarried since the death of the Veteran?',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['remarried'],
+    properties: {
+      remarried: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/remarriageDetails.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/remarriageDetails.js
@@ -1,0 +1,53 @@
+import {
+  radioUI,
+  radioSchema,
+  textUI,
+  textSchema,
+  titleUI,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { remarriageEndOptions } from '../../../utils/labels';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Remarriage details',
+  path: 'household/remarriage-details',
+  depends: formData => formData.remarried === true,
+  uiSchema: {
+    ...titleUI('Remarriage details'),
+    remarriageEndReason: radioUI({
+      title: 'How did the marriage end?',
+      labels: remarriageEndOptions,
+    }),
+    remarriageEndOtherReason: {
+      ...textUI({
+        title: 'Tell us how the marriage ended.',
+        required: formData => formData?.remarriageEndReason === 'OTHER',
+      }),
+      'ui:options': {
+        expandUnder: 'remarriageEndReason',
+        expandUnderCondition: 'OTHER',
+      },
+    },
+    remarriageDate: currentOrPastDateUI({
+      title: 'Date of marriage',
+      monthSelect: false,
+    }),
+    remarriageEndDate: currentOrPastDateUI({
+      title: 'Date marriage ended',
+      hint: 'Leave blank if you are still married',
+      monthSelect: false,
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['remarriageEndReason', 'remarriageDate'],
+    properties: {
+      remarriageEndReason: radioSchema(Object.keys(remarriageEndOptions)),
+      remarriageEndOtherReason: textSchema,
+      remarriageDate: currentOrPastDateSchema,
+      remarriageEndDate: currentOrPastDateSchema,
+    },
+  },
+};

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -35,6 +35,11 @@ import legalStatusOfMarriage from './chapters/04-household-information/legalStat
 import marriageStatus from './chapters/04-household-information/marriageStatus';
 import reasonForSeparation from './chapters/04-household-information/reasonForSeparation';
 import separationDetails from './chapters/04-household-information/separationDetails';
+import remarriage from './chapters/04-household-information/remarriage';
+import remarriageDetails from './chapters/04-household-information/remarriageDetails';
+import additionalMarriages from './chapters/04-household-information/additionalMarriages';
+import previousMarriages from './chapters/04-household-information/previousMarriages';
+import { previousMarriagesPages } from './chapters/04-household-information/previousMarriagesPages';
 import dicBenefits from './chapters/05-claim-information/dicBenefits';
 import nursingHome from './chapters/05-claim-information/nursingHome';
 import { treatmentPages } from './chapters/05-claim-information/treatmentPages';
@@ -253,6 +258,39 @@ const formConfig = {
           uiSchema: separationDetails.uiSchema,
           schema: separationDetails.schema,
         },
+        remarriage: {
+          path: 'household/remarriage',
+          title: 'Remarriage',
+          depends: formData => formData.claimantRelationship === 'SPOUSE',
+          uiSchema: remarriage.uiSchema,
+          schema: remarriage.schema,
+        },
+        remarriageDetails: {
+          path: 'household/remarriage-details',
+          title: 'Remarriage details',
+          depends: formData =>
+            formData.claimantRelationship === 'SPOUSE' &&
+            formData.remarried === true,
+          uiSchema: remarriageDetails.uiSchema,
+          schema: remarriageDetails.schema,
+        },
+        additionalMarriages: {
+          path: 'household/additional-marriages',
+          title: 'Additional marriages',
+          depends: formData =>
+            formData.claimantRelationship === 'SPOUSE' &&
+            formData.remarried === true,
+          uiSchema: additionalMarriages.uiSchema,
+          schema: additionalMarriages.schema,
+        },
+        previousMarriages: {
+          path: 'household/previous-marriage-question',
+          title: 'Previous marriages',
+          depends: formData => formData.claimantRelationship === 'SPOUSE',
+          uiSchema: previousMarriages.uiSchema,
+          schema: previousMarriages.schema,
+        },
+        ...previousMarriagesPages,
       },
     },
     // Chapter 5 - Claim Information

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -46,6 +46,19 @@ export const separationReasonOptions = {
   OTHER: 'Other',
 };
 
+export const previousMarriageEndOptions = {
+  DEATH: 'Death',
+  DIVORCE: 'Divorce',
+  OTHER: 'Other',
+};
+
+export const remarriageEndOptions = {
+  DID_NOT_END: 'Did not end',
+  SPOUSE_DEATH: "Spouse's death",
+  DIVORCE: 'Divorce',
+  OTHER: 'Other',
+};
+
 export const bankAccountTypeOptions = {
   CHECKING: 'Checking',
   SAVINGS: 'Savings',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request adds new functionality and refactors the household information section of the survivors benefits application form. The major changes include introducing new form pages to collect remarriage and marriage history details, updating alert components to guide users on required documentation, and expanding label options for marriage-related questions.

### Form flow and schema enhancements

* Added new form pages for `remarriage`, `remarriageDetails`, `additionalMarriages`, and `previousMarriages` to the household information chapter, improving how remarriage and marriage history are collected from users. These pages use updated schemas and UI patterns for better consistency and validation. [[1]](diffhunk://#diff-8d5b343dabcc502447f5e8e8121f539cc27d195dab2b68cfe886bae11d27cc46R1-R24) [[2]](diffhunk://#diff-ed3648baed26b59657ae7205f8f72dacda23b789415f3cd7c0194c66f12224a5R1-R53) [[3]](diffhunk://#diff-9c1eeea7bf40a0d5c225f9397c6e6499b3b566767c52b8c3b0c0dc35ababd763R1-R39) [[4]](diffhunk://#diff-c0654e1596a96ffe05d1cdf9df85ec21a5a84d8269c2cae0ad285f619b102f94R1-R30) [[5]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364R38-R42) [[6]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364R261-R293)

### User guidance and alerts

* Introduced new expandable alert components: `CourtOrderSeparationAlert` and `AdditionalMarriagesAlert` in `FormAlerts/index.jsx`, which inform users about required documentation for court-ordered separations and additional marriages. These alerts are integrated into the relevant form pages. [[1]](diffhunk://#diff-084cb62f9701371da62741ee8771f209d88ee3e0d0ca75e5b767f26c0c25e9a7R4-R38) [[2]](diffhunk://#diff-084cb62f9701371da62741ee8771f209d88ee3e0d0ca75e5b767f26c0c25e9a7L56-L66) [[3]](diffhunk://#diff-9c1eeea7bf40a0d5c225f9397c6e6499b3b566767c52b8c3b0c0dc35ababd763R1-R39)

### Label and options expansion

* Added new label sets for marriage end reasons (`remarriageEndOptions` and `previousMarriageEndOptions`) to `labels.jsx`, supporting more nuanced user responses in the new form pages.

These changes collectively improve the application's ability to collect comprehensive household and marital history, provide clearer instructions to users, and maintain a more organized codebase.

## Related issue(s)
N/A

## Testing done
Manual testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |<img width="550" height="557" alt="Screenshot 2025-10-30 at 3 13 55 PM" src="https://github.com/user-attachments/assets/1eaa8c4b-348e-40fd-9292-6f3a45a0d25c" />
<img width="550" height="889" alt="Screenshot 2025-10-30 at 3 14 53 PM" src="https://github.com/user-attachments/assets/202933ca-54ea-4c24-a2de-d716b76b4f93" />
<img width="555" height="575" alt="Screenshot 2025-10-30 at 3 15 33 PM" src="https://github.com/user-attachments/assets/4224fcff-2e62-4d2f-a026-bb39719feb08" />
<img width="555" height="703" alt="Screenshot 2025-10-30 at 3 15 43 PM" src="https://github.com/user-attachments/assets/546dcd09-efc7-4e53-a4e5-8d0cf69af517" />
<img width="555" height="807" alt="Screenshot 2025-10-30 at 3 16 03 PM" src="https://github.com/user-attachments/assets/6574ea3c-4590-4662-8cb5-22449ffb01f8" />
<img width="555" height="620" alt="Screenshot 2025-10-30 at 3 16 18 PM" src="https://github.com/user-attachments/assets/49c21426-0997-4415-8eca-146a871a516e" />
<img width="555" height="620" alt="Screenshot 2025-10-30 at 3 16 30 PM" src="https://github.com/user-attachments/assets/1c2e40df-32c2-46f8-8ef7-dd242149fef7" />
<img width="555" height="884" alt="Screenshot 2025-10-30 at 3 16 44 PM" src="https://github.com/user-attachments/assets/aece292e-f20a-4311-af9b-710623a7926d" />
<img width="555" height="808" alt="Screenshot 2025-10-30 at 3 16 54 PM" src="https://github.com/user-attachments/assets/3a9166c6-f725-4a6b-b135-6b07986f8b7f" />
<img width="555" height="668" alt="Screenshot 2025-10-30 at 3 17 22 PM" src="https://github.com/user-attachments/assets/ba820b50-a031-4f83-b33d-1efc01bfa526" />
<img width="555" height="783" alt="Screenshot 2025-10-30 at 3 17 35 PM" src="https://github.com/user-attachments/assets/7f582be9-68b7-4118-bead-ef2daf04c05a" />
<img width="555" height="681" alt="Screenshot 2025-10-30 at 3 17 49 PM" src="https://github.com/user-attachments/assets/ebc86bd5-f725-4573-9dcb-07d00a25eeb8" />
<img width="555" height="723" alt="Screenshot 2025-10-30 at 3 18 20 PM" src="https://github.com/user-attachments/assets/6673e906-0332-4e95-9991-d8f71ca8286e" />|

## What areas of the site does it impact?
534EZ form

## Acceptance criteria
New claimant marriages chapter steps

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
