### PR TITLE
534ez update modal and maxAlert on dependents

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
@@ -39,8 +39,8 @@ import { VaForm214138Alert } from '../../../components/FormAlerts';
 /**
  * Dependent children (array builder)
  */
-
-const options = {
+/** @type {ArrayBuilderOptions} */
+export const options = {
   arrayPath: 'dependents',
   nounSingular: 'dependent child',
   nounPlural: 'dependent children',
@@ -48,6 +48,35 @@ const options = {
   maxItems: 3,
   isItemIncomplete: item => !item?.dependentFullName || !item?.dateOfBirth,
   text: {
+    cancelAddTitle: 'Cancel adding this dependent child?',
+    cancelEditTitle: 'Cancel editing this dependent child?',
+    cancelAddDescription:
+      'If you cancel, we won’t add this dependent to your list of dependent children. You’ll return to a page where you can add a new dependent child.',
+    cancelEditDescription:
+      'If you cancel, you’ll lose any changes you made to this dependent child and you will be returned to the dependent children review page.',
+    cancelAddYes: 'Yes, cancel adding',
+    cancelAddNo: 'No, continue adding',
+    cancelEditYes: 'Yes, cancel editing',
+    cancelEditNo: 'No, continue editing',
+    deleteDescription:
+      'This will delete the information from your list of dependent children. You’ll return to a page where you can add a new dependent child.',
+    deleteNo: 'No, keep',
+    deleteTitle: 'Delete this dependent child?',
+    deleteYes: 'Yes, delete',
+    alertMaxItems: (
+      <div>
+        <p className="vads-u-margin-top--0">
+          You have added the maximum number of allowed dependent children for
+          this application. Additional dependents can be added using VA Form
+          686c and uploaded at the end of this application.
+        </p>
+        <va-link
+          href="https://www.va.gov/find-forms/about-form-21-686c/"
+          external
+          text="Get VA Form 21P-686c to download"
+        />
+      </div>
+    ),
     getItemName: item => {
       if (
         item &&
@@ -60,22 +89,9 @@ const options = {
     },
     cardDescription: () => '',
   },
-  alertMaxItems: (
-    <div>
-      <p className="vads-u-margin-top--0">
-        You have added the maximum number of allowed dependent children for this
-        application. Additional dependents can be added using VA Form 686c and
-        uploaded at the end of this application.
-      </p>
-      <va-link
-        href="https://www.va.gov/find-forms/about-form-21-686c/"
-        external
-        text="Get VA Form 21P-686c to download"
-      />
-    </div>
-  ),
 };
 
+/** @returns {PageSchema} */
 const introPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
@@ -99,6 +115,7 @@ const introPage = {
   },
 };
 
+/** @returns {PageSchema} */
 const summaryPage = {
   uiSchema: {
     'ui:description': () => null,
@@ -120,6 +137,7 @@ const summaryPage = {
   },
 };
 
+/** @returns {PageSchema} */
 const namePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
@@ -157,6 +175,7 @@ const namePage = {
   },
 };
 
+/** @returns {PageSchema} */
 const dobPlacePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
@@ -248,6 +267,7 @@ const dobPlacePage = {
   },
 };
 
+/** @returns {PageSchema} */
 const relationshipPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Relationship to dependent'),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Move alert max text into the correct config option.
- Add custom modal text to dependent array builder

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124242
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124274

## Testing done

- manual testing

## Screenshots
<img width="568" height="803" alt="Screenshot 2025-11-04 at 2 25 37 PM" src="https://github.com/user-attachments/assets/6eecd39d-fb6f-4f1c-a06b-3da5c4571b9f" />
<img width="566" height="451" alt="Screenshot 2025-11-04 at 2 22 52 PM" src="https://github.com/user-attachments/assets/2fb691c2-2f0c-42a4-ba65-ce27a5a1d6de" />
<img width="571" height="389" alt="Screenshot 2025-11-04 at 2 22 40 PM" src="https://github.com/user-attachments/assets/64d541c7-ba32-47e9-8d1e-1da4c39647b9" />
<img width="575" height="432" alt="Screenshot 2025-11-04 at 2 22 34 PM" src="https://github.com/user-attachments/assets/e18a1f30-9af8-433a-9492-5f047eb2ada2" />


## What areas of the site does it impact?

The summary page of Chapter 4 dependents

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A
