### PR TITLE
SC 117051 Cleanup for variable names

### DIFF
--- a/src/applications/appeals/995/components/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/components/ConfirmationPage.jsx
@@ -24,7 +24,7 @@ import {
   getPrivateEvidence,
   getOtherEvidence,
 } from '../utils/evidence';
-import { LIMITED_CONSENT_RESPONSE } from '../constants';
+import { HAS_PRIVATE_LIMITATION } from '../constants';
 import { getReadableDate } from '../../shared/utils/dates';
 
 // Components
@@ -200,7 +200,7 @@ export const ConfirmationPage = () => {
           privacyAgreementAccepted={data.privacyAgreementAccepted}
           reviewMode
           showListOnly
-          limitedConsentResponse={data?.[LIMITED_CONSENT_RESPONSE]}
+          limitedConsentResponse={data?.[HAS_PRIVATE_LIMITATION]}
         />
       ) : null}
 

--- a/src/applications/appeals/995/components/EvidencePrivateRecordsRequest.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecordsRequest.jsx
@@ -6,8 +6,8 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import {
   EVIDENCE_VA_DETAILS_URL,
-  EVIDENCE_VA,
-  EVIDENCE_PRIVATE,
+  HAS_VA_EVIDENCE,
+  HAS_PRIVATE_EVIDENCE,
 } from '../constants';
 
 import {
@@ -40,7 +40,7 @@ const EvidencePrivateRequest = ({
       const val = event.detail.value === 'y';
       setFormData({
         ...data,
-        [EVIDENCE_PRIVATE]: val,
+        [HAS_PRIVATE_EVIDENCE]: val,
       });
       setError(null);
       recordEvent({
@@ -51,7 +51,7 @@ const EvidencePrivateRequest = ({
       });
     },
     onGoBack: () => {
-      if (data[EVIDENCE_VA]) {
+      if (data[HAS_VA_EVIDENCE]) {
         // go to last VA location entry, but only if they requested it
         goToPath(`/${EVIDENCE_VA_DETAILS_URL}?index=${locations.length - 1}`);
       } else {
@@ -60,7 +60,7 @@ const EvidencePrivateRequest = ({
       }
     },
     onGoForward: () => {
-      if (typeof data[EVIDENCE_PRIVATE] === 'undefined') {
+      if (typeof data[HAS_PRIVATE_EVIDENCE] === 'undefined') {
         setError(errorMessages.requiredYesNo);
         setTimeout(focusFirstError);
       } else {
@@ -84,14 +84,14 @@ const EvidencePrivateRequest = ({
           label="Yes"
           name="private"
           value="y"
-          checked={data[EVIDENCE_PRIVATE]}
+          checked={data[HAS_PRIVATE_EVIDENCE]}
           description={privateRecordsRadioDescription.yes}
         />
         <va-radio-option
           label="No"
           name="private"
           value="n"
-          checked={data[EVIDENCE_PRIVATE] === false}
+          checked={data[HAS_PRIVATE_EVIDENCE] === false}
           description={privateRecordsRadioDescription.no}
         />
       </VaRadio>

--- a/src/applications/appeals/995/components/EvidenceSummary.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummary.jsx
@@ -13,7 +13,7 @@ import { content } from '../content/evidenceSummary';
 import { EvidencePrivateContent } from './EvidencePrivateContent';
 import { EvidenceUploadContent } from './EvidenceUploadContent';
 import { EvidenceVaContent } from './EvidenceVaContent';
-import { LIMITED_CONSENT_RESPONSE } from '../constants';
+import { HAS_PRIVATE_LIMITATION } from '../constants';
 import { customPageProps995 } from '../../shared/props';
 import { focusFirstError } from '../../shared/utils/focus';
 
@@ -204,7 +204,7 @@ const EvidenceSummary = ({
         <EvidenceVaContent list={vaEvidence} {...props} />
         <EvidencePrivateContent
           list={privateEvidence}
-          limitedConsentResponse={data?.[LIMITED_CONSENT_RESPONSE]}
+          limitedConsentResponse={data?.[HAS_PRIVATE_LIMITATION]}
           limitedConsent={limitedConsent}
           privacyAgreementAccepted={privacyAgreementAccepted}
           {...props}

--- a/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
@@ -10,7 +10,7 @@ import { content } from '../content/evidenceSummary';
 import { EvidencePrivateContent } from './EvidencePrivateContent';
 import { EvidenceUploadContent } from './EvidenceUploadContent';
 import { EvidenceVaContent } from './EvidenceVaContent';
-import { SUMMARY_EDIT, LIMITED_CONSENT_RESPONSE } from '../constants';
+import { SUMMARY_EDIT, HAS_PRIVATE_LIMITATION } from '../constants';
 import { data995 } from '../../shared/props';
 
 const EvidenceSummaryReview = ({ data, editPage }) => {
@@ -80,7 +80,7 @@ const EvidenceSummaryReview = ({ data, editPage }) => {
       <EvidenceVaContent list={vaEvidence} {...props} />
       <EvidencePrivateContent
         list={privateEvidence}
-        limitedConsentResponse={data?.[LIMITED_CONSENT_RESPONSE]}
+        limitedConsentResponse={data?.[HAS_PRIVATE_LIMITATION]}
         limitedConsent={limitedConsent}
         privacyAgreementAccepted={privacyAgreementAccepted}
         {...props}

--- a/src/applications/appeals/995/config/submit-transformer.js
+++ b/src/applications/appeals/995/config/submit-transformer.js
@@ -1,4 +1,4 @@
-import { EVIDENCE_OTHER, SUPPORTED_BENEFIT_TYPES_LIST } from '../constants';
+import { HAS_OTHER_EVIDENCE, SUPPORTED_BENEFIT_TYPES_LIST } from '../constants';
 import {
   getHomeless,
   getAddress,
@@ -47,7 +47,7 @@ export function transform(form) {
       },
       included: addIncludedIssues(formData),
       form4142: getForm4142(formData),
-      additionalDocuments: formData[EVIDENCE_OTHER]
+      additionalDocuments: formData[HAS_OTHER_EVIDENCE]
         ? additionalDocuments
         : null,
     };

--- a/src/applications/appeals/995/constants/index.js
+++ b/src/applications/appeals/995/constants/index.js
@@ -41,10 +41,10 @@ export const OTHER_HOUSING_RISK_MAX = 100;
 export const POINT_OF_CONTACT_MAX = 150;
 export const TREATMENT_FACILITY_OTHER_MAX = 115;
 
-export const EVIDENCE_VA = 'view:hasVaEvidence';
-export const EVIDENCE_PRIVATE = 'view:hasPrivateEvidence';
-export const EVIDENCE_OTHER = 'view:hasOtherEvidence';
-export const LIMITED_CONSENT_RESPONSE = 'view:hasPrivateLimitation';
+export const HAS_VA_EVIDENCE = 'view:hasVaEvidence';
+export const HAS_PRIVATE_EVIDENCE = 'view:hasPrivateEvidence';
+export const HAS_OTHER_EVIDENCE = 'view:hasOtherEvidence';
+export const HAS_PRIVATE_LIMITATION = 'view:hasPrivateLimitation';
 export const MST_OPTION = 'mstOption';
 
 // Including a default until we determine how to get around the user restarting

--- a/src/applications/appeals/995/pages/evidencePrivateRecords.js
+++ b/src/applications/appeals/995/pages/evidencePrivateRecords.js
@@ -1,4 +1,4 @@
-import { EVIDENCE_PRIVATE } from '../constants';
+import { HAS_PRIVATE_EVIDENCE } from '../constants';
 
 import {
   validatePrivateName,
@@ -145,7 +145,7 @@ export default {
     oneOf: [
       {
         properties: {
-          [EVIDENCE_PRIVATE]: {
+          [HAS_PRIVATE_EVIDENCE]: {
             type: 'boolean',
             enum: [true],
           },
@@ -157,7 +157,7 @@ export default {
       },
       {
         properties: {
-          [EVIDENCE_PRIVATE]: {
+          [HAS_PRIVATE_EVIDENCE]: {
             type: 'boolean',
             enum: [false],
           },

--- a/src/applications/appeals/995/pages/evidencePrivateRequest.js
+++ b/src/applications/appeals/995/pages/evidencePrivateRequest.js
@@ -1,8 +1,8 @@
-import { EVIDENCE_PRIVATE } from '../constants';
+import { HAS_PRIVATE_EVIDENCE } from '../constants';
 
 export default {
   uiSchema: {
-    [EVIDENCE_PRIVATE]: {
+    [HAS_PRIVATE_EVIDENCE]: {
       'ui:options': {
         hideOnReview: true,
       },
@@ -11,10 +11,10 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      [EVIDENCE_PRIVATE]: {
+      [HAS_PRIVATE_EVIDENCE]: {
         type: 'boolean',
       },
     },
-    required: [EVIDENCE_PRIVATE],
+    required: [HAS_PRIVATE_EVIDENCE],
   },
 };

--- a/src/applications/appeals/995/pages/evidenceVaDetails.js
+++ b/src/applications/appeals/995/pages/evidenceVaDetails.js
@@ -1,4 +1,4 @@
-import { EVIDENCE_VA } from '../constants';
+import { HAS_VA_EVIDENCE } from '../constants';
 
 import {
   validateVaLocation,
@@ -41,7 +41,7 @@ const schema = {
   oneOf: [
     {
       properties: {
-        [EVIDENCE_VA]: {
+        [HAS_VA_EVIDENCE]: {
           type: 'boolean',
           enum: [true],
         },
@@ -53,7 +53,7 @@ const schema = {
     },
     {
       properties: {
-        [EVIDENCE_VA]: {
+        [HAS_VA_EVIDENCE]: {
           type: 'boolean',
           enum: [false],
         },

--- a/src/applications/appeals/995/pages/evidenceVaPrompt.js
+++ b/src/applications/appeals/995/pages/evidenceVaPrompt.js
@@ -8,12 +8,12 @@ import {
   requestVaRecordsTitle,
 } from '../content/evidenceVaPrompt';
 
-import { EVIDENCE_VA } from '../constants';
+import { HAS_VA_EVIDENCE } from '../constants';
 import errorMessages from '../../shared/content/errorMessages';
 
 export default {
   uiSchema: {
-    [EVIDENCE_VA]: yesNoUI({
+    [HAS_VA_EVIDENCE]: yesNoUI({
       title: requestVaRecordsTitle,
       hint: requestVaRecordsHint,
       enableAnalytics: true,
@@ -33,7 +33,7 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      [EVIDENCE_VA]: yesNoSchema,
+      [HAS_VA_EVIDENCE]: yesNoSchema,
       'view:vaEvidenceInfo': {
         type: 'object',
         properties: {},

--- a/src/applications/appeals/995/pages/evidenceWillUpload.js
+++ b/src/applications/appeals/995/pages/evidenceWillUpload.js
@@ -8,12 +8,12 @@ import {
   evidenceWillUploadInfo,
 } from '../content/evidenceWillUpload';
 
-import { EVIDENCE_OTHER } from '../constants';
+import { HAS_OTHER_EVIDENCE } from '../constants';
 import errorMessages from '../../shared/content/errorMessages';
 
 export default {
   uiSchema: {
-    [EVIDENCE_OTHER]: yesNoUI({
+    [HAS_OTHER_EVIDENCE]: yesNoUI({
       title: evidenceWillUploadTitle,
       enableAnalytics: true,
       labelHeaderLevel: '3',
@@ -34,9 +34,9 @@ export default {
   },
   schema: {
     type: 'object',
-    required: [EVIDENCE_OTHER],
+    required: [HAS_OTHER_EVIDENCE],
     properties: {
-      [EVIDENCE_OTHER]: yesNoSchema,
+      [HAS_OTHER_EVIDENCE]: yesNoSchema,
       'view:otherEvidenceInfo': {
         type: 'object',
         properties: {},

--- a/src/applications/appeals/995/pages/limitedConsentPrompt.js
+++ b/src/applications/appeals/995/pages/limitedConsentPrompt.js
@@ -4,11 +4,11 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { content } from '../content/limitedConsent';
 import { isOnReviewPage } from '../../shared/utils/helpers';
-import { LIMITED_CONSENT_RESPONSE } from '../constants';
+import { HAS_PRIVATE_LIMITATION } from '../constants';
 
 export default {
   uiSchema: {
-    [LIMITED_CONSENT_RESPONSE]: yesNoUI({
+    [HAS_PRIVATE_LIMITATION]: yesNoUI({
       title: content.promptQuestion,
       enableAnalytics: true,
       labelHeaderLevel: '3',
@@ -30,7 +30,7 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      [LIMITED_CONSENT_RESPONSE]: yesNoSchema,
+      [HAS_PRIVATE_LIMITATION]: yesNoSchema,
       'view:evidenceLimitInfo': {
         type: 'object',
         properties: {},

--- a/src/applications/appeals/995/tests/995.cypress.helpers.js
+++ b/src/applications/appeals/995/tests/995.cypress.helpers.js
@@ -12,7 +12,7 @@ import {
   EVIDENCE_VA_DETAILS_URL,
   EVIDENCE_PRIVATE_PROMPT_URL,
   EVIDENCE_PRIVATE_DETAILS_URL,
-  EVIDENCE_PRIVATE,
+  HAS_PRIVATE_EVIDENCE,
   EVIDENCE_UPLOAD_URL,
 } from '../constants';
 import {
@@ -260,7 +260,7 @@ export const pageHooks = {
     cy.injectAxeThenAxeCheck();
     afterHook(() => {
       cy.get('@testData').then(data => {
-        const hasPrivate = data[EVIDENCE_PRIVATE];
+        const hasPrivate = data[HAS_PRIVATE_EVIDENCE];
 
         cy.get(`va-radio-option[value="${hasPrivate ? 'y' : 'n'}"]`).click();
         clickContinue();

--- a/src/applications/appeals/995/tests/components/EvidencePrivateRecordsRequest.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidencePrivateRecordsRequest.unit.spec.jsx
@@ -11,8 +11,8 @@ import {
 import EvidencePrivateRecordsRequest from '../../components/EvidencePrivateRecordsRequest';
 import { privateRecordsRequestTitle } from '../../content/evidencePrivateRecordsRequest';
 import {
-  EVIDENCE_PRIVATE,
-  EVIDENCE_VA,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_VA_EVIDENCE,
   EVIDENCE_VA_DETAILS_URL,
 } from '../../constants';
 import errorMessages from '../../../shared/content/errorMessages';
@@ -66,7 +66,7 @@ describe('<EvidencePrivateRecordsRequest>', () => {
 
   it('should submit page', () => {
     const goSpy = sinon.spy();
-    const data = { [EVIDENCE_PRIVATE]: true };
+    const data = { [HAS_PRIVATE_EVIDENCE]: true };
     const { container } = render(
       <div>
         <EvidencePrivateRecordsRequest data={data} goForward={goSpy} />
@@ -81,7 +81,7 @@ describe('<EvidencePrivateRecordsRequest>', () => {
 
   it('should allow setting va-radio-option', () => {
     const setFormDataSpy = sinon.spy();
-    const data = { [EVIDENCE_PRIVATE]: true };
+    const data = { [HAS_PRIVATE_EVIDENCE]: true };
     const changeEvent = new MouseEvent('vaValueChange', {
       detail: { value: 'n' },
     });
@@ -95,12 +95,13 @@ describe('<EvidencePrivateRecordsRequest>', () => {
     );
 
     fireEvent($('va-radio', container), changeEvent);
-    expect(setFormDataSpy.calledWith({ [EVIDENCE_PRIVATE]: false })).to.be.true;
+    expect(setFormDataSpy.calledWith({ [HAS_PRIVATE_EVIDENCE]: false })).to.be
+      .true;
   });
 
   it('should call goBack to get to the VA record request page', () => {
     const goSpy = sinon.spy();
-    const data = { [EVIDENCE_VA]: false };
+    const data = { [HAS_VA_EVIDENCE]: false };
     const { container } = render(
       <div>
         <EvidencePrivateRecordsRequest data={data} goBack={goSpy} />
@@ -113,7 +114,7 @@ describe('<EvidencePrivateRecordsRequest>', () => {
 
   it('should call goToPath to go to the last VA record location page', () => {
     const goSpy = sinon.spy();
-    const data = { [EVIDENCE_VA]: true, locations: [{}, {}] };
+    const data = { [HAS_VA_EVIDENCE]: true, locations: [{}, {}] };
     const { container } = render(
       <div>
         <EvidencePrivateRecordsRequest data={data} goToPath={goSpy} />

--- a/src/applications/appeals/995/tests/components/EvidenceSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummary.unit.spec.jsx
@@ -7,11 +7,11 @@ import { records } from '../data/evidence-records';
 import EvidenceSummary from '../../components/EvidenceSummary';
 import { content } from '../../content/evidenceSummary';
 import {
-  EVIDENCE_PRIVATE,
-  EVIDENCE_VA,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_VA_EVIDENCE,
   EVIDENCE_VA_PROMPT_URL,
-  EVIDENCE_OTHER,
-  LIMITED_CONSENT_RESPONSE,
+  HAS_OTHER_EVIDENCE,
+  HAS_PRIVATE_LIMITATION,
 } from '../../constants';
 import {
   clickBack,
@@ -41,12 +41,12 @@ const setupSummary = ({
     <div>
       <EvidenceSummary
         data={{
-          [EVIDENCE_VA]: vaMR,
-          [EVIDENCE_PRIVATE]: privateMR,
-          [EVIDENCE_OTHER]: other,
+          [HAS_VA_EVIDENCE]: vaMR,
+          [HAS_PRIVATE_EVIDENCE]: privateMR,
+          [HAS_OTHER_EVIDENCE]: other,
           ...list,
           privacyAgreementAccepted: privacy,
-          [LIMITED_CONSENT_RESPONSE]: limit?.length > 0,
+          [HAS_PRIVATE_LIMITATION]: limit?.length > 0,
           limitedConsent: limit,
         }}
         goBack={goBack}
@@ -67,12 +67,12 @@ describe('EvidenceSummary', () => {
       const { container } = render(
         <EvidenceSummary
           data={{
-            [EVIDENCE_VA]: true,
-            [EVIDENCE_PRIVATE]: true,
-            [EVIDENCE_OTHER]: true,
+            [HAS_VA_EVIDENCE]: true,
+            [HAS_PRIVATE_EVIDENCE]: true,
+            [HAS_OTHER_EVIDENCE]: true,
             ...records(),
             privacyAgreementAccepted: true,
-            [LIMITED_CONSENT_RESPONSE]: true,
+            [HAS_PRIVATE_LIMITATION]: true,
             limitedConsent: 'Limited consent details',
           }}
           goBack={() => {}}
@@ -196,12 +196,12 @@ describe('EvidenceSummary', () => {
       const { container } = render(
         <EvidenceSummary
           data={{
-            [EVIDENCE_VA]: true,
-            [EVIDENCE_PRIVATE]: true,
-            [EVIDENCE_OTHER]: true,
+            [HAS_VA_EVIDENCE]: true,
+            [HAS_PRIVATE_EVIDENCE]: true,
+            [HAS_OTHER_EVIDENCE]: true,
             ...records(),
             privacyAgreementAccepted: true,
-            [LIMITED_CONSENT_RESPONSE]: true,
+            [HAS_PRIVATE_LIMITATION]: true,
             limitedConsent: 'Limited consent details',
           }}
           goBack={() => {}}

--- a/src/applications/appeals/995/tests/components/EvidenceSummaryReview.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummaryReview.unit.spec.jsx
@@ -7,9 +7,9 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import { records } from '../data/evidence-records';
 import EvidenceSummaryReview from '../../components/EvidenceSummaryReview';
 import {
-  EVIDENCE_PRIVATE,
-  EVIDENCE_VA,
-  EVIDENCE_OTHER,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_VA_EVIDENCE,
+  HAS_OTHER_EVIDENCE,
   SUMMARY_EDIT,
 } from '../../constants';
 import { content } from '../../content/evidenceSummary';
@@ -26,9 +26,9 @@ const setupSummary = ({
   render(
     <EvidenceSummaryReview
       data={{
-        [EVIDENCE_VA]: vaMR,
-        [EVIDENCE_PRIVATE]: privateMR,
-        [EVIDENCE_OTHER]: other,
+        [HAS_VA_EVIDENCE]: vaMR,
+        [HAS_PRIVATE_EVIDENCE]: privateMR,
+        [HAS_OTHER_EVIDENCE]: other,
         ...list,
         limitedConsent: limit,
       }}

--- a/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
@@ -11,7 +11,7 @@ import * as focusUtils from '~/platform/utilities/ui/focus';
 import EvidenceVaRecords from '../../components/EvidenceVaRecords';
 import {
   errorMessages,
-  EVIDENCE_VA,
+  HAS_VA_EVIDENCE,
   EVIDENCE_VA_DETAILS_URL,
   NO_ISSUES_SELECTED,
 } from '../../constants';
@@ -139,7 +139,7 @@ describe('EvidenceVaRecords', () => {
       setFormData: setDataSpy,
       data: {
         ...mockData,
-        [EVIDENCE_VA]: true,
+        [HAS_VA_EVIDENCE]: true,
         locations: [{ ...vaLocations[0], issues: [] }],
       },
     });
@@ -160,7 +160,7 @@ describe('EvidenceVaRecords', () => {
       setFormData: setDataSpy,
       data: {
         ...mockData,
-        [EVIDENCE_VA]: true,
+        [HAS_VA_EVIDENCE]: true,
         locations: [vaLocations[1]],
       },
     });
@@ -185,7 +185,7 @@ describe('EvidenceVaRecords', () => {
       const goSpy = sinon.spy();
       const data = {
         ...mockData,
-        [EVIDENCE_VA]: true,
+        [HAS_VA_EVIDENCE]: true,
         locations: [vaLocations[0]],
       };
 
@@ -209,7 +209,7 @@ describe('EvidenceVaRecords', () => {
       const goSpy = sinon.spy();
       const data = {
         ...mockData,
-        [EVIDENCE_VA]: true,
+        [HAS_VA_EVIDENCE]: true,
         locations: [vaLocations[1]],
       };
 
@@ -275,7 +275,7 @@ describe('EvidenceVaRecords', () => {
       const goSpy = sinon.spy();
       const data = {
         ...mockData,
-        [EVIDENCE_VA]: true,
+        [HAS_VA_EVIDENCE]: true,
         locations: [vaLocations[0], {}, vaLocations[1]],
       };
 
@@ -302,7 +302,7 @@ describe('EvidenceVaRecords', () => {
     it('should navigate from zero index, with valid data, to next index when inserting another entry', async () => {
       const goSpy = sinon.spy();
       const locations = [vaLocations[0], vaLocations[1], {}];
-      const data = { ...mockData, [EVIDENCE_VA]: true, locations };
+      const data = { ...mockData, [HAS_VA_EVIDENCE]: true, locations };
       const index = 0;
       const page = setup({
         index,
@@ -363,7 +363,7 @@ describe('EvidenceVaRecords', () => {
         const index = 1;
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [vaLocations[0], {}, vaLocations[1]],
         };
 
@@ -408,7 +408,7 @@ describe('EvidenceVaRecords', () => {
         const setDataSpy = sinon.spy();
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [vaLocations[0], {}],
         };
         const page = setup({
@@ -435,7 +435,7 @@ describe('EvidenceVaRecords', () => {
         const index = 1;
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [vaLocations[0], {}, vaLocations[1]],
         };
         const page = setup({
@@ -495,7 +495,7 @@ describe('EvidenceVaRecords', () => {
         const index = 1;
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [
             vaLocations[0],
             { locationAndName: 'foo' },
@@ -527,7 +527,7 @@ describe('EvidenceVaRecords', () => {
         const index = 1;
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [
             vaLocations[0],
             { locationAndName: 'foo' },
@@ -571,7 +571,7 @@ describe('EvidenceVaRecords', () => {
           setFormData: setDataSpy,
           data: {
             ...mockData,
-            [EVIDENCE_VA]: true,
+            [HAS_VA_EVIDENCE]: true,
             locations: [
               vaLocations[0],
               vaLocations[1],
@@ -608,7 +608,7 @@ describe('EvidenceVaRecords', () => {
           goToPath: goSpy,
           data: {
             ...mockData,
-            [EVIDENCE_VA]: true,
+            [HAS_VA_EVIDENCE]: true,
             locations: [vaLocations[0], { locationAndName: 'foo' }],
           },
         });
@@ -633,7 +633,7 @@ describe('EvidenceVaRecords', () => {
         );
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [{ locationAndName: name }],
         };
         const page = setup({ index: 0, data });
@@ -652,7 +652,7 @@ describe('EvidenceVaRecords', () => {
       it('should show an error when the issue is not unique', async () => {
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [vaLocations[0], vaLocations[0]],
         };
         const page = setup({ index: 1, data });
@@ -679,7 +679,7 @@ describe('EvidenceVaRecords', () => {
         const index = 1;
         const data = {
           ...mockData,
-          [EVIDENCE_VA]: true,
+          [HAS_VA_EVIDENCE]: true,
           locations: [vaLocations[0], {}, vaLocations[1]],
         };
         const page = setup({

--- a/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
@@ -10,7 +10,7 @@ import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { SET_DATA } from 'platform/forms-system/src/js/actions';
 import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
 import App from '../../containers/App';
-import { EVIDENCE_VA } from '../../constants';
+import { HAS_VA_EVIDENCE } from '../../constants';
 import { CONTESTABLE_ISSUES_API } from '../../constants/apis';
 import { SELECTED } from '../../../shared/constants';
 import {
@@ -306,7 +306,7 @@ describe('App', () => {
         ...hasComp,
         contestedIssues: [],
         legacyCount: 0,
-        [EVIDENCE_VA]: true,
+        [HAS_VA_EVIDENCE]: true,
         locations: [{ issues: ['abc', 'def'] }],
         additionalIssues: [{ issue: 'bbb', [SELECTED]: true }],
         internalTesting: true,

--- a/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.jsx
@@ -10,7 +10,7 @@ import {
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
-import { EVIDENCE_OTHER } from '../../constants';
+import { HAS_OTHER_EVIDENCE } from '../../constants';
 
 describe('Additional evidence upload', () => {
   const page = formConfig.chapters.evidence.pages.evidenceUpload;
@@ -68,7 +68,7 @@ describe('Additional evidence upload', () => {
           definitions={{}}
           schema={schema}
           data={{
-            [EVIDENCE_OTHER]: true,
+            [HAS_OTHER_EVIDENCE]: true,
             additionalDocuments: [
               {
                 name: 'test.pdf',

--- a/src/applications/appeals/995/tests/pages/evidenceVaPrompt.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceVaPrompt.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import formConfig from '../../config/form';
-import { EVIDENCE_VA } from '../../constants';
+import { HAS_VA_EVIDENCE } from '../../constants';
 import {
   requestVaRecordsTitle,
   requestVaRecordsHint,
@@ -80,7 +80,7 @@ describe('Supplemental Claims VA evidence request page', () => {
           definitions={{}}
           schema={schema}
           uiSchema={uiSchema}
-          data={{ [EVIDENCE_VA]: true }}
+          data={{ [HAS_VA_EVIDENCE]: true }}
           formData={{}}
           onSubmit={onSubmit}
         />

--- a/src/applications/appeals/995/tests/pages/evidenceWillUpload.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceWillUpload.unit.spec.jsx
@@ -7,7 +7,7 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
-import { EVIDENCE_OTHER } from '../../constants';
+import { HAS_OTHER_EVIDENCE } from '../../constants';
 import errorMessages from '../../../shared/content/errorMessages';
 
 describe('Supplemental Claims evidence upload request page', () => {
@@ -61,7 +61,7 @@ describe('Supplemental Claims evidence upload request page', () => {
         definitions={{}}
         schema={schema}
         uiSchema={uiSchema}
-        data={{ [EVIDENCE_OTHER]: true }}
+        data={{ [HAS_OTHER_EVIDENCE]: true }}
         formData={{}}
         onSubmit={onSubmit}
       />,

--- a/src/applications/appeals/995/tests/pages/limitedConsentPrompt.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/limitedConsentPrompt.unit.spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import formConfig from '../../config/form';
-import { LIMITED_CONSENT_RESPONSE } from '../../constants';
+import { HAS_PRIVATE_LIMITATION } from '../../constants';
 import * as helpers from '../../../shared/utils/helpers';
 
 describe('Supplemental Claims Limited Consent Prompt Page', () => {
@@ -35,7 +35,7 @@ describe('Supplemental Claims Limited Consent Prompt Page', () => {
   });
 
   it('should call updateUiSchema and updateSchema', () => {
-    const options = uiSchema[LIMITED_CONSENT_RESPONSE]['ui:options'];
+    const options = uiSchema[HAS_PRIVATE_LIMITATION]['ui:options'];
     const isOnReviewPageStub = sinon
       .stub(helpers, 'isOnReviewPage')
       .returns(true);

--- a/src/applications/appeals/995/tests/utils/evidence.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/evidence.unit.spec.jsx
@@ -9,7 +9,11 @@ import {
   removeNonSelectedIssuesFromEvidence,
   onFormLoaded,
 } from '../../utils/evidence';
-import { EVIDENCE_VA, EVIDENCE_PRIVATE, EVIDENCE_OTHER } from '../../constants';
+import {
+  HAS_VA_EVIDENCE,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_OTHER_EVIDENCE,
+} from '../../constants';
 import { SELECTED } from '../../../shared/constants';
 
 describe('getIndex', () => {
@@ -43,23 +47,23 @@ describe('getIndex', () => {
 describe('getVAEvidence', () => {
   it('should return expected value', () => {
     expect(
-      getVAEvidence({ [EVIDENCE_VA]: undefined, locations: [{}] }),
+      getVAEvidence({ [HAS_VA_EVIDENCE]: undefined, locations: [{}] }),
     ).to.deep.equal([]);
 
     expect(
-      getVAEvidence({ [EVIDENCE_VA]: true, locations: [{}] }),
+      getVAEvidence({ [HAS_VA_EVIDENCE]: true, locations: [{}] }),
     ).to.deep.equal([{}]);
 
-    expect(getVAEvidence({ [EVIDENCE_VA]: true, locations: [] })).to.deep.equal(
-      [],
-    );
-
     expect(
-      getVAEvidence({ [EVIDENCE_VA]: false, locations: [{}] }),
+      getVAEvidence({ [HAS_VA_EVIDENCE]: true, locations: [] }),
     ).to.deep.equal([]);
 
     expect(
-      getVAEvidence({ [EVIDENCE_VA]: true, locations: [{ test: 'test' }] }),
+      getVAEvidence({ [HAS_VA_EVIDENCE]: false, locations: [{}] }),
+    ).to.deep.equal([]);
+
+    expect(
+      getVAEvidence({ [HAS_VA_EVIDENCE]: true, locations: [{ test: 'test' }] }),
     ).to.deep.equal([{ test: 'test' }]);
   });
 });
@@ -68,18 +72,27 @@ describe('getPrivateEvidence', () => {
   it('should return expected value', () => {
     expect(
       getPrivateEvidence({
-        [EVIDENCE_PRIVATE]: undefined,
+        [HAS_PRIVATE_EVIDENCE]: undefined,
         providerFacility: [{}],
       }),
     ).to.deep.equal([]);
     expect(
-      getPrivateEvidence({ [EVIDENCE_PRIVATE]: true, providerFacility: [{}] }),
+      getPrivateEvidence({
+        [HAS_PRIVATE_EVIDENCE]: true,
+        providerFacility: [{}],
+      }),
     ).to.deep.equal([{}]);
     expect(
-      getPrivateEvidence({ [EVIDENCE_PRIVATE]: true, providerFacility: [] }),
+      getPrivateEvidence({
+        [HAS_PRIVATE_EVIDENCE]: true,
+        providerFacility: [],
+      }),
     ).to.deep.equal([]);
     expect(
-      getPrivateEvidence({ [EVIDENCE_PRIVATE]: false, providerFacility: [{}] }),
+      getPrivateEvidence({
+        [HAS_PRIVATE_EVIDENCE]: false,
+        providerFacility: [{}],
+      }),
     ).to.deep.equal([]);
   });
 });
@@ -88,18 +101,24 @@ describe('getOtherEvidence', () => {
   it('should return expected value', () => {
     expect(
       getOtherEvidence({
-        [EVIDENCE_OTHER]: undefined,
+        [HAS_OTHER_EVIDENCE]: undefined,
         additionalDocuments: [{}],
       }),
     ).to.deep.equal([]);
     expect(
-      getOtherEvidence({ [EVIDENCE_OTHER]: true, additionalDocuments: [{}] }),
+      getOtherEvidence({
+        [HAS_OTHER_EVIDENCE]: true,
+        additionalDocuments: [{}],
+      }),
     ).to.deep.equal([{}]);
     expect(
-      getOtherEvidence({ [EVIDENCE_OTHER]: true, additionalDocuments: [] }),
+      getOtherEvidence({ [HAS_OTHER_EVIDENCE]: true, additionalDocuments: [] }),
     ).to.deep.equal([]);
     expect(
-      getOtherEvidence({ [EVIDENCE_OTHER]: false, additionalDocuments: [{}] }),
+      getOtherEvidence({
+        [HAS_OTHER_EVIDENCE]: false,
+        additionalDocuments: [{}],
+      }),
     ).to.deep.equal([]);
   });
 });
@@ -113,8 +132,8 @@ describe('evidenceNeedsUpdating', () => {
     providerFacility = [{ issues: ['abc', 'def'] }],
   } = {}) => {
     return {
-      [EVIDENCE_VA]: hasVa,
-      [EVIDENCE_PRIVATE]: hasPrivate,
+      [HAS_VA_EVIDENCE]: hasVa,
+      [HAS_PRIVATE_EVIDENCE]: hasPrivate,
       contestedIssues: [
         {
           attributes: { ratingIssueSubjectText: 'def' },
@@ -144,8 +163,8 @@ describe('evidenceNeedsUpdating', () => {
   });
 
   it('should return false if provider facility evidence undefined', () => {
-    expect(evidenceNeedsUpdating({ [EVIDENCE_VA]: true, locations: [{}] })).to
-      .be.false;
+    expect(evidenceNeedsUpdating({ [HAS_VA_EVIDENCE]: true, locations: [{}] }))
+      .to.be.false;
   });
 
   it('should return false if no updates needed', () => {
@@ -174,7 +193,7 @@ describe('removeNonSelectedIssuesFromEvidence', () => {
       { issue: 'test 2', [SELECTED]: true },
       { issue: 'test 4', [SELECTED]: false },
     ],
-    [EVIDENCE_VA]: true,
+    [HAS_VA_EVIDENCE]: true,
     locations: [
       {
         foo: true,
@@ -187,7 +206,7 @@ describe('removeNonSelectedIssuesFromEvidence', () => {
         issues: ['test 1', 'test 2', addLocation].filter(Boolean),
       },
     ],
-    [EVIDENCE_PRIVATE]: true,
+    [HAS_PRIVATE_EVIDENCE]: true,
     providerFacility: [
       {
         foo: false,

--- a/src/applications/appeals/995/tests/utils/form-data-retrieval.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/form-data-retrieval.unit.spec.jsx
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import {
-  EVIDENCE_OTHER,
-  EVIDENCE_PRIVATE,
-  EVIDENCE_VA,
-  LIMITED_CONSENT_RESPONSE,
+  HAS_OTHER_EVIDENCE,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_VA_EVIDENCE,
+  HAS_PRIVATE_LIMITATION,
 } from '../../constants';
 import {
   hasPrivateEvidence,
@@ -17,8 +17,8 @@ describe('utils: form data retrieval', () => {
   describe('hasPrivateLimitation', () => {
     it('should return expected value', () => {
       const getData = limit => ({
-        [EVIDENCE_PRIVATE]: true,
-        [LIMITED_CONSENT_RESPONSE]: limit,
+        [HAS_PRIVATE_EVIDENCE]: true,
+        [HAS_PRIVATE_LIMITATION]: limit,
       });
 
       expect(hasPrivateLimitation(getData(false))).to.be.false;
@@ -31,25 +31,27 @@ describe('utils: form data retrieval', () => {
 
   describe('hasPrivateEvidence', () => {
     it('should return expected value', () => {
-      expect(hasPrivateEvidence({ [EVIDENCE_PRIVATE]: undefined })).to.be.false;
-      expect(hasPrivateEvidence({ [EVIDENCE_PRIVATE]: true })).to.be.true;
-      expect(hasPrivateEvidence({ [EVIDENCE_PRIVATE]: false })).to.be.false;
+      expect(hasPrivateEvidence({ [HAS_PRIVATE_EVIDENCE]: undefined })).to.be
+        .false;
+      expect(hasPrivateEvidence({ [HAS_PRIVATE_EVIDENCE]: true })).to.be.true;
+      expect(hasPrivateEvidence({ [HAS_PRIVATE_EVIDENCE]: false })).to.be.false;
     });
   });
 
   describe('hasVAEvidence', () => {
     it('should return expected value', () => {
-      expect(hasVAEvidence({ [EVIDENCE_VA]: undefined })).to.be.undefined;
-      expect(hasVAEvidence({ [EVIDENCE_VA]: true })).to.be.true;
-      expect(hasVAEvidence({ [EVIDENCE_VA]: false })).to.be.false;
+      expect(hasVAEvidence({ [HAS_VA_EVIDENCE]: undefined })).to.be.undefined;
+      expect(hasVAEvidence({ [HAS_VA_EVIDENCE]: true })).to.be.true;
+      expect(hasVAEvidence({ [HAS_VA_EVIDENCE]: false })).to.be.false;
     });
   });
 
   describe('hasOtherEvidence', () => {
     it('should return expected value', () => {
-      expect(hasOtherEvidence({ [EVIDENCE_OTHER]: undefined })).to.be.undefined;
-      expect(hasOtherEvidence({ [EVIDENCE_OTHER]: true })).to.be.true;
-      expect(hasOtherEvidence({ [EVIDENCE_OTHER]: false })).to.be.false;
+      expect(hasOtherEvidence({ [HAS_OTHER_EVIDENCE]: undefined })).to.be
+        .undefined;
+      expect(hasOtherEvidence({ [HAS_OTHER_EVIDENCE]: true })).to.be.true;
+      expect(hasOtherEvidence({ [HAS_OTHER_EVIDENCE]: false })).to.be.false;
     });
   });
 

--- a/src/applications/appeals/995/tests/utils/submit/evidence.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/submit/evidence.unit.spec.jsx
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import {
-  EVIDENCE_OTHER,
-  EVIDENCE_PRIVATE,
-  EVIDENCE_VA,
-  LIMITED_CONSENT_RESPONSE,
+  HAS_OTHER_EVIDENCE,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_VA_EVIDENCE,
+  HAS_PRIVATE_LIMITATION,
 } from '../../../constants';
 import {
   getEvidence,
@@ -115,7 +115,7 @@ describe('dedupeVALocations', () => {
 describe('getEvidence', () => {
   const getData = ({ hasVa = true } = {}) => ({
     data: {
-      [EVIDENCE_VA]: hasVa,
+      [HAS_VA_EVIDENCE]: hasVa,
       form5103Acknowledged: true,
       locations: [
         {
@@ -198,7 +198,7 @@ describe('getEvidence', () => {
     const { data } = getData();
     const evidence = {
       ...data,
-      [EVIDENCE_OTHER]: true,
+      [HAS_OTHER_EVIDENCE]: true,
       additionalDocuments: [{}],
     };
     expect(getEvidence(evidence).evidenceSubmission.evidenceType).to.deep.equal(
@@ -210,7 +210,7 @@ describe('getEvidence', () => {
     const { data } = getData({ hasVa: false });
     const evidence = {
       ...data,
-      [EVIDENCE_OTHER]: true,
+      [HAS_OTHER_EVIDENCE]: true,
       additionalDocuments: [{}],
     };
     expect(getEvidence(evidence).evidenceSubmission.evidenceType).to.deep.equal(
@@ -236,7 +236,7 @@ describe('getEvidence', () => {
 
   it('should send noTreatmentDates as true when no date is provided', () => {
     const evidence = {
-      [EVIDENCE_VA]: true,
+      [HAS_VA_EVIDENCE]: true,
       form5103Acknowledged: true,
       locations: [
         {
@@ -345,7 +345,7 @@ describe('getForm4142', () => {
 
   it('should return 4142 form data with undefined acceptance', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: true,
+      [HAS_PRIVATE_EVIDENCE]: true,
       ...getData(),
       privacyAgreementAccepted: undefined,
     };
@@ -357,7 +357,7 @@ describe('getForm4142', () => {
 
   it('should return 4142 form data', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: true,
+      [HAS_PRIVATE_EVIDENCE]: true,
       ...getData(),
     };
     expect(getForm4142(data)).to.deep.equal({
@@ -368,14 +368,14 @@ describe('getForm4142', () => {
 
   it('should return empty object since private evidence not selected', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: false,
+      [HAS_PRIVATE_EVIDENCE]: false,
       ...getData(),
     };
     expect(getForm4142(data)).to.deep.equal(null);
   });
   it('should combine duplicate facilities', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: true,
+      [HAS_PRIVATE_EVIDENCE]: true,
       ...getData(),
     };
     data.providerFacility.push(data.providerFacility[0]); // add duplicate
@@ -388,8 +388,8 @@ describe('getForm4142', () => {
 
   it('should return with limited consent when y/n is set to yes', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: true,
-      [LIMITED_CONSENT_RESPONSE]: true,
+      [HAS_PRIVATE_EVIDENCE]: true,
+      [HAS_PRIVATE_LIMITATION]: true,
       ...getData(),
       privacyAgreementAccepted: undefined,
     };
@@ -398,8 +398,8 @@ describe('getForm4142', () => {
 
   it('should return with empty limited consent when y/n is set to no', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: true,
-      [LIMITED_CONSENT_RESPONSE]: false,
+      [HAS_PRIVATE_EVIDENCE]: true,
+      [HAS_PRIVATE_LIMITATION]: false,
       ...getData(),
       privacyAgreementAccepted: undefined,
     };
@@ -414,7 +414,7 @@ describe('getForm4142', () => {
 
   it('should return with empty limited consent when y/n is not set at all', () => {
     const data = {
-      [EVIDENCE_PRIVATE]: true,
+      [HAS_PRIVATE_EVIDENCE]: true,
       ...getData(),
       privacyAgreementAccepted: undefined,
     };

--- a/src/applications/appeals/995/utils/form-data-retrieval.js
+++ b/src/applications/appeals/995/utils/form-data-retrieval.js
@@ -1,16 +1,17 @@
 import {
-  EVIDENCE_OTHER,
-  EVIDENCE_PRIVATE,
-  EVIDENCE_VA,
-  LIMITED_CONSENT_RESPONSE,
+  HAS_OTHER_EVIDENCE,
+  HAS_PRIVATE_EVIDENCE,
+  HAS_VA_EVIDENCE,
+  HAS_PRIVATE_LIMITATION,
   MST_OPTION,
 } from '../constants';
 
-export const hasPrivateEvidence = formData => !!formData?.[EVIDENCE_PRIVATE];
+export const hasPrivateEvidence = formData =>
+  !!formData?.[HAS_PRIVATE_EVIDENCE];
 export const hasPrivateLimitation = formData =>
-  hasPrivateEvidence(formData) && !!formData?.[LIMITED_CONSENT_RESPONSE];
-export const hasVAEvidence = formData => formData?.[EVIDENCE_VA];
-export const hasOtherEvidence = formData => formData?.[EVIDENCE_OTHER];
+  hasPrivateEvidence(formData) && !!formData?.[HAS_PRIVATE_LIMITATION];
+export const hasVAEvidence = formData => formData?.[HAS_VA_EVIDENCE];
+export const hasOtherEvidence = formData => formData?.[HAS_OTHER_EVIDENCE];
 export const hasMstOption = formData => formData?.[MST_OPTION];
 export const hasHousingRisk = formData => formData?.housingRisk;
 export const hasOtherHousingRisk = formData =>

--- a/src/applications/appeals/995/utils/submit/evidence.js
+++ b/src/applications/appeals/995/utils/submit/evidence.js
@@ -7,7 +7,7 @@ import {
 import { getFacilityType } from './facilities';
 import '../../../shared/definitions';
 import { fixDateFormat } from '../../../shared/utils/replace';
-import { LIMITED_CONSENT_RESPONSE } from '../../constants';
+import { HAS_PRIVATE_LIMITATION } from '../../constants';
 
 /**
  * @typedef VALocation
@@ -209,7 +209,7 @@ export const getForm4142 = formData => {
   }
 
   const { limitedConsent, privacyAgreementAccepted = true } = formData;
-  const limitedConsentResponse = formData?.[LIMITED_CONSENT_RESPONSE]
+  const limitedConsentResponse = formData?.[HAS_PRIVATE_LIMITATION]
     ? limitedConsent
     : '';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

I renamed all the variables in `appeals/995` pertaining to `view:has[something]` to be more descriptive so they are easier to understand in other places. There are no other changes than this in this PR!

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/117051