### PR TITLE
Revert "Deployment reroute for emergencies (#39178)"

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -4,11 +4,11 @@ on:
   workflow_run:
     workflows: [Continuous Integration]
     types: [completed]
-    branches: [production-bypass]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: false 
 
 env:
   BUILD_ENV: vagovprod
@@ -19,6 +19,7 @@ jobs:
     name: Build
     runs-on: ubuntu-16-cores-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
 
     steps:
       - name: Checkout
@@ -55,6 +56,7 @@ jobs:
       - name: Compress and archive build
         run: tar -C build/${{ env.BUILD_ENV }} -cjf ${{ env.BUILD_ENV }}.tar.bz2 .
 
+
       - name: Configure AWS credentials (1)
         uses: ./.github/workflows/configure-aws-credentials
         with:
@@ -81,37 +83,37 @@ jobs:
 
       - name: Upload build
         run: aws s3 cp ${{ env.BUILD_ENV }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${{ env.COMMIT_SHA }}/${{ env.BUILD_ENV }}.tar.bz2 --acl public-read --region us-gov-west-1
-
+  
   tag-commit:
-    name: Tag Commit
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          fetch-depth: 0
-
-      - name: Configure AWS Credentials
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
-
-      - name: Get bot token from Parameter Store
-        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Generate Version
-        id: version
-        uses: paulhatch/semantic-version@v5.4.0
-        with:
-          tag_prefix: "v"
-
-      - name: Create tag
-        run: git tag ${{ steps.version.outputs.version_tag }} ${{ env.COMMIT_SHA }} && git push origin ${{ steps.version.outputs.version_tag }}
+      name: Tag Commit
+      needs: [build]
+      runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
+      
+      steps:
+        - name: Checkout
+          uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+          with:
+            fetch-depth: 0
+  
+        - name: Configure AWS Credentials
+          uses: ./.github/workflows/configure-aws-credentials
+          with:
+            aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws_region: us-gov-west-1
+  
+        - name: Get bot token from Parameter Store
+          uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
+          with:
+            ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+            env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+  
+        - name: Generate Version
+          id: version
+          uses: paulhatch/semantic-version@v5.4.0
+          with:
+            tag_prefix: "v"
+  
+        - name: Create tag
+          run: git tag ${{ steps.version.outputs.version_tag }} ${{ env.COMMIT_SHA }} && git push origin ${{ steps.version.outputs.version_tag }} 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,9 +3,9 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
 
 concurrency:
   group: ${{ github.ref != 'refs/heads/main' && github.ref || github.sha }}
@@ -37,7 +37,7 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-              
+
       - name: Install dependencies
         uses: ./.github/workflows/install
         timeout-minutes: 30
@@ -52,8 +52,8 @@ jobs:
         id: get-changed-apps
         uses: ./.github/workflows/get-changed-apps
         with:
-          delimiter: ','
-          output-type: 'entry_name, continuous_deployment'
+          delimiter: ","
+          output-type: "entry_name, continuous_deployment"
 
       - name: Get Mapbox Token
         if: ${{ matrix.buildtype == 'vagovprod' }}
@@ -91,7 +91,7 @@ jobs:
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
 
-  determine-cd-eligibility: 
+  determine-cd-eligibility:
     name: Determine CD Eligibility
     runs-on: ubuntu-latest
     needs: [build]
@@ -124,7 +124,7 @@ jobs:
         if: ${{ always() }}
         id: deploy-to-prod
         run: echo "can_deploy=$CAN_DEPLOY_TO_PROD" >> $GITHUB_OUTPUT
-      
+
       - name: Log output
         run: echo ${{ steps.deploy-to-prod.outputs.can_deploy }}
   fetch-allow-lists:
@@ -140,7 +140,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -220,8 +219,8 @@ jobs:
         id: get-changed-apps
         uses: ./.github/workflows/get-changed-apps
         with:
-          delimiter: ','
-          output-type: 'entry_name, url, folder'
+          delimiter: ","
+          output-type: "entry_name, url, folder"
 
       - name: Download Unit Test Stability Allow List
         uses: ./.github/workflows/download-artifact
@@ -287,7 +286,7 @@ jobs:
         if: ${{ always() }}
         id: apps-to-stress-test
         run: echo "apps_to_test=$APPS_TO_STRESS_TEST" >> $GITHUB_OUTPUT
-      
+
       - name: Set output of TESTS
         id: cypress-tests
         run: echo selected=$TESTS >> $GITHUB_OUTPUT
@@ -376,14 +375,14 @@ jobs:
         working-directory: qa-standards-dashboard-data
         env:
           TEST_TYPE: unit_test
-      
+
       - name: Check for newly added disallowed tests
         run: node script/github-actions/double-check-allow-list.js
         env:
           TEST_TYPE: unit_test
           TESTS: ${{ env.DISALLOWED_TESTS }}
-          TESTS_PROPERTY: 'DISALLOWED_TESTS'
-          
+          TESTS_PROPERTY: "DISALLOWED_TESTS"
+
       - name: Create test results folder
         run: mkdir -p test-results
 
@@ -395,13 +394,13 @@ jobs:
           else
             yarn test:unit:gha yarn test:unit:gha "{src,script}/**/*.unit.spec.js?(x)" --coverage --log-level verbose
           fi
-          
+
         env:
           MOCHA_FILE: test-results/unit-tests.xml
           CHANGED_FILES: ${{ needs.tests-prep.outputs.changed_file_paths }}
           APP_FOLDERS: ${{ needs.tests-prep.outputs.app_folders }}
           IS_STRESS_TEST: false
-      
+
       - name: Archive unit test results
         if: ${{ always() && steps.run-tests.outputs.tests_ran == 'true' }}
         uses: ./.github/workflows/upload-artifact
@@ -425,7 +424,7 @@ jobs:
 
     env:
       APPS_TO_VERIFY: ${{ needs.tests-prep.outputs.apps-to-stress-test }}
-      DISALLOWED_TESTS: '[]'
+      DISALLOWED_TESTS: "[]"
 
     strategy:
       fail-fast: false
@@ -475,7 +474,7 @@ jobs:
       - name: Rename results directory to avoid merge collisions
         run: |
           mv mocha/results/unit-tests.json mocha/results/unit-tests-${{ matrix.runs }}.json
-    
+
       - name: Archive unit test results
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
@@ -501,7 +500,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -532,7 +530,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
       - name: Download Unit Test results
         uses: ./.github/workflows/download-artifact
@@ -581,7 +578,7 @@ jobs:
         id: get-changed-apps
         uses: ./.github/workflows/get-changed-apps
         with:
-          output-type: 'entry_name'
+          output-type: "entry_name"
 
       - name: Audit dependencies
         if: steps.get-changed-apps.outputs.entry_names == ''
@@ -611,7 +608,7 @@ jobs:
         id: get-changed-apps
         uses: ./.github/workflows/get-changed-apps
         with:
-          output-type: 'folder'
+          output-type: "folder"
 
       - name: Annotate ESLint results
         run: |
@@ -668,7 +665,7 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
+
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
         with:
@@ -689,7 +686,7 @@ jobs:
     name: Fetch ECR Credentials
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    needs: [build] 
+    needs: [build]
 
     steps:
       - name: Checkout
@@ -704,14 +701,14 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2    
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: false
 
     outputs:
       ecr_user: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
       ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-      
+
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: ubuntu-16-cores-latest
@@ -721,7 +718,7 @@ jobs:
       needs.build.result == 'success' &&
       needs.tests-prep.result == 'success' &&
       needs.tests-prep.outputs.e2e_count != '0'
-      
+
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
@@ -748,8 +745,6 @@ jobs:
       # requires the cypress-tests job to run was not satisfied. This update forces
       # the job to always run, and skips each step if no tests are selected.
       # Previously, the above conditional was included in the job's if statement.
-      
-          
 
       - name: Checkout vets-website
         if: needs.tests-prep.outputs.cypress-tests != '[]'
@@ -808,7 +803,7 @@ jobs:
             .cache/yarn
             /github/home/.cache/Cypress
             node_modules
-            
+
       - name: Download Tests to run
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: ./.github/workflows/download-artifact
@@ -821,7 +816,7 @@ jobs:
         run: node script/github-actions/double-check-allow-list.js
         env:
           TEST_TYPE: e2e
-          TEST_PROPERTY: 'TESTS'
+          TEST_PROPERTY: "TESTS"
 
       - name: Start server
         if: needs.tests-prep.outputs.cypress-tests != '[]'
@@ -968,7 +963,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-      
+
       - name: Manual dependencies install
         run: |
           yarn install \
@@ -988,7 +983,7 @@ jobs:
         run: git fetch origin ${{ github.head_ref }}
       - name: Merge in feature branch
         run: git merge origin/${{ github.ref_name }} --no-edit
-          
+
       - name: Create test results folder
         run: mkdir -p test-results
 
@@ -997,7 +992,7 @@ jobs:
         with:
           name: changed-unit-tests
           path: .
-          
+
       - name: Run unit tests
         id: run-tests
         run: |
@@ -1020,7 +1015,6 @@ jobs:
         with:
           name: unit-test-node-compatibility-report
           path: mocha/results
-         
 
   update-e2e-allow-list:
     name: Update E2E Test Stability Allow List
@@ -1046,7 +1040,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -1078,7 +1071,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
       - name: Download Cypress E2E Mochawesome test results
         uses: ./.github/workflows/download-artifact
@@ -1217,7 +1209,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
       # --------------------------------------------------
       # | Publish Unit Test Report and Upload to BigQuery |
@@ -1231,7 +1222,7 @@ jobs:
         with:
           name: unit-test-report
           path: qa-standards-dashboard-data/src/testing-reports/data
-      
+
       - name: Archive unit test coverage
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
@@ -1258,8 +1249,6 @@ jobs:
       - name: Upload Unit Test report to s3
         run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
 
-
-      
       - name: Unit test results
         if: ${{ always() }}
         uses: ./.github/workflows/checks-action
@@ -1269,8 +1258,6 @@ jobs:
           conclusion: ${{ needs.unit-tests.result }}
           output: |
             {"summary": ${{ env.MOCHAWESOME_REPORT_RESULTS || '{}' }}}
-
-
 
   testing-reports-unit-tests-stress-test:
     name: Testing Reports - Unit Test Stability Review
@@ -1301,7 +1288,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -1350,7 +1336,7 @@ jobs:
         run: |
           rm -f src/testing-reports/data/unit-tests.json
           node src/testing-reports/manual-merge.js
-         
+
       - name: Create Unit Test report
         run: yarn unit-mochawesome-to-bigquery
         working-directory: qa-standards-dashboard-data
@@ -1390,7 +1376,7 @@ jobs:
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -1442,7 +1428,7 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-   # --------------------------------------
+      # --------------------------------------
       # | Publish Unit Test Coverage Report       |
       # -------------------------------------
       - name: Generate full coverage on main
@@ -1469,7 +1455,7 @@ jobs:
         run: |
           mkdir -p qa-standards-dashboard-data/src/testing-reports/data
           cp qa-standards-dashboard-data/coverage/coverage-summary.json qa-standards-dashboard-data/src/testing-reports/data
-      
+
       - name: Archive coverage txt
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
@@ -1489,11 +1475,11 @@ jobs:
           else
             echo 'No coverage report exists as no tests were run.'
           fi
-                
+
       # -------------------------
       # | Unit Tests Summary |
       # -------------------------
-        
+
       - name: Get code coverage
         if: ${{ always() }}
         id: code-coverage
@@ -1542,7 +1528,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -1574,7 +1559,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
         # --------------------------------------
         # | Publish Cypress E2E Testing Report |
@@ -1667,7 +1651,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -1699,7 +1682,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
         # --------------------------------------
         # | Publish Cypress E2E Testing Report |
@@ -1756,7 +1738,7 @@ jobs:
           conclusion: ${{ needs.stress-test-cypress-tests.result }}
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-  
+
   test-stability-review-merge-status:
     name: QA Merge Status
     runs-on: ubuntu-22.04
@@ -1785,7 +1767,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
@@ -1807,8 +1788,8 @@ jobs:
         id: get-changed-apps
         uses: ./.github/workflows/get-changed-apps
         with:
-          delimiter: ','
-          output-type: 'folder'
+          delimiter: ","
+          output-type: "folder"
 
       - name: Init Dashboard Data Repo
         uses: ./.github/workflows/init-data-repo
@@ -1862,16 +1843,16 @@ jobs:
         uses: ./.github/workflows/annotations
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          check_title: 'E2E Test Stability Allow List Annotations'
-          input_json: './e2e-annotations.json'
+          check_title: "E2E Test Stability Allow List Annotations"
+          input_json: "./e2e-annotations.json"
 
       - name: Annotate Unit Test Files accordingly
         if: ${{ env.unit-test-annotations-json != '[]' }}
         uses: ./.github/workflows/annotations
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          check_title: 'Unit Test Stability Allow List Annotations'
-          input_json: './unit-test-annotations.json'
+          check_title: "Unit Test Stability Allow List Annotations"
+          input_json: "./unit-test-annotations.json"
 
       - name: Verify Merge Eligibility
         run: node script/github-actions/verify-merge-eligibility.js
@@ -1889,7 +1870,8 @@ jobs:
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
-    needs: [build, tests-prep, cypress-tests, unit-tests, security-audit, linting]
+    needs:
+      [build, tests-prep, cypress-tests, unit-tests, security-audit, linting]
 
     env:
       IS_SINGLE_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
@@ -1944,7 +1926,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get AWS IAM role
         uses: ./.github/workflows/inject-secrets
@@ -1961,7 +1942,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
       - name: Upload build
         run: |
@@ -2039,7 +2019,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
 
       - name: Get AWS IAM role
         if: steps.check-deployability.outputs.is_deployable == 'true'
@@ -2058,7 +2037,6 @@ jobs:
           role: ${{ env.AWS_FRONTEND_NONPROD_ROLE != '' && env.AWS_FRONTEND_NONPROD_ROLE || env.AWS_FRONTEND_PROD_ROLE }}
           role_duration: 900
           session_name: vsp-frontendteam-githubaction
-          
 
       - name: Deploy
         if: steps.check-deployability.outputs.is_deployable == 'true'
@@ -2072,79 +2050,73 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}
           ASSET_DEST: s3://${{ matrix.asset_bucket }}
-  debug-cd-output:
-    needs: [determine-cd-eligibility]
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "deploy_to_prod raw: [${{ needs.determine-cd-eligibility.outputs.deploy_to_prod }}]"
-          
-  cd-prod-deploy:
-    name: CD Production Deploy
-    runs-on: ubuntu-22.04
-    needs: [build, set-deploy-environments, determine-cd-eligibility]
-    if: always() && ${{ startsWith(needs.determine-cd-eligibility.outputs.deploy_to_prod, 'yes') && github.ref == 'refs/heads/main' && needs.set-deploy-environments.result == 'success' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          fetch-depth: 0
 
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
+  # cd-prod-deploy:
+  #   name: CD Production Deploy
+  #   runs-on: ubuntu-22.04
+  #   needs: [build, set-deploy-environments, determine-cd-eligibility]
+  #   if: always() && ${{ startsWith(needs.determine-cd-eligibility.outputs.deploy_to_prod, 'yes') && github.ref == 'refs/heads/main' && needs.set-deploy-environments.result == 'success' }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Get Slack channel
-        id: get-slack-channel
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          output-type: 'slack_channel'
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
 
-      - name: Determine Slack channel
-        id: determine-channel
-        shell: bash
-        run: |
-          entries="${{ needs.build.outputs.entry_names }}"
-          channel="${{ steps.get-slack-channel.outputs.slack_channels }}"
-          if [[ "$entries" == *","* ]]; then
-            echo "channel=" >> $GITHUB_OUTPUT
-          else
-            echo "channel=$channel" >> $GITHUB_OUTPUT
-          fi
+  #     - name: Get Slack channel
+  #       id: get-slack-channel
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         output-type: 'slack_channel'
 
-      - name: Debug CD gating values
-        run: |
-          echo "entry_names=${{ needs.build.outputs.entry_names }}"
-          echo "continuous_deployment=${{ needs.build.outputs.continuous_deployment }}"
-          echo "slack_channel=${{ steps.determine-channel.outputs.channel }}"
+  #     - name: Determine Slack channel
+  #       id: determine-channel
+  #       shell: bash
+  #       run: |
+  #         entries="${{ needs.build.outputs.entry_names }}"
+  #         channel="${{ steps.get-slack-channel.outputs.slack_channels }}"
+  #         if [[ "$entries" == *","* ]]; then
+  #           echo "channel=" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "channel=$channel" >> $GITHUB_OUTPUT
+  #         fi
 
-      - name: Check if today is a holiday
-        id: holiday-check
-        uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
+  #     - name: Debug CD gating values
+  #       run: |
+  #         echo "entry_names=${{ needs.build.outputs.entry_names }}"
+  #         echo "continuous_deployment=${{ needs.build.outputs.continuous_deployment }}"
+  #         echo "slack_channel=${{ steps.determine-channel.outputs.channel }}"
 
-      - name: Dispatch Event to Next Workflow
-        if: steps.holiday-check.outputs.is_holiday == 'false'
-        run: |
-          curl -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/dispatches \
-          -d "$(jq -n --arg sha "${{ github.sha }}" \
-          --arg ref "${{ github.ref }}" \
-          --arg entry "${{ needs.build.outputs.entry_names }}" \
-          --arg slack_channel "${{ steps.determine-channel.outputs.channel }}" \
-          '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, entry_app: $entry, slack_channel: $slack_channel}}')"
+  #     - name: Check if today is a holiday
+  #       id: holiday-check
+  #       uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
 
-      - name: Cancel CD dispatch due to holiday
-        if: steps.holiday-check.outputs.is_holiday == 'true'
-        run: echo "Skipping CD dispatch; holiday freeze is active."
-                         
+  #     - name: Dispatch Event to Next Workflow
+  #       if: steps.holiday-check.outputs.is_holiday == 'false'
+  #       run: |
+  #         curl -X POST \
+  #         -H "Accept: application/vnd.github.v3+json" \
+  #         -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+  #         https://api.github.com/repos/${{ github.repository }}/dispatches \
+  #         -d "$(jq -n --arg sha "${{ github.sha }}" \
+  #         --arg ref "${{ github.ref }}" \
+  #         --arg entry "${{ needs.build.outputs.entry_names }}" \
+  #         --arg slack_channel "${{ steps.determine-channel.outputs.channel }}" \
+  #         '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, entry_app: $entry, slack_channel: $slack_channel}}')"
+
+  #     - name: Cancel CD dispatch due to holiday
+  #       if: steps.holiday-check.outputs.is_holiday == 'true'
+  #       run: echo "Skipping CD dispatch; holiday freeze is active."
+
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-22.04
@@ -2177,7 +2149,7 @@ jobs:
         if: env.ALERT_TEAMS == 'true'
         uses: ./.github/workflows/get-changed-apps
         with:
-          output-type: 'slack_group'
+          output-type: "slack_group"
 
       - name: Notify application team in Slack
         if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
@@ -2250,14 +2222,14 @@ jobs:
         working-directory: qa-standards-dashboard-data
         env:
           TEST_TYPE: unit_test
-      
+
       - name: Check for newly added disallowed tests
         run: node script/github-actions/double-check-allow-list.js
         env:
           TEST_TYPE: unit_test
           TESTS: ${{ env.TESTS_TO_STRESS_TEST }}
-          TESTS_PROPERTY: 'TESTS_TO_STRESS_TEST'
-          
+          TESTS_PROPERTY: "TESTS_TO_STRESS_TEST"
+
       - name: Create test results folder
         run: mkdir -p test-results
 
@@ -2274,7 +2246,7 @@ jobs:
         env:
           MOCHA_FILE: test-results/stress-tests.xml
           IS_STRESS_TEST: true
-      
+
       - name: Archive stress test results
         if: ${{ always() && steps.run-tests.outputs.tests_ran == 'true' }}
         uses: ./.github/workflows/upload-artifact

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -14,8 +14,8 @@ on:
         description: "Bypass holiday freeze and force enable deploy workflows"
         required: false
         default: "false"
-  schedule:
-    - cron: 0 18 * * 1,4
+  # schedule:
+  #   - cron: 0 18 * * 1,4
 
 env:
   CHANNEL_ID: C0MQ281DJ # vfs-platform-builds

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -6,16 +6,16 @@ on:
       release_wait:
         description: Minutes to wait before creating release
         required: false
-        default: "0"
+        default: '0'
       commit_sha:
         description: Deploy specific commit
         required: false
       bypass_freeze:
-        description: "Bypass holiday freeze and force enable deploy workflows"
+        description: 'Bypass holiday freeze and force enable deploy workflows'
         required: false
-        default: "false"
-  # schedule:
-  #   - cron: 0 17 * * 1-5
+        default: 'false'
+  schedule:
+    - cron: 0 17 * * 1-5
 
 env:
   CHANNEL_ID: C0MQ281DJ # vfs-platform-builds
@@ -29,9 +29,9 @@ jobs:
     outputs:
       is_holiday: ${{ steps.holiday-check.outputs.is_holiday }}
     steps:
-      - name: Check if today is a holiday
-        id: holiday-check
-        uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
+    - name: Check if today is a holiday
+      id: holiday-check
+      uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
 
   cancel-run-if-holiday:
     runs-on: ubuntu-latest
@@ -48,17 +48,17 @@ jobs:
       workflow_enabled_vets_website: ${{ steps.check-status.outputs.workflow_enabled_vets_website }}
       workflow_enabled_content_build: ${{ steps.check-status.outputs.workflow_enabled_content_build }}
       reenabled: ${{ steps.enable-workflows.outputs.reenabled }}
-    steps:
-      - name: Get bot token from Parameter Store (bypass)
-        if: ${{ github.event.inputs.bypass_freeze == 'true' }}
-        uses: ./.github/workflows/inject-secrets
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+    steps: 
+    - name: Get bot token from Parameter Store (bypass)
+      if: ${{ github.event.inputs.bypass_freeze == 'true' }}
+      uses: ./.github/workflows/inject-secrets
+      with:
+        ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+        env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-      - name: Bypass Check - Force Enable Workflows
-        if: ${{ github.event.inputs.bypass_freeze == 'true' }}
-        run: |
+    - name: Bypass Check - Force Enable Workflows
+      if: ${{ github.event.inputs.bypass_freeze == 'true' }}
+      run: |
           echo "Bypass activated – force enabling deploy workflows."
           curl -X PATCH -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
             -H "Accept: application/vnd.github.v3+json" \
@@ -67,59 +67,57 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/department-of-veterans-affairs/content-build/actions/workflows/daily-production-release.yml/enable
 
-      - name: Disable workflows if today is a holiday
-        if: ${{ false }}
-        run: echo "Freeze enforcement handled by freeze-enforcer.yml."
+    - name: Disable workflows if today is a holiday
+      if: ${{ false }}
+      run: echo "Freeze enforcement handled by freeze-enforcer.yml."
 
-      - name: Checkout
-        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
+    - name: Checkout
+      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
-      - name: Configure AWS credentials for secret injection
-        if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
+    - name: Configure AWS credentials for secret injection
+      if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
+      uses: ./.github/workflows/configure-aws-credentials
+      with:
+        aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws_region: us-gov-west-1
 
-      - name: Get bot token from Parameter Store
-        if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
-        uses: ./.github/workflows/inject-secrets
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+    - name: Get bot token from Parameter Store
+      if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
+      uses: ./.github/workflows/inject-secrets
+      with:
+        ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+        env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-      - name: Check Workflow Status
-        id: check-status
-        if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
-        run: |
-          check_status() {
-            local repo=$1
-            local key=$(echo "$repo" | tr '-' '_')
-            local response=$(curl -s -L \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
-              "https://api.github.com/repos/department-of-veterans-affairs/$repo/actions/workflows/daily-production-release.yml")
+    - name: Check Workflow Status
+      id: check-status
+      if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
+      run: |
+        check_status() {
+          local repo=$1
+          local key=$(echo "$repo" | tr '-' '_')
+          local response=$(curl -s -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
+            "https://api.github.com/repos/department-of-veterans-affairs/$repo/actions/workflows/daily-production-release.yml")
 
-            local state=$(echo "$response" | jq -r '.state')
+          local state=$(echo "$response" | jq -r '.state')
 
-            if [[ "$state" == "active" ]]; then
-              echo "$repo is already enabled. No action needed."
-              echo "workflow_enabled_${key}=true" >> $GITHUB_OUTPUT
-            else
-              echo "$repo is disabled. Re-enabling now."
-              echo "workflow_enabled_${key}=false" >> $GITHUB_OUTPUT
-            fi
-          }
+          if [[ "$state" == "active" ]]; then
+            echo "$repo is already enabled. No action needed."
+            echo "workflow_enabled_${key}=true" >> $GITHUB_OUTPUT
+          else
+            echo "$repo is disabled. Re-enabling now."
+            echo "workflow_enabled_${key}=false" >> $GITHUB_OUTPUT
+          fi
+        }
 
-          check_status "content-build"
+        check_status "content-build"
 
-      - name: Enable Workflows if Disabled
-        id: enable-workflows
-        if: ${{ steps.check-status.outputs.workflow_enabled_content_build == 'false' }}
-        run: |
+    - name: Enable Workflows if Disabled
+      id: enable-workflows
+      if: ${{ steps.check-status.outputs.workflow_enabled_content_build == 'false' }}
+      run: |
           echo "Enabling content-build daily deploy workflow."
           http_code=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
             -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
@@ -146,35 +144,33 @@ jobs:
   notify-freeze-ends:
     name: Notify Freeze Ended
     runs-on: ubuntu-latest
-    needs: [holiday-checker, main-deployment]
-    if: ${{
-      github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.outputs.reenabled == 'true'
-      }}
+    needs: [holiday-checker, main-deployment] 
+    if: ${{ 
+          github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.outputs.reenabled == 'true'
+         }}  
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
-      - name: Notify Slack (COP) - Code Freeze Ended
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: false
-        with:
-          payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
-          channel_id: "C04868KS69L" # Frontend COP
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Checkout Repository
+      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+    - name: Notify Slack (COP) - Code Freeze Ended
+      uses: ./.github/workflows/slack-notify
+      continue-on-error: false
+      with:
+        payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
+        channel_id:  'C04868KS69L' # Frontend COP
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Short delay before SRE Slack (Ended)
-        run: sleep 2
+    - name: Short delay before SRE Slack (Ended)
+      run: sleep 2
 
-      - name: Notify Slack (SRE) - Code Freeze Ended
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: false
-        with:
-          payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
-          channel_id: "C06JM7UUHE3" # platform-sre-team
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Notify Slack (SRE) - Code Freeze Ended
+      uses: ./.github/workflows/slack-notify
+      continue-on-error: false
+      with:
+        payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
+        channel_id:  'C06JM7UUHE3' # platform-sre-team
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   notify-bypass:
     name: Notify Bypass Activation
@@ -183,15 +179,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
-
       - name: Notify Slack (COP) - Deploy Freeze Bypassed
         uses: ./.github/workflows/slack-notify
         continue-on-error: false
         with:
           payload: '{"attachments": [{"color": "#0000FF", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "ℹ️ *Deploy Freeze Bypassed:* Emergency bypass activated. Deployment workflows for `vets-website` and `content-build` have been force enabled."}}]}]}'
-          channel_id: "C04868KS69L"
+          channel_id: 'C04868KS69L'
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -203,46 +196,44 @@ jobs:
         continue-on-error: false
         with:
           payload: '{"attachments": [{"color": "#0000FF", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "ℹ️ *Deploy Freeze Bypassed:* Emergency bypass activated. Deployment workflows for `vets-website` and `content-build` have been force enabled."}}]}]}'
-          channel_id: "C06JM7UUHE3"
+          channel_id: 'C06JM7UUHE3'
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
+      
   notify-code-freeze-failure:
     name: Notify Code Freeze Failure
     runs-on: ubuntu-latest
     needs: [holiday-checker, main-deployment]
     if: ${{
-      always() && github.event.inputs.bypass_freeze != 'true' && (
-      (needs.holiday-checker.outputs.is_holiday == 'true' && cancelled()) ||
-      (needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.result == 'failure')
-      )
-      }}
+          always() && github.event.inputs.bypass_freeze != 'true' && (
+            (needs.holiday-checker.outputs.is_holiday == 'true' && cancelled()) ||
+            (needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.result == 'failure')
+          )
+        }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
+    - name: Checkout Repository
+      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
-      - name: Notify Slack (COP) - Code Freeze Failure
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: false
-        with:
-          payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
-          channel_id: "C04868KS69L"
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Notify Slack (COP) - Code Freeze Failure
+      uses: ./.github/workflows/slack-notify
+      continue-on-error: false
+      with:
+        payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
+        channel_id:  'C04868KS69L'
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Short delay before SRE Slack (Failure)
-        run: sleep 2
+    - name: Short delay before SRE Slack (Failure)
+      run: sleep 2
 
-      - name: Notify Slack (SRE) - Code Freeze Failure
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: false
-        with:
-          payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
-          channel_id: "C06JM7UUHE3"
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Notify Slack (SRE) - Code Freeze Failure
+      uses: ./.github/workflows/slack-notify
+      continue-on-error: false
+      with:
+        payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
+        channel_id:  'C06JM7UUHE3'
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   get-workflow-environment:
     runs-on: ubuntu-latest
@@ -274,7 +265,6 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
-          ref: production-bypass
 
       - name: Get latest tag
         id: get-latest-tag
@@ -305,8 +295,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
 
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
@@ -317,7 +305,7 @@ jobs:
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          payload: |
+          payload: | 
             {
               "attachments": [
                 {
@@ -341,11 +329,11 @@ jobs:
     needs: [set-env, notify-start]
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
-          ref: production-bypass
 
       - name: Configure AWS Credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -387,6 +375,7 @@ jobs:
               \"prerelease\": false
             }"
 
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
@@ -400,8 +389,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
 
       - name: Configure AWS credentials (1)
         uses: ./.github/workflows/configure-aws-credentials
@@ -441,8 +428,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          ref: production-bypass
 
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
@@ -472,3 +457,5 @@ jobs:
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -6,16 +6,16 @@ on:
       release_wait:
         description: Minutes to wait before creating release
         required: false
-        default: '0'
+        default: "0"
       commit_sha:
         description: Deploy specific commit
         required: false
       bypass_freeze:
-        description: 'Bypass holiday freeze and force enable deploy workflows'
+        description: "Bypass holiday freeze and force enable deploy workflows"
         required: false
-        default: 'false'
+        default: "false"
   schedule:
-    - cron: 0 17 * * 1-5
+    - cron: 0 18 * * 1,4
 
 env:
   CHANNEL_ID: C0MQ281DJ # vfs-platform-builds
@@ -29,9 +29,9 @@ jobs:
     outputs:
       is_holiday: ${{ steps.holiday-check.outputs.is_holiday }}
     steps:
-    - name: Check if today is a holiday
-      id: holiday-check
-      uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
+      - name: Check if today is a holiday
+        id: holiday-check
+        uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
 
   cancel-run-if-holiday:
     runs-on: ubuntu-latest
@@ -48,17 +48,17 @@ jobs:
       workflow_enabled_vets_website: ${{ steps.check-status.outputs.workflow_enabled_vets_website }}
       workflow_enabled_content_build: ${{ steps.check-status.outputs.workflow_enabled_content_build }}
       reenabled: ${{ steps.enable-workflows.outputs.reenabled }}
-    steps: 
-    - name: Get bot token from Parameter Store (bypass)
-      if: ${{ github.event.inputs.bypass_freeze == 'true' }}
-      uses: ./.github/workflows/inject-secrets
-      with:
-        ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-        env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+    steps:
+      - name: Get bot token from Parameter Store (bypass)
+        if: ${{ github.event.inputs.bypass_freeze == 'true' }}
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-    - name: Bypass Check - Force Enable Workflows
-      if: ${{ github.event.inputs.bypass_freeze == 'true' }}
-      run: |
+      - name: Bypass Check - Force Enable Workflows
+        if: ${{ github.event.inputs.bypass_freeze == 'true' }}
+        run: |
           echo "Bypass activated – force enabling deploy workflows."
           curl -X PATCH -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
             -H "Accept: application/vnd.github.v3+json" \
@@ -67,57 +67,57 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/department-of-veterans-affairs/content-build/actions/workflows/daily-production-release.yml/enable
 
-    - name: Disable workflows if today is a holiday
-      if: ${{ false }}
-      run: echo "Freeze enforcement handled by freeze-enforcer.yml."
+      - name: Disable workflows if today is a holiday
+        if: ${{ false }}
+        run: echo "Freeze enforcement handled by freeze-enforcer.yml."
 
-    - name: Checkout
-      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
-    - name: Configure AWS credentials for secret injection
-      if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
-      uses: ./.github/workflows/configure-aws-credentials
-      with:
-        aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws_region: us-gov-west-1
+      - name: Configure AWS credentials for secret injection
+        if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-gov-west-1
 
-    - name: Get bot token from Parameter Store
-      if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
-      uses: ./.github/workflows/inject-secrets
-      with:
-        ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-        env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+      - name: Get bot token from Parameter Store
+        if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-    - name: Check Workflow Status
-      id: check-status
-      if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
-      run: |
-        check_status() {
-          local repo=$1
-          local key=$(echo "$repo" | tr '-' '_')
-          local response=$(curl -s -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
-            "https://api.github.com/repos/department-of-veterans-affairs/$repo/actions/workflows/daily-production-release.yml")
+      - name: Check Workflow Status
+        id: check-status
+        if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' }}
+        run: |
+          check_status() {
+            local repo=$1
+            local key=$(echo "$repo" | tr '-' '_')
+            local response=$(curl -s -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
+              "https://api.github.com/repos/department-of-veterans-affairs/$repo/actions/workflows/daily-production-release.yml")
 
-          local state=$(echo "$response" | jq -r '.state')
+            local state=$(echo "$response" | jq -r '.state')
 
-          if [[ "$state" == "active" ]]; then
-            echo "$repo is already enabled. No action needed."
-            echo "workflow_enabled_${key}=true" >> $GITHUB_OUTPUT
-          else
-            echo "$repo is disabled. Re-enabling now."
-            echo "workflow_enabled_${key}=false" >> $GITHUB_OUTPUT
-          fi
-        }
+            if [[ "$state" == "active" ]]; then
+              echo "$repo is already enabled. No action needed."
+              echo "workflow_enabled_${key}=true" >> $GITHUB_OUTPUT
+            else
+              echo "$repo is disabled. Re-enabling now."
+              echo "workflow_enabled_${key}=false" >> $GITHUB_OUTPUT
+            fi
+          }
 
-        check_status "content-build"
+          check_status "content-build"
 
-    - name: Enable Workflows if Disabled
-      id: enable-workflows
-      if: ${{ steps.check-status.outputs.workflow_enabled_content_build == 'false' }}
-      run: |
+      - name: Enable Workflows if Disabled
+        id: enable-workflows
+        if: ${{ steps.check-status.outputs.workflow_enabled_content_build == 'false' }}
+        run: |
           echo "Enabling content-build daily deploy workflow."
           http_code=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
             -H "Authorization: token ${VA_VSP_BOT_GITHUB_TOKEN:-${{ secrets.GITHUB_TOKEN }}}" \
@@ -144,33 +144,33 @@ jobs:
   notify-freeze-ends:
     name: Notify Freeze Ended
     runs-on: ubuntu-latest
-    needs: [holiday-checker, main-deployment] 
-    if: ${{ 
-          github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.outputs.reenabled == 'true'
-         }}  
+    needs: [holiday-checker, main-deployment]
+    if: ${{
+      github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.outputs.reenabled == 'true'
+      }}
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-    - name: Notify Slack (COP) - Code Freeze Ended
-      uses: ./.github/workflows/slack-notify
-      continue-on-error: false
-      with:
-        payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
-        channel_id:  'C04868KS69L' # Frontend COP
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Checkout Repository
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+      - name: Notify Slack (COP) - Code Freeze Ended
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: false
+        with:
+          payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
+          channel_id: "C04868KS69L" # Frontend COP
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Short delay before SRE Slack (Ended)
-      run: sleep 2
+      - name: Short delay before SRE Slack (Ended)
+        run: sleep 2
 
-    - name: Notify Slack (SRE) - Code Freeze Ended
-      uses: ./.github/workflows/slack-notify
-      continue-on-error: false
-      with:
-        payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
-        channel_id:  'C06JM7UUHE3' # platform-sre-team
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Notify Slack (SRE) - Code Freeze Ended
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: false
+        with:
+          payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
+          channel_id: "C06JM7UUHE3" # platform-sre-team
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   notify-bypass:
     name: Notify Bypass Activation
@@ -184,7 +184,7 @@ jobs:
         continue-on-error: false
         with:
           payload: '{"attachments": [{"color": "#0000FF", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "ℹ️ *Deploy Freeze Bypassed:* Emergency bypass activated. Deployment workflows for `vets-website` and `content-build` have been force enabled."}}]}]}'
-          channel_id: 'C04868KS69L'
+          channel_id: "C04868KS69L"
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -196,44 +196,44 @@ jobs:
         continue-on-error: false
         with:
           payload: '{"attachments": [{"color": "#0000FF", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "ℹ️ *Deploy Freeze Bypassed:* Emergency bypass activated. Deployment workflows for `vets-website` and `content-build` have been force enabled."}}]}]}'
-          channel_id: 'C06JM7UUHE3'
+          channel_id: "C06JM7UUHE3"
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      
+
   notify-code-freeze-failure:
     name: Notify Code Freeze Failure
     runs-on: ubuntu-latest
     needs: [holiday-checker, main-deployment]
     if: ${{
-          always() && github.event.inputs.bypass_freeze != 'true' && (
-            (needs.holiday-checker.outputs.is_holiday == 'true' && cancelled()) ||
-            (needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.result == 'failure')
-          )
-        }}
+      always() && github.event.inputs.bypass_freeze != 'true' && (
+      (needs.holiday-checker.outputs.is_holiday == 'true' && cancelled()) ||
+      (needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.result == 'failure')
+      )
+      }}
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+      - name: Checkout Repository
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
-    - name: Notify Slack (COP) - Code Freeze Failure
-      uses: ./.github/workflows/slack-notify
-      continue-on-error: false
-      with:
-        payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
-        channel_id:  'C04868KS69L'
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Notify Slack (COP) - Code Freeze Failure
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: false
+        with:
+          payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
+          channel_id: "C04868KS69L"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Short delay before SRE Slack (Failure)
-      run: sleep 2
+      - name: Short delay before SRE Slack (Failure)
+        run: sleep 2
 
-    - name: Notify Slack (SRE) - Code Freeze Failure
-      uses: ./.github/workflows/slack-notify
-      continue-on-error: false
-      with:
-        payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
-        channel_id:  'C06JM7UUHE3'
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Notify Slack (SRE) - Code Freeze Failure
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: false
+        with:
+          payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
+          channel_id: "C06JM7UUHE3"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   get-workflow-environment:
     runs-on: ubuntu-latest
@@ -305,7 +305,7 @@ jobs:
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          payload: | 
+          payload: |
             {
               "attachments": [
                 {
@@ -329,7 +329,6 @@ jobs:
     needs: [set-env, notify-start]
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
@@ -374,7 +373,6 @@ jobs:
               \"draft\": false,
               \"prerelease\": false
             }"
-
 
   deploy:
     name: Deploy
@@ -457,5 +455,3 @@ jobs:
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  


### PR DESCRIPTION
## Summary

- This reverts commit bfaf77422388d4f85e4260732adb2297cea29632.
- Returns workflow to state it was in prior to launching the OOB deployment workaround for the shutdown. 
- Comment out single app deploys until shutdown is over
- Adjust cron timer to Mon + Thurs only for daily deploy, as well as adjust timing for DST (weekend of Nov 1).
- Deactivate cron timer as the timing will conflict with the manual redeploy. A separate PR will reactivate it after the manual redeploy is complete.


