### PR TITLE
534ez update submit key to survivorsBenefitsClaim

### DIFF
--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -63,7 +63,7 @@ export const transform = (formConfig, form) => {
   let transformedData = transformForSubmit(formConfig, form);
   transformedData = calculateSeparationDuration(transformedData);
   return JSON.stringify({
-    survivorsBenefits: {
+    survivorsBenefitsClaim: {
       form: transformedData,
     },
     localTime: format(new Date(), "yyyy-MM-dd'T'HH:mm:ssXXX"),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When submitting the form with the new api, the key for submission is incorrect. It is currently suvivorsBenefits, but needs to be survivorBenefitsClaim

## Related issue(s)

## Testing done

- Manually tested submit on localhost to check for network request. 


## Screenshots

| Before | After |
| ------ | ----- |
| <img width="752" height="208" alt="Screenshot 2025-11-04 at 9 32 07 AM" src="https://github.com/user-attachments/assets/53fc8a91-2a0c-405b-96ff-e260991ece2b" /> | <img width="834" height="231" alt="Screenshot 2025-11-04 at 9 32 36 AM" src="https://github.com/user-attachments/assets/4ea4636d-4f56-4edc-9485-30c396c30fc1" /> |

## What areas of the site does it impact?

Just the submit transformer of the 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
