### PR TITLE
124108 sm web   suppress success banner on medications redirect for a11y compliance

### DIFF
--- a/src/applications/mhv-secure-messaging/actions/messages.js
+++ b/src/applications/mhv-secure-messaging/actions/messages.js
@@ -162,17 +162,20 @@ export const sendMessage = (
   message,
   attachments,
   ohTriageGroup = false,
+  suppressAlert = false,
 ) => async dispatch => {
   try {
     await createMessage(message, attachments, ohTriageGroup);
 
-    dispatch(
-      addAlert(
-        Constants.ALERT_TYPE_SUCCESS,
-        '',
-        Constants.Alerts.Message.SEND_MESSAGE_SUCCESS,
-      ),
-    );
+    if (!suppressAlert) {
+      dispatch(
+        addAlert(
+          Constants.ALERT_TYPE_SUCCESS,
+          '',
+          Constants.Alerts.Message.SEND_MESSAGE_SUCCESS,
+        ),
+      );
+    }
     dispatch(resetRecentRecipient());
     dispatch(setThreadRefetchRequired(true));
   } catch (e) {

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -451,6 +451,7 @@ const ComposeForm = props => {
                 sendData,
                 attachments.length > 0,
                 draftInProgress.ohTriageGroup,
+                !!redirectPath, // suppress alert when redirectPath exists
               ),
             );
             dispatch(clearDraftInProgress());

--- a/src/applications/mhv-secure-messaging/tests/actions/messages.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/actions/messages.unit.spec.jsx
@@ -327,6 +327,80 @@ describe('messages actions', () => {
       });
   });
 
+  it('should dispatch success alert on sendMessage when suppressAlert is false', async () => {
+    const store = mockStore();
+    mockApiRequest(messageResponse);
+    await store
+      .dispatch(
+        sendMessage(
+          {
+            category: 'EDUCATION',
+            body: 'Test body',
+            subject: 'Test subject',
+            recipientId: '2710520',
+          },
+          true,
+          false,
+          false, // suppressAlert = false
+        ),
+      )
+      .then(() => {
+        const actions = store.getActions();
+        // Verify success alert is dispatched
+        expect(actions).to.deep.include({
+          type: Actions.Alerts.ADD_ALERT,
+          payload: {
+            alertType: 'success',
+            header: '',
+            content: Constants.Alerts.Message.SEND_MESSAGE_SUCCESS,
+            className: undefined,
+            link: undefined,
+            title: undefined,
+            response: undefined,
+          },
+        });
+      });
+  });
+
+  it('should NOT dispatch success alert on sendMessage when suppressAlert is true', async () => {
+    const store = mockStore();
+    mockApiRequest(messageResponse);
+    await store
+      .dispatch(
+        sendMessage(
+          {
+            category: 'EDUCATION',
+            body: 'Test body',
+            subject: 'Test subject',
+            recipientId: '2710520',
+          },
+          true,
+          false,
+          true, // suppressAlert = true
+        ),
+      )
+      .then(() => {
+        const actions = store.getActions();
+        // Verify success alert is NOT dispatched
+        expect(actions).to.not.deep.include({
+          type: Actions.Alerts.ADD_ALERT,
+          payload: {
+            alertType: 'success',
+            header: '',
+            content: Constants.Alerts.Message.SEND_MESSAGE_SUCCESS,
+            className: undefined,
+            link: undefined,
+            title: undefined,
+            response: undefined,
+          },
+        });
+        // Verify other actions are still dispatched
+        expect(actions).to.deep.include({
+          type: Actions.AllRecipients.RESET_RECENT,
+        });
+      });
+  });
+
   it('should dispatch action on sendReply', async () => {
     const store = mockStore();
     mockApiRequest(messageResponse);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
@@ -97,6 +97,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[0].id);
         });
+      cy.findByText('Message Sent.').should('not.exist');
       cy.url().should('include', decodeURIComponent(redirectPath));
     });
 
@@ -171,6 +172,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[1].id);
         });
+      cy.findByText('Message Sent.').should('not.exist');
       cy.url().should('include', decodeURIComponent(redirectPath));
     });
 
@@ -229,6 +231,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[0].id);
         });
+      cy.findByText('Message Sent.').should('not.exist');
       cy.url().should('include', decodeURIComponent(redirectPath));
     });
 
@@ -291,6 +294,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[0].id);
         });
+      cy.findByText('Message Sent.').should('be.visible');
       cy.url().should('include', '/my-health/secure-messages/inbox/');
     });
   });
@@ -360,6 +364,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[0].id);
         });
+      cy.findByText('Message Sent.').should('not.exist');
       cy.url().should('include', decodeURIComponent(redirectPath));
     });
 
@@ -411,6 +416,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[0].id);
         });
+      cy.findByText('Message Sent.').should('not.exist');
       cy.url().should('include', decodeURIComponent(redirectPath));
     });
 
@@ -457,6 +463,7 @@ describe('SM Medications Renewal Request', () => {
           expect(request.subject).to.eq('Renewal Needed');
           expect(request.recipient_id).to.eq(+mockRecipients.data[0].id);
         });
+      cy.findByText('Message Sent.').should('be.visible');
       cy.url().should('include', '/my-health/secure-messages/inbox/');
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request updates the behavior of the message sending flow in Secure Messaging to allow suppression of the success alert when a redirect is occurring (such as after a medication renewal request). It introduces a new `suppressAlert` parameter to the `sendMessage` action, updates the compose form to use it based on redirect logic, and adds/updates unit and end-to-end tests to verify the correct alert behavior in both scenarios.

**Message sending and alert logic:**

* Added a `suppressAlert` parameter to the `sendMessage` action in `messages.js`, so that the success alert can be conditionally suppressed when needed.
* Updated the `ComposeForm` component to pass `suppressAlert=true` to `sendMessage` when a `redirectPath` exists, preventing the success alert from showing during redirects.

**Testing updates:**

* Added and updated unit tests for `sendMessage` to verify that the success alert is dispatched only when `suppressAlert` is `false`.
* Added component tests to ensure `sendMessage` is called with the correct `suppressAlert` value depending on whether a `redirectPath` is present.
* Updated end-to-end tests for medication renewal requests to assert that the "Message Sent." alert is not shown when redirecting, and is shown when returning to the inbox [[1]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R100) [[2]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R175) [[3]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R234) [[4]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R297) [[5]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R367) [[6]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R419) [[7]](diffhunk://#diff-f2b53a13e5d0be78ed5fb3de719faeeb8a1a4968c8f7c2370ff7e738e1876e83R466).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124108

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
