### PR TITLE
Autosuggest/22473 location input must announce errors to screenreaders

### DIFF
--- a/src/applications/facility-locator/components/search-form/autosuggest/InputWithClear.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/InputWithClear.jsx
@@ -27,18 +27,25 @@ function InputWithClear({
   isOpen,
   showDownCaret,
   showClearButton,
+  errorMessageId,
 }) {
+  const inputProps = {
+    ref: inputRef,
+    ...downshiftInputProps,
+    ...(errorMessageId && { 'aria-describedby': errorMessageId }),
+  };
+
   return (
     <div className={className}>
       <div className="input-with-clear-container vads-u-width--full">
-        {/* 
-            cannot use a va-text-input because shadow DOM won't allow placement 
+        {/*
+            cannot use a va-text-input because shadow DOM won't allow placement
             of the button inside the input and also won't allow extending the input
             to 100% width.
          */}
         <input
           className="input-with-clear vads-u-width--full"
-          {...getInputProps({ ref: inputRef, ...downshiftInputProps })}
+          {...getInputProps(inputProps)}
           data-testid={`${inputId}-input-with-clear`}
         />
         <InputControlsContainer
@@ -64,6 +71,7 @@ InputWithClear.propTypes = {
   onClearClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   downshiftInputProps: PropTypes.object,
+  errorMessageId: PropTypes.string,
   inputRef: PropTypes.any,
   // others not specified, may be passed from function
 };

--- a/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
@@ -46,6 +46,7 @@ function Autosuggest({
   showOptionsRestriction = undefined,
   errorMessageId,
 }) {
+  // test2
   const {
     isOpen,
     getToggleButtonProps,

--- a/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
@@ -44,6 +44,7 @@ function Autosuggest({
   useProgressiveDisclosure,
   AutosuggestOptionComponent = AutosuggestOption,
   showOptionsRestriction = undefined,
+  errorMessageId,
 }) {
   const {
     isOpen,
@@ -108,6 +109,7 @@ function Autosuggest({
           showClearButton={!!inputValue}
           onClearClick={inputClearClick}
           downshiftInputProps={downshiftInputProps}
+          errorMessageId={errorMessageId}
         />
         <AutosuggestOptions
           getItemProps={getItemProps}

--- a/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
@@ -118,6 +118,14 @@ function AddressAutosuggest({
     debouncedUpdateSearch(value);
   };
 
+  // remove aria-describedby if error resolved
+  const resolveError = () => {
+    const addressInput = document.getElementById('street-city-state-zip');
+    if (addressInput?.hasAttribute('aria-describedby')) {
+      addressInput.removeAttribute('aria-describedby');
+    }
+  };
+
   useEffect(
     () => {
       // If the location is changed, and there is no value in searchString or inputValue then show the error
@@ -150,7 +158,11 @@ function AddressAutosuggest({
     () => {
       // Focus the error message when it appears so screen readers announce it
       if (showAddressError && errorRef.current) {
+        const addressInput = document.getElementById('street-city-state-zip');
+        addressInput?.setAttribute('aria-describedby', 'input-error-message');
         errorRef.current.focus();
+      } else {
+        resolveError();
       }
     },
     [showAddressError],

--- a/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
@@ -27,6 +27,7 @@ function AddressAutosuggest({
   const [showAddressError, setShowAddressError] = useState(false);
   const [isTouched, setIsTouched] = useState(false);
   const [isGeocoding, setIsGeocoding] = useState(false);
+  const errorRef = React.useRef(null);
 
   const inputClearClick = useCallback(
     () => {
@@ -145,6 +146,18 @@ function AddressAutosuggest({
     [searchString, geolocationInProgress],
   );
 
+  useEffect(
+    () => {
+      // Focus the error message when it appears so screen readers announce it
+      if (showAddressError && errorRef.current) {
+        errorRef.current.focus();
+      }
+    },
+    [showAddressError],
+  );
+
+  const errorMessageId = 'street-city-state-zip-error-message';
+
   return (
     <Autosuggest
       inputValue={inputValue || ''}
@@ -174,9 +187,16 @@ function AddressAutosuggest({
         },
       }}
       onClearClick={inputClearClick}
-      inputError={<AddressInputError showError={showAddressError || false} />}
+      inputError={
+        <AddressInputError
+          ref={errorRef}
+          showError={showAddressError || false}
+          errorId={errorMessageId}
+        />
+      }
       showError={showAddressError}
       inputId="street-city-state-zip"
+      errorMessageId={errorMessageId}
       inputRef={inputRef}
       /* eslint-disable prettier/prettier */
       labelSibling={(

--- a/src/applications/facility-locator/components/search-form/location/AddressInputError.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressInputError.jsx
@@ -1,19 +1,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-function AddressInputError({ showError }) {
+const AddressInputError = React.forwardRef(({ showError, errorId }, ref) => {
   if (!showError) {
     return null;
   }
   return (
-    <span className="usa-input-error-message" role="alert">
+    <span
+      className="usa-input-error-message"
+      role="alert"
+      ref={ref}
+      tabIndex="-1"
+    >
       <span className="sr-only">Error</span>
-      Enter a zip code or a city and state in the search box
+      <span id={errorId}>
+        Enter a zip code or a city and state in the search box
+      </span>
     </span>
   );
-}
+});
+
+AddressInputError.displayName = 'AddressInputError';
 
 AddressInputError.propTypes = {
+  errorId: PropTypes.string,
   showError: PropTypes.bool,
 };
 

--- a/src/applications/facility-locator/components/search-form/location/AddressInputError.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressInputError.jsx
@@ -2,20 +2,32 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const AddressInputError = React.forwardRef(({ showError, errorId }, ref) => {
-  if (!showError) {
-    return null;
+  // This method of rendering two new span elements inside the error container
+  // copies the method of error handling displayed in the platform's
+  // standard error handling on an input
+  function ErrorContent() {
+    if (!showError) {
+      return null;
+    }
+
+    return (
+      <>
+        <span className="usa-sr-only sr-only">Error</span>
+        <span className="usa-error-message" id={errorId}>
+          Enter a zip code or a city and state in the search box
+        </span>
+      </>
+    );
   }
+
   return (
     <span
       className="usa-input-error-message"
       role="alert"
       ref={ref}
-      tabIndex="-1"
+      tabIndex={showError ? -1 : 0}
     >
-      <span className="sr-only">Error</span>
-      <span id={errorId}>
-        Enter a zip code or a city and state in the search box
-      </span>
+      <ErrorContent />
     </span>
   );
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Custom location input in the facility locator form has been modified to match current VDS standard error behavior for inputs
- To reproduce:
  1.  Go to [autosuggest prototype](https://staging.va.gov/find-locations/) and use a screenreader
  2. TAB into, then out of, the location field, without typing anything to trigger the error (Note: if https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22458 is complete, you will need to click 'Search' to trigger the error)
  3. See the error "Enter a zip code or a city and state in the search box" display. Note that no error is announced.

- In order to match the standard input error handling several changes were made:
  - A aria-describedby attribute was added to the input when it errors, with details of the error
  - The way that the error text is rendered on the page was changed to reflect the VDS input error behavior:
    - Two more span elements containing more error information are rendered 
  - A ref was used to transfer focus to the errored element
  - A variable was defined for the error ID, in order to respond to potential dynamic error messages


- **The solution:** 
  - At this time, the decision is to align the effects of the error as close to the VDS standard input's behavior when it experiences an error. 
  - Please note: the standard input error behavior does NOT announce the input error to the screen reader. 
  - We are copying the standard error behavior in several respects, but not conforming completely, in order to prompt the screenreader to announce the error
  - We will revise when revised recommendations for error handling are issued 
- Facilities Team
- No flipper

## Related issue(s)

- [[FL autosuggest prototype] The location input must announce errors to screenreaders ](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22473)
- Relevant discovery:
  - [[Bug] Forms not putting focus on errors #4993](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4993#issuecomment-3439658887)

## Testing done

- In the previous phenotype:  
  - Upon erroring, a span that was not present at initial page load would be generated
  - The screen reader would not announce the error
  - There was no aria-describedby attribute upon the input when erroring
  - The focus would remain upon the next element, which was wherever the user tabbed/clicked into 
- The changes were tested in chrome and safari 
- Currently, errors on the input now trigger:
  - The addition of futher details to an initial error container, that have an ID relative to the error
  - An aria-describedby attribute is added to the input
  - Focus is returned to the errored element label/error text/input parent container which matches the VDS input error handling 
 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Each screenshot is taken immediately after the error occured.

|         | Standard VDS Input | Staging | Dev Changes |
| ------- | ------ | ----- | ----- |
| Desktop |  <img width="538" height="803" alt="vds" src="https://github.com/user-attachments/assets/8ae5ec63-a21a-43b0-8555-de2848e72324" />  | <img width="737" height="930" alt="staging" src="https://github.com/user-attachments/assets/0b16c440-1309-4750-8af8-e5214e2f424e" />  | <img width="597" height="676" alt="localhost" src="https://github.com/user-attachments/assets/6efaf8f8-7405-4b0d-839d-e61091b4df9a" /> |
| When screenshot taken | Taken immediately after tabbing into Submit and hitting enter.  | Taken after tabbing out of the location input.| Taken after tabbing out of the location input. |
| Focus after error | errored element label/error text/input parent container | Remains on the same element | errored element label/error text |
| Screenreader announces error | No | No  | Yes |
## What areas of the site does it impact?

Facilities locator form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Originally, the plan with this PR was to retain the lack of screen reader announcement of the error, but also copy the error behavior of the standard input as much as possible other than that. Then, when the VDS team addresses this accessibility bug, we will revise our component to comply with their suggest fix. However, upon consideration, I felt it was perhaps odd to reinstate a problem when it was currently solved by @bryan-thompsoncodes in code. Perhaps we could solve this issue for now, and revise our error handling later when VDS generates recommendations? 
