### PR TITLE
10-7959a | Update schema definitions

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
@@ -1,11 +1,8 @@
-import { cloneDeep } from 'lodash';
 import {
   addressUI,
   addressSchema,
   dateOfBirthUI,
   dateOfBirthSchema,
-  fullNameUI,
-  fullNameSchema,
   titleUI,
   radioUI,
   radioSchema,
@@ -20,11 +17,13 @@ import {
   validAddressCharsOnly,
   validObjectCharsOnly,
 } from '../../shared/validations';
-import content from '../locales/en/content.json';
+import {
+  champvaMemberNumberSchema,
+  fullNameMiddleInitialSchema,
+  fullNameMiddleInitialUI,
+} from '../definitions';
 import { personalizeTitleByName } from '../utils/helpers';
-
-const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
-fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
+import content from '../locales/en/content.json';
 
 export const applicantNameDobSchema = {
   uiSchema: {
@@ -43,7 +42,7 @@ export const applicantNameDobSchema = {
     type: 'object',
     required: ['applicantDOB'],
     properties: {
-      applicantName: fullNameSchema,
+      applicantName: fullNameMiddleInitialSchema,
       applicantDOB: dateOfBirthSchema,
     },
   },
@@ -70,12 +69,7 @@ export const applicantMemberNumberSchema = {
     type: 'object',
     required: ['applicantMemberNumber'],
     properties: {
-      applicantMemberNumber: {
-        type: 'string',
-        pattern: '^[0-9]+$',
-        maxLength: 9,
-        minLength: 8,
-      },
+      applicantMemberNumber: champvaMemberNumberSchema,
     },
   },
 };
@@ -106,7 +100,6 @@ export const applicantAddressSchema = {
           no: content['form-input--option--no'],
           unknown: content['form-input--option--unknown'],
         },
-        classNames: ['dd-privacy-hidden'],
       }),
     },
     'ui:validations': [

--- a/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
@@ -9,13 +9,13 @@ import {
 import { fileUploadUi as fileUploadUI } from '../../shared/components/fileUploads/upload';
 import { fileUploadBlurb } from '../../shared/components/fileUploads/attachments';
 import { FileFieldCustomSimple } from '../../shared/components/fileUploads/FileUpload';
-import { blankSchema } from './sponsorInformation';
 import { LLM_UPLOAD_WARNING } from '../components/llmUploadWarning';
 import { LLM_RESPONSE } from '../components/llmUploadResponse';
 import SubmittingClaimsAddtlInfo from '../components/FormDescriptions/SubmittingClaimsAddtlInfo';
 import MedicalEobDescription from '../components/FormDescriptions/MedicalEobDescription';
 import PharmacyClaimsDescription from '../components/FormDescriptions/PharmacyClaimsDescription';
 import MedicalClaimsDescription from '../components/FormDescriptions/MedicalClaimsDescription';
+import { blankSchema, fileUploadSchema } from '../definitions';
 import content from '../locales/en/content.json';
 
 const addtlInfoNotes = {
@@ -100,18 +100,7 @@ export const medicalClaimUploadSchema = {
       'view:notes': blankSchema,
       // schema for LLM message
       'view:fileClaim': blankSchema,
-      medicalUpload: {
-        type: 'array',
-        minItems: 1,
-        items: {
-          type: 'object',
-          properties: {
-            name: {
-              type: 'string',
-            },
-          },
-        },
-      },
+      medicalUpload: fileUploadSchema,
       'view:uploadAlert': blankSchema,
     },
   },
@@ -148,18 +137,7 @@ export const eobUploadSchema = isPrimary => {
         'view:notes': blankSchema,
         // schema for LLM message
         'view:fileClaim': blankSchema,
-        [keyName]: {
-          type: 'array',
-          minItems: 1,
-          items: {
-            type: 'object',
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-          },
-        },
+        [keyName]: fileUploadSchema,
         'view:uploadAlert': blankSchema,
       },
     },
@@ -190,18 +168,7 @@ export const pharmacyClaimUploadSchema = {
       'view:notes': blankSchema,
       // schema for LLM message
       'view:fileClaim': blankSchema,
-      pharmacyUpload: {
-        type: 'array',
-        minItems: 1,
-        items: {
-          type: 'object',
-          properties: {
-            name: {
-              type: 'string',
-            },
-          },
-        },
-      },
+      pharmacyUpload: fileUploadSchema,
       'view:uploadAlert': blankSchema,
     },
   },

--- a/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
@@ -19,8 +19,8 @@ import {
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import { privWrapper } from '../../shared/utilities';
 import { validFieldCharsOnly } from '../../shared/validations';
-import content from '../locales/en/content.json';
 import { personalizeTitleByName, replaceStrValues } from '../utils/helpers';
+import content from '../locales/en/content.json';
 
 const INSURANCE_TYPE_LABELS = {
   group: content['health-insurance--type-label--group'],

--- a/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
@@ -1,4 +1,3 @@
-import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 import {
   titleUI,
   descriptionUI,
@@ -19,6 +18,7 @@ import {
   ResubmissionDocsUploadDescription,
 } from '../components/FormDescriptions/ResubmissionDescriptions';
 import ClaimIdentificationInfo from '../components/FormDescriptions/ClaimIdentificationInfo';
+import { blankSchema, fileUploadSchema } from '../definitions';
 import content from '../locales/en/content.json';
 
 const ID_NUMBER_OPTIONS = [
@@ -75,14 +75,7 @@ export const resubmissionLetterUpload = {
     required: ['resubmissionLetterUpload'],
     properties: {
       'view:fileClaim': blankSchema,
-      resubmissionLetterUpload: {
-        type: 'array',
-        minItems: 1,
-        items: {
-          type: 'object',
-          properties: { name: { type: 'string' } },
-        },
-      },
+      resubmissionLetterUpload: fileUploadSchema,
       'view:uploadAlert': blankSchema,
     },
   },
@@ -108,14 +101,7 @@ export const resubmissionDocsUpload = {
     required: ['resubmissionDocsUpload'],
     properties: {
       'view:fileClaim': blankSchema,
-      resubmissionDocsUpload: {
-        type: 'array',
-        minItems: 1,
-        items: {
-          type: 'object',
-          properties: { name: { type: 'string' } },
-        },
-      },
+      resubmissionDocsUpload: fileUploadSchema,
       'view:uploadAlert': blankSchema,
     },
   },

--- a/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
@@ -1,10 +1,7 @@
-import { cloneDeep } from 'lodash';
 import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import {
   addressUI,
   addressSchema,
-  fullNameUI,
-  fullNameSchema,
   titleUI,
   radioUI,
   radioSchema,
@@ -15,17 +12,18 @@ import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 import {
   validAddressCharsOnly,
   validFieldCharsOnly,
   validObjectCharsOnly,
 } from '../../shared/validations';
+import {
+  blankSchema,
+  fullNameMiddleInitialSchema,
+  fullNameMiddleInitialUI,
+} from '../definitions';
 import { personalizeTitleByRole } from '../utils/helpers';
 import content from '../locales/en/content.json';
-
-const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
-fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const certifierRoleSchema = {
   uiSchema: {
@@ -101,7 +99,7 @@ export const certifierNameSchema = {
   schema: {
     type: 'object',
     properties: {
-      certifierName: fullNameSchema,
+      certifierName: fullNameMiddleInitialSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959a/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/sponsorInformation.js
@@ -1,7 +1,4 @@
-import { cloneDeep } from 'lodash';
 import {
-  fullNameUI,
-  fullNameSchema,
   titleUI,
   addressUI,
   addressSchema,
@@ -15,13 +12,12 @@ import {
   validObjectCharsOnly,
 } from '../../shared/validations';
 import VeteranNameDescription from '../components/FormDescriptions/VeteranNameDescription';
+import {
+  fullNameMiddleInitialSchema,
+  fullNameMiddleInitialUI,
+} from '../definitions';
 import { personalizeTitleByRole } from '../utils/helpers';
 import content from '../locales/en/content.json';
-
-export const blankSchema = { type: 'object', properties: {} };
-
-const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
-fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const sponsorNameSchema = {
   uiSchema: {
@@ -42,7 +38,7 @@ export const sponsorNameSchema = {
   schema: {
     type: 'object',
     properties: {
-      sponsorName: fullNameSchema,
+      sponsorName: fullNameMiddleInitialSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -10,6 +10,7 @@ import transformForSubmit from './submitTransformer';
 import { FileFieldCustomSimple } from '../../shared/components/fileUploads/FileUpload';
 import NotEnrolledPage from '../components/FormPages/NotEnrolledPage';
 import AddressSelectionPage from '../components/FormPages/AddressSelectionPage';
+import { blankSchema } from '../definitions';
 import {
   certifierRoleSchema,
   certifierBenefitStatusSchema,
@@ -39,12 +40,10 @@ import {
   applicantContactSchema,
 } from '../chapters/beneficiaryInformation';
 import {
-  blankSchema,
   sponsorAddressSchema,
   sponsorNameSchema,
   sponsorContactSchema,
 } from '../chapters/sponsorInformation';
-
 import {
   claimIdentificationNumber,
   resubmissionLetterUpload,

--- a/src/applications/ivc-champva/10-7959a/definitions/index.js
+++ b/src/applications/ivc-champva/10-7959a/definitions/index.js
@@ -1,0 +1,28 @@
+import { merge } from 'lodash';
+import {
+  fullNameSchema,
+  fullNameUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import content from '../locales/en/content.json';
+
+export const blankSchema = { type: 'object', properties: {} };
+
+export const champvaMemberNumberSchema = {
+  type: 'string',
+  pattern: '^[0-9]+$',
+  maxLength: 9,
+  minLength: 8,
+};
+
+export const fileUploadSchema = {
+  type: 'array',
+  minItems: 1,
+  items: { type: 'object', properties: { name: { type: 'string' } } },
+};
+
+export const fullNameMiddleInitialUI = merge({}, fullNameUI(), {
+  middle: { 'ui:title': content['form-label--middle-initial'] },
+});
+export const fullNameMiddleInitialSchema = merge({}, fullNameSchema, {
+  properties: { middle: { type: 'string', maxLength: 1 } },
+});

--- a/src/applications/ivc-champva/10-7959a/locales/en/content.json
+++ b/src/applications/ivc-champva/10-7959a/locales/en/content.json
@@ -34,6 +34,7 @@
   "form-input--option--yes": "Yes",
   "form-label--address-military": "Address is on military base outside of the United States.",
   "form-label--beneficiary": "Does the beneficiary",
+  "form-label--middle-initial": "Middle initial",
   "form-label--your": "Do you",
   "health-insurance--button--cancel-add": "Cancel adding this insurance",
   "health-insurance--cancel-add-title": "Cancel adding this plan?",

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/basic-resubmission.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/basic-resubmission.json
@@ -37,20 +37,20 @@
     "applicantMemberNumber": "123123123",
     "applicantName": {
       "first": "Beneficiary",
-      "middle": "Terry",
+      "middle": "T",
       "last": "Jones",
       "suffix": "II"
     },
     "applicantDOB": "2022-03-23",
     "sponsorName": {
       "first": "Sponsor",
-      "middle": "Quincy",
+      "middle": "Q",
       "last": "Jones",
       "suffix": "Sr."
     },
     "certifierRole": "applicant",
     "certifierReceivedPacket": true,
-    "statementOfTruthSignature": "Beneficiary Terry Jones",
+    "statementOfTruthSignature": "Beneficiary T Jones",
     "statementOfTruthCertified": true
   }
 }

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/military-address-no-ohi-pharmacy-work.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/military-address-no-ohi-pharmacy-work.json
@@ -31,20 +31,20 @@
     "applicantMemberNumber": "123123123",
     "applicantName": {
       "first": "Beneficiary",
-      "middle": "Terry",
+      "middle": "T",
       "last": "Jones",
       "suffix": "II"
     },
     "applicantDOB": "2022-03-23",
     "sponsorName": {
       "first": "Sponsor",
-      "middle": "Quincy",
+      "middle": "Q",
       "last": "Jones",
       "suffix": "Sr."
     },
     "certifierRole": "applicant",
     "certifierReceivedPacket": true,
-    "statementOfTruthSignature": "Beneficiary Terry Jones",
+    "statementOfTruthSignature": "Beneficiary T Jones",
     "statementOfTruthCertified": true
   }
 }

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/no-packet.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/no-packet.json
@@ -31,20 +31,20 @@
     "applicantMemberNumber": "123123123",
     "applicantName": {
       "first": "Beneficiary",
-      "middle": "Terry",
+      "middle": "T",
       "last": "Jones",
       "suffix": "II"
     },
     "applicantDOB": "2022-03-23",
     "sponsorName": {
       "first": "Sponsor",
-      "middle": "Quincy",
+      "middle": "Q",
       "last": "Jones",
       "suffix": "Sr."
     },
     "certifierRole": "applicant",
     "certifierReceivedPacket": false,
-    "statementOfTruthSignature": "Beneficiary Terry Jones",
+    "statementOfTruthSignature": "Beneficiary T Jones",
     "statementOfTruthCertified": true
   }
 }

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/test-data.json
@@ -16,7 +16,7 @@
     },
     "certifierName": {
       "first": "Jerry",
-      "middle": "Middle",
+      "middle": "M",
       "last": "Jones",
       "suffix": "Jr."
     },
@@ -25,7 +25,7 @@
     "claimStatus": "new",
     "sponsorName": {
       "first": "Sponsor",
-      "middle": "Quincy",
+      "middle": "Q",
       "last": "Jones",
       "suffix": "Jr."
     },

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/third-party-foreign-address-ohi-medical-claim-work-auto.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/third-party-foreign-address-ohi-medical-claim-work-auto.json
@@ -37,14 +37,14 @@
     "applicantMemberNumber": "123123123",
     "applicantName": {
       "first": "Jim",
-      "middle": "Middle",
+      "middle": "M",
       "last": "Lastname",
       "suffix": "II"
     },
     "applicantDOB": "2022-05-14",
     "sponsorName": {
       "first": "John",
-      "middle": "Middle",
+      "middle": "M",
       "last": "Jones",
       "suffix": "Sr."
     },
@@ -62,7 +62,7 @@
     },
     "certifierName": {
       "first": "Jerry",
-      "middle": "Middle",
+      "middle": "M",
       "last": "Jones",
       "suffix": "Jr."
     },
@@ -82,7 +82,7 @@
         "providerPhone": "1231231235"
       }
     ],
-    "statementOfTruthSignature": "Certifier Middle Jones",
+    "statementOfTruthSignature": "Certifier M Jones",
     "statementOfTruthCertified": true
   }
 }

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/two-ohi-other-type.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/two-ohi-other-type.json
@@ -30,14 +30,14 @@
     "applicantMemberNumber": "321321321",
     "applicantName": {
       "first": "Beneficiary",
-      "middle": "Middle",
+      "middle": "M",
       "last": "Jones",
       "suffix": "II"
     },
     "applicantDOB": "2018-01-22",
     "sponsorName": {
       "first": "Sponsor",
-      "middle": "Middle",
+      "middle": "M",
       "last": "Jones",
       "suffix": "II"
     },
@@ -59,6 +59,6 @@
       }
     ],
     "statementOfTruthCertified": true,
-    "statementOfTruthSignature": "Beneficiary Middle Jones"
+    "statementOfTruthSignature": "Beneficiary M Jones"
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR centralizes and applies updates to schema definitions for various values in the app. The main purpose is to fix the middle initial schema, where the definition did not apply a character limit. The rest of the PR simply takes various schema definitions and centralizes them in one file.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#123394

## Testing done

- Prior to update, the middle initial value could be a full name when we only want the first initial
- After the update, the field is limited to a max of one character

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Middle initial is limited to one character
- Random schema definitions are consolidated into a single file

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
