### PR TITLE
21P-8416 Update submit-transformer to return form data as string

### DIFF
--- a/src/applications/medical-expense-report/config/submit-transformer.js
+++ b/src/applications/medical-expense-report/config/submit-transformer.js
@@ -2,32 +2,31 @@ import { format } from 'date-fns-tz';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 
 function swapNames(formData) {
-  const transformedValue = formData;
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = parsedFormData;
   if (
-    formData?.claimantNotVeteran === false &&
-    formData.claimantFullName.first &&
-    formData.claimantFullName.last &&
-    !formData.veteranFullName?.first &&
-    !formData.veteranFullName?.last
+    parsedFormData?.claimantNotVeteran === false &&
+    parsedFormData.claimantFullName?.first &&
+    parsedFormData.claimantFullName?.last &&
+    !parsedFormData.veteranFullName?.first &&
+    !parsedFormData.veteranFullName?.last
   ) {
-    transformedValue.veteranFullName = {
-      first: formData.claimantFullName.first,
-      middle: formData.claimantFullName.middle,
-      last: formData.claimantFullName.last,
-      suffix: formData.claimantFullName.suffix,
-    };
-    transformedValue.claimantFullName = {
-      first: undefined,
-      middle: undefined,
-      last: undefined,
-      suffix: undefined,
-    };
+    transformedValue.veteranFullName = {};
+    transformedValue.veteranFullName.first =
+      parsedFormData.claimantFullName?.first;
+    transformedValue.veteranFullName.middle =
+      parsedFormData.claimantFullName?.middle;
+    transformedValue.veteranFullName.last =
+      parsedFormData.claimantFullName?.last;
+    transformedValue.veteranFullName.suffix =
+      parsedFormData.claimantFullName?.suffix;
+    transformedValue.claimantFullName = {};
   }
-  return transformedValue;
+  return JSON.stringify(transformedValue);
 }
 
 export const transform = (formConfig, form) => {
-  let transformedData = JSON.parse(transformForSubmit(formConfig, form));
+  let transformedData = transformForSubmit(formConfig, form);
   transformedData = swapNames(transformedData);
   return JSON.stringify({
     medicalExpenseReportsClaim: {

--- a/src/applications/medical-expense-report/tests/unit/utils/transform.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/utils/transform.unit.spec.jsx
@@ -38,9 +38,10 @@ describe('submit transformer', () => {
 
     const result = transform(formConfig, formData);
     const parsedResult = JSON.parse(result);
+    const parsedForm = JSON.parse(parsedResult.medicalExpenseReportsClaim.form);
     expect(parsedResult).to.have.property('medicalExpenseReportsClaim');
     expect(parsedResult.medicalExpenseReportsClaim).to.have.property('form');
-    expect(parsedResult.medicalExpenseReportsClaim.form).to.deep.equal({
+    expect(parsedForm).to.deep.equal({
       claimantNotVeteran: false,
       claimantFullName: {},
       veteranFullName: {
@@ -51,7 +52,6 @@ describe('submit transformer', () => {
       },
     });
     expect(parsedResult).to.have.property('localTime');
-    // Additional checks for localTime format can be added here
   });
   it('should transform form data correctly for submission as not veteran', () => {
     const formConfig = {}; // Mock form config if needed
@@ -73,9 +73,10 @@ describe('submit transformer', () => {
 
     const result = transform(formConfig, formData);
     const parsedResult = JSON.parse(result);
+    const parsedForm = JSON.parse(parsedResult.medicalExpenseReportsClaim.form);
     expect(parsedResult).to.have.property('medicalExpenseReportsClaim');
     expect(parsedResult.medicalExpenseReportsClaim).to.have.property('form');
-    expect(parsedResult.medicalExpenseReportsClaim.form).to.deep.equal({
+    expect(parsedForm).to.deep.equal({
       claimantNotVeteran: true,
       claimantFullName: {
         first: 'John',
@@ -91,6 +92,5 @@ describe('submit transformer', () => {
       },
     });
     expect(parsedResult).to.have.property('localTime');
-    // Additional checks for localTime format can be added here
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update tests
- Rewrite submit-transformer to return form object as a string instead of json object

## Related issue(s)

No issue, noticed this when testing out new code. 

## Testing done

- Updated unit tests
- Built local version of vets-api and submitted requests against it

## Screenshots

N/A

## What areas of the site does it impact?

Just the submit of 8416

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
