### PR TITLE
(BIO) bump vets-json-schema - adds 21-0779 21-2680 21P-8416

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0a3ddc2b647869ba38d0dcae2886a729b7dde13d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dec5c9d969c5afd6a8cc7a97d220727af6ff77db",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22724,9 +22724,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0a3ddc2b647869ba38d0dcae2886a729b7dde13d":
-  version "25.2.15"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0a3ddc2b647869ba38d0dcae2886a729b7dde13d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#dec5c9d969c5afd6a8cc7a97d220727af6ff77db":
+  version "25.2.20"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dec5c9d969c5afd6a8cc7a97d220727af6ff77db"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
Brings in the changes form vets-json-schema:
* new schema 21-0779
* new schema 21-2680.
* new attributes in 21P-8416
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1073
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1071
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1070

New schemas will be used/tested in
https://github.com/department-of-veterans-affairs/vets-api/pull/24904
https://github.com/department-of-veterans-affairs/vets-api/pull/24917

There are no code changes in vets-api, so I expect that existing test will pass and be sufficient.
