### PR TITLE
Fix va-file-input-multiple E2E Tests

### DIFF
--- a/src/applications/claims-status/tests/e2e/10.va-file-input-multiple.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/10.va-file-input-multiple.cypress.spec.js
@@ -73,24 +73,30 @@ describe('VA File Input Multiple', () => {
   const uploadFile = (fileName, fileIndex = 0) => {
     getFileInput(fileIndex)
       .find('input[type="file"]')
-      .selectFile({
-        contents: Cypress.Buffer.from('test content'),
-        fileName,
-      });
+      .selectFile(
+        {
+          contents: Cypress.Buffer.from('test content'),
+          fileName,
+        },
+        { force: true },
+      );
   };
 
   const uploadEncryptedPDF = (fileName, fileIndex = 0) => {
     getFileInput(fileIndex)
       .find('input[type="file"]')
-      .selectFile({
-        contents: Cypress.Buffer.from('%PDF-1.4\n/Encrypt\nsome content'),
-        fileName,
-        mimeType: 'application/pdf',
-      });
+      .selectFile(
+        {
+          contents: Cypress.Buffer.from('%PDF-1.4\n/Encrypt\nsome content'),
+          fileName,
+          mimeType: 'application/pdf',
+        },
+        { force: true },
+      );
   };
 
   const getAboveFileInputError = (fileIndex = 0) =>
-    getFileInput(fileIndex).find('#file-input-error-alert');
+    getFileInput(fileIndex).find('[role="alert"]');
 
   const getFileError = (fileIndex = 0) =>
     getFileInput(fileIndex).find('#input-error-message');
@@ -106,9 +112,9 @@ describe('VA File Input Multiple', () => {
   const clickDeleteButton = (fileIndex = 0, expectedFileName) => {
     getFileInput(fileIndex)
       .should('contain.text', expectedFileName)
-      .find('va-button-icon[aria-label*="delete file"]')
+      .find('va-button-icon')
       .shadow()
-      .find('button')
+      .find('button[aria-label*="delete file"]')
       .click();
   };
 


### PR DESCRIPTION
## Summary

This PR fixes E2E tests for `va-file-input-multiple` that broke due to recent component library updates (PRs [#1819](https://github.com/department-of-veterans-affairs/component-library/pull/1819) and [#1832](https://github.com/department-of-veterans-affairs/component-library/pull/1832)).

### Changes

**Updated test selectors to match component library changes:**

1. **Error messages:** Changed from hardcoded ID `#file-input-error-alert` to semantic selector `[role="alert"]`
2. **Delete button:** Updated selector to look for `aria-label` on the `<button>` inside `va-button-icon` shadow DOM instead of on the `va-button-icon` element itself
3. **File upload:** Added `{ force: true }` to `selectFile()` calls in helper functions (`uploadFile()` and `uploadEncryptedPDF()`) because file input now uses `visibility: hidden`

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#123978

## Testing Done

- All 31 E2E tests now pass (previously 8 failing)
- Tests validated across all scenarios: file validation, encrypted PDFs, document type selection, file removal, and data retention

**Run tests:**
```bash
yarn cy:run --spec src/applications/claims-status/tests/e2e/10.va-file-input-multiple.cypress.spec.js
```

## What areas of the site does it impact?

- Claims Status Tool E2E tests
- File upload functionality testing

## Acceptance Criteria

- [x] All 31 E2E tests pass
- [x] Selectors use semantic, resilient patterns (no hardcoded IDs)
- [x] Tests follow platform engineering best practices for selector stability