### PR TITLE
21P-534ez Chapter 5 updates

### DIFF
--- a/src/applications/survivors-benefits/components/FormAlerts/index.jsx
+++ b/src/applications/survivors-benefits/components/FormAlerts/index.jsx
@@ -44,8 +44,8 @@ const RequestFormAlert = ({
     </p>
     <p>{children}</p>
     <p>
-      We’ll ask you to upload this form at the end of this application. Or you
-      can send it to us by mail.
+      We’ll ask you to upload this document at the end of this application. Or
+      you can send it to us by mail.
     </p>
     <p>
       <va-link href={formLink} external text={`Get ${formName} to download`} />

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/dicBenefits.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/dicBenefits.js
@@ -1,29 +1,25 @@
 import {
   radioUI,
   radioSchema,
-  arrayBuilderItemFirstPageTitleUI,
+  titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { dicOptions } from '../../../utils/labels';
 
-const uiSchema = {
-  ...arrayBuilderItemFirstPageTitleUI({ title: 'D.I.C. benefits' }),
-  'view:dicType': radioUI({
-    title:
-      'What Dependency and indemnity compensation (D.I.C.) benefit are you claiming?',
-    labels: dicOptions,
-    classNames: 'vads-u-margin-bottom--2',
-  }),
-};
-
-const schema = {
-  type: 'object',
-  properties: {
-    'view:dicType': radioSchema(Object.keys(dicOptions)),
-  },
-  required: ['view:dicType'],
-};
-
+/** @type {PageSchema} */
 export default {
-  uiSchema,
-  schema,
+  uiSchema: {
+    ...titleUI('DIC benefits'),
+    dicType: radioUI({
+      title:
+        'What Dependency and indemnity compensation (DIC) benefit are you claiming?',
+      labels: dicOptions,
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['dicType'],
+    properties: {
+      dicType: radioSchema(Object.keys(dicOptions)),
+    },
+  },
 };

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/helpers.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/helpers.js
@@ -1,0 +1,7 @@
+import { format, parseISO } from 'date-fns';
+
+export const transformDate = dateStr => {
+  if (!dateStr) return null;
+  const date = parseISO(dateStr);
+  return format(date, 'MM/dd/yyyy');
+};

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/nursingHome.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/nursingHome.js
@@ -1,7 +1,7 @@
 import {
-  arrayBuilderItemFirstPageTitleUI,
-  radioUI,
-  radioSchema,
+  titleUI,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import {
   SpecialMonthlyPensionEvidenceAlert,
@@ -9,52 +9,43 @@ import {
 } from '../../../components/FormAlerts';
 import { isYes } from '../../../utils/helpers';
 
-const uiSchema = {
-  ...arrayBuilderItemFirstPageTitleUI({
-    title: 'Nursing home or increased survivor entitlement',
-  }),
-  needRegularAssistance: radioUI({
-    title:
-      'Are you claiming special monthly pension or special monthly D.I.C. because you need the regular assistance of another person, have severe visual problems, or are generally confined to your immediate premises?',
-    classNames: 'vads-u-margin-bottom--2',
-  }),
-  needRegularAssistanceAlert: {
-    'ui:description': SpecialMonthlyPensionEvidenceAlert,
-    'ui:options': {
-      hideIf: formData => !isYes(formData?.needRegularAssistance),
-      displayEmptyObjectOnReview: true,
-    },
-  },
-  inNursingHome: radioUI({
-    title: 'Are you in a nursing home?',
-  }),
-  inNursingHomeAlert: {
-    'ui:description': RequestNursingHomeInformationAlert,
-    'ui:options': {
-      hideIf: formData => !isYes(formData?.inNursingHome),
-      displayEmptyObjectOnReview: true,
-    },
-  },
-};
-
-const schema = {
-  type: 'object',
-  properties: {
-    needRegularAssistance: radioSchema(['Yes', 'No']),
-    needRegularAssistanceAlert: {
-      type: 'object',
-      properties: {},
-    },
-    inNursingHome: radioSchema(['Yes', 'No']),
-    inNursingHomeAlert: {
-      type: 'object',
-      properties: {},
-    },
-  },
-  required: ['needRegularAssistance', 'inNursingHome'],
-};
-
+/** @type {PageSchema} */
 export default {
-  uiSchema,
-  schema,
+  uiSchema: {
+    ...titleUI('Nursing home or increased survivor entitlement'),
+    needRegularAssistance: yesNoUI(
+      'Are you claiming special monthly pension or special monthly DIC because you need the regular assistance of another person, have severe visual problems, or are generally confined to your immediate premises?',
+    ),
+    needRegularAssistanceAlert: {
+      'ui:description': SpecialMonthlyPensionEvidenceAlert,
+      'ui:options': {
+        hideIf: formData => !isYes(formData?.needRegularAssistance),
+        displayEmptyObjectOnReview: true,
+      },
+    },
+    inNursingHome: yesNoUI('Are you in a nursing home?'),
+    inNursingHomeAlert: {
+      'ui:description': RequestNursingHomeInformationAlert,
+      'ui:options': {
+        hideIf: formData => !isYes(formData?.inNursingHome),
+        displayEmptyObjectOnReview: true,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      needRegularAssistance: yesNoSchema,
+      needRegularAssistanceAlert: {
+        type: 'object',
+        properties: {},
+      },
+      inNursingHome: yesNoSchema,
+      inNursingHomeAlert: {
+        type: 'object',
+        properties: {},
+      },
+    },
+    required: ['needRegularAssistance', 'inNursingHome'],
+  },
 };

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -8,10 +8,7 @@ import {
   textSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
-
-// Short description shown on the intro page.
-const treatmentDescription =
-  'In the next few questions, we’ll ask you about VA medical centers where the Veteran received treatment pertaining to your claim.';
+import { transformDate } from './helpers';
 
 /** @type {ArrayBuilderOptions} */
 const options = {
@@ -19,9 +16,19 @@ const options = {
   nounSingular: 'VA medical center',
   nounPlural: 'VA medical centers',
   required: false,
+  maxItems: 3,
   text: {
-    getItemName: 'VA medical center',
-    cardDescription: '',
+    summaryTitle: 'Review VA medical centers',
+    alertMaxItems:
+      'You have added the maximum number of allowed VA medical centers for this application. You may edit or delete a name or choose to continue on in the application.',
+    getItemName: formData =>
+      formData.vaMedicalCenterName || 'VA medical center',
+    cardDescription: formData =>
+      formData.startDate && formData.endDate
+        ? `${transformDate(formData.startDate)} - ${transformDate(
+            formData.endDate,
+          )}`
+        : 'Treatment dates not provided',
   },
 };
 
@@ -30,10 +37,9 @@ const introPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Treatment at VA medical centers',
-      nounSingular: options.nounSingular,
-      nounPlural: options.nounPlural,
     }),
-    'ui:description': treatmentDescription,
+    'ui:description':
+      'Next we’ll ask you about VA medical centers where the Veteran received treatment pertaining to your claim. You may add up to 3 VA medical centers.',
   },
   schema: {
     type: 'object',
@@ -90,24 +96,14 @@ const treatmentDatePage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Dates of treatment',
-      nounSingular: options.nounSingular,
-      nounPlural: options.nounPlural,
     }),
     startDate: currentOrPastDateUI({
       title: 'Start date of treatment',
       monthSelect: false,
-      'ui:description':
-        'Enter 2 digits for the month and day and 4 digits for the year.',
-      required: formData =>
-        formData?.firstTimeReporting !== undefined &&
-        formData?.firstTimeReporting === false,
     }),
     endDate: currentOrPastDateUI({
       title: 'End date of treatment',
       monthSelect: false,
-      required: formData =>
-        formData?.firstTimeReporting !== undefined &&
-        formData?.firstTimeReporting === false,
     }),
   },
   schema: {
@@ -124,24 +120,28 @@ export const treatmentPages = arrayBuilderPages(options, pageBuilder => ({
   dicBenefitsIntro: pageBuilder.introPage({
     title: 'Treatment at VA medical centers',
     path: 'claim-information/dic/treatment',
+    depends: formData => formData?.dicType === 'DIC',
     uiSchema: introPage.uiSchema,
     schema: introPage.schema,
   }),
   dicBenefitsSummary: pageBuilder.summaryPage({
-    title: 'D.I.C. benefits',
+    title: 'DIC benefits',
     path: 'claim-information/dic/add',
+    depends: formData => formData?.dicType === 'DIC',
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,
   }),
   dicNameLocationPage: pageBuilder.itemPage({
     title: 'VA medical center name and location',
     path: 'claim-information/dic/:index/name-location',
+    depends: formData => formData?.dicType === 'DIC',
     uiSchema: nameLocationPage.uiSchema,
     schema: nameLocationPage.schema,
   }),
   dicTreatmentDates: pageBuilder.itemPage({
     title: 'Dates of treatment',
     path: 'claim-information/dic/:index/dates',
+    depends: formData => formData?.dicType === 'DIC',
     uiSchema: treatmentDatePage.uiSchema,
     schema: treatmentDatePage.schema,
   }),

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -20,7 +20,7 @@ export const options = {
   text: {
     summaryTitle: 'Review VA medical centers',
     alertMaxItems:
-      'You have added the maximum number of allowed VA medical centers for this application. You may edit or delete a name or choose to continue on in the application.',
+      'You have added the maximum number of allowed VA medical centers for this application. You may edit or delete a VA medical center or choose to continue on in the application.',
     getItemName: formData =>
       formData.vaMedicalCenterName || 'VA medical center',
     cardDescription: formData =>

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -39,7 +39,7 @@ const introPage = {
       title: 'Treatment at VA medical centers',
     }),
     'ui:description':
-      'Next we’ll ask you about VA medical centers where the Veteran received treatment pertaining to your claim. You may add up to 3 VA medical centers.',
+      'Next we’ll ask you about VA medical centers where the Veteran received treatment pertaining to your claim. You may edit or delete a VA medical center or choose to continue on in the application.',
   },
   schema: {
     type: 'object',

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -11,7 +11,7 @@ import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array
 import { transformDate } from './helpers';
 
 /** @type {ArrayBuilderOptions} */
-const options = {
+export const options = {
   arrayPath: 'vaMedicalCenters',
   nounSingular: 'VA medical center',
   nounPlural: 'VA medical centers',

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -314,6 +314,8 @@ const formConfig = {
         dicBenefits: {
           title: 'D.I.C. benefits',
           path: 'claim-information/dic',
+          depends: formData =>
+            formData?.claims?.dependencyIndemnityComp === true,
           uiSchema: dicBenefits.uiSchema,
           schema: dicBenefits.schema,
         },

--- a/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/dicBenefits.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/dicBenefits.unit.spec.jsx
@@ -6,33 +6,23 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-import formConfig from '../../../../config/form';
+import dicBenefits from '../../../../config/chapters/05-claim-information/dicBenefits';
 import { dicOptions } from '../../../../utils/labels';
 
 describe('DIC Benefits Page', () => {
-  const {
-    schema,
-    uiSchema,
-    arrayPath,
-    title,
-  } = formConfig.chapters.claimInformation.pages.dicBenefits;
+  const { schema, uiSchema } = dicBenefits;
   it('renders the DIC benefits options', async () => {
     const form = render(
-      <DefinitionTester
-        arrayPath={arrayPath}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-      />,
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={{}} />,
     );
     const formDOM = getFormDOM(form);
     const vaRadio = $('va-radio', formDOM);
     const options = $$('va-radio-option', formDOM);
     const optionKeys = Object.keys(dicOptions);
 
-    expect(form.getByRole('heading')).to.have.text(title);
+    expect(form.getByRole('heading')).to.have.text('DIC benefits');
     expect(vaRadio.getAttribute('label')).to.equal(
-      'What Dependency and indemnity compensation (D.I.C.) benefit are you claiming?',
+      'What Dependency and indemnity compensation (DIC) benefit are you claiming?',
     );
     expect(vaRadio.getAttribute('required')).to.equal('true');
 

--- a/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/nursingHome.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/nursingHome.unit.spec.jsx
@@ -34,7 +34,7 @@ describe('Nursing Home Page', () => {
 
     expect(vaRadios.length).to.equal(2);
     expect(vaRadios[0].getAttribute('label')).to.equal(
-      'Are you claiming special monthly pension or special monthly D.I.C. because you need the regular assistance of another person, have severe visual problems, or are generally confined to your immediate premises?',
+      'Are you claiming special monthly pension or special monthly DIC because you need the regular assistance of another person, have severe visual problems, or are generally confined to your immediate premises?',
     );
     expect(vaRadios[0].getAttribute('required')).to.equal('true');
 
@@ -56,18 +56,18 @@ describe('Nursing Home Page', () => {
 
     expect(vaAlerts.length).to.equal(0);
     assistanceRadio.__events.vaValueChange({
-      detail: { value: 'Yes' },
+      detail: { value: 'Y' },
     });
     expect($$('va-alert-expandable', formDOM).length).to.equal(1);
     nursingHomeRadio.__events.vaValueChange({
-      detail: { value: 'Yes' },
+      detail: { value: 'Y' },
     });
     expect($$('va-alert-expandable', formDOM).length).to.equal(2);
     assistanceRadio.__events.vaValueChange({
-      detail: { value: 'No' },
+      detail: { value: 'N' },
     });
     nursingHomeRadio.__events.vaValueChange({
-      detail: { value: 'No' },
+      detail: { value: 'N' },
     });
     expect($$('va-alert-expandable', formDOM).length).to.equal(0);
   });

--- a/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/treatmentPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/treatmentPages.unit.spec.jsx
@@ -6,7 +6,10 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-import { treatmentPages } from '../../../../config/chapters/05-claim-information/treatmentPages';
+import {
+  treatmentPages,
+  options,
+} from '../../../../config/chapters/05-claim-information/treatmentPages';
 
 const arrayPath = 'vaMedicalCenters';
 
@@ -76,8 +79,8 @@ describe('Treatment Pages', () => {
 
     const vaStartDate = $('va-memorable-date[name*="root_startDate"]', formDOM);
     const vaEndDate = $('va-memorable-date[name*="root_endDate"]', formDOM);
-    expect(vaStartDate.getAttribute('required')).to.equal('false');
-    expect(vaEndDate.getAttribute('required')).to.equal('false');
+    expect(vaStartDate.getAttribute('required')).to.equal('true');
+    expect(vaEndDate.getAttribute('required')).to.equal('true');
   });
   it('renders the treatment page dates again', async () => {
     const { dicTreatmentDates } = treatmentPages;
@@ -88,7 +91,7 @@ describe('Treatment Pages', () => {
         schema={dicTreatmentDates.schema}
         uiSchema={dicTreatmentDates.uiSchema}
         pagePerItemIndex={0}
-        data={{ firstTimeReporting: false, vaMedicalCenters: [formData] }}
+        data={{ vaMedicalCenters: [formData] }}
       />,
     );
     const formDOM = getFormDOM(form);
@@ -99,5 +102,47 @@ describe('Treatment Pages', () => {
     const vaEndDate = $('va-memorable-date[name*="root_endDate"]', formDOM);
     expect(vaStartDate.getAttribute('required')).to.equal('true');
     expect(vaEndDate.getAttribute('required')).to.equal('true');
+  });
+  it('should return the correct card description with itemName and cardDescription', () => {
+    const item = {
+      vaMedicalCenterName: 'Hospital ABC',
+      startDate: '2004-04-04',
+      endDate: '2005-05-05',
+    };
+    const { getByText: nameText } = render(options.text.getItemName(item));
+    const { getByText: descriptionText } = render(
+      options.text.cardDescription(item),
+    );
+    expect(nameText('Hospital ABC')).to.exist;
+    expect(descriptionText('04/04/2004 - 05/05/2005')).to.exist;
+  });
+  it('should return the default card description with itemName and cardDescription', () => {
+    const item = {};
+    const { getByText: nameText } = render(options.text.getItemName(item));
+    const { getByText: descriptionText } = render(
+      options.text.cardDescription(item),
+    );
+    expect(nameText('VA medical center')).to.exist;
+    expect(descriptionText('Treatment dates not provided')).to.exist;
+  });
+  it('should return correct depends function', () => {
+    const {
+      dicBenefitsIntro,
+      dicBenefitsSummary,
+      dicNameLocationPage,
+      dicTreatmentDates,
+    } = treatmentPages;
+
+    const formDataTrue = { dicType: 'DIC' };
+    const formDataFalse = { dicType: 'NOT_DIC' };
+
+    expect(dicBenefitsIntro.depends(formDataTrue)).to.be.true;
+    expect(dicBenefitsIntro.depends(formDataFalse)).to.be.false;
+    expect(dicBenefitsSummary.depends(formDataTrue)).to.be.true;
+    expect(dicBenefitsSummary.depends(formDataFalse)).to.be.false;
+    expect(dicNameLocationPage.depends(formDataTrue)).to.be.true;
+    expect(dicNameLocationPage.depends(formDataFalse)).to.be.false;
+    expect(dicTreatmentDates.depends(formDataTrue)).to.be.true;
+    expect(dicTreatmentDates.depends(formDataFalse)).to.be.false;
   });
 });

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -2,11 +2,10 @@
 // Always use keys for data storage
 
 export const dicOptions = {
-  DIC: 'D.I.C.',
-  DIC_1151:
-    'D.I.C. under U.S.C. 1151 (Note: D.I.C. under 38 U.S.C. is a rare benefit. Please refer to the Instructions page 5 for guidance on 38 U.S.C. 1151)',
+  DIC: 'DIC',
+  DIC_1151: 'DIC under U.S.C. 1151',
   DIC_REEVALUATION:
-    'D.I.C. due to claimant election of a re-evaluation of a previously denied claim based on expanded eligibility under PL 117-168 (PACT Act)',
+    'DIC due to claimant election of a re-evaluation of a previously denied claim based on expanded eligibility under PL 117-168 (PACT Act)',
 };
 
 export const servicesOptions = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update content on chapter 5
- Update flow based on chapter 2 DIC question
- Add unit test coverage

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123937
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123638
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123650
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123640
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123645
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123656
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123654

## Testing done

- Manual testing
- Updated unit tests for better coverage

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="552" height="517" alt="Screenshot 2025-10-31 at 5 04 32 PM" src="https://github.com/user-attachments/assets/b5c821ae-491a-4053-8b75-b992fa7b9929" /> <img width="445" height="622" alt="Screenshot 2025-10-31 at 5 28 19 PM" src="https://github.com/user-attachments/assets/795977f1-9368-4811-a90c-51fcd83ab4cc" /> <img width="575" height="465" alt="Screenshot 2025-10-31 at 5 24 41 PM" src="https://github.com/user-attachments/assets/7a854638-1cfe-4352-b783-fc1ded35fb21" />| <img width="587" height="394" alt="Screenshot 2025-10-31 at 5 05 00 PM" src="https://github.com/user-attachments/assets/b3051eef-e6b1-4a46-a05d-d419aa4db3db" /> <img width="500" height="625" alt="Screenshot 2025-10-31 at 5 29 04 PM" src="https://github.com/user-attachments/assets/50bb75c6-3093-4aa3-a5cd-06f5718dbba5" /> <img width="538" height="288" alt="Screenshot 2025-10-31 at 5 42 37 PM" src="https://github.com/user-attachments/assets/c04b5c19-d9b4-4f5f-84b7-fb1b094094a7" /> <img width="518" height="259" alt="Screenshot 2025-10-31 at 5 42 55 PM" src="https://github.com/user-attachments/assets/c5254d48-5d17-468c-ba47-057716ac1cf9" /> <img width="587" height="750" alt="Screenshot 2025-10-31 at 5 43 42 PM" src="https://github.com/user-attachments/assets/4069cb7b-fdb5-4262-86fd-e0801e71c2ec" /> |

New after screenshots:
<img width="598" height="1073" alt="Screenshot 2025-11-03 at 8 55 59 AM" src="https://github.com/user-attachments/assets/da43b3d7-e448-4ed6-8a6c-1147bf1a776e" />
<img width="647" height="759" alt="Screenshot 2025-11-03 at 9 40 54 AM" src="https://github.com/user-attachments/assets/2830b142-fcfd-4a82-92e0-31f9973cd5cd" />


## What areas of the site does it impact?

Chapter 5 of the 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
