### PR TITLE
[DBC] `all_claims`: `formConfig.dev.showNavLinks = true`

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -140,6 +140,10 @@ import ConfirmationAncillaryFormsWizard from '../components/ConfirmationAncillar
 /** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
+  dev: {
+    showNavLinks: true,
+    collapsibleNavLinks: true,
+  },
   urlPrefix: '/',
   intentToFileUrl: '/evss_claims/intent_to_file/compensation',
   submitUrl: `${


### PR DESCRIPTION
`SipsDevModal` lets you start where you want. `DevModeNavLinks` lets you jump around after having started.

From what I can see, this dev feature is only documented in the JSDoc's for `forms-system` [here](https://github.com/department-of-veterans-affairs/vets-website/blob/94fe018d37f09188e1522b94dd7c60d2eac3cd8a/src/platform/forms-system/src/js/types.js#L86-L89):
```js
/**
 * @typedef {Object} Dev
 * @property {boolean} [showNavLinks] - Show navigation links on every page to every route in your form (dev only)
 * @property {boolean} [collapsibleNavLinks] - Must be used with `showNavLinks: true`. If true, the nav links will be wrapped in a `va-additional-info` component
 * @property {boolean} [disableWindowUnloadInCI] - Disables the window unload listener in CI environments to prevent tests from failing due to the "Are you sure you want to leave?" prompt.
 */
```

<img width="1380" height="834" alt="Screenshot 2025-11-04 at 11 12 55 AM" src="https://github.com/user-attachments/assets/4d0abf98-3a67-497a-a41a-8e197d6f14f0" />
