### PR TITLE
Save in progress/no auth.fix

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -284,8 +284,8 @@ export const ANALYTICS_EVENTS = {
 };
 
 // new /v0/disability_compensation_in_progress_forms/21-526EZ. Not using the
-// platform/forms/helpers/inProgressApi because the mock doesn't include the
-// environment.API_URL
+// platform/forms/save-in-progress/api/inProgressApi because the mock doesn't
+// include the environment.API_URL
 export const MOCK_SIPS_API =
   VA_FORM_IDS_IN_PROGRESS_FORMS_API[VA_FORM_IDS.FORM_21_526EZ];
 

--- a/src/platform/forms/exportsFile.js
+++ b/src/platform/forms/exportsFile.js
@@ -74,7 +74,11 @@ import {
   removeInProgressForm,
 } from './save-in-progress/actions';
 
-import { removeFormApi, saveFormApi } from './save-in-progress/api';
+import {
+  removeFormApi,
+  saveFormApi,
+  inProgressApi,
+} from './save-in-progress/api';
 
 import ApplicationStatus from './save-in-progress/ApplicationStatus';
 
@@ -114,7 +118,6 @@ import {
 import { makeField, dirtyAllFields } from './fields';
 
 import {
-  inProgressApi,
   getPageList,
   groupPagesIntoChapters,
   isInProgressPath,

--- a/src/platform/forms/helpers.js
+++ b/src/platform/forms/helpers.js
@@ -1,17 +1,7 @@
 import { groupBy, matches } from 'lodash';
-import environment from '../utilities/environment';
-import {
-  VA_FORM_IDS_IN_PROGRESS_FORMS_API,
-  memoizedGetFormLink,
-} from './constants';
+import { memoizedGetFormLink } from './constants';
 
 export const getFormLink = memoizedGetFormLink();
-
-export function inProgressApi(formId) {
-  const apiUrl =
-    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
-  return `${environment.API_URL}${apiUrl}${formId}`;
-}
 
 export function getPageList(routes, prefix = '') {
   return routes

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -3,8 +3,7 @@ import * as Sentry from '@sentry/browser';
 import recordEvent from '../../monitoring/record-event';
 import { logOut } from '../../user/authentication/actions';
 import { apiRequest } from '../../utilities/api';
-import { inProgressApi } from '../helpers';
-import { removeFormApi, saveFormApi } from './api';
+import { inProgressApi, removeFormApi, saveFormApi } from './api';
 import { REMOVING_SAVED_FORM_SUCCESS } from '../../user/profile/actions';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -2,8 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 import recordEvent from '../../monitoring/record-event';
 import { logOut } from '../../user/authentication/actions';
-import { apiRequest } from '../../utilities/api';
-import { inProgressApi, removeFormApi, saveFormApi } from './api';
+import { formApi, removeFormApi, saveFormApi } from './api';
 import { REMOVING_SAVED_FORM_SUCCESS } from '../../user/profile/actions';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';
@@ -317,13 +316,12 @@ export function fetchInProgressForm(
   //  redux store, but form.migrations doesn’t exist (nor should it, really)
   return (dispatch, getState) => {
     const { trackingPrefix } = getState().form;
-    const apiUrl = inProgressApi(formId);
 
     // Update UI while we’re waiting for the API
     dispatch(setFetchFormPending(prefill));
 
     // Query the api and return a promise (for navigation / error handling afterward)
-    return apiRequest(apiUrl, { method: 'GET' })
+    return formApi(formId, { method: 'GET' })
       .then(resBody => {
         // Return not-found if empty object
         if (

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/browser';
-import { apiRequest } from '../../utilities/api';
+import { apiRequestWithResponse, isJson } from '../../utilities/api';
 import {
   VA_FORM_IDS_SKIP_INFLECTION,
   VA_FORM_IDS_IN_PROGRESS_FORMS_API,
@@ -14,7 +14,15 @@ export function inProgressApi(formId) {
 
 export function formApi(formId, optionalSettings) {
   const apiUrl = inProgressApi(formId);
-  return apiRequest(apiUrl, optionalSettings);
+  return apiRequestWithResponse(apiUrl, optionalSettings).then(response => {
+    const data = isJson(response) ? response.json() : Promise.resolve(response);
+
+    if (response.ok || response.status === 304) {
+      return data;
+    }
+
+    return data.then(Promise.reject.bind(Promise));
+  });
 }
 
 export function removeFormApi(formId) {

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -20,7 +20,6 @@ export function formApi(formId, optionalSettings) {
       return response;
     }
 
-    if (isJson(response)) return response.json().then(v => Promise.reject(v));
     return Promise.reject(response);
   });
 }

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -15,13 +15,13 @@ export function inProgressApi(formId) {
 export function formApi(formId, optionalSettings) {
   const apiUrl = inProgressApi(formId);
   return apiRequestWithResponse(apiUrl, optionalSettings).then(response => {
-    const data = isJson(response) ? response.json() : Promise.resolve(response);
-
     if (response.ok || response.status === 304) {
-      return data;
+      if (isJson(response)) return response.json();
+      return response;
     }
 
-    return data.then(Promise.reject.bind(Promise));
+    if (isJson(response)) return response.json().then(v => Promise.reject(v));
+    return Promise.reject(response);
   });
 }
 

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/browser';
-import { apiRequestWithResponse, isJson } from '../../utilities/api';
+import { apiRequestWithResponse } from '../../utilities/api';
 import {
   VA_FORM_IDS_SKIP_INFLECTION,
   VA_FORM_IDS_IN_PROGRESS_FORMS_API,
@@ -15,11 +15,7 @@ export function inProgressApi(formId) {
 export function formApi(formId, optionalSettings) {
   const apiUrl = inProgressApi(formId);
   return apiRequestWithResponse(apiUrl, optionalSettings).then(response => {
-    if (response.ok || response.status === 304) {
-      if (isJson(response)) return response.json();
-      return response;
-    }
-
+    if (response.ok || response.status === 304) return response.json();
     return Promise.reject(response);
   });
 }

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -1,7 +1,16 @@
 import * as Sentry from '@sentry/browser';
 import { apiRequest } from '../../utilities/api';
-import { inProgressApi } from '../helpers';
-import { VA_FORM_IDS_SKIP_INFLECTION } from '../constants';
+import {
+  VA_FORM_IDS_SKIP_INFLECTION,
+  VA_FORM_IDS_IN_PROGRESS_FORMS_API,
+} from '../constants';
+import environment from '../../utilities/environment';
+
+export function inProgressApi(formId) {
+  const apiUrl =
+    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
+  return `${environment.API_URL}${apiUrl}${formId}`;
+}
 
 export function removeFormApi(formId) {
   const apiUrl = inProgressApi(formId);

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -12,9 +12,13 @@ export function inProgressApi(formId) {
   return `${environment.API_URL}${apiUrl}${formId}`;
 }
 
-export function removeFormApi(formId) {
+export function formApi(formId, optionalSettings) {
   const apiUrl = inProgressApi(formId);
-  return apiRequest(apiUrl, {
+  return apiRequest(apiUrl, optionalSettings);
+}
+
+export function removeFormApi(formId) {
+  return formApi(formId, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -48,7 +52,6 @@ export function saveFormApi(
     },
     formData,
   });
-  const apiUrl = inProgressApi(formId);
   const saveFormApiHeaders = {
     'X-Key-Inflection': 'camel',
     'Content-Type': 'application/json',
@@ -57,7 +60,7 @@ export function saveFormApi(
     delete saveFormApiHeaders['X-Key-Inflection'];
   }
 
-  return apiRequest(apiUrl, {
+  return formApi(formId, {
     method: 'PUT',
     headers: saveFormApiHeaders,
     body,

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -24,7 +24,7 @@ import {
 } from '../../save-in-progress/actions';
 
 import { logOut } from '../../../user/authentication/actions';
-import { inProgressApi } from '../../helpers';
+import { inProgressApi } from '../../save-in-progress/api';
 
 const getState = () => ({ form: { trackingPrefix: 'test' } });
 

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -503,7 +503,7 @@ describe('Schemaform save / load actions:', () => {
       it('dispatches a no-auth if the api returns a 401', () => {
         server.use(
           rest.get(inProgressApi(VA_FORM_IDS.FORM_10_10EZ), (req, res, ctx) => {
-            return res(ctx.status(401), ctx.json({ status: 401 }));
+            return res(ctx.status(401));
           }),
         );
         const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_10_10EZ, {}, true);
@@ -530,7 +530,7 @@ describe('Schemaform save / load actions:', () => {
       it('dispatches a success if the api returns an empty object', () => {
         server.use(
           rest.get(inProgressApi(VA_FORM_IDS.FORM_10_10EZ), (req, res, ctx) => {
-            return res(ctx.status(401), ctx.json({}));
+            return res(ctx.status(200), ctx.json({}));
           }),
         );
         const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_10_10EZ, {}, true);

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -11,7 +11,7 @@ import {
 } from '../oauth/utilities';
 import { checkAndUpdateSSOeSession } from '../sso';
 
-export const isJson = response => {
+const isJson = response => {
   const contentType = response.headers.get('Content-Type');
   return contentType && contentType.includes('application/json');
 };

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -76,37 +76,11 @@ export function fetchAndUpdateSessionExpiration(url, settings) {
   });
 }
 
-/**
- *
- * @param {string} resource - The URL to fetch. If it starts with a leading "/"
- * it will be appended to the baseUrl. Otherwise it will be used as an absolute
- * URL.
- * @param {Object} [{}] optionalSettings - Custom settings you want to apply to
- * the fetch request. Will be mixed with, and potentially override, the
- * defaultSettings
- * @param {Function} **(DEPRECATED)** success - Callback to execute after successfully resolving
- * the initial fetch request.
- * @param {Function} **(DEPRECATED)** error - Callback to execute if the fetch fails to resolve.
- */
-export function apiRequest(resource, optionalSettings, success, error) {
+function apiRequestWithResponse(resource, optionalSettings) {
   const apiVersion = (optionalSettings && optionalSettings.apiVersion) || 'v0';
   const baseUrl = `${environment.API_URL}/${apiVersion}`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
   const csrfTokenStored = localStorage.getItem('csrfToken');
-
-  if (success) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'the "success" callback has been deprecated, please use a promise chain instead',
-    );
-  }
-
-  if (error) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'the "error" callback has been deprecated, please use a promise chain instead',
-    );
-  }
 
   const defaultSettings = {
     method: 'GET',
@@ -147,6 +121,39 @@ export function apiRequest(resource, optionalSettings, success, error) {
         }
       }
 
+      return response;
+    });
+}
+
+/**
+ *
+ * @param {string} resource - The URL to fetch. If it starts with a leading "/"
+ * it will be appended to the baseUrl. Otherwise it will be used as an absolute
+ * URL.
+ * @param {Object} [{}] optionalSettings - Custom settings you want to apply to
+ * the fetch request. Will be mixed with, and potentially override, the
+ * defaultSettings
+ * @param {Function} **(DEPRECATED)** success - Callback to execute after successfully resolving
+ * the initial fetch request.
+ * @param {Function} **(DEPRECATED)** error - Callback to execute if the fetch fails to resolve.
+ */
+export function apiRequest(resource, optionalSettings, success, error) {
+  if (success) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'the "success" callback has been deprecated, please use a promise chain instead',
+    );
+  }
+
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'the "error" callback has been deprecated, please use a promise chain instead',
+    );
+  }
+
+  return apiRequestWithResponse(resource, optionalSettings)
+    .then(response => {
       const data = isJson(response)
         ? response.json()
         : Promise.resolve(response);

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -163,15 +163,13 @@ export function apiRequest(resource, optionalSettings, success, error) {
 
   return apiRequestWithResponse(resource, optionalSettings)
     .then(response => {
-      const data = isJson(response)
-        ? response.json()
-        : Promise.resolve(response);
-
       if (response.ok || response.status === 304) {
-        return data;
+        if (isJson(response)) return response.json();
+        return response;
       }
 
-      return data.then(Promise.reject.bind(Promise));
+      if (isJson(response)) return response.json().then(v => Promise.reject(v));
+      return Promise.reject(response);
     })
     .then(success)
     .catch(error);

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -130,32 +130,29 @@ export function apiRequest(resource, optionalSettings, success, error) {
       return Promise.reject(err);
     })
     .then(response => {
-      const data = isJson(response)
-        ? response.json()
-        : Promise.resolve(response);
-
       // Get CSRF Token from API header
       const csrfToken = response.headers.get('X-CSRF-Token');
-
       if (csrfToken && csrfToken !== csrfTokenStored) {
         localStorage.setItem('csrfToken', csrfToken);
       }
 
-      if (response.ok || response.status === 304) {
-        return data;
-      }
-
       if (environment.isProduction()) {
-        const { pathname } = window.location;
-
         const shouldRedirectToSessionExpired =
           response.status === 401 &&
-          !pathname.includes('auth/login/callback') &&
+          !window.location.pathname.includes('auth/login/callback') &&
           sessionStorage.getItem('shouldRedirectExpiredSession') === 'true';
 
         if (shouldRedirectToSessionExpired) {
           window.location = '/session-expired';
         }
+      }
+
+      const data = isJson(response)
+        ? response.json()
+        : Promise.resolve(response);
+
+      if (response.ok || response.status === 304) {
+        return data;
       }
 
       return data.then(Promise.reject.bind(Promise));

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -11,7 +11,7 @@ import {
 } from '../oauth/utilities';
 import { checkAndUpdateSSOeSession } from '../sso';
 
-const isJson = response => {
+export const isJson = response => {
   const contentType = response.headers.get('Content-Type');
   return contentType && contentType.includes('application/json');
 };
@@ -76,7 +76,16 @@ export function fetchAndUpdateSessionExpiration(url, settings) {
   });
 }
 
-function apiRequestWithResponse(resource, optionalSettings) {
+/**
+ * @param {string} resource - The URL to fetch. If it starts with a leading "/"
+ * it will be appended to the baseUrl. Otherwise it will be used as an absolute
+ * URL.
+ * @param {Object} [{}] optionalSettings - Custom settings you want to apply to
+ * the fetch request. Will be mixed with, and potentially override, the
+ * defaultSettings.
+ * @returns {Promise<Response>} A promise that resolves with a response.
+ */
+export function apiRequestWithResponse(resource, optionalSettings) {
   const apiVersion = (optionalSettings && optionalSettings.apiVersion) || 'v0';
   const baseUrl = `${environment.API_URL}/${apiVersion}`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -168,6 +168,7 @@ export function apiRequest(resource, optionalSettings, success, error) {
         return response;
       }
 
+      // JSON parse errors are masking HTTP errors here, probably for the worse.
       if (isJson(response)) return response.json().then(v => Promise.reject(v));
       return Promise.reject(response);
     })


### PR DESCRIPTION
# Problem
There was a [refactor](https://github.com/department-of-veterans-affairs/vets-website/pull/22602) to reuse a platform-wide function `apiRequest` within `save-in-progress` (SIP) actions. It looks like this caused a regression that lost those actions' ability to distinguish between different HTTP error codes and, in turn, the UI's ability to exhibit behavior tailored to the case of `401`, the `no-auth` case.

# Solution
This commit extracts an internal API request utility function that resolves with the response so that callers have access to data like the HTTP status code that they can more robustly interpret, as SIP expects to do. `apiRequest` then becomes a small wrapper around that and another small wrapper `formApi` is introduced to meet SIP's expectations.

Through our fix/refactor, we isolate all and only the erroneous behavior we were importing __before__ and show the correct behavior __after__.

## Before
```javascript
response => {
  if (response.ok || response.status === 304) {
    if (isJson(response)) return response.json();
    return response;
  }

  if (isJson(response)) return response.json().then(v => Promise.reject(v));
  return Promise.reject(response);
}
```

## After
```javascript
response => {
  if (response.ok || response.status === 304) return response.json();
  return Promise.reject(response);
}
```

Each atomic step of the fix/refactor is captured in its own commit.

## Steps
1. Reorder conditional work in `apiRequest`.
2. Extract response-preserving fn to facilitate SIP fix.
3. More appropriate location for form API URL helper.
4. Consolidate into a new form API helper.
5. Copy `apiRequest` implementation before introducing fix.
6. Reshape `apiRequest` & its copy before introducing fix.
7. Fix - only provide response as rejection value.
8. Comment on an existing deficiency of `apiRequest`.
9. Fix - reflect that form API client has a JSON backend.
