### PR TITLE
Pension | Update dependents pages

### DIFF
--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
@@ -12,8 +12,8 @@ import {
   currencySchema,
   dateOfBirthUI,
   dateOfBirthSchema,
-  fullNameUI,
-  fullNameSchema,
+  fullNameNoSuffixUI,
+  fullNameNoSuffixSchema,
   radioUI,
   radioSchema,
   ssnUI,
@@ -113,12 +113,12 @@ const fullNamePage = {
       title: 'Dependent child',
       nounSingular: options.nounSingular,
     }),
-    fullName: fullNameUI(title => `Child’s ${title}`),
+    fullName: fullNameNoSuffixUI(title => `Child’s ${title}`),
   },
   schema: {
     type: 'object',
     properties: {
-      fullName: fullNameSchema,
+      fullName: fullNameNoSuffixSchema,
     },
     required: ['fullName'],
   },
@@ -356,7 +356,7 @@ const addressPage = {
       {
         'ui:title': 'Who do they live with?',
       },
-      fullNameUI(),
+      fullNameNoSuffixUI(),
     ),
     monthlyPayment: merge(
       {},
@@ -377,7 +377,7 @@ const addressPage = {
     type: 'object',
     properties: {
       childAddress: addressSchema({ omit: ['isMilitary', 'street3'] }),
-      personWhoLivesWithChild: fullNameSchema,
+      personWhoLivesWithChild: fullNameNoSuffixSchema,
       monthlyPayment: currencySchema,
     },
   },

--- a/src/applications/pensions/tests/unit/chapters/04-household-information/dependentChildrenPages.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/04-household-information/dependentChildrenPages.unit.spec.jsx
@@ -1,8 +1,8 @@
 import merge from 'lodash/merge';
 import {
   arrayBuilderItemFirstPageTitleUI,
-  fullNameUI,
-  fullNameSchema,
+  fullNameNoSuffixUI,
+  fullNameNoSuffixSchema,
   ssnUI,
   ssnSchema,
 } from '~/platform/forms-system/src/js/web-component-patterns';
@@ -62,18 +62,18 @@ describe('dependents full name page', () => {
         title: 'dependent full name',
         nounSingular: 'dependent child',
       }),
-      fullName: fullNameUI(title => `Child's ${title}`),
+      fullName: fullNameNoSuffixUI(title => `Child's ${title}`),
     },
     schema: {
       type: 'object',
       properties: {
-        fullName: fullNameSchema,
+        fullName: fullNameNoSuffixSchema,
       },
       required: ['fullName'],
     },
   };
   const pageTitle = 'dependent';
-  const expectedNumberOfFields = 4;
+  const expectedNumberOfFields = 3;
   testNumberOfWebComponentFields(
     formConfig,
     dependentChildFullNamePage.schema,
@@ -112,7 +112,6 @@ describe('dependents full name page', () => {
     dependentChildFullNamePage.uiSchema,
     {
       'va-text-input': 3,
-      'va-select': 1,
     },
     pageTitle,
   );


### PR DESCRIPTION
## Summary

This PR updates the **Dependent Children** pages in the **Pension Benefits form (VA Form 21P-527EZ)** to remove the **suffix field** from the full name component when the `pension_multiple_page_responses` feature toggle is enabled.  
This change aligns the frontend form data with the **schema and PDF form structure**, ensuring successful submission and reducing data validation errors.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120516  

## Related issue(s)

- Multiple-page list-and-loop improvements for Pension Benefits  
- Aligns data capture logic with back-end schema updates and PDF mapping requirements  

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/pension_multiple_page_responses`  
4. Navigate to the **Pension Benefits form**:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Proceed to the **Dependent Children** section  

## How to verify

1. Navigate to the **Dependent Children** pages.  
2. Confirm that when `pension_multiple_page_responses` is **enabled**:  
   - The **suffix field** is **not displayed** in the full name component.  
   - The **first**, **middle**, and **last name fields** remain visible and functional.  
3. Disable the toggle and confirm the suffix field reappears for legacy behavior.  
4. Submit a form locally or using mock submission and verify:
   - The submitted data matches the schema (no suffix field present).  
   - PDF generation and backend mapping are successful.  
5. Confirm there are no console errors or validation failures during submission.  
6. Validate heading hierarchy, input labeling, and overall accessibility remain unchanged.  

## What areas of the site does it impact?

- **Pension Benefits form (21P-527EZ)**  
- **Dependent Children** list-and-loop pages under `pension_multiple_page_responses`  

## Screenshots

| Before | After |
|--------|-------|
| Full name included suffix on dependent children pages | Suffix removed on dependent children pages |

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- Pension Benefits multiple-page response enhancements  
- **Behind** `pension_multiple_page_responses` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm that suffix removal aligns with the current schema and PDF mapping logic, and that no regressions are introduced for legacy full name components or dependent data submissions.
