### PR TITLE
123539 MHV SM - start a new message flow   analytics data dog rum monitoring

### DIFF
--- a/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
@@ -267,7 +267,10 @@ const AttachmentsList = props => {
       <ul className="attachments-list">
         {!!attachments.length &&
           attachments.map(file => (
-            <li key={file.name + file.size}>
+            <li
+              key={file.name + file.size}
+              data-dd-action-name="Attachment Item"
+            >
               {editingEnabled && (
                 <div className="editable-attachment vads-u-display--flex vads-u-flex-direction--row">
                   <span

--- a/src/applications/mhv-secure-messaging/components/MessageList/MessageListItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/MessageListItem.jsx
@@ -90,7 +90,10 @@ const MessageListItem = props => {
             </span>
           ) : (
             <div>
-              <div data-dd-privacy="mask">
+              <div
+                data-dd-privacy="mask"
+                data-dd-action-name="Message List Item Recipient and Sender Info"
+              >
                 {location.pathname === Paths.DRAFTS && (
                   <>
                     <span className="thread-list-draft">(Draft)</span> -{' '}
@@ -98,7 +101,12 @@ const MessageListItem = props => {
                 )}
                 To: {suggestedNameDisplay || recipientName}
               </div>
-              <div data-dd-privacy="mask">From: {senderName}</div>
+              <div
+                data-dd-privacy="mask"
+                data-dd-action-name="Message List Item Sender Info"
+              >
+                From: {senderName}
+              </div>
             </div>
           )}
         </div>

--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -205,6 +205,7 @@ const SearchForm = props => {
         role="status"
         aria-live="polite"
         data-testid="search-message-folder-input-label"
+        data-dd-action-name="Filter Messages matches label"
         className={`vads-u-margin-top--4 ${
           resultsCount === undefined ? null : 'filter-results-in-folder'
         }`}

--- a/src/applications/mhv-secure-messaging/containers/App.jsx
+++ b/src/applications/mhv-secure-messaging/containers/App.jsx
@@ -4,6 +4,7 @@ import { Switch } from 'react-router-dom';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import {
   DowntimeNotification,
   externalServices,
@@ -80,8 +81,10 @@ const App = () => {
     clientToken: 'pub1325dfe255119729611410e2f47f4f99',
     site: 'ddog-gov.com',
     service: 'va.gov-mhv-secure-messaging',
-    sessionSampleRate: 50, // controls the percentage of overall sessions being tracked
-    sessionReplaySampleRate: 50, // is applied after the overall sample rate, and controls the percentage of sessions tracked as Browser RUM & Session Replay
+    // controls the percentage of overall sessions being tracked
+    sessionSampleRate: environment.isStaging() ? 100 : 50,
+    // is applied after the overall sample rate, and controls the percentage of sessions tracked as Browser RUM & Session Replay
+    sessionReplaySampleRate: environment.isStaging() ? 100 : 50,
     trackInteractions: true,
     trackFrustrations: true,
     trackUserInteractions: true,

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { datadogRum } from '@datadog/browser-rum';
 import {
   VaRadio,
   VaRadioOption,
@@ -57,6 +58,17 @@ const RecentCareTeams = () => {
       }
     },
     [allRecipients, dispatch],
+  );
+
+  useEffect(
+    () => {
+      if (recentRecipients?.length > 0) {
+        datadogRum.addAction('Recent Care Teams loaded', {
+          recentCareTeamsCount: recentRecipients.length,
+        });
+      }
+    },
+    [recentRecipients],
   );
 
   useEffect(
@@ -158,6 +170,7 @@ const RecentCareTeams = () => {
                 value={recipient.triageTeamId}
                 description={healthCareSystemName}
                 data-dd-privacy="mask"
+                data-dd-action-name="Recent Care Teams radio option"
               />
             );
           })}

--- a/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
+++ b/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import PropType from 'prop-types';
@@ -11,6 +17,7 @@ import {
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
+import { datadogRum } from '@datadog/browser-rum';
 
 import { populatedDraft } from '../selectors';
 import { ErrorMessages, Paths } from '../util/constants';
@@ -45,6 +52,7 @@ const SelectCareTeam = () => {
   const [careTeamComboInputValue, setCareTeamComboInputValue] = useState('');
   const [showContactListLink, setShowContactListLink] = useState(false);
   const [recipientsSelectKey, setRecipientsSelectKey] = useState(0); // controls resetting the careTeam combo box when the careSystem changes
+  const careSystemSwitchCountRef = useRef(0);
 
   const MAX_RADIO_OPTIONS = 6;
 
@@ -131,10 +139,22 @@ const SelectCareTeam = () => {
     focusElement(document.querySelector('h1'));
   }, []);
 
+  // Send DataDog RUM action on component unmount with the count of care system switches
+  useEffect(() => {
+    return () => {
+      if (careSystemSwitchCountRef.current > 0) {
+        datadogRum.addAction('Care System Radio Switch Count', {
+          switchCount: careSystemSwitchCountRef.current,
+        });
+      }
+    };
+  }, []);
+
   const onRadioChangeHandler = e => {
     if (e?.detail?.value) {
       const careSystem = ehrDataByVhaId[e.detail.value];
       if (e.detail.value !== draftInProgress?.careSystemVhaId) {
+        careSystemSwitchCountRef.current += 1;
         setRecipientsSelectKey(prevKey => prevKey + 1);
         dispatch(
           updateDraftInProgress({

--- a/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
+++ b/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
@@ -140,13 +140,12 @@ const SelectCareTeam = () => {
   }, []);
 
   // Send DataDog RUM action on component unmount with the count of care system switches
+  // Should call addAction even if the count is zero
   useEffect(() => {
     return () => {
-      if (careSystemSwitchCountRef.current > 0) {
-        datadogRum.addAction('Care System Radio Switch Count', {
-          switchCount: careSystemSwitchCountRef.current,
-        });
-      }
+      datadogRum.addAction('Care System Radio Switch Count', {
+        switchCount: careSystemSwitchCountRef.current,
+      });
     };
   }, []);
 

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/AttachmentsList.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/AttachmentsList.unit.spec.jsx
@@ -509,4 +509,95 @@ describe('useLargeAttachments logic', () => {
       expect(mockSetAttachFileError.calledWith(null)).to.be.true;
     });
   });
+
+  describe('Datadog RUM action names', () => {
+    it('should have data-dd-action-name on attachment list item', () => {
+      const customProps = {
+        attachments: [
+          {
+            id: 2664842,
+            messageId: 2664846,
+            name: 'test-file.pdf',
+            attachmentSize: 31127,
+            download:
+              'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664842',
+          },
+        ],
+        attachmentScanError: false,
+        editingEnabled: true,
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <AttachmentsList {...customProps} />,
+        {
+          initialState: {},
+          reducers: reducer,
+          path: Paths.COMPOSE,
+        },
+      );
+
+      const attachmentsList = screen.container.querySelector(
+        '.attachments-list',
+      );
+      const attachmentListItems = attachmentsList.querySelectorAll('li');
+      expect(attachmentListItems).to.have.length(1);
+      expect(
+        attachmentListItems[0].getAttribute('data-dd-action-name'),
+      ).to.equal('Attachment Item');
+    });
+
+    it('should have data-dd-action-name on all attachment list items when multiple attachments exist', () => {
+      const customProps = {
+        attachments: [
+          {
+            id: 2664842,
+            messageId: 2664846,
+            name: 'test-file-1.pdf',
+            attachmentSize: 31127,
+            download:
+              'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664842',
+          },
+          {
+            id: 2664843,
+            messageId: 2664846,
+            name: 'test-file-2.jpg',
+            attachmentSize: 45200,
+            download:
+              'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664843',
+          },
+          {
+            id: 2664844,
+            messageId: 2664846,
+            name: 'test-file-3.docx',
+            attachmentSize: 128000,
+            download:
+              'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664844',
+          },
+        ],
+        attachmentScanError: false,
+        editingEnabled: false,
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <AttachmentsList {...customProps} />,
+        {
+          initialState: {},
+          reducers: reducer,
+          path: Paths.MESSAGE_THREAD,
+        },
+      );
+
+      const attachmentsList = screen.container.querySelector(
+        '.attachments-list',
+      );
+      const attachmentListItems = attachmentsList.querySelectorAll('li');
+      expect(attachmentListItems).to.have.length(3);
+
+      attachmentListItems.forEach(item => {
+        expect(item.getAttribute('data-dd-action-name')).to.equal(
+          'Attachment Item',
+        );
+      });
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/MessageListItem.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/MessageListItem.unit.spec.jsx
@@ -107,4 +107,216 @@ describe('MessageListItem component', () => {
       'vads-u-font-weight--bold',
     );
   });
+
+  describe('Datadog RUM action names', () => {
+    it('should have data-dd-action-name on message subject link', () => {
+      const customProps = {
+        ...props,
+        message: {
+          ...props.message,
+          category: 'OTHER',
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <MessageListItem {...customProps} />,
+        {
+          initialState,
+          reducers: reducer,
+          path: `/search/results`,
+        },
+      );
+
+      const subjectLink = screen.getByRole('link');
+      expect(subjectLink.getAttribute('data-dd-action-name')).to.equal(
+        'Link to Message Subject Details',
+      );
+    });
+
+    it('should have data-dd-action-name on recipient info in sent folder', () => {
+      const sent = {
+        folderId: -1,
+        name: 'Sent',
+        count: 49,
+        unreadCount: 35,
+        systemFolder: true,
+      };
+
+      const customProps = {
+        ...props,
+        activeFolder: sent,
+        message: {
+          ...props.message,
+          category: 'OTHER',
+        },
+      };
+
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          search: {
+            ...initialState.sm.search,
+            folder: sent,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <MessageListItem {...customProps} />,
+        {
+          customState,
+          reducers: reducer,
+          path: `/sent/`,
+        },
+      );
+
+      const recipientDiv = screen.getByText((content, element) => {
+        return (
+          element.getAttribute('data-dd-action-name') ===
+          'Message List Item Recipient and Sender Info'
+        );
+      });
+      expect(recipientDiv).to.exist;
+      expect(recipientDiv.textContent).to.include('To:');
+    });
+
+    it('should have data-dd-action-name on sender info in sent folder', () => {
+      const sent = {
+        folderId: -1,
+        name: 'Sent',
+        count: 49,
+        unreadCount: 35,
+        systemFolder: true,
+      };
+
+      const customProps = {
+        ...props,
+        activeFolder: sent,
+        message: {
+          ...props.message,
+          category: 'OTHER',
+        },
+      };
+
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          search: {
+            ...initialState.sm.search,
+            folder: sent,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <MessageListItem {...customProps} />,
+        {
+          customState,
+          reducers: reducer,
+          path: `/sent/`,
+        },
+      );
+
+      const senderDiv = screen.getByText((content, element) => {
+        return (
+          element.getAttribute('data-dd-action-name') ===
+          'Message List Item Sender Info'
+        );
+      });
+      expect(senderDiv).to.exist;
+      expect(senderDiv.textContent).to.include('From:');
+    });
+
+    it('should have data-dd-action-name on recipient info in drafts folder', () => {
+      const drafts = {
+        folderId: -2,
+        name: 'Drafts',
+        count: 5,
+        unreadCount: 0,
+        systemFolder: true,
+      };
+
+      const customProps = {
+        ...props,
+        activeFolder: drafts,
+        message: {
+          ...props.message,
+          category: 'OTHER',
+        },
+      };
+
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          search: {
+            ...initialState.sm.search,
+            folder: drafts,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <MessageListItem {...customProps} />,
+        {
+          customState,
+          reducers: reducer,
+          path: `/drafts/`,
+        },
+      );
+
+      const recipientDiv = screen.getByText((content, element) => {
+        return (
+          element.getAttribute('data-dd-action-name') ===
+          'Message List Item Recipient and Sender Info'
+        );
+      });
+      expect(recipientDiv).to.exist;
+      expect(recipientDiv.textContent).to.include('To:');
+    });
+
+    it('should show draft label in drafts folder', () => {
+      const drafts = {
+        folderId: -2,
+        name: 'Drafts',
+        count: 5,
+        unreadCount: 0,
+        systemFolder: true,
+      };
+
+      const customProps = {
+        ...props,
+        activeFolder: drafts,
+        message: {
+          ...props.message,
+          category: 'OTHER',
+        },
+      };
+
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          search: {
+            ...initialState.sm.search,
+            folder: drafts,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(
+        <MessageListItem {...customProps} />,
+        {
+          customState,
+          reducers: reducer,
+          path: `/drafts/`,
+        },
+      );
+
+      const draftLabel = screen.getByText('(Draft)');
+      expect(draftLabel).to.exist;
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/Search/SearchForm.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Search/SearchForm.unit.spec.jsx
@@ -368,9 +368,12 @@ describe('Search form', () => {
       const screen = setup(customProps);
 
       const messageIdInfo = screen.container.querySelector(
-        'va-additional-info[trigger="What\'s a message ID?"]',
+        'va-additional-info',
       );
       expect(messageIdInfo).to.exist;
+      expect(messageIdInfo.getAttribute('trigger')).to.equal(
+        "What's a message ID?",
+      );
       expect(messageIdInfo.getAttribute('data-dd-action-name')).to.equal(
         "What's a message ID? Expandable Info",
       );

--- a/src/applications/mhv-secure-messaging/tests/components/Search/SearchForm.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Search/SearchForm.unit.spec.jsx
@@ -277,4 +277,140 @@ describe('Search form', () => {
     );
     expect(screen.getByText('January 1st 2022 to December 31st 2022'));
   });
+
+  describe('Datadog RUM action names', () => {
+    it('should have data-dd-action-name on filter results label', () => {
+      const searchTerm = 'test';
+      const query = {
+        category: 'other',
+        fromDate: '2022-09-19T00:00:00-07:00',
+        toDate: '2022-12-19T21:55:17.766Z',
+        queryData: { searchTerm },
+      };
+      const customProps = {
+        ...defaultProps,
+        keyword: searchTerm,
+        resultsCount: searchResults.length,
+        query,
+        threadCount: threadList.length,
+      };
+      const screen = setup(customProps);
+
+      const resultsLabel = screen.getByTestId(
+        'search-message-folder-input-label',
+      );
+      expect(resultsLabel.getAttribute('data-dd-action-name')).to.equal(
+        'Filter Messages matches label',
+      );
+    });
+
+    it('should have data-dd-action-name on filter messages heading for inbox', () => {
+      const screen = setup();
+
+      const heading = screen.getByRole('heading', {
+        name: 'Filter messages in inbox',
+      });
+      expect(heading.getAttribute('data-dd-action-name')).to.equal(
+        'Filter Messages in Inbox',
+      );
+    });
+
+    it('should have data-dd-action-name on filter messages heading for custom folder', () => {
+      const customFolder = {
+        folderId: 123,
+        name: 'My Custom Folder',
+        count: 10,
+        unreadCount: 2,
+        systemFolder: false,
+      };
+      const customProps = {
+        ...defaultProps,
+        folder: customFolder,
+      };
+
+      const customState = {
+        sm: {
+          folders: {
+            folderList,
+            folder: customFolder,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SearchForm {...customProps} />, {
+        initialState: customState,
+        reducers: reducer,
+        path: `/folders/${customFolder.folderId}`,
+      });
+
+      const heading = screen.getByRole('heading', {
+        name: /Filter messages in My Custom Folder/i,
+      });
+      expect(heading.getAttribute('data-dd-action-name')).to.equal(
+        'Filter Messages in Custom Folder',
+      );
+    });
+
+    it('should have data-dd-action-name on filter input field', () => {
+      const screen = setup();
+
+      const filterInput = screen.getByTestId('keyword-search-input');
+      expect(filterInput.getAttribute('data-dd-action-name')).to.equal(
+        'Input Field - Filter',
+      );
+    });
+
+    it('should have data-dd-action-name on message ID info expandable', () => {
+      const customProps = {
+        ...defaultProps,
+        threadCount: threadList.length,
+      };
+      const screen = setup(customProps);
+
+      const messageIdInfo = screen.container.querySelector(
+        'va-additional-info[trigger="What\'s a message ID?"]',
+      );
+      expect(messageIdInfo).to.exist;
+      expect(messageIdInfo.getAttribute('data-dd-action-name')).to.equal(
+        "What's a message ID? Expandable Info",
+      );
+    });
+
+    it('should have data-dd-action-name on apply filters button', () => {
+      const customProps = {
+        ...defaultProps,
+        threadCount: threadList.length,
+      };
+      const screen = setup(customProps);
+
+      const applyButton = screen.getByTestId('filter-messages-button');
+      expect(applyButton.getAttribute('data-dd-action-name')).to.equal(
+        'Filter Button',
+      );
+    });
+
+    it('should have dd-action-name on clear filters button when results exist', () => {
+      const searchTerm = 'test';
+      const query = {
+        category: 'other',
+        queryData: { searchTerm },
+      };
+      const customProps = {
+        ...defaultProps,
+        keyword: searchTerm,
+        resultsCount: searchResults.length,
+        query,
+        threadCount: threadList.length,
+      };
+      const screen = setup(customProps);
+
+      const clearButton = screen.container.querySelector(
+        'va-button[text="Clear filters"]',
+      );
+      expect(clearButton).to.exist;
+      expect(clearButton.getAttribute('dd-action-name')).to.equal(
+        'Clear filters Button',
+      );
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/navigate-away-tests/secure-messaging-navigate-away-from-saved-reply-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/navigate-away-tests/secure-messaging-navigate-away-from-saved-reply-draft.cypress.spec.js
@@ -46,6 +46,7 @@ describe('SM NAVIGATE AWAY FROM SAVED REPLY DRAFT', () => {
 
   it('navigate away with changed data', () => {
     PatientComposePage.getMessageBodyField()
+      .should('be.enabled')
       .clear()
       .type('updated data');
 
@@ -65,6 +66,7 @@ describe('SM NAVIGATE AWAY FROM SAVED REPLY DRAFT', () => {
 
   it('navigate away with changed data and attachment', () => {
     PatientComposePage.getMessageBodyField()
+      .should('be.enabled')
       .clear()
       .type('updated data');
     PatientComposePage.attachMessageFromFile();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- adding tracking of recent care teams count on`/recent` page. custom action - `Recent Care Teams loaded`
- adding tag for _Tag how many times users are selecting/toggling between the different VA healthcare systems_ . custom action name - `Care System Radio Switch Count`
- _Track how many just don't answer the health care system question and go straight to the Select a care team question_ -> this can be tracked using above action `Care System Radio Switch Count` which will be 0 in that case

This pull request enhances user interaction tracking and analytics in the secure messaging application by integrating DataDog RUM actions and improving the granularity of event capture across several components. The changes focus on adding custom action names to key UI elements, tracking user behavior such as care system switching, and adjusting session sampling rates for analytics environments.

**Analytics and User Interaction Tracking Improvements:**

* Integrated DataDog RUM action logging in care team selection components:
  - In `RecentCareTeams`, logs when recent care teams are loaded, including the count, and tags radio options for selection tracking. [[1]](diffhunk://#diff-667f8705f38954723c2004c1eee4f1d388ebad8b5542e8c1b79c733c1192176dR4) [[2]](diffhunk://#diff-667f8705f38954723c2004c1eee4f1d388ebad8b5542e8c1b79c733c1192176dR63-R73) [[3]](diffhunk://#diff-667f8705f38954723c2004c1eee4f1d388ebad8b5542e8c1b79c733c1192176dR173)
  - In `SelectCareTeam`, tracks the number of times a user switches care systems via radio buttons and logs this count on component unmount. [[1]](diffhunk://#diff-bac517ad4c5a26d12c6577e01c90d03970f17ef75372404abb9b039caa6ddbd2R55) [[2]](diffhunk://#diff-bac517ad4c5a26d12c6577e01c90d03970f17ef75372404abb9b039caa6ddbd2R142-R157)

**Environment-based Analytics Configuration:**

* Updated session sampling rates for DataDog RUM in `App.jsx` to use 100% sampling in staging environments and 50% in production, improving analytics reliability during testing. [[1]](diffhunk://#diff-7804b644e6b4ca2bce5b7ab0d45f66c55c82b4f57811bc24c5388802b8cd267aR7) [[2]](diffhunk://#diff-7804b644e6b4ca2bce5b7ab0d45f66c55c82b4f57811bc24c5388802b8cd267aL83-R87)

* Added custom `data-dd-action-name` attributes to important UI elements in `AttachmentsList`, `MessageListItem`, `SearchForm`, and care team selection/radio options to allow more granular tracking of user interactions in DataDog RUM. [[1]](diffhunk://#diff-235e7ffa5273bebd2a62586b21922f50842d7537f3f20e46f77f1a8033862d7bL270-R273) [[2]](diffhunk://#diff-5f5e75844fb0f98be99c54cd026e6468a57a00992ab48058b8758f737ae1a8a4L93-R109) [[3]](diffhunk://#diff-94fcc2be38f30169975fa715208a4e046565c496747cb46da511a092dcf74c7bR208) [[4]](diffhunk://#diff-667f8705f38954723c2004c1eee4f1d388ebad8b5542e8c1b79c733c1192176dR173)


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123539

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
