### PR TITLE
534ez update Chapter 4 marriage pages

### DIFF
--- a/src/applications/survivors-benefits/components/FormAlerts/index.jsx
+++ b/src/applications/survivors-benefits/components/FormAlerts/index.jsx
@@ -141,11 +141,13 @@ UnauthenticatedWarningAlert.propTypes = {
 
 export const handleAlertMaxItems = () => (
   <div>
-    You have added the maximum number of allowed previous marriages for this
-    application. Additional marriages can be added using VA Form 21-4138 and
-    uploaded at the end of this application.
+    <p className="vads-u-margin-top--0">
+      You have added the maximum number of allowed previous marriages for this
+      application. Additional marriages can be added using VA Form 21-4138 and
+      uploaded at the end of this application.
+    </p>
     <va-link
-      href="/find-forms/about-form-21-4138/"
+      href="https://www.va.gov/find-forms/about-form-21-4138/"
       external
       text="Get VA Form 21-4138 to download"
     />

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/additionalMarriages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/additionalMarriages.js
@@ -15,7 +15,7 @@ export default {
   uiSchema: {
     ...titleUI('Additional marriages'),
     additionalMarriages: yesNoUI({
-      title: 'Did you have more than 1 marriage after the Veteran death?',
+      title: 'Did you have more than 1 marriage after the Veteran’s death?',
     }),
     additionalMarriagesAlert: {
       'ui:description': AdditionalMarriagesAlert,

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteran.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteran.js
@@ -36,7 +36,7 @@ export default {
       },
       marriageEndOtherReason: {
         ...textUI({
-          title: 'Tell us how the marriage ended?',
+          title: 'Tell us how the marriage ended',
           required: formData =>
             formData?.marriageEndDetails?.marriageEndReason === 'OTHER',
         }),
@@ -68,7 +68,7 @@ export default {
     }),
     marriageTypeOther: {
       ...textUI({
-        title: 'Tell us how you got married.',
+        title: 'Tell us how you got married',
         required: formData => formData?.marriageType === 'OTHER_WAY',
       }),
       'ui:options': {
@@ -84,8 +84,10 @@ export default {
     required: [
       'marriedAtDeath',
       'marriageDate',
+      'marriageEndDate',
       'placeOfMarriage',
       'marriageType',
+      'placeMarriageEnded',
     ],
     properties: {
       marriedAtDeath: yesNoSchema,

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriages.js
@@ -12,7 +12,7 @@ export default {
   uiSchema: {
     ...titleUI('Previous marriages'),
     recognizedAsSpouse: yesNoUI({
-      title: 'Did we recognize you as a Veteran spouse before their death?',
+      title: 'Did we recognize you as the Veteran’s spouse before their death?',
     }),
     hadPreviousMarriages: yesNoUI({
       title:

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   arrayBuilderItemFirstPageTitleUI,
+  arrayBuilderItemSubsequentPageTitleUI,
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
   fullNameSchema,
@@ -73,6 +74,21 @@ const options = {
     (item?.marriageEndReason === 'OTHER' && !item?.marriageEndOtherExplanation),
   maxItems: 2,
   text: {
+    cancelAddTitle: 'Cancel adding this previous marriage?',
+    cancelEditTitle: 'Cancel editing this previous marriage?',
+    cancelAddDescription:
+      'If you cancel, we won’t add this previous marriage to your list of marriages. You’ll return to a page where you can add another previous marriage.',
+    cancelEditDescription:
+      'If you cancel, you’ll lose any changes you made to this previous marriage and you will be returned to the previous marriage review page.',
+    cancelAddYes: 'Yes, cancel adding',
+    cancelAddNo: 'No, continue adding',
+    cancelEditYes: 'Yes, cancel editing',
+    cancelEditNo: 'No, continue editing',
+    deleteDescription:
+      'This will delete the information from your list of previous marriages. You’ll return to a page where you can add a new previous marriage.',
+    deleteNo: 'No, keep',
+    deleteTitle: 'Delete this previous marriage?',
+    deleteYes: 'Yes, delete',
     alertMaxItems: handleAlertMaxItems,
     getItemName: item => {
       const name = item?.previousSpouseName;
@@ -97,9 +113,9 @@ function introDescription() {
         the Veteran. You may add up to 2 marriages.
       </p>
       <p>
-        <strong>Note:</strong> We usually don't need to contact a previous
-        spouse of a Veteran's spouse. In very rare cases where we need
-        information from this person, we'll contact you first.
+        <strong>Note:</strong> We usually don’t need to contact a previous
+        spouse. In very rare cases where we need information from this person,
+        we’ll contact you first.
       </p>
     </div>
   );
@@ -150,7 +166,7 @@ const summaryPage = {
 const previousMarriageItemPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Previous spouse name',
+      title: 'Previous spouse’s name',
       nounSingular: options.nounSingular,
     }),
     previousSpouseName: fullNameUI(),
@@ -167,6 +183,9 @@ const previousMarriageItemPage = {
 /** @returns {PageSchema} */
 const marriageDateAndLocationPage = {
   uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      'When and where did you get married?',
+    ),
     marriageToVeteranDate: currentOrPastDateUI({
       title: 'Date of marriage',
       monthSelect: false,
@@ -256,6 +275,9 @@ const marriageDateAndLocationPage = {
 /** @returns {PageSchema} */
 const marriageEndDateAndLocationPage = {
   uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      'When and where did your marriage end?',
+    ),
     marriageEndDate: currentOrPastDateUI({
       title: 'Date marriage ended',
       monthSelect: false,
@@ -357,7 +379,8 @@ const marriageEndPage = {
   uiSchema: {
     marriageEndReason: radioUI({
       title: 'How did the marriage end?',
-      label: previousMarriageEndOptions,
+      labels: previousMarriageEndOptions,
+      labelHeaderLevel: 3,
     }),
     marriageEndOtherExplanation: {
       ...textUI({
@@ -420,7 +443,7 @@ export const previousMarriagesPages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     previousMarriageItemPage: pageBuilder.itemPage({
-      title: 'Previous spouse name',
+      title: 'Previous spouse’s name',
       path: 'household/previous-marriage/:index/name',
       depends: formData =>
         formData.claimantRelationship === 'SPOUSE' &&

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -23,6 +23,7 @@ import {
   STATE_VALUES,
   COUNTRY_NAMES,
   COUNTRY_VALUES,
+  previousMarriageEndOptions,
 } from '../../../utils/labels';
 import { handleAlertMaxItems } from '../../../components/FormAlerts';
 
@@ -205,10 +206,10 @@ const marriageDatePlacePage = {
 
 const endedPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('How did the marriage end?'),
     marriageEndedBy: radioUI({
       title: 'How did the marriage end?',
-      labels: { DEATH: 'Death', DIVORCE: 'Divorce', OTHER: 'Other' },
+      labels: previousMarriageEndOptions,
+      labelHeaderLevel: 3,
     }),
     marriageEndedOther: textUI({
       title: 'Tell us how the marriage ended',
@@ -221,7 +222,7 @@ const endedPage = {
   schema: {
     type: 'object',
     properties: {
-      marriageEndedBy: radioSchema(['DEATH', 'DIVORCE', 'OTHER']),
+      marriageEndedBy: radioSchema(Object.keys(previousMarriageEndOptions)),
       marriageEndedOther: textSchema,
     },
     required: ['marriageEndedBy'],


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update how did marriage end radio labels to h3
- Updated alert max text link
- Previous marriage content updates
- Added missing headings
- Fixed radio buttons being all caps
- Added required to fields

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123840
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123739
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124019
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124024
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124025
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124023
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124111
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124027
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124054
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124177
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124055
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124112


## Testing done

- manual testing

## Screenshots
**Veteran's marriages**
<img width="1306" height="1059" alt="Screenshot 2025-11-03 at 9 15 27 PM" src="https://github.com/user-attachments/assets/5072c4e9-07a4-495d-a947-06dbd1da67f1" />

**Claimants marriages**
<img width="576" height="411" alt="Screenshot 2025-11-03 at 9 23 02 PM" src="https://github.com/user-attachments/assets/a792a5d2-451b-4e62-9e25-d1e6ac1d4607" />
<img width="621" height="446" alt="Screenshot 2025-11-03 at 9 25 10 PM" src="https://github.com/user-attachments/assets/66b4b99b-b39c-42d6-9f21-3177eb899f2b" />
<img width="604" height="551" alt="Screenshot 2025-11-03 at 9 25 24 PM" src="https://github.com/user-attachments/assets/a5537f63-3246-4a07-8718-65686b5a8ca3" />
<img width="916" height="1251" alt="Screenshot 2025-11-03 at 9 26 12 PM" src="https://github.com/user-attachments/assets/cb0d409f-0d27-4950-9025-ee45afd324b0" />
<img width="726" height="877" alt="Screenshot 2025-11-03 at 9 27 01 PM" src="https://github.com/user-attachments/assets/4889b68e-aa79-431d-94f7-b89c1e6a0808" />
<img width="759" height="966" alt="Screenshot 2025-11-03 at 9 27 25 PM" src="https://github.com/user-attachments/assets/3af2a53c-ba8f-4afb-a409-11619c1a255d" />
<img width="690" height="665" alt="Screenshot 2025-11-03 at 9 27 42 PM" src="https://github.com/user-attachments/assets/3b36a93d-f875-4a38-b37e-450a1d3290c9" />
<img width="782" height="901" alt="Screenshot 2025-11-03 at 9 27 56 PM" src="https://github.com/user-attachments/assets/d75cd4f3-d35d-4b52-a136-9fe786484f75" />
<img width="819" height="801" alt="Screenshot 2025-11-03 at 9 28 30 PM" src="https://github.com/user-attachments/assets/3672bb12-404e-403a-a914-1b0d0e67076c" />
<img width="630" height="470" alt="Screenshot 2025-11-03 at 9 28 47 PM" src="https://github.com/user-attachments/assets/6be2b748-1201-4d19-a4b7-7cd2f9785418" />
<img width="680" height="561" alt="Screenshot 2025-11-03 at 9 28 40 PM" src="https://github.com/user-attachments/assets/ec54515d-b907-482e-8c5a-805ef434e03e" />
<img width="558" height="387" alt="Screenshot 2025-11-03 at 9 28 34 PM" src="https://github.com/user-attachments/assets/be417fe1-6262-4582-ba9b-e28ca3f028ec" />


## What areas of the site does it impact?

The previous marriage sections of 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A
