### PR TITLE
Fix flaky vitals e2e test

### DIFF
--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.cypress.spec.js
@@ -24,11 +24,7 @@ describe('Medical Records View Vitals', () => {
 
     Vitals.goToVitalPage();
 
-    // Use the frozen clock date for timeframe calculation
-    const today = new Date();
-    const timeFrame = `${today.getFullYear()}-${(today.getMonth() + 1)
-      .toString()
-      .padStart(2, '0')}`;
+    const timeFrame = '2025-10';
     Vitals.checkUrl({ timeFrame });
 
     cy.injectAxeThenAxeCheck();

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.cypress.spec.js
@@ -5,12 +5,11 @@ import vitalsData from '../fixtures/vitals/sample-lighthouse.json';
 
 describe('Medical Records View Vitals', () => {
   const site = new MedicalRecordsSite();
+  const mockDate = new Date(2025, 9, 15); // October 15, 2025
 
   beforeEach(() => {
-    // Freeze time to stabilize timeframe-dependent URL assertions (UTC to local differences on CI)
-    // Use a fixed date in October 2025 to align with CI expectation logic
-    const fixedDate = new Date('2025-10-15T12:00:00Z');
-    cy.clock(fixedDate.getTime(), ['Date']);
+    cy.clock(mockDate, ['Date']);
+
     site.login(oracleHealthUser, false);
     site.mockFeatureToggles({
       isAcceleratingEnabled: true,
@@ -24,7 +23,10 @@ describe('Medical Records View Vitals', () => {
 
     Vitals.goToVitalPage();
 
-    const timeFrame = '2025-10';
+    const today = mockDate;
+    const timeFrame = `${today.getFullYear()}-${(today.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}`;
     Vitals.checkUrl({ timeFrame });
 
     cy.injectAxeThenAxeCheck();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

**Fixed a flaky E2E test that fails at month boundaries due to timezone/date handling.**

- **Bug**: The vitals E2E test (`view-vitals-list.oracle-health.cypress.spec.js`) uses `cy.clock()` to freeze time to October 15, 2025, but then calls `new Date()` in the test code which returns the actual current date.
- **How to reproduce**: Run the test on any date in November 2025 (or later). The test expects `?timeFrame=2025-11` but the frozen app shows `?timeFrame=2025-10`, causing a mismatch.
- **Solution**: Updated to use the established mockDate pattern consistent with other E2E tests (labs-and-tests). The test now declares const mockDate = new Date(2025, 9, 15) at the top level and references it with const today = mockDate in the test body. This makes the test deterministic and matches the codebase pattern.
- **Team**: MHV Medical Records team. This is a pre-existing test maintenance issue.
- **Flipper**: N/A - Test fix only

## Related issue(s)

- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/124091

## Testing done

**Old behavior**: Test calculated timeframe dynamically using `new Date()`, which didn't respect the `cy.clock()` frozen time. This caused failures whenever the current month differed from the frozen clock month (October).

**Steps to verify**:
- Run the test on any date in November 2025 or later

**Tests completed**:
-  Ran E2E test locally on November 3, 2025 - passes with fix, fails without fix
-  Confirmed no linter errors
-  Test retries 3 times and passes on first attempt with fix

**Results**: Test now passes consistently regardless of current date or CI timezone.

## Screenshots

N/A - Test fix only, no UI changes

## What areas of the site does it impact?

Only affects the vitals E2E test suite. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - self-documenting code comment)
- [x] Screenshot of the developed feature is added (N/A - test fix)
- [x] Accessibility testing has been performed (N/A - test fix)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - test fix)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - test fix)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)
