### PR TITLE
Copy of Submission - do not display questions with no optional selections

### DIFF
--- a/src/applications/disability-benefits/all-claims/ConfirmationPrisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/ConfirmationPrisonerOfWar.unit.spec.jsx
@@ -194,6 +194,8 @@ describe('ConfirmationPrisonerOfWar', () => {
     expect(container.textContent).to.contain(
       'From January 1, 2020 to June 30, 2020',
     );
-    expect(container.textContent).to.contain('None selected');
+    expect(container.textContent).to.not.contain(
+      'Which of your conditions is connected to your POW experience?',
+    );
   });
 });

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
@@ -5,21 +5,17 @@ import { sippableId, capitalizeEachWord } from '../../utils';
 
 const ToxicExposureConditions = ({ formData }) => {
   // first, get list of toxic exposure conditions the user has claimed
-  // return null if no TE conditions
+  // return null if "none" is selected OR if the optional question has no selections
   // then, cross-check that with the list of conditions they checked
   // and display the readable (non-Sippable) names of those conditions
 
   const teConditions = formData?.toxicExposure?.conditions || {};
-  const hasConditionKeys = Object.keys(teConditions).some(
-    key => key !== 'none' && teConditions[key] === true,
-  );
-  if (teConditions?.none === true || !hasConditionKeys) {
-    return null;
-  }
-
   const claimedKeys = Object.keys(teConditions).filter(
     key => key !== 'none' && teConditions[key] === true,
   );
+  if (teConditions?.none === true || claimedKeys.length === 0) {
+    return null;
+  }
   const conditionsContainer = formData?.newDisabilities || [];
   const finalList = conditionsContainer
     .filter(condition => claimedKeys.includes(sippableId(condition.condition)))

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationFields/ToxicExposureConditions.jsx
@@ -8,10 +8,17 @@ const ToxicExposureConditions = ({ formData }) => {
   // return null if no TE conditions
   // then, cross-check that with the list of conditions they checked
   // and display the readable (non-Sippable) names of those conditions
+
   const teConditions = formData?.toxicExposure?.conditions || {};
-  if (teConditions?.none === true) return null;
+  const hasConditionKeys = Object.keys(teConditions).some(
+    key => key !== 'none' && teConditions[key] === true,
+  );
+  if (teConditions?.none === true || !hasConditionKeys) {
+    return null;
+  }
+
   const claimedKeys = Object.keys(teConditions).filter(
-    key => key !== 'none' && teConditions[key],
+    key => key !== 'none' && teConditions[key] === true,
   );
   const conditionsContainer = formData?.newDisabilities || [];
   const finalList = conditionsContainer

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPrisonerOfWar.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPrisonerOfWar.jsx
@@ -18,7 +18,7 @@ const ConfirmationPrisonerOfWar = ({ formData }) => {
   // and display the readable (non-Sippable) names of those conditions
   const powDisabilities = formData?.['view:isPow']?.powDisabilities || {};
   const claimedKeys = Object.keys(powDisabilities).filter(
-    key => key !== 'none' && powDisabilities[key],
+    key => key !== 'none' && powDisabilities[key] === true,
   );
 
   const conditionsContainer = formData?.newDisabilities || [];
@@ -44,7 +44,7 @@ const ConfirmationPrisonerOfWar = ({ formData }) => {
     },
     powDisabilities: {
       label: 'Which of your conditions is connected to your POW experience?',
-      data: finalList.length ? finalList : 'None selected',
+      data: finalList.length ? finalList : null,
     },
   };
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('Toxic Exposure Conditions', () => {
     uiSchema,
   } = formConfig.chapters.disabilities.pages.toxicExposureConditions;
 
-  it('expect that nothing shows up when no toxic exposure conditions are selected', () => {
+  it('expect that nothing shows up when user selects "I am not claiming any conditions related to toxic exposure " checkbox', () => {
     const formData = {
       toxicExposure: {
         conditions: {
@@ -33,7 +33,23 @@ describe('Toxic Exposure Conditions', () => {
     const { queryByText } = render(
       <ToxicExposureConditions formData={formData} />,
     );
-    // const element = document.getElementById('nonExistentElement'); // Attempt to find an element that shouldn't be there
+
+    expect(queryByText(/toxic exposure/i)).to.be.null;
+    expect(queryByText(/none claimed/i)).to.be.null;
+    expect(queryByText(/asthma/i)).to.be.null;
+    expect(queryByText(/copd/i)).to.be.null;
+  });
+
+  it('expect that nothing shows up when no toxic exposure selection is made (the page is optional)', () => {
+    const formData = {
+      toxicExposure: {
+        conditions: {},
+      },
+      newDisabilities: [{ condition: 'Asthma' }, { condition: 'COPD' }],
+    };
+    const { queryByText } = render(
+      <ToxicExposureConditions formData={formData} />,
+    );
 
     expect(queryByText(/toxic exposure/i)).to.be.null;
     expect(queryByText(/none claimed/i)).to.be.null;

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('Toxic Exposure Conditions', () => {
     expect(queryByText(/copd/i)).to.be.null;
   });
 
-  it('expect that nothing shows up when no toxic exposure selection is made (the page is optional)', () => {
+  it('expect that nothing shows up when no toxic exposure selection is made (the question is optional)', () => {
     const formData = {
       toxicExposure: {
         conditions: {},

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConditions.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('Toxic Exposure Conditions', () => {
     uiSchema,
   } = formConfig.chapters.disabilities.pages.toxicExposureConditions;
 
-  it('expect that nothing shows up when user selects "I am not claiming any conditions related to toxic exposure " checkbox', () => {
+  it('expect that nothing shows up when user selects "I am not claiming any conditions related to toxic exposure" checkbox', () => {
     const formData = {
       toxicExposure: {
         conditions: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
This PR updates two areas of the confirmation page that should not display when no option is selected.
  - 1: Toxic exposure section 
    - should not display if the optional page is skipped
    - should not display if "I am not claiming any conditions related to toxic exposure" is selected
    - should only display if at least one condition has been selected
  - 2: The POW disabilities question 
    - should not display if no conditions are selected
    - should only display if at least one conditions has been selected

- _(Which team do you work for, does your team own the maintenance of this component?)_
VA DBC Core team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
This work is gated behind `disability_526_show_confirmation_review`

## Related issue(s)

- a11y ticket where this section was initially failing an axe check https://github.com/department-of-veterans-affairs/va.gov-team/issues/122820
- Spike about being consistent on optional questions https://github.com/department-of-veterans-affairs/va.gov-team/issues/122798 this ticket links to the canvas that says "we should be consistent with optional questions. generally we don't show them if there is no response so this should follow suit."


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
Setup: Make sure the `disability_526_show_confirmation_review` flipper is on (should be on by default). Turn off the new conditions `workflow flipper disability_compensation_new_conditions_workflow`

1. Fill out the form 526, the only specific data entries required are listed in steps 2 and 3
2. On the Toxic Exposure Page
  - State 1 (no selection): Do not select anything on the Toxic Exposure page (it is optional). The resulting json will have an empty conditions object
  `"toxicExposure": {
    "conditions": {}, ...
    },`
  -- State 2 ("none" selected): select "I am not claiming any conditions related to toxic exposure"
3. On the POW page
  - State 1 ('false'): select no
  - State 2 ('true'): select 'yes' and skip selecting a condition

4. Successfully submit the form in order to view the confirmation page

5. On the confirmation page, verify each state (detailed in screenshots below):
    - that the "Toxic Exposure" heading no longer appears
    - that the POW section no longer shows "Which of your conditions is connected to your POW experience?"
    - the axe dev tool passes a full page scan (with the accordion expanded)

- _Describe the tests completed and the results_
Tests have been updated to reflect the expected behavior

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  <img width="634" height="706" alt="Screenshot 2025-10-31 at 12 51 28 PM" src="https://github.com/user-attachments/assets/7e66b53e-57dc-4647-be80-e52c47101f55" /> | <img width="580" height="610" alt="Screenshot 2025-11-03 at 7 15 50 PM" src="https://github.com/user-attachments/assets/2b2a0518-5f03-4f0a-8793-7dd06c663eb8" /> |

## Verification of changes
| **State Tested** | **Page Screenshot**  | **Confirmation Screenshot (CoS)**
|------------------|----------------------|-----------------
| TE conditions - page skipped | <img width="554" height="294" alt="Screenshot 2025-11-03 at 3 11 57 PM" src="https://github.com/user-attachments/assets/dbff0397-884d-4b7b-8619-64a7a5f98887" /> |  <img width="289" height="267" alt="Screenshot 2025-11-03 at 3 45 56 PM" src="https://github.com/user-attachments/assets/45a9ac64-f02a-4057-acdd-d41af0b01428" /> 
| TE conditions - "none" selected | <img width="509" height="271" alt="Screenshot 2025-11-03 at 3 15 24 PM" src="https://github.com/user-attachments/assets/7c3a9535-324c-4571-92b5-ee4d4574772c" /> | <img width="314" height="318" alt="Screenshot 2025-11-03 at 3 48 27 PM" src="https://github.com/user-attachments/assets/2a7518e9-7c8b-4500-8b6d-08097b8b4b2f" /> 
| POW - true, no conditions | <img width="562" height="749" alt="Screenshot 2025-11-03 at 3 47 54 PM" src="https://github.com/user-attachments/assets/3cf92d04-a003-4582-b926-a8c436e1f7ba" /> |<img width="314" height="318" alt="Screenshot 2025-11-03 at 3 48 27 PM" src="https://github.com/user-attachments/assets/2a7518e9-7c8b-4500-8b6d-08097b8b4b2f" /> 
| POW - false | <img width="421" height="186" alt="Screenshot 2025-11-03 at 3 40 20 PM" src="https://github.com/user-attachments/assets/c16d63c0-07d9-47e3-bd8b-8b7536064064" />   | <img width="289" height="267" alt="Screenshot 2025-11-03 at 3 45 56 PM" src="https://github.com/user-attachments/assets/45a9ac64-f02a-4057-acdd-d41af0b01428" /> 

## Proof of local submission
<img width="742" height="992" alt="Screenshot 2025-11-03 at 7 16 18 PM" src="https://github.com/user-attachments/assets/33af0a67-c95c-4045-858d-850ab75c24d1" />


## What areas of the site does it impact?
This only impacts the form 526 Confirmation page

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
