### PR TITLE
534ez wrap additional info content in paragraph tag

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/02-claimant-information/claimantInformation.js
+++ b/src/applications/survivors-benefits/config/chapters/02-claimant-information/claimantInformation.js
@@ -20,9 +20,11 @@ const seriouslyDisabledDescription = (
       trigger="What we consider a seriously disabled adult child"
       class="vads-u-margin-bottom--4"
     >
-      A child is seriously disabled if they developed a permanent physical or
-      mental disability before they turned 18 years old. A seriously disabled
-      child can’t support or care for themselves.
+      <p>
+        A child is seriously disabled if they developed a permanent physical or
+        mental disability before they turned 18 years old. A seriously disabled
+        child can’t support or care for themselves.
+      </p>
     </va-additional-info>
   </>
 );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Wrap content in additional info component in a p tag

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124018

## Testing done

- Manual testing, looking at inspector

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1342" height="470" alt="Screenshot 2025-11-03 at 1 40 04 PM" src="https://github.com/user-attachments/assets/d10919cc-8f38-4ea0-8d23-39d56099b3d1" /> | <img width="1342" height="555" alt="Screenshot 2025-11-03 at 1 38 41 PM" src="https://github.com/user-attachments/assets/8700d182-43ad-4912-87d2-345ca3953ad7" /> |

## What areas of the site does it impact?

One field on 534ez form. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A