### PR TITLE
Appointment list VO focus update - make date number unfocusable to avoid repetition

### DIFF
--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
@@ -91,6 +91,7 @@ export default function AppointmentColumnLayout({
             )}
           >
             <h3
+              aria-hidden="true"
               className={classNames(
                 'vads-u-text-align--center',
                 'vads-u-margin-top--0',
@@ -98,7 +99,7 @@ export default function AppointmentColumnLayout({
                 { 'vads-u-display--none': !first },
               )}
             >
-              <span aria-hidden="false" data-dd-privacy="mask">
+              <span data-dd-privacy="mask">
                 {formatInTimeZone(startDate, data.timezone, 'd')}
               </span>
             </h3>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We're adding the aria-hidden label to the heading to prevent the date number from being repeated when using SRs
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111646

## Testing done

- Tested locally using various VRs, thanks @eselkin for helping me test this!

## Screenshots

These videos are the results with the changes in this PR. For behaviors before this change, see the linked issue for the previous behaviors.

VO on mac:

https://github.com/user-attachments/assets/edf02a8d-3543-4463-bf64-96ebd07af4f7

JAWS:

https://github.com/user-attachments/assets/e4157f20-e5f6-48cf-a802-86c4ee19d55f

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user