### PR TITLE
Fix E2E tests to expect trailing slash in secondary nav 

### DIFF
--- a/src/applications/mhv-medical-records/tests/e2e/pages/AllergiesListPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/AllergiesListPage.js
@@ -45,7 +45,7 @@ class AllergiesListPage extends BaseListPage {
     cy.get('[data-testid="mhv-sec-nav-item"]')
       .eq(4)
       .find('a')
-      .should('have.attr', 'href', '/my-health/medical-records');
+      .should('have.attr', 'href', '/my-health/medical-records/');
   };
 }
 export default new AllergiesListPage();

--- a/src/applications/mhv-medical-records/tests/e2e/pages/AllergyDetailsPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/AllergyDetailsPage.js
@@ -68,7 +68,7 @@ class AllergyDetailsPage extends BaseDetailsPage {
     cy.get('[data-testid="mhv-sec-nav-item"]')
       .eq(4)
       .find('a')
-      .should('have.attr', 'href', '/my-health/medical-records');
+      .should('have.attr', 'href', '/my-health/medical-records/');
   };
 }
 export default new AllergyDetailsPage();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders

## Summary

- Fixed E2E tests to expect trailing slashes in secondary nav URLs
- PR #39650 added trailing slashes to `MhvSecondaryNav` component but only updated unit tests, not E2E tests
- This caused `medical-records-validate-secondary-nav.cypress.spec.js` to fail in CI
- Updated `AllergiesListPage.js` and `AllergyDetailsPage.js` to expect `/my-health/medical-records/` with trailing slash
- Team: Medical Records (MHV)

## Related issue(s)

- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/124161

## Testing done
  - Passes locally `medical-records-validate-secondary-nav.cypress.spec.js` 
  - Verified both test page objects (`AllergiesListPage.js` and `AllergyDetailsPage.js`) now expect `/my-health/medical-records/` with trailing slash
  - No production code changes, only test assertions updated to match component implementation from PR #39650

## Screenshots

N/A - Test file changes only, no UI changes

## What areas of the site does it impact?

E2E test suite only. No production code or user-facing changes. This fixes the test expectations to align with the component changes made in PR #39650.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A - test changes only)
- [ ] Screenshot of the developed feature is added (N/A - test changes only)
- [ ] Accessibility testing has been performed (N/A - test changes only)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution (N/A)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test changes only, no authentication flow changes)
