### PR TITLE
Form-system: fix bug when replacing file in file input multiple

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
@@ -171,12 +171,15 @@ const VaFileInputMultipleField = props => {
       type,
     };
 
-    const encryptedFile = childrenProps.formData[index];
-    // check to see if we are adding an encrypted pdf
-    // where the additional info was added before the password
+    const existingFile = childrenProps.formData[index];
+    // if existingFile is not null then either
+    // 1. it is a placeholder for an encrypted file where additional info was added before the password OR
+    // 2. a file that is being replaced
     let files;
-    if (encryptedFile?.additionalData) {
-      newFile.additionalData = encryptedFile.additionalData;
+    if (existingFile) {
+      if (encrypted[index] && existingFile.additionalData) {
+        newFile.additionalData = existingFile.additionalData;
+      }
       files = [...childrenProps.formData];
       files[index] = newFile;
     } else {
@@ -293,9 +296,9 @@ const VaFileInputMultipleField = props => {
         f => f.file.name === _file.name && f.file.size === _file.size,
       );
     };
-    const _file = state.at(-1);
     switch (action) {
       case 'FILE_ADDED': {
+        const _file = state.at(-1);
         const _currentIndex = state.length - 1;
         errorManager.setInternalFileInputErrors(_currentIndex, false);
         handleFileAdded(_file, _currentIndex, mockFormData);
@@ -304,7 +307,7 @@ const VaFileInputMultipleField = props => {
       }
       case 'FILE_UPDATED': {
         const index = findFileIndex(state, file);
-        handleFileAdded(_file, index);
+        handleFileAdded({ file }, index);
         setCurrentIndex(index);
         break;
       }

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
@@ -198,7 +198,7 @@ const VaFileInputMultipleField = props => {
     assignFileUploadToStore(uploadedFile, index);
   };
 
-  const handleFileAdded = async ({ file }, index, mockFormData) => {
+  const handleFileAdded = async (file, index, mockFormData) => {
     const { fileError, encryptedCheck } = await getFileError(file, uiOptions);
     const _errors = [...errors];
 
@@ -298,16 +298,15 @@ const VaFileInputMultipleField = props => {
     };
     switch (action) {
       case 'FILE_ADDED': {
-        const _file = state.at(-1);
         const _currentIndex = state.length - 1;
         errorManager.setInternalFileInputErrors(_currentIndex, false);
-        handleFileAdded(_file, _currentIndex, mockFormData);
+        handleFileAdded(file, _currentIndex, mockFormData);
         setCurrentIndex(_currentIndex);
         break;
       }
       case 'FILE_UPDATED': {
         const index = findFileIndex(state, file);
-        handleFileAdded({ file }, index);
+        handleFileAdded(file, index);
         setCurrentIndex(index);
         break;
       }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes a bug in the fileInputMulitiple pattern where a user tries to change a previously uploaded file the first file is not removed and the field enters a broken state.

## Related issue(s)

[5115](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5115)

## Testing done

local testing

## Screenshots

**Before**: 


https://github.com/user-attachments/assets/f65fb90a-fab0-457b-bad7-f270f75ef7dc



**After**:



https://github.com/user-attachments/assets/145c4e8e-d849-4208-bdd6-3b3caa79c756



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
