### PR TITLE
534 ez separation duration transform

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/reasonForSeparation.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/reasonForSeparation.js
@@ -12,16 +12,18 @@ export default {
   depends: formData => formData.livedContinuouslyWithVeteran === false,
   uiSchema: {
     ...titleUI('Reason for separation'),
-    separationReason: radioUI({
+    separationDueToAssignedReasons: radioUI({
       title: 'What was the reason for separation?',
       labels: separationReasonOptions,
     }),
   },
   schema: {
     type: 'object',
-    required: ['separationReason'],
+    required: ['separationDueToAssignedReasons'],
     properties: {
-      separationReason: radioSchema(Object.keys(separationReasonOptions)),
+      separationDueToAssignedReasons: radioSchema(
+        Object.keys(separationReasonOptions),
+      ),
     },
   },
 };

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/separationDetails.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/separationDetails.js
@@ -15,11 +15,11 @@ export default {
   title: 'Separation details',
   path: 'household/separation-details',
   depends: formData =>
-    formData.separationReason === 'RELATIONSHIP_DIFFERENCES' ||
-    formData.separationReason === 'OTHER',
+    formData.separationDueToAssignedReasons === 'RELATIONSHIP_DIFFERENCES' ||
+    formData.separationDueToAssignedReasons === 'OTHER',
   uiSchema: {
     ...titleUI('Separation details'),
-    separationReasonExplanation: textUI({
+    separationExplanation: textUI({
       title: 'Tell us the reason for the separation',
     }),
     separationStartDate: currentOrPastDateUI({
@@ -44,13 +44,13 @@ export default {
   schema: {
     type: 'object',
     required: [
-      'separationReasonExplanation',
+      'separationExplanation',
       'separationStartDate',
       'separationEndDate',
       'courtOrderedSeparation',
     ],
     properties: {
-      separationReasonExplanation: textSchema,
+      separationExplanation: textSchema,
       separationStartDate: currentOrPastDateSchema,
       separationEndDate: currentOrPastDateSchema,
       courtOrderedSeparation: yesNoSchema,

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -59,12 +59,14 @@ import supportingDocuments from './chapters/07-additional-information/supporting
 import uploadDocuments from './chapters/07-additional-information/uploadDocuments';
 // TODO: Will be added after mvp release
 // import reviewDocuments from './chapters/07-additional-information/reviewDocuments';
+import { transform } from './submit-transformer';
 
 /** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/survivors_benefits/v0/form534ez`,
+  transformForSubmit: transform,
   trackingPrefix: 'survivors-534ez',
   v3SegmentedProgressBar: true,
   prefillEnabled: true,

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -260,8 +260,9 @@ const formConfig = {
           title: 'Separation details',
           depends: formData =>
             formData.claimantRelationship === 'SPOUSE' &&
-            (formData.separationReason === 'RELATIONSHIP_DIFFERENCES' ||
-              formData.separationReason === 'OTHER'),
+            (formData.separationDueToAssignedReasons ===
+              'RELATIONSHIP_DIFFERENCES' ||
+              formData.separationDueToAssignedReasons === 'OTHER'),
           uiSchema: separationDetails.uiSchema,
           schema: separationDetails.schema,
         },

--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -1,0 +1,26 @@
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import { durationInDays } from '../utils/helpers';
+
+function calculateSeparationDuration(formData) {
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = { ...parsedFormData };
+
+  // Calculate separation duration if both dates are present
+  if (
+    transformedValue.separationStartDate &&
+    transformedValue.separationEndDate
+  ) {
+    transformedValue.separationDurationInDays = durationInDays(
+      transformedValue.separationStartDate,
+      transformedValue.separationEndDate,
+    );
+  }
+
+  return JSON.stringify(transformedValue);
+}
+
+export const transform = (formConfig, form) => {
+  let transformedData = transformForSubmit(formConfig, form);
+  transformedData = calculateSeparationDuration(transformedData);
+  return transformedData;
+};

--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -1,6 +1,7 @@
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import { format } from 'date-fns-tz';
 import { durationInDays } from '../utils/helpers';
+import { separationReasonOptions } from '../utils/labels';
 
 function calculateSeparationDuration(formData) {
   const parsedFormData = JSON.parse(formData);
@@ -23,9 +24,10 @@ function calculateSeparationDuration(formData) {
     const additionalItems = [];
 
     if (parsedFormData?.separationDueToAssignedReasons) {
-      additionalItems.push(
-        `Reason: ${parsedFormData.separationDueToAssignedReasons}`,
-      );
+      // Get the display value from the labels object
+      const reasonKey = parsedFormData.separationDueToAssignedReasons;
+      const reasonLabel = separationReasonOptions[reasonKey];
+      additionalItems.push(`Reason: ${reasonLabel}`);
     }
 
     if (parsedFormData?.separationStartDate) {

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -19,7 +19,7 @@
   "hadPreviousMarriages": false,
   "remarried": false,
   "separationReason": "MEDICAL_FINANCIAL",
-  "separationReasonExplanation": "Court Order",
+  "separationExplanation": "Court Order",
   "separationStartDate": "2005-02-20",
   "separationEndDate": "2006-02-20",
   "courtOrderedSeparation": true,

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -3,6 +3,9 @@
     "first": "John",
     "last": "Doe"
   },
+  "claims" : {
+    "dependencyIndemnityComp" : true
+  },
   "veteranDateOfBirth": "1989-02-16",
   "hasBankAccount": false,
   "moreThanFourSources": false,
@@ -12,9 +15,9 @@
   "view:whatTransferredAssets": {},
   "totalAssets": 100,
   "hasAssetsOverThreshold": false,
-  "needRegularAssistance": "No",
-  "inNursingHome": "No",
-  "view:dicType": "DIC",
+  "needRegularAssistance": false,
+  "inNursingHome": false,
+  "dicType": "DIC",
   "recognizedAsSpouse": true,
   "hadPreviousMarriages": false,
   "remarried": false,
@@ -66,7 +69,6 @@
   "veteranSocialSecurityNumber": "230635555",
   "view:warningAlert": {},
   "seriouslyDisabled": {},
-  "claims": {},
   "branchOfService": {},
   "unitPhoneNumber": {},
   "unitAddress": {

--- a/src/applications/survivors-benefits/tests/utils/helpers.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/utils/helpers.unit.spec.jsx
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { durationInDays } from '../../utils/helpers';
+
+describe('durationInDays', () => {
+  it('should return correct number of days between two dates', () => {
+    const startDate = '2024-01-01';
+    const endDate = '2024-01-31';
+    const result = durationInDays(startDate, endDate);
+    expect(result).to.equal(30);
+  });
+
+  it('should handle same start and end date', () => {
+    const startDate = '2024-06-15';
+    const endDate = '2024-06-15';
+    const result = durationInDays(startDate, endDate);
+    expect(result).to.equal(0);
+  });
+
+  it('should handle end date before start date', () => {
+    const startDate = '2024-12-01';
+    const endDate = '2024-11-30';
+    const result = durationInDays(startDate, endDate);
+    expect(result).to.equal(-1);
+  });
+});

--- a/src/applications/survivors-benefits/utils/helpers.jsx
+++ b/src/applications/survivors-benefits/utils/helpers.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { isBefore, isAfter, isEqual, parseISO } from 'date-fns';
+import {
+  isBefore,
+  isAfter,
+  isEqual,
+  parseISO,
+  differenceInDays,
+} from 'date-fns';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { waitForShadowRoot } from 'platform/utilities/ui/webComponents';
 
@@ -178,3 +184,15 @@ export async function addStyleToShadowDomOnPages(
 export const isYes = val =>
   val === true ||
   (typeof val === 'string' && val.toLowerCase().startsWith('y'));
+
+/**
+ * Calculates the duration in days between two dates
+ *
+ * @export
+ * @param {string} startDate - The start date in ISO format (YYYY-MM-DD)
+ * @param {string} endDate - The end date in ISO format (YYYY-MM-DD)
+ * @return {number} The duration in days between the two dates
+ */
+export const durationInDays = (startDate, endDate) => {
+  return differenceInDays(new Date(endDate), new Date(startDate));
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request introduces several improvements and refactors to the survivors benefits application, focusing on separation details, form submission handling, and test/mocking infrastructure. The most significant changes are the renaming and restructuring of separation-related fields, the implementation of a custom form data transformer for submission, and enhanced support for intent-to-file and test mocks.

**Form field refactors and submission logic:**

* Renamed the separation reason field from `separationReason` to `separationDueToAssignedReasons` and updated all related references in configuration files (`reasonForSeparation.js`, `separationDetails.js`, and usages in `form.js`). Also, renamed `separationReasonExplanation` to `separationExplanation` for clarity and consistency. [[1]](diffhunk://#diff-b8ca35b42a9a9f846ca80789d19e58a1b8a131ae05664bf49fcfa4f991abf4dcL15-R26) [[2]](diffhunk://#diff-ab7483db8a5bfe49ceded1ba9dd5c23a1a6206f38e683bf93f4d7366ce1dde5cL18-R22) [[3]](diffhunk://#diff-ab7483db8a5bfe49ceded1ba9dd5c23a1a6206f38e683bf93f4d7366ce1dde5cL47-R53) [[4]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364L270-R262)

* Added a custom form submission transformer (`submit-transformer.js`) that calculates the duration of separation in days and appends additional separation details to the explanation before sending the data to the backend. The submission endpoint was updated to `/survivors_benefits/v0/form534ez`. [[1]](diffhunk://#diff-989caeae9d2f2a6964b389657742dfacdb572840369bdbe94c7fb85ebd7956b0R1-R69) [[2]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364R59-R66)

**Intent-to-file and test infrastructure:**

* Integrated the IntentToFile component into the main app container (`SurvivorsBenefitsApp.jsx`) to support pension intent-to-file workflows.

* Added comprehensive mock data and handlers for intent-to-file, completed form responses, and claim attachments in test fixtures, improving local testing and e2e reliability. [[1]](diffhunk://#diff-9d8d57d0d9d8cac96e6c667f5d1207eefc9b6ec0f47f3c4a6bf7dbb6b655a3f9R1-R94) [[2]](diffhunk://#diff-1c8d209b854ae04227a5515c3f4d6ccf9b37536a5e0da627d8e2ec0ce21776e6R2-R76) [[3]](diffhunk://#diff-377c1a94593a07b979e98d6dbc122f932ed75c87ad7b6b0f89636104e093a734R1-R59)

**Utility and test enhancements:**

* Implemented a new helper function `durationInDays` to calculate the number of days between two dates, with corresponding unit tests for edge cases. [[1]](diffhunk://#diff-acd60ffba267f9ad4676fe72c87392a9932ff4ef60f054f1c945201e8b3a7b73L2-R8) [[2]](diffhunk://#diff-acd60ffba267f9ad4676fe72c87392a9932ff4ef60f054f1c945201e8b3a7b73R187-R198) [[3]](diffhunk://#diff-3702d0d4bcc4ace24f17c8057cda79f3fc9c1c715578ff2ebcad7809266bfd45R1-R25)

**Other minor improvements:**

* Updated the confirmation page to use `claimantFullName` instead of `veteranFullName` for the full name path, ensuring correct representation.

* Removed unused imports and configuration options for a cleaner codebase. [[1]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364L3-L11) [[2]](diffhunk://#diff-37f59903a2f87368392c04551770365cc5375c4245bb1e2a8d4444a2ace3f364L79-L87)

## Related issue(s)
N/A

## Testing done
Manual testing and confirmation of the transform

## Screenshots
N/A no front-end changes

## What areas of the site does it impact?
534EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
