### PR TITLE
0969 | Post MVP - discontinued income summary pages

### DIFF
--- a/src/applications/income-and-asset-statement/components/SummaryDescriptions.jsx
+++ b/src/applications/income-and-asset-statement/components/SummaryDescriptions.jsx
@@ -103,3 +103,30 @@ export const UnreportedAssetsSummaryDescription = () => {
     </>
   );
 };
+
+export const DiscontinuedIncomeSummaryDescription = () => {
+  return (
+    <>
+      <p>
+        Here are some examples of discontinued or irregular income you’ll need
+        to disclose for the reporting period you entered in Step 1:
+      </p>
+      <ul>
+        <li>Wages from a previous job</li>
+        <li>Interest or dividends from recently closed or emptied accounts</li>
+        <li>Unemployment benefits </li>
+        <li>Lottery or gambling winnings</li>
+      </ul>
+      <p>
+        If you’re submitting this form with your initial claim, include income
+        from the previous calendar year.
+      </p>
+      <p>
+        {' '}
+        <strong>Note:</strong> You may need to submit evidence that you no
+        longer receive this income, like a bank statement or a letter confirming
+        a closed account.
+      </p>
+    </>
+  );
+};

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/11-discontinued-incomes/discontinuedIncomePages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/11-discontinued-incomes/discontinuedIncomePages.unit.spec.jsx
@@ -1,9 +1,11 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
 import formConfig from '../../../../config/form';
 import {
   discontinuedIncomePages,
   options,
 } from '../../../../config/chapters/10-discontinued-incomes/discontinuedIncomePages';
-
+import * as helpers from '../../../../helpers';
 import testData from '../../../e2e/fixtures/data/test-data.json';
 import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
 
@@ -21,52 +23,92 @@ import {
 } from '../pageTests.spec';
 
 describe('discontinued income list and loop pages', () => {
-  const { discontinuedIncomePagesSummary } = discontinuedIncomePages;
+  let showUpdatedContentStub;
 
-  describe('isItemIncomplete function', () => {
-    const baseItem = testData.data.discontinuedIncomes[0];
-    testOptionsIsItemIncomplete(options, baseItem);
+  beforeEach(() => {
+    showUpdatedContentStub = sinon.stub(helpers, 'showUpdatedContent');
   });
 
-  describe('isItemIncomplete function tested with zeroes', () => {
-    const baseItem = testDataZeroes.data.discontinuedIncomes[0];
-    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  afterEach(() => {
+    if (showUpdatedContentStub && showUpdatedContentStub.restore) {
+      showUpdatedContentStub.restore();
+    }
   });
 
-  describe('text getItemName function', () => {
-    testOptionsTextGetItemNameRecurringIncome(options);
+  const {
+    discontinuedIncomePagesSummary,
+    discontinuedIncomePagesVeteranSummary,
+    discontinuedIncomePagesSpouseSummary,
+    discontinuedIncomePagesChildSummary,
+    discontinuedIncomePagesCustodianSummary,
+    discontinuedIncomePagesParentSummary,
+  } = discontinuedIncomePages;
+
+  describe('text', () => {
+    describe('isItemIncomplete function', () => {
+      const baseItem = testData.data.discontinuedIncomes[0];
+      testOptionsIsItemIncomplete(options, baseItem);
+    });
+
+    describe('isItemIncomplete function tested with zeroes', () => {
+      const baseItem = testDataZeroes.data.discontinuedIncomes[0];
+      testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+    });
+
+    describe('text getItemName function', () => {
+      testOptionsTextGetItemNameRecurringIncome(options);
+    });
+
+    describe('text cardDescription function', () => {
+      /* eslint-disable no-unused-vars */
+      const {
+        payer,
+        incomeFrequency,
+        incomeLastReceivedDate,
+        recipientRelationship,
+        recipientName,
+        ...baseItem
+      } = testData.data.discontinuedIncomes[0];
+      /* eslint-enable no-unused-vars */
+      testOptionsTextCardDescription(options, baseItem);
+    });
+
+    describe('text cardDescription function with zero values', () => {
+      /* eslint-disable no-unused-vars */
+      const {
+        payer,
+        incomeFrequency,
+        incomeLastReceivedDate,
+        recipientRelationship,
+        recipientName,
+        ...baseItem
+      } = testDataZeroes.data.discontinuedIncomes[0];
+      /* eslint-enable no-unused-vars */
+      testOptionsTextCardDescription(options, baseItem);
+    });
+
+    describe('summaryTitle function', () => {
+      it('should show review title', () => {
+        expect(options.text.summaryTitle).to.eql(
+          'Review  discontinued and irregular income',
+        );
+      });
+    });
+
+    describe('summaryDescriptionWithoutItems', () => {
+      it('should return null when showUpdatedContent is false', () => {
+        expect(options.text.summaryDescriptionWithoutItems).to.be.null;
+      });
+    });
   });
 
-  describe('text cardDescription function', () => {
-    /* eslint-disable no-unused-vars */
-    const {
-      payer,
-      incomeFrequency,
-      incomeLastReceivedDate,
-      recipientRelationship,
-      recipientName,
-      ...baseItem
-    } = testData.data.discontinuedIncomes[0];
-    /* eslint-enable no-unused-vars */
-    testOptionsTextCardDescription(options, baseItem);
-  });
+  describe('MVP summary page', () => {
+    beforeEach(() => {
+      showUpdatedContentStub.returns(false);
+    });
 
-  describe('text cardDescription function with zero values', () => {
-    /* eslint-disable no-unused-vars */
-    const {
-      payer,
-      incomeFrequency,
-      incomeLastReceivedDate,
-      recipientRelationship,
-      recipientName,
-      ...baseItem
-    } = testDataZeroes.data.discontinuedIncomes[0];
-    /* eslint-enable no-unused-vars */
-    testOptionsTextCardDescription(options, baseItem);
-  });
-
-  describe('summary page', () => {
     const { schema, uiSchema } = discontinuedIncomePagesSummary;
+
     testNumberOfFieldsByType(
       formConfig,
       schema,
@@ -91,6 +133,176 @@ describe('discontinued income list and loop pages', () => {
       testData.data,
       { loggedIn: true },
     );
+  });
+
+  describe('Post MVP summary pages', () => {
+    beforeEach(() => {
+      showUpdatedContentStub.returns(true);
+    });
+
+    describe('veteran summary page', () => {
+      const { schema, uiSchema } = discontinuedIncomePagesVeteranSummary;
+      const formData = { ...testData.data, claimantType: 'VETERAN' };
+
+      it('should display when showUpdatedContent is true and claimantType is VETERAN', () => {
+        const { depends } = discontinuedIncomePagesVeteranSummary;
+        expect(depends(formData)).to.be.true;
+      });
+
+      it('should have modified hint text for veteran', () => {
+        expect(
+          uiSchema['view:isAddingDiscontinuedIncomes'][
+            'ui:options'
+          ].updateUiSchema()['ui:options'].hint,
+        ).to.include(
+          'Your dependents include your spouse, including a same-sex and common-law partner and children who you financially support.',
+        );
+      });
+
+      testSubmitsWithoutErrors(
+        formConfig,
+        schema,
+        uiSchema,
+        'spouse summary page',
+        formData,
+        { loggedIn: true },
+      );
+    });
+
+    describe('spouse summary page', () => {
+      const { schema, uiSchema } = discontinuedIncomePagesSpouseSummary;
+      const formData = { ...testData.data, claimantType: 'SPOUSE' };
+
+      it('should display when showUpdatedContent is true and claimantType is SPOUSE', () => {
+        const { depends } = discontinuedIncomePagesSpouseSummary;
+        expect(depends(formData)).to.be.true;
+      });
+
+      it('should have modified hint text for spouse', () => {
+        expect(
+          uiSchema['view:isAddingDiscontinuedIncomes'][
+            'ui:options'
+          ].updateUiSchema()['ui:options'].hint,
+        ).to.include(
+          'Your dependents include children who you financially support',
+        );
+      });
+
+      testSubmitsWithoutErrors(
+        formConfig,
+        schema,
+        uiSchema,
+        'spouse summary page',
+        formData,
+        { loggedIn: true },
+      );
+    });
+
+    describe('child summary page', () => {
+      const { schema, uiSchema } = discontinuedIncomePagesChildSummary;
+      const formData = { ...testData.data, claimantType: 'CHILD' };
+
+      it('should display when showUpdatedContent is true and claimantType is CHILD', () => {
+        const { depends } = discontinuedIncomePagesChildSummary;
+        expect(depends(formData)).to.be.true;
+      });
+
+      it('should have modified title text for child', () => {
+        expect(
+          uiSchema['view:isAddingDiscontinuedIncomes']['ui:title'],
+        ).to.equal(
+          'Have you received income that has ended during the reporting period or in the last full calendar year (if this is your first claim)?',
+        );
+      });
+
+      it('should have no hint text for child', () => {
+        expect(uiSchema['view:isAddingDiscontinuedIncomes']['ui:options'].hint)
+          .to.be.undefined;
+      });
+
+      it('should have correct option labels', () => {
+        const { labels } = uiSchema['view:isAddingDiscontinuedIncomes'][
+          'ui:options'
+        ].updateUiSchema()['ui:options'];
+        expect(labels.Y).to.equal('Yes, I have income to report');
+        expect(labels.N).to.equal('No, I don’t have income to report');
+      });
+
+      it('should have correct labelHeaderLevel configuration', () => {
+        const { labelHeaderLevel } = uiSchema[
+          'view:isAddingDiscontinuedIncomes'
+        ]['ui:options'].updateUiSchema()['ui:options'];
+
+        expect(labelHeaderLevel).to.equal('2');
+      });
+
+      testSubmitsWithoutErrors(
+        formConfig,
+        schema,
+        uiSchema,
+        'child summary page',
+        formData,
+        { loggedIn: true },
+      );
+    });
+
+    describe('custodian summary page', () => {
+      const { schema, uiSchema } = discontinuedIncomePagesCustodianSummary;
+      const formData = { ...testData.data, claimantType: 'CUSTODIAN' };
+
+      it('should display when showUpdatedContent is true and claimantType is CUSTODIAN', () => {
+        const { depends } = discontinuedIncomePagesCustodianSummary;
+        expect(depends(formData)).to.be.true;
+      });
+
+      it('should have modified hint text for custodian', () => {
+        expect(
+          uiSchema['view:isAddingDiscontinuedIncomes'][
+            'ui:options'
+          ].updateUiSchema()['ui:options'].hint,
+        ).to.include(
+          'Your dependents include your spouse, including a same-sex and common-law partner and the Veteran’s children who you financially support.',
+        );
+      });
+
+      testSubmitsWithoutErrors(
+        formConfig,
+        schema,
+        uiSchema,
+        'custodian summary page',
+        formData,
+        { loggedIn: true },
+      );
+    });
+
+    describe('parent summary page', () => {
+      const { schema, uiSchema } = discontinuedIncomePagesParentSummary;
+      const formData = { ...testData.data, claimantType: 'PARENT' };
+
+      it('should display when showUpdatedContent is true and claimantType is PARENT', () => {
+        const { depends } = discontinuedIncomePagesParentSummary;
+        expect(depends(formData)).to.be.true;
+      });
+
+      it('should have modified hint text for parent', () => {
+        expect(
+          uiSchema['view:isAddingDiscontinuedIncomes'][
+            'ui:options'
+          ].updateUiSchema()['ui:options'].hint,
+        ).to.include(
+          'Your dependents include your spouse, including a same-sex and common-law partner.',
+        );
+      });
+
+      testSubmitsWithoutErrors(
+        formConfig,
+        schema,
+        uiSchema,
+        'parent summary page',
+        formData,
+        { loggedIn: true },
+      );
+    });
   });
 
   describe('relationship page', () => {


### PR DESCRIPTION
## Summary

This PR adds **Post-MVP summary pages** for the **Discontinued Income** chapter in the **Income and Asset Statement (VA Form 21P-0969)**.  
The new summary pages align with updated **array builder patterns** and **Post-MVP design requirements**, ensuring consistency in structure and content across all income-related chapters.

These updates introduce the `summaryTitle` and `summaryTitleWithoutItems` configurations, improved accessibility markup, and support for all claimant types.

## Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111736  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111732  

## How to Test

1. Enable the Post-MVP feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`
2. Launch the form:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`
3. Progress to the **Discontinued Income** chapter.
4. Verify the page title and description on the summary page without items
5. Add at least one discontinued income item, then continue to the summary page.
6. Verify:
   - The summary page displays correctly with updated headings and hint text.
   - No layout or alignment issues are present.
   - Accessibility roles and heading levels follow design standards.
7. Repeat with multiple claimant types (Veteran, Spouse, Parent, Custodian) to ensure all paths render properly.

## Areas Impacted

- **Income and Asset Statement (21P-0969)**  
- **Discontinued Income** list-and-loop chapter (summary and information pages)

## Feature Toggle

- `income_and_assets_content_updates`  

## Screenshots

| Before | After |
|--------|-------|
| No summary page title or description for discontinued income | Post-MVP summary pages without items |

## Quality Assurance & Testing

- [ ] Unit tests updated or added where applicable.  
- [ ] Accessibility and heading hierarchy verified.  
- [ ] No PII or PHI present in logs or test data.  
- [ ] Linting and CI checks pass.  
- [ ] Tested locally across claimant types.

## Definition of Done

- New summary pages are implemented and functional.  
- Content aligns with Post-MVP design standards.  
- Successfully gated behind feature toggle.  
- Regression testing completed for other income chapters.

## Requested Feedback

Please confirm:
- Summary page alignment and heading levels match other Post-MVP income chapters.
- Accessibility and content accuracy across claimant types.
- Toggle behavior works as expected when disabled/enabled.