### PR TITLE
0969 | Post MVP - Update summary page without title semantics

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/07-trusts/trustPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/07-trusts/trustPages.js
@@ -226,7 +226,8 @@ const veteranSummaryPage = {
         title: updatedTitleNoItems,
         hint:
           'Your dependents include your spouse, including a same-sex and common-law partner and children who you financially support.',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -245,7 +246,8 @@ const spouseSummaryPage = {
       {
         title: updatedTitleNoItems,
         hint: 'Your dependents include children who you financially support. ',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -264,7 +266,8 @@ const childSummaryPage = {
       {
         title: updatedTitleNoItems,
         hint: null,
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -283,7 +286,8 @@ const parentSummaryPage = {
         title: updatedTitleNoItems,
         hint:
           'Your dependents include your spouse, including a same-sex and common-law partner.',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -303,7 +307,8 @@ const custodianSummaryPage = {
         title: updatedTitleNoItems,
         hint:
           'Your dependents include your spouse, including a same-sex and common-law partner and the Veteran’s children who you financially support.',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -750,7 +755,7 @@ export const trustPages = arrayBuilderPages(options, pageBuilder => ({
     path: 'trusts/:index/document-upload',
     depends: (formData, index) =>
       showUpdatedContent() &&
-      formData?.trusts[index]?.['view:addFormQuestion'] === true,
+      formData?.[options.arrayPath]?.[index]?.['view:addFormQuestion'] === true,
     uiSchema: supportingDocumentUpload.uiSchema,
     schema: supportingDocumentUpload.schema,
   }),
@@ -759,7 +764,8 @@ export const trustPages = arrayBuilderPages(options, pageBuilder => ({
     path: 'trusts/:index/document-mailing-address',
     depends: (formData, index) =>
       showUpdatedContent() &&
-      formData?.trusts[index]?.['view:addFormQuestion'] === false,
+      formData?.[options.arrayPath]?.[index]?.['view:addFormQuestion'] ===
+        false,
     uiSchema: documentMailingAddressPage.uiSchema,
     schema: documentMailingAddressPage.schema,
   }),

--- a/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/08-annuities/annuityPages.js
@@ -155,7 +155,8 @@ const veteranSummaryPage = {
         title: updatedTitleNoItems,
         hint:
           'Your dependents include your spouse, including a same-sex and common-law partner and children who you financially support.',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -174,7 +175,8 @@ const spouseSummaryPage = {
       {
         title: updatedTitleNoItems,
         hint: 'Your dependents include children who you financially support. ',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -193,7 +195,8 @@ const childSummaryPage = {
       {
         title: 'Do you have an annuity?',
         hint: null,
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -212,7 +215,8 @@ const parentSummaryPage = {
         title: updatedTitleNoItems,
         hint:
           'Your dependents include your spouse, including a same-sex and common-law partner.',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {
@@ -232,7 +236,8 @@ const custodianSummaryPage = {
         title: updatedTitleNoItems,
         hint:
           'Your dependents include your spouse, including a same-sex and common-law partner and the Veteran’s children who you financially support.',
-        ...sharedYesNoOptionsBase,
+        labelHeaderLevel: '1',
+        labelHeaderLevelStyle: '2',
         labels: yesNoOptionLabels,
       },
       {


### PR DESCRIPTION
## Summary

This PR updates the **Trust** and **Annuity** summary pages (without titles) in the **Income and Asset Statement form (VA Form 21P-0969)** to align with **Design QA feedback**.  
Specifically, it replaces **yes/no question text headings** from `<h2>` to `<h1>` elements to ensure proper **semantic hierarchy** and **accessibility compliance** when the page lacks a distinct title element.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116444  

## Related issue(s)

- Follows broader Design QA efforts for Post-MVP chapter heading alignment  
- Supports improved screen reader navigation and consistent VADS hierarchy standards  

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Proceed to the **Trusts** or **Annuities** chapter  

## How to verify

1. Navigate to the **Trusts** and **Annuities** chapters and view the **summary pages (without titles)**.  
2. Inspect the yes/no question text and confirm:
   - Headings previously using `<h2>` are now `<h1>`.  
   - The new structure follows correct document outline order.  
3. Validate heading levels across the full form flow:
   - No duplicate `<h1>` elements per page.  
   - Logical heading progression (`h1 → h2 → h3`) is maintained across other content.  
4. Confirm visual rendering is unaffected (font size and spacing remain consistent with VADS design).  
5. Verify accessibility:
   - Screen reader announces heading levels correctly.  
   - No WCAG violations reported for heading order or hierarchy.  
6. Confirm no console errors, lint warnings, or layout regressions.  

## What areas of the site does it impact?

- **Income and Asset Statement (VA Form 21P-0969)**  
- **Trusts** and **Annuities** summary pages (no-title variants)  

## Screenshots

| Before | After |
|--------|-------|
| `<h2>` used for yes/no question headings | Updated to `<h1>` for proper semantic hierarchy and a11y compliance |

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- 0969 Post-MVP Design QA and Accessibility  
- **Behind** `income_and_assets_content_updates` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm heading level adjustments meet Design QA expectations and maintain accessibility standards without altering page layout or styling.