### PR TITLE
0969 | Post MVP - Add relationship pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
@@ -251,7 +251,7 @@ const parentSummaryPage = {
 const veteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Recurring income relationship',
+      title: incomeRecipientPageTitle,
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
@@ -288,7 +288,7 @@ const veteranIncomeRecipientPage = {
 const spouseIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Recurring income relationship',
+      title: incomeRecipientPageTitle,
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
@@ -321,7 +321,7 @@ const spouseIncomeRecipientPage = {
 const custodianIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Recurring income relationship',
+      title: incomeRecipientPageTitle,
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
@@ -356,7 +356,7 @@ const custodianIncomeRecipientPage = {
 const parentIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Recurring income relationship',
+      title: incomeRecipientPageTitle,
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
@@ -387,7 +387,7 @@ const parentIncomeRecipientPage = {
 const nonVeteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Discontinued income relationship',
+      title: incomeRecipientPageTitle,
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({

--- a/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
@@ -16,7 +16,6 @@ import {
   textUI,
   textSchema,
 } from '~/platform/forms-system/src/js/web-component-patterns';
-import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
@@ -25,21 +24,30 @@ import {
   isDefined,
   isIncomeTypeInfoIncomplete,
   isRecipientInfoIncomplete,
-  otherRecipientRelationshipExplanationRequired,
+  otherRecipientRelationshipTypeUI,
   recipientNameRequired,
   requireExpandedArrayField,
   resolveRecipientFullName,
+  sharedRecipientRelationshipBase,
   showUpdatedContent,
   sharedYesNoOptionsBase,
 } from '../../../helpers';
-import { incomeFrequencyLabels, relationshipLabels } from '../../../labels';
+import {
+  custodianRelationshipLabels,
+  incomeFrequencyLabels,
+  parentRelationshipLabels,
+  relationshipLabelDescriptions,
+  relationshipLabels,
+  spouseRelationshipLabels,
+} from '../../../labels';
 import { DiscontinuedIncomeSummaryDescription } from '../../../components/SummaryDescriptions';
+import { DependentDescription } from '../../../components/DependentDescription';
 
 /** @type {ArrayBuilderOptions} */
 export const options = {
   arrayPath: 'discontinuedIncomes',
   nounSingular: 'discontinued income',
-  nounPlural: 'discontinued incomes',
+  nounPlural: 'discontinued income',
   required: false,
   isItemIncomplete: item =>
     isRecipientInfoIncomplete(item) ||
@@ -106,6 +114,7 @@ const updatedTitleNoItems =
   'Have you or your dependents received income that has ended during the reporting period or in the last full calendar year (if this is your first claim)?';
 const updatedTitleWithItems = 'Do you have more discontinued income to report?';
 const summaryPageTitle = 'Discontinued and irregular income';
+const incomeRecipientPageTitle = 'Discontinued income relationship';
 const yesNoOptionLabels = {
   Y: 'Yes, I have income to report',
   N: 'No, I don’t have income to report',
@@ -239,31 +248,156 @@ const parentSummaryPage = {
 };
 
 /** @returns {PageSchema} */
-const relationshipPage = {
+const veteranIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Recurring income relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: Object.fromEntries(
+        Object.entries(relationshipLabels).filter(
+          ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      descriptions: relationshipLabelDescriptions,
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'discontinuedIncomes',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(relationshipLabels).filter(
+          key => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const spouseIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Recurring income relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: spouseRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key === 'CHILD',
+        ),
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'discontinuedIncomes',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(Object.keys(spouseRelationshipLabels)),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const custodianIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Recurring income relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: custodianRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key !== 'CHILD',
+        ),
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'discontinuedIncomes',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(custodianRelationshipLabels),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const parentIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Recurring income relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: parentRelationshipLabels,
+      descriptions: {
+        SPOUSE: 'The Veteran’s other parent should file a separate claim',
+      },
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'discontinuedIncomes',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(Object.keys(parentRelationshipLabels)),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const nonVeteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Discontinued income relationship',
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      title: 'Who received the income?',
+      title: 'Who received this income?',
+      ...sharedYesNoOptionsBase,
       labels: relationshipLabels,
     }),
-    otherRecipientRelationshipType: {
-      'ui:title': 'Describe their relationship to the Veteran',
-      'ui:webComponentField': VaTextInputField,
-      'ui:options': {
-        expandUnder: 'recipientRelationship',
-        expandUnderCondition: 'OTHER',
-        expandedContentFocus: true,
-      },
-      'ui:required': (formData, index) =>
-        otherRecipientRelationshipExplanationRequired(
-          formData,
-          index,
-          'discontinuedIncomes',
-        ),
-    },
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'discontinuedIncomes',
+    ),
     'ui:options': {
       ...requireExpandedArrayField('otherRecipientRelationshipType'),
     },
@@ -387,7 +521,7 @@ export const discontinuedIncomePages = arrayBuilderPages(
   pageBuilder => ({
     discontinuedIncomePagesVeteranSummary: pageBuilder.summaryPage({
       title: summaryPageTitle,
-      path: 'discontinued-incomes-summary-veteran',
+      path: 'discontinued-income-summary-veteran',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'VETERAN',
       uiSchema: veteranSummaryPage.uiSchema,
@@ -395,7 +529,7 @@ export const discontinuedIncomePages = arrayBuilderPages(
     }),
     discontinuedIncomePagesSpouseSummary: pageBuilder.summaryPage({
       title: summaryPageTitle,
-      path: 'discontinued-incomes-summary-spouse',
+      path: 'discontinued-income-summary-spouse',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'SPOUSE',
       uiSchema: spouseSummaryPage.uiSchema,
@@ -403,7 +537,7 @@ export const discontinuedIncomePages = arrayBuilderPages(
     }),
     discontinuedIncomePagesChildSummary: pageBuilder.summaryPage({
       title: summaryPageTitle,
-      path: 'discontinued-incomes-summary-child',
+      path: 'discontinued-income-summary-child',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'CHILD',
       uiSchema: childSummaryPage.uiSchema,
@@ -411,7 +545,7 @@ export const discontinuedIncomePages = arrayBuilderPages(
     }),
     discontinuedIncomePagesCustodianSummary: pageBuilder.summaryPage({
       title: summaryPageTitle,
-      path: 'discontinued-incomes-summary-custodian',
+      path: 'discontinued-income-summary-custodian',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
       uiSchema: custodianSummaryPage.uiSchema,
@@ -419,7 +553,7 @@ export const discontinuedIncomePages = arrayBuilderPages(
     }),
     discontinuedIncomePagesParentSummary: pageBuilder.summaryPage({
       title: summaryPageTitle,
-      path: 'discontinued-incomes-summary-parent',
+      path: 'discontinued-income-summary-parent',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'PARENT',
       uiSchema: parentSummaryPage.uiSchema,
@@ -428,20 +562,65 @@ export const discontinuedIncomePages = arrayBuilderPages(
     // Ensure MVP summary page is listed last so it’s not accidentally overridden by claimantType-specific summary pages
     discontinuedIncomePagesSummary: pageBuilder.summaryPage({
       title: 'Discontinued incomes',
-      path: 'discontinued-incomes-summary',
+      path: 'discontinued-income-summary',
       depends: () => !showUpdatedContent(),
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
-    discontinuedIncomeRelationshipPage: pageBuilder.itemPage({
-      title: 'Discontinued income relationship',
-      path: 'discontinued-incomes/:index/relationship',
-      uiSchema: relationshipPage.uiSchema,
-      schema: relationshipPage.schema,
+    discontinuedIncomeVeteranRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="VETERAN" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'discontinued-income/:index/veteran-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'VETERAN',
+      uiSchema: veteranIncomeRecipientPage.uiSchema,
+      schema: veteranIncomeRecipientPage.schema,
+    }),
+    discontinuedIncomeSpouseRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="SPOUSE" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'discontinued-income/:index/spouse-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'SPOUSE',
+      uiSchema: spouseIncomeRecipientPage.uiSchema,
+      schema: spouseIncomeRecipientPage.schema,
+    }),
+    discontinuedIncomeCustodianRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="CUSTODIAN" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'discontinued-income/:index/custodian-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+      uiSchema: custodianIncomeRecipientPage.uiSchema,
+      schema: custodianIncomeRecipientPage.schema,
+    }),
+    discontinuedIncomeParentRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="PARENT" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'discontinued-income/:index/parent-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'PARENT',
+      uiSchema: parentIncomeRecipientPage.uiSchema,
+      schema: parentIncomeRecipientPage.schema,
+    }),
+    discontinuedIncomeNonVeteranRecipientPage: pageBuilder.itemPage({
+      title: incomeRecipientPageTitle,
+      path: 'discontinued-income/:index/income-recipient',
+      depends: () => !showUpdatedContent(),
+      uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
+      schema: nonVeteranIncomeRecipientPage.schema,
     }),
     discontinuedIncomeRecipientNamePage: pageBuilder.itemPage({
       title: 'Discontinued income recipient name',
-      path: 'discontinued-incomes/:index/recipient-name',
+      path: 'discontinued-income/:index/recipient-name',
       depends: (formData, index) =>
         recipientNameRequired(formData, index, 'discontinuedIncomes'),
       uiSchema: recipientNamePage.uiSchema,
@@ -449,31 +628,31 @@ export const discontinuedIncomePages = arrayBuilderPages(
     }),
     discontinuedIncomePayerPage: pageBuilder.itemPage({
       title: 'Discontinued income payer',
-      path: 'discontinued-incomes/:index/payer',
+      path: 'discontinued-income/:index/payer',
       uiSchema: incomePayerPage.uiSchema,
       schema: incomePayerPage.schema,
     }),
     discontinuedIncomeTypePage: pageBuilder.itemPage({
       title: 'Discontinued income type',
-      path: 'discontinued-incomes/:index/type',
+      path: 'discontinued-income/:index/type',
       uiSchema: incomeTypePage.uiSchema,
       schema: incomeTypePage.schema,
     }),
     discontinuedIncomeFrequencyPage: pageBuilder.itemPage({
       title: 'Discontinued income frequency',
-      path: 'discontinued-incomes/:index/frequency',
+      path: 'discontinued-income/:index/frequency',
       uiSchema: incomeFrequencyPage.uiSchema,
       schema: incomeFrequencyPage.schema,
     }),
     discontinuedIncomeDatePage: pageBuilder.itemPage({
       title: 'Discontinued income date',
-      path: 'discontinued-incomes/:index/date',
+      path: 'discontinued-income/:index/date',
       uiSchema: incomeDatePage.uiSchema,
       schema: incomeDatePage.schema,
     }),
     discontinuedIncomeAmountPage: pageBuilder.itemPage({
       title: 'Discontinued income amount',
-      path: 'discontinued-incomes/:index/amount',
+      path: 'discontinued-income/:index/amount',
       uiSchema: incomeAmountPage.uiSchema,
       schema: incomeAmountPage.schema,
     }),

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/11-discontinued-incomes/discontinuedIncomePages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/11-discontinued-incomes/discontinuedIncomePages.unit.spec.jsx
@@ -42,6 +42,11 @@ describe('discontinued income list and loop pages', () => {
     discontinuedIncomePagesChildSummary,
     discontinuedIncomePagesCustodianSummary,
     discontinuedIncomePagesParentSummary,
+    discontinuedIncomeVeteranRecipientPage,
+    discontinuedIncomeSpouseRecipientPage,
+    discontinuedIncomeCustodianRecipientPage,
+    discontinuedIncomeParentRecipientPage,
+    discontinuedIncomeNonVeteranRecipientPage,
   } = discontinuedIncomePages;
 
   describe('text', () => {
@@ -305,13 +310,17 @@ describe('discontinued income list and loop pages', () => {
     });
   });
 
-  describe('relationship page', () => {
+  describe('MVP income recipient page', () => {
+    beforeEach(() => {
+      showUpdatedContentStub.returns(false);
+    });
+
     const schema =
-      discontinuedIncomePages.discontinuedIncomeRelationshipPage.schema
-        .properties.discontinuedIncomes.items;
-    const uiSchema =
-      discontinuedIncomePages.discontinuedIncomeRelationshipPage.uiSchema
+      discontinuedIncomeNonVeteranRecipientPage.schema.properties
         .discontinuedIncomes.items;
+    const uiSchema =
+      discontinuedIncomeNonVeteranRecipientPage.uiSchema.discontinuedIncomes
+        .items;
 
     testNumberOfFieldsByType(
       formConfig,
@@ -342,6 +351,73 @@ describe('discontinued income list and loop pages', () => {
       'relationship',
       'root_otherRecipientRelationshipType',
     );
+
+    describe('Non-Veteran recipient page', () => {
+      it('should display when showUpdatedContent is false', () => {
+        const formData = { ...testData.data, claimantType: 'SPOUSE' };
+        const { depends } = discontinuedIncomeNonVeteranRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+  });
+
+  describe('Updated recipient pages', () => {
+    beforeEach(() => {
+      showUpdatedContentStub.returns(true);
+    });
+
+    describe('Veteran recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'VETERAN' };
+
+      it('should display when showUpdatedContent is true and claimantType is VETERAN', () => {
+        const { depends } = discontinuedIncomeVeteranRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Spouse recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'SPOUSE' };
+
+      it('should display when showUpdatedContent is true and claimantType is SPOUSE', () => {
+        const { depends } = discontinuedIncomeSpouseRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Custodian recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'CUSTODIAN' };
+
+      it('should display when showUpdatedContent is true and claimantType is CUSTODIAN', () => {
+        const { depends } = discontinuedIncomeCustodianRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Parent recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'PARENT' };
+
+      it('should display when showUpdatedContent is true and claimantType is PARENT', () => {
+        const { depends } = discontinuedIncomeParentRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Income recipient pages', () => {
+      const formData = { ...testData.data, claimantType: 'CHILD' };
+
+      it('should NOT display any recipient pages when claimantType is CHILD', () => {
+        expect(discontinuedIncomeNonVeteranRecipientPage.depends(formData)).to
+          .be.false;
+        expect(discontinuedIncomeVeteranRecipientPage.depends(formData)).to.be
+          .false;
+        expect(discontinuedIncomeSpouseRecipientPage.depends(formData)).to.be
+          .false;
+        expect(discontinuedIncomeCustodianRecipientPage.depends(formData)).to.be
+          .false;
+        expect(discontinuedIncomeParentRecipientPage.depends(formData)).to.be
+          .false;
+      });
+    });
   });
 
   describe('recipient name page', () => {


### PR DESCRIPTION
## Summary

This PR adds the **“Relationship to the Veteran”** recipient pages to the **Discontinued Income** chapter for **Post-MVP** updates in the **VA Form 21P-0969** (Income and Asset Statement).  

These pages introduce claimant-specific recipient relationship logic, aligning with the latest **Post-MVP array builder patterns** used across other income-related chapters such as **Recurring Income**, **Unreported Income**, and **Royalties**.  

The implementation ensures consistent page structure, content, and accessibility across all claimant types.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111734

## How to Test

1. Enable the Post-MVP feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`
2. Launch the form locally:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`
3. Proceed to the **Discontinued Income** chapter.
4. Add a discontinued income entry for each claimant type.
5. Verify:
   - The **“Discontinued income relationship”** page renders correctly.
   - Page content updates dynamically based on the claimant type.
   - Navigation and data persistence work correctly through the list-and-loop sequence.
  6. Verify no MVP regressions

## Areas Impacted

- **Discontinued Income** chapter (relationship to veteran pages)  
- **Array Builder utilities** for claimant-type page handling

## Feature Toggle

- `income_and_assets_content_updates`

## Screenshots

| Before | After |
|--------|--------|
| No relationship recipient pages for discontinued income | Added recipient relationship pages with Post-MVP logic and consistent design |

## Quality Assurance & Testing

- [x] Unit and E2E tests updated or added where applicable.  
- [x] Verified dynamic claimant-type content rendering.  
- [x] Accessibility tests confirm proper heading and label associations.  
- [x] Linting and CI checks pass.  
- [x] No PII/PHI data in logs or tests.

## Definition of Done

- Recipient relationship pages implemented for all claimant types.  
- Functionality and navigation match Post-MVP standards.  
- Gated behind the feature toggle.  
- Tested across claimant types for accuracy and completeness.

## Requested Feedback

Please confirm:
- Relationship to Veteran pages follow expected structure and logic.  
- Content and labels accurately reflect claimant context.  
- Integration with the Post-MVP toggle behaves as expected.