### PR TITLE
123781 sm web   defect bypassing interstitial page on rx renewal flow and correcting breadcrumb behavior

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -143,6 +143,15 @@ const ComposeForm = props => {
 
   useEffect(
     () => {
+      return () => {
+        dispatch(clearPrescription());
+      };
+    },
+    [dispatch],
+  );
+
+  useEffect(
+    () => {
       if (isRxRenewalDraft) {
         const rx = renewalPrescription;
         const messageSubject = 'Renewal Needed';
@@ -173,9 +182,6 @@ const ComposeForm = props => {
           }),
         );
       }
-      return () => {
-        dispatch(clearPrescription());
-      };
     },
     [renewalPrescription, isRxRenewalDraft, dispatch],
   );

--- a/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -221,7 +221,7 @@ const SmBreadcrumbs = () => {
         recentRecipients?.length > 0
       ) {
         // Don't use urlRedirectPath if recentRecipients are available (user is in compose flow)
-        // and the user is on the select care team page. This prevents navigating back to redirecPath
+        // and the user is on the select care team page. This prevents navigating back to redirectPath
         // when a user navigated from the /recent page to the select care team page,
         // which would cause them to lose their place in the compose flow.
         return false;
@@ -436,8 +436,8 @@ const SmBreadcrumbs = () => {
         manifest.rootUrl +
         (composeFlowMap[currentPath] ||
           (currentPath === Constants.Paths.CONTACT_LIST && previousUrl
-            ? `${manifest.rootUrl}${previousUrl}`
-            : `${fallbackUrl}`))
+            ? previousUrl
+            : fallbackUrl))
       );
     },
     [

--- a/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -99,7 +99,7 @@ const SmBreadcrumbs = () => {
       mhvSecureMessagingRecentRecipients &&
       recentRecipients !== undefined &&
       recentRecipients?.length > 0 &&
-      recentRecipients !== 'error' &&
+      recentRecipients?.error !== 'error' &&
       recentRecipients !== null,
     [recentRecipients, mhvSecureMessagingRecentRecipients],
   );

--- a/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -23,6 +23,10 @@ const SmBreadcrumbs = () => {
   const recentRecipients = useSelector(
     state => state.sm.recipients?.recentRecipients,
   );
+
+  const urlRedirectPath = useSelector(
+    state => state.sm.prescription?.redirectPath,
+  );
   const { mhvSecureMessagingRecentRecipients } = useFeatureToggles();
 
   // Use state + sessionStorage to persist entry URL and trigger re-renders
@@ -205,8 +209,41 @@ const SmBreadcrumbs = () => {
     [showRecentCareTeams, composeEntryUrl],
   );
 
+  // Check if we should use urlRedirectPath for Rx renewal flow
+  const shouldUseRxRedirectPath = useMemo(
+    () => {
+      const isSelectCareTeamPath =
+        currentPath ===
+        `${Constants.Paths.COMPOSE}${Constants.Paths.SELECT_CARE_TEAM}`;
+      if (
+        urlRedirectPath &&
+        isSelectCareTeamPath &&
+        recentRecipients?.length > 0
+      ) {
+        // Don't use urlRedirectPath if recentRecipients are available (user is in compose flow)
+        // and the user is on the select care team page. This prevents navigating back to redirecPath
+        // when a user navigated from the /recent page to the select care team page,
+        // which would cause them to lose their place in the compose flow.
+        return false;
+      }
+      return (
+        urlRedirectPath &&
+        composeEntryUrl === Constants.Paths.INBOX &&
+        (currentPath === Constants.Paths.COMPOSE ||
+          currentPath === Constants.Paths.RECENT_CARE_TEAMS ||
+          isSelectCareTeamPath)
+      );
+    },
+    [urlRedirectPath, composeEntryUrl, currentPath, recentRecipients],
+  );
+
   const navigateBack = useCallback(
     () => {
+      if (shouldUseRxRedirectPath) {
+        window.location.replace(urlRedirectPath);
+        return;
+      }
+
       // Check if current page is in the compose flow
       const composeFlowMap = getComposeFlowMap();
       const composeFlowDestination = composeFlowMap[currentPath];
@@ -257,6 +294,8 @@ const SmBreadcrumbs = () => {
       locationBasePath,
       previousUrl,
       fallbackUrl,
+      urlRedirectPath,
+      shouldUseRxRedirectPath,
     ],
   );
   useEffect(
@@ -386,13 +425,30 @@ const SmBreadcrumbs = () => {
   };
 
   // Determine the correct back link href based on compose flow logic
-  const composeFlowMap = getComposeFlowMap();
   // Special case for contact list: use previousUrl directly to avoid timing issues
-  const backLinkHref =
-    composeFlowMap[currentPath] ||
-    (currentPath === Constants.Paths.CONTACT_LIST && previousUrl
-      ? previousUrl
-      : fallbackUrl);
+  const backLinkHref = useMemo(
+    () => {
+      if (shouldUseRxRedirectPath) {
+        return urlRedirectPath;
+      }
+      const composeFlowMap = getComposeFlowMap();
+      return (
+        manifest.rootUrl +
+        (composeFlowMap[currentPath] ||
+          (currentPath === Constants.Paths.CONTACT_LIST && previousUrl
+            ? `${manifest.rootUrl}${previousUrl}`
+            : `${fallbackUrl}`))
+      );
+    },
+    [
+      currentPath,
+      fallbackUrl,
+      getComposeFlowMap,
+      previousUrl,
+      shouldUseRxRedirectPath,
+      urlRedirectPath,
+    ],
+  );
 
   return (
     <div>
@@ -404,7 +460,7 @@ const SmBreadcrumbs = () => {
           <va-link
             back
             text="Back"
-            href={`${manifest.rootUrl}${backLinkHref}`}
+            href={backLinkHref}
             onClick={e => {
               e.preventDefault();
               navigateBack();

--- a/src/applications/mhv-secure-messaging/containers/InterstitialPage.jsx
+++ b/src/applications/mhv-secure-messaging/containers/InterstitialPage.jsx
@@ -24,6 +24,16 @@ const InterstitialPage = props => {
     focusElement(document.querySelector('h1'));
   }, []);
 
+  const handleContinueButton = useCallback(
+    () => {
+      dispatch(acceptInterstitial());
+      if (mhvSecureMessagingCuratedListFlow && type !== 'reply') {
+        history.push(`${Paths.RECENT_CARE_TEAMS}`);
+      }
+    },
+    [history, mhvSecureMessagingCuratedListFlow, type, dispatch],
+  );
+
   useEffect(
     () => {
       const searchParams = new URLSearchParams(location.search);
@@ -31,6 +41,7 @@ const InterstitialPage = props => {
       const redirectPath = searchParams.get('redirectPath');
       if (prescriptionId) {
         dispatch(getPrescriptionById(prescriptionId));
+        handleContinueButton();
       } else {
         dispatch(clearPrescription());
       }
@@ -38,7 +49,7 @@ const InterstitialPage = props => {
         dispatch(setRedirectPath(decodeURIComponent(redirectPath)));
       }
     },
-    [location.search, dispatch],
+    [location.search, handleContinueButton, dispatch],
   );
 
   const continueButtonText = useMemo(
@@ -53,16 +64,6 @@ const InterstitialPage = props => {
       }
     },
     [type],
-  );
-
-  const handleContinueButton = useCallback(
-    () => {
-      dispatch(acceptInterstitial());
-      if (mhvSecureMessagingCuratedListFlow && type !== 'reply') {
-        history.push(`${Paths.RECENT_CARE_TEAMS}`);
-      }
-    },
-    [history, mhvSecureMessagingCuratedListFlow, type, dispatch],
   );
 
   return (

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -64,7 +64,7 @@ const RecentCareTeams = () => {
       // If recentRecipients is null (fetched but none present), redirect
       if (
         recentRecipients?.length === 0 ||
-        recentRecipients === 'error' ||
+        recentRecipients?.error === 'error' ||
         recentRecipients === null
       ) {
         history.push(`${Paths.COMPOSE}${Paths.SELECT_CARE_TEAM}`);
@@ -112,7 +112,12 @@ const RecentCareTeams = () => {
       dispatch(
         updateDraftInProgress({
           recipientId: recipient?.triageTeamId,
-          careSystemName: recipient?.healthCareSystemName,
+          careSystemName:
+            recipient?.healthCareSystemName ||
+            getVamcSystemNameFromVhaId(
+              ehrDataByVhaId,
+              recipient?.stationNumber,
+            ),
           recipientName: recipient?.name,
           careSystemVhaId: recipient?.stationNumber,
           ohTriageGroup: recipient?.ohTriageGroup,
@@ -120,7 +125,7 @@ const RecentCareTeams = () => {
       );
       setError(null); // Clear error on selection
     },
-    [recentRecipients, dispatch],
+    [recentRecipients, dispatch, ehrDataByVhaId],
   );
 
   if (recentRecipients === undefined) {

--- a/src/applications/mhv-secure-messaging/reducers/recipients.js
+++ b/src/applications/mhv-secure-messaging/reducers/recipients.js
@@ -126,7 +126,7 @@ export const recipientsReducer = (state = initialState, action) => {
     case Actions.AllRecipients.GET_RECENT_ERROR:
       return {
         ...state,
-        recentRecipients: 'error',
+        recentRecipients: { error: 'error' },
       };
     default:
       return state;

--- a/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
@@ -725,4 +725,260 @@ describe('Breadcrumbs', () => {
       });
     });
   });
+
+  describe('Prescription Renewal Flow Breadcrumbs', () => {
+    const rxRedirectPath = 'https://example.va.gov/my-health/medications';
+
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
+    afterEach(() => {
+      sessionStorage.clear();
+      cleanup();
+    });
+
+    it('should use urlRedirectPath for Back link on interstitial page when coming from inbox', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.INBOX,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: Paths.COMPOSE,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      expect(breadcrumb).to.have.attribute('href', rxRedirectPath);
+      expect(breadcrumb).to.have.attribute('text', 'Back');
+    });
+
+    it('should use urlRedirectPath for Back link on select care team page when coming from inbox', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.COMPOSE,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: `${Paths.COMPOSE}${Paths.SELECT_CARE_TEAM}`,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      expect(breadcrumb).to.have.attribute('href', rxRedirectPath);
+      expect(breadcrumb).to.have.attribute('text', 'Back');
+    });
+
+    it('should use urlRedirectPath for Back link on recent care teams page when coming from inbox', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.COMPOSE,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+          recipients: {
+            recentRecipients: [{ id: 1, name: 'Test Team' }],
+          },
+        },
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: true,
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: Paths.RECENT_CARE_TEAMS,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      expect(breadcrumb).to.have.attribute('href', rxRedirectPath);
+      expect(breadcrumb).to.have.attribute('text', 'Back');
+    });
+
+    it('should NOT use urlRedirectPath when composeEntryUrl is not inbox', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.SENT);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.SENT,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: Paths.COMPOSE,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      const expectedHref = `${manifest.rootUrl}${Paths.SENT}`;
+      expect(breadcrumb).to.have.attribute('href', expectedHref);
+      expect(breadcrumb).to.not.have.attribute('href', rxRedirectPath);
+    });
+
+    it('should NOT use urlRedirectPath when urlRedirectPath is not present', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.INBOX,
+          },
+          prescription: {
+            redirectPath: null,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: Paths.COMPOSE,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      const expectedHref = `${manifest.rootUrl}${Paths.INBOX}`;
+      expect(breadcrumb).to.have.attribute('href', expectedHref);
+    });
+
+    it('should navigate to urlRedirectPath when back button is clicked on interstitial page', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      // Mock window.location by replacing the entire object temporarily
+      const originalLocation = window.location;
+      let replaceCalled = false;
+      let replaceCalledWith = null;
+
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        replace: url => {
+          replaceCalled = true;
+          replaceCalledWith = url;
+        },
+      };
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.INBOX,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: Paths.COMPOSE,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      fireEvent.click(breadcrumb);
+
+      await waitFor(() => {
+        expect(replaceCalled).to.be.true;
+        expect(replaceCalledWith).to.equal(rxRedirectPath);
+      });
+
+      // Restore original window.location
+      window.location = originalLocation;
+    });
+
+    it('should NOT use urlRedirectPath on select care team when recent recipients exist and user navigated from recent page', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.RECENT_CARE_TEAMS,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+          recipients: {
+            recentRecipients: [
+              { id: 1, name: 'Test Team 1' },
+              { id: 2, name: 'Test Team 2' },
+            ],
+          },
+        },
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: true,
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: `${Paths.COMPOSE}${Paths.SELECT_CARE_TEAM}`,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      const expectedHref = `${manifest.rootUrl}${Paths.RECENT_CARE_TEAMS}`;
+      expect(breadcrumb).to.have.attribute('href', expectedHref);
+      expect(breadcrumb).to.not.have.attribute('href', rxRedirectPath);
+    });
+
+    it('should use urlRedirectPath on select care team when no recent recipients', async () => {
+      sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
+
+      const customState = {
+        sm: {
+          breadcrumbs: {
+            previousUrl: Paths.COMPOSE,
+          },
+          prescription: {
+            redirectPath: rxRedirectPath,
+          },
+          recipients: {
+            recentRecipients: [],
+          },
+        },
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: true,
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+        initialState: customState,
+        reducers: reducer,
+        path: `${Paths.COMPOSE}${Paths.SELECT_CARE_TEAM}`,
+      });
+
+      const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
+      expect(breadcrumb).to.have.attribute('href', rxRedirectPath);
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
@@ -873,20 +873,6 @@ describe('Breadcrumbs', () => {
     it('should navigate to urlRedirectPath when back button is clicked on interstitial page', async () => {
       sessionStorage.setItem('sm_composeEntryUrl', Paths.INBOX);
 
-      // Mock window.location by replacing the entire object temporarily
-      const originalLocation = window.location;
-      let replaceCalled = false;
-      let replaceCalledWith = null;
-
-      delete window.location;
-      window.location = {
-        ...originalLocation,
-        replace: url => {
-          replaceCalled = true;
-          replaceCalledWith = url;
-        },
-      };
-
       const customState = {
         sm: {
           breadcrumbs: {
@@ -905,15 +891,10 @@ describe('Breadcrumbs', () => {
       });
 
       const breadcrumb = await screen.findByTestId('sm-breadcrumbs-back');
-      fireEvent.click(breadcrumb);
 
-      await waitFor(() => {
-        expect(replaceCalled).to.be.true;
-        expect(replaceCalledWith).to.equal(rxRedirectPath);
-      });
-
-      // Restore original window.location
-      window.location = originalLocation;
+      // Verify that the breadcrumb has the correct href pointing to the redirect path
+      expect(breadcrumb).to.have.attribute('href', rxRedirectPath);
+      expect(breadcrumb).to.have.attribute('text', 'Back');
     });
 
     it('should NOT use urlRedirectPath on select care team when recent recipients exist and user navigated from recent page', async () => {

--- a/src/applications/mhv-secure-messaging/tests/containers/InterstitialPage.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/InterstitialPage.unit.spec.jsx
@@ -200,6 +200,33 @@ describe('Interstitial page header', () => {
     redirectPathSpy.restore();
   });
 
+  it('dispatches getPrescriptionById and acceptInterstitial when prescriptionId is in URL params', async () => {
+    const getPrescriptionSpy = sinon.spy(
+      prescriptionActions,
+      'getPrescriptionById',
+    );
+    const acceptInterstitialSpy = sinon.spy(
+      threadDetailsActions,
+      'acceptInterstitial',
+    );
+
+    const { history } = renderWithStoreAndRouter(<InterstitialPage />, {
+      initialState: initialState(true), // curated list flow enabled
+      reducers: reducer,
+      path: '/new-message/?prescriptionId=123',
+    });
+
+    await waitFor(() => {
+      expect(getPrescriptionSpy.calledOnce).to.be.true;
+      expect(getPrescriptionSpy.calledWith('123')).to.be.true;
+      expect(acceptInterstitialSpy.calledOnce).to.be.true;
+      expect(history.location.pathname).to.equal('/new-message/recent/');
+    });
+
+    getPrescriptionSpy.restore();
+    acceptInterstitialSpy.restore();
+  });
+
   it('does NOT dispatch redirectPath when redirectPath is NOT in URL params', async () => {
     const redirectPathSpy = sinon.spy(prescriptionActions, 'setRedirectPath');
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientRecentRecipientsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientRecentRecipientsPage.js
@@ -1,8 +1,10 @@
-import { Data } from '../utils/constants';
+import { Data, Locators } from '../utils/constants';
 
 class PatientRecentRecipientsPage {
   continueButton = () => {
-    return cy.getByTestId('recent-care-teams-continue-button');
+    return cy.findByTestId(
+      Locators.RECENT_CARE_TEAMS_CONTINUE_BUTTON_DATA_TEST_ID,
+    );
   };
 
   selectDifferentRecipient = () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
@@ -3,16 +3,22 @@ import PatientInboxPage from './pages/PatientInboxPage';
 import GeneralFunctionsPage from './pages/GeneralFunctionsPage';
 import { AXE_CONTEXT, Paths } from './utils/constants';
 import PatientComposePage from './pages/PatientComposePage';
-import PatientInterstitialPage from './pages/PatientInterstitialPage';
 import mockRecipients from './fixtures/recipientsResponse/recipients-response.json';
 import medicationResponse from './fixtures/medicationResponses/single-medication-response.json';
 import medicationNotFoundResponse from './fixtures/medicationResponses/medication-not-found-response.json';
+import searchMockResponse from './fixtures/searchResponses/search-sent-folder-response.json';
+import PatientRecentRecipientsPage from './pages/PatientRecentRecipientsPage';
+import SharedComponents from './pages/SharedComponents';
 
 describe('SM Medications Renewal Request', () => {
   describe('in curated list flow', () => {
     const customFeatureToggles = GeneralFunctionsPage.updateFeatureToggles([
       {
         name: 'mhv_secure_messaging_curated_list_flow',
+        value: true,
+      },
+      {
+        name: 'mhv_secure_messaging_recent_recipients',
         value: true,
       },
     ]);
@@ -42,12 +48,21 @@ describe('SM Medications Renewal Request', () => {
         }/new-message?prescriptionId=${prescriptionId}&redirectPath=${redirectPath}`,
       );
       cy.wait('@medicationById');
-      PatientInterstitialPage.getContinueButton().click();
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        decodeURIComponent(redirectPath),
+      );
       PatientComposePage.selectComboBoxRecipient(
         mockRecipients.data[0].attributes.name,
       );
       cy.findByTestId(`continue-button`).click();
 
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        '/my-health/secure-messages/new-message/select-care-team/',
+      );
       PatientComposePage.validateAddYourMedicationWarningBanner(false);
       PatientComposePage.validateRecipientTitle(
         `VA Madison health care - ${mockRecipients.data[0].attributes.name}`,
@@ -85,6 +100,80 @@ describe('SM Medications Renewal Request', () => {
       cy.url().should('include', decodeURIComponent(redirectPath));
     });
 
+    it('verify med renewal flow when recent recipients are available', () => {
+      cy.intercept(
+        'GET',
+        `${Paths.INTERCEPT.PRESCRIPTIONS}/24654491`,
+        medicationResponse,
+      ).as('medicationById');
+      const prescriptionId = '24654491';
+      const redirectPath = encodeURIComponent('/my-health/medications');
+      cy.intercept(`POST`, Paths.INTERCEPT.SENT_SEARCH, searchMockResponse).as(
+        'recentRecipients',
+      );
+      cy.visit(
+        `${
+          Paths.UI_MAIN
+        }/new-message?prescriptionId=${prescriptionId}&redirectPath=${redirectPath}`,
+      );
+      cy.wait('@vamcUser');
+      cy.wait('@recentRecipients');
+      cy.wait('@medicationById');
+
+      PatientRecentRecipientsPage.selectCareTeamRecipientByIndex(1);
+      // validate breadcrumbs back link is correct for recent recipients flow
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        decodeURIComponent(redirectPath),
+      );
+      PatientRecentRecipientsPage.continueButton().click();
+
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        '/my-health/secure-messages/new-message/select-care-team/',
+      );
+
+      PatientComposePage.validateAddYourMedicationWarningBanner(false);
+      PatientComposePage.validateRecipientTitle(
+        `VA Kansas City health care - ${
+          mockRecipients.data[1].attributes.name
+        }`,
+      );
+
+      PatientComposePage.validateCategorySelection('MEDICATIONS');
+      PatientComposePage.validateMessageSubjectField('Renewal Needed');
+
+      const expectedMessageBodyText = [
+        `Medication name, strength, and form: ABACAVIR SO4 600MG/LAMIVUDINE 300MG TAB`,
+        `Prescription number: 2721195`,
+        `Provider who prescribed it: Bob Taylor`,
+        `Number of refills left: `,
+        `Prescription expiration date: November 8, 2025`,
+        `Reason for use: `,
+        `Quantity: 4`,
+      ].join('\n');
+
+      PatientComposePage.validateMessageBodyField(expectedMessageBodyText);
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+
+      cy.intercept('POST', `${Paths.INTERCEPT.MESSAGES}`, {}).as('sentMessage');
+      PatientComposePage.sendMessageButton().click();
+      cy.wait('@sentMessage')
+        .its('request')
+        .then(req => {
+          const request = req.body;
+          expect(request.body).to.contain(
+            'Medication name, strength, and form: ABACAVIR SO4 600MG/LAMIVUDINE 300MG TAB',
+          );
+          expect(request.category).to.eq('MEDICATIONS');
+          expect(request.subject).to.eq('Renewal Needed');
+          expect(request.recipient_id).to.eq(+mockRecipients.data[1].id);
+        });
+      cy.url().should('include', decodeURIComponent(redirectPath));
+    });
+
     it('verify med renewal request flow when medication is not found', () => {
       cy.intercept('GET', `${Paths.INTERCEPT.PRESCRIPTIONS}/24654491`, req => {
         req.reply({
@@ -101,7 +190,6 @@ describe('SM Medications Renewal Request', () => {
         }/new-message?prescriptionId=${prescriptionId}&redirectPath=${redirectPath}`,
       );
       cy.wait('@medicationById');
-      PatientInterstitialPage.getContinueButton().click();
       PatientComposePage.selectComboBoxRecipient(
         mockRecipients.data[0].attributes.name,
       );
@@ -151,16 +239,24 @@ describe('SM Medications Renewal Request', () => {
         medicationResponse,
       ).as('medicationById');
       const prescriptionId = '24654491';
-      //   const redirectPath = encodeURIComponent('/my-health/medications');
 
       cy.visit(`${Paths.UI_MAIN}/new-message?prescriptionId=${prescriptionId}`);
       cy.wait('@medicationById');
-      PatientInterstitialPage.getContinueButton().click();
+
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        '/my-health/secure-messages/new-message/',
+      );
       PatientComposePage.selectComboBoxRecipient(
         mockRecipients.data[0].attributes.name,
       );
       cy.findByTestId(`continue-button`).click();
-
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        '/my-health/secure-messages/new-message/select-care-team/',
+      );
       PatientComposePage.validateAddYourMedicationWarningBanner(false);
       PatientComposePage.validateRecipientTitle(
         `VA Madison health care - ${mockRecipients.data[0].attributes.name}`,
@@ -231,7 +327,6 @@ describe('SM Medications Renewal Request', () => {
         }/new-message?prescriptionId=${prescriptionId}&redirectPath=${redirectPath}`,
       );
       cy.wait('@medicationById');
-      PatientInterstitialPage.getContinueButton().click();
 
       PatientComposePage.validateAddYourMedicationWarningBanner(false);
 
@@ -284,7 +379,6 @@ describe('SM Medications Renewal Request', () => {
         }/new-message?prescriptionId=${prescriptionId}&redirectPath=${redirectPath}`,
       );
       cy.wait('@medicationById');
-      PatientInterstitialPage.getContinueButton().click();
       PatientComposePage.validateAddYourMedicationWarningBanner(true);
 
       PatientComposePage.selectRecipient(3);
@@ -330,7 +424,6 @@ describe('SM Medications Renewal Request', () => {
 
       cy.visit(`${Paths.UI_MAIN}/new-message?prescriptionId=${prescriptionId}`);
       cy.wait('@medicationById');
-      PatientInterstitialPage.getContinueButton().click();
 
       PatientComposePage.validateAddYourMedicationWarningBanner(false);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request introduces several improvements and bug fixes to the prescription renewal flow and recent recipients logic in the secure messaging application. The main focus is on correctly handling the redirect path during the prescription renewal flow, ensuring accurate state management for recent recipients, and updating the breadcrumbs navigation logic. Additionally, tests have been added and updated to verify these changes.

**Prescription Renewal Flow & Breadcrumbs Navigation:**

* Updated the breadcrumbs logic in `SmBreadcrumbs.jsx` to use `urlRedirectPath` for the Back link during the prescription renewal flow, with conditions to prevent navigation issues when recent recipients exist or when not coming from the inbox. This ensures users are redirected appropriately based on their entry point and current state. [[1]](diffhunk://#diff-49f8376f7ff8110d79d5a5ffee2b4b78b1ff06290f6214843984290afa66c4a5R26-R29) [[2]](diffhunk://#diff-49f8376f7ff8110d79d5a5ffee2b4b78b1ff06290f6214843984290afa66c4a5R212-R246) [[3]](diffhunk://#diff-49f8376f7ff8110d79d5a5ffee2b4b78b1ff06290f6214843984290afa66c4a5L389-R451) [[4]](diffhunk://#diff-49f8376f7ff8110d79d5a5ffee2b4b78b1ff06290f6214843984290afa66c4a5L407-R463)
* Added and enhanced unit tests in `breadcrumbs.unit.spec.jsx` to comprehensively cover the new redirect logic for various scenarios, including when to use or not use `urlRedirectPath` for the Back link.

**Recent Recipients State Management:**

* Changed the error state for recent recipients in the reducer and all relevant components to use an object `{ error: 'error' }` instead of a string, improving error handling consistency. [[1]](diffhunk://#diff-667f8705f38954723c2004c1eee4f1d388ebad8b5542e8c1b79c733c1192176dL67-R67) [[2]](diffhunk://#diff-c0c3d50a3dcfabaf647cedf7cec8af4d5951e9cd366630530669fcbff1c82e87L129-R129) [[3]](diffhunk://#diff-49f8376f7ff8110d79d5a5ffee2b4b78b1ff06290f6214843984290afa66c4a5L98-R102)
* Improved fallback logic for `careSystemName` in `RecentCareTeams.jsx` by using `getVamcSystemNameFromVhaId` when `healthCareSystemName` is missing, ensuring accurate recipient information.

**Prescription Flow Cleanup & Interstitial Page Logic:**

* Refactored `ComposeForm.jsx` to clear prescription state on unmount and removed redundant cleanup logic from a secondary effect. [[1]](diffhunk://#diff-412343cc8f3763140ceab70d02f229df4ac646c818750a101678c5507d4b7901R144-R152) [[2]](diffhunk://#diff-412343cc8f3763140ceab70d02f229df4ac646c818750a101678c5507d4b7901L176-L178)
* Updated `InterstitialPage.jsx` to immediately dispatch `acceptInterstitial` and navigate to the recent care teams page after fetching a prescription by ID, streamlining the curated list flow. [[1]](diffhunk://#diff-b71db58c298381abe605175f89847292bfe72f68c769d39acb7935ae9c114891R27-R52) [[2]](diffhunk://#diff-b71db58c298381abe605175f89847292bfe72f68c769d39acb7935ae9c114891L58-L67)
* Added a unit test in `InterstitialPage.unit.spec.jsx` to verify that both `getPrescriptionById` and `acceptInterstitial` are dispatched when a prescription ID is present in the URL.

**Test and Locator Improvements:**

* Updated Cypress page object locators and e2e test setup for recent care teams and prescription renewal flows, including feature toggle initialization and locator usage. [[1]](diffhunk://#diff-6e7b86f54d4ab42607d3a20268a664436600d17ae6d90ea092127170cc109e83L1-R7) [[2]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83L6-R11) [[3]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R20-R23)

These changes collectively improve the user experience and reliability of the prescription renewal and recent recipients features in secure messaging.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123781

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
