### PR TITLE
Update appointment list print view

### DIFF
--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
@@ -182,14 +182,19 @@ export default function AppointmentColumnLayout({
                   data-dd-privacy="mask"
                 >
                   {featureListViewClinicInfo ? (
-                    <a
-                      href={link}
-                      aria-label={detailAriaLabel}
-                      className="vaos-appts__focus--hide-outline"
-                      onClick={e => e.preventDefault()}
-                    >
-                      {appointmentLocality}
-                    </a>
+                    <>
+                      <a
+                        href={link}
+                        aria-label={detailAriaLabel}
+                        className="vaos-appts__focus--hide-outline vaos-hide-for-print"
+                        onClick={e => e.preventDefault()}
+                      >
+                        {appointmentLocality}
+                      </a>
+                      <span className="vaos-print-only">
+                        {appointmentLocality}
+                      </span>
+                    </>
                   ) : (
                     appointmentLocality
                   )}

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.jsx
@@ -133,7 +133,10 @@ export default function AppointmentsPage() {
       >
         {pageTitle}
       </h1>
-      <CernerAlert className="vads-u-margin-bottom--3" pageTitle={pageTitle} />
+      <CernerAlert
+        className="vaos-hide-for-print vads-u-margin-bottom--3"
+        pageTitle={pageTitle}
+      />
       {/* {featureBookingExclusion && (
         <CernerTransitionAlert
           className="vads-u-margin-bottom--3"
@@ -156,6 +159,7 @@ export default function AppointmentsPage() {
       {isInPilotUserStations && (
         <div
           className={classNames(
+            'vaos-hide-for-print',
             'vads-u-padding-y--3',
             'vads-u-margin-bottom--3',
             'vads-u-margin-top--1',

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -3,7 +3,7 @@ import { VaTelephone } from '@department-of-veterans-affairs/component-library/d
 
 export default function NeedHelp() {
   return (
-    <div className="vads-u-margin-top--9 vads-u-margin-bottom--3">
+    <div className="vaos-hide-for-print vads-u-margin-top--9 vads-u-margin-bottom--3">
       <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0">
         Need help?
       </h2>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates our appointment list print view to match the updated design in the linked issue
- United Appointments Experience
- Parts of the change is controlled by the `va_online_scheduling_list_view_clinic_info ` toggle (i.e. the new clinic info) and part of the changes are applicable to all scenarios (i.e. removing needs help, cerner alert, and request/referrals link)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119205

## Testing done

- Tested locally, see screenshots

## Screenshots

### `va_online_scheduling_list_view_clinic_info` on

- Upcoming
  - Before: [upcoming-on-before.pdf](https://github.com/user-attachments/files/23306776/upcoming-on-before.pdf)
  - After: [upcoming-on-after.pdf](https://github.com/user-attachments/files/23306774/upcoming-on-after.pdf)

- Past
  - Before: [past-on-before.pdf](https://github.com/user-attachments/files/23306770/past-on-before.pdf)
  - After: [past-on-after.pdf](https://github.com/user-attachments/files/23306764/past-on-after.pdf)

### `va_online_scheduling_list_view_clinic_info` off

- Upcoming
  - Before: [upcoming-off-before.pdf](https://github.com/user-attachments/files/23306793/upcoming-off-before.pdf)
  - After: [upcoming-off-after.pdf](https://github.com/user-attachments/files/23306792/upcoming-off-after.pdf)

- Past
  - Before: [past-off-before.pdf](https://github.com/user-attachments/files/23306781/past-off-before.pdf)
  - After: [past-off-after.pdf](https://github.com/user-attachments/files/23306778/past-off-after.pdf)


## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

