### PR TITLE
Pension | Update introduction page

### DIFF
--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
+import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import DisabilityRatingAlert from './DisabilityRatingAlert';
 import { FormReactivationAlert } from './FormAlerts';
@@ -9,6 +11,7 @@ import { FormReactivationAlert } from './FormAlerts';
 const IntroductionPage = props => {
   const { route } = props;
   const { formConfig, pageList } = route;
+  const loggedIn = useSelector(isLoggedIn);
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const pbbFormsRequireLoa3 = useToggleValue(TOGGLE_NAMES.pbbFormsRequireLoa3);
@@ -19,7 +22,7 @@ const IntroductionPage = props => {
         title="Apply for Veterans Pension benefits"
         subTitle="Application for Veterans Pension (VA Form 21P-527EZ)"
       />
-      <DisabilityRatingAlert />
+      {loggedIn && <DisabilityRatingAlert />}
       <p className="va-introtext">
         Use our online tool to fill out and submit your application for Veterans
         Pension benefits. If you’re a wartime Veteran and you’re at least 65


### PR DESCRIPTION
## Summary

This PR updates the **Pension Benefits (VA Form 21P-527EZ)** introduction page logic to **hide the disability rating alert** when the user is **not signed in**.

Previously, the alert attempted to render for all users, which could cause confusion or unnecessary API calls for users without an authenticated session. This update ensures the alert is only shown to signed-in users who have an available disability rating.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118306

## Details

- Updated the **Introduction Page** logic to:
  - Check if the user is authenticated before displaying the disability rating alert.
  - Prevent the disability rating API call and alert rendering when the user is not signed in.
- This change improves performance, reduces unnecessary API calls, and prevents confusing messaging for anonymous users.

## How to Test

1. Run the app locally and navigate to:  
   `http://localhost:3001/pension/application/527EZ/introduction`
2. **Without signing in**:  
   - Confirm that the disability rating alert **does not display**.
3. **After signing in**:  
   - Confirm that the disability rating alert **displays correctly** with the user’s combined disability rating (if available).

## Areas Impacted

- Introduction page (`IntroductionPage.jsx`)
- Conditional rendering logic for disability rating alert
- API call to `v0/rated_disabilities`

## Feature Toggle

- None (this is a default behavior update)

## Screenshots

| State | Before | After |
|--------|--------|--------|
| Not signed in | Alert displayed unnecessarily | Alert hidden |
| Signed in | Alert displayed normally | Alert displayed normally |

## Quality Assurance & Testing

- [x] Verified alert hidden for anonymous users  
- [x] Verified alert shown for signed-in users  
- [x] Checked accessibility labels and heading structure remain valid  
- [x] Unit tests updated where applicable  
- [x] CI/linting pass  
- [x] No PII/PHI exposed

## Definition of Done

- Alert only renders for signed-in users.  
- Introduction page displays correctly across both states (signed in and anonymous).  
- All tests and accessibility checks pass.