### PR TITLE
Adds mhv-medications CHANGELOG.md for October 2025

### DIFF
--- a/src/applications/mhv-medications/CHANGELOG.md
+++ b/src/applications/mhv-medications/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog: MHV Medications (Sept 30 - Nov 3, 2025)
+
+## Refactoring & Code Quality
+- **#120943**: Removed moment.js dependency from medications, improved date handling consistency (Oct 30)
+- **RefillAlert → DelayedRefillAlert**: Refactored component naming and structure (Oct 21)
+- **RefillNotification refactor**: Improved component structure, added aria-labels, moved constants, created smaller sub-components (Oct 15) -- aria labels?
+
+## Accessibility Improvements
+- **#118720**: Enhanced screen reader messaging when sorting/filtering medications in list view (Oct 21)
+- **#121180**: Added aria-label to medications filter list for screen reader compatibility and fixed Firefox issues (Oct 16)
+- Fixed h2 not rendering in RefillAlert component (Oct 9)
+
+## PDF & TXT File Enhancements
+- **#122091**: Updated medication details PDF and TXT file content with edge case handling (Oct 27)
+- **#38787**: Added partial fill data to generated PDF and TXT files with unit tests (Oct 23)
+- **#118661**: Updated print/download dropdown to use filtered list instead of full list (Oct 9)
+- **#118663**: Updated PDF and TXT file content and format, refactored configs, improved recent Rx refill logic (Oct 20)
+
+## Content & UI Updates
+- **#121896**: Refactored status descriptions for pending refills and renewals across PDF, TXT, Print, and Web views (Oct 22)
+- **#119115**: Updated content on details page for "Active: Refill in progress" medications to improve line formatting (Oct 10)
+- **#119376**: Updated small content change for the filter on the Medications list page (Oct 8)
+
+## Feature Additions
+- **#119376**: Created new `NewCernerFacilityAlert` Alert with va-alert-expandable when showNewFacilityAlert toggle is ON and user has transitional facility (Oct 16)
+
+## Bug Fixes & Testing
+- **#119106**: Fixed PropType validation error - changed 'hasError' prop from object to boolean in PrintonlyPage (Oct 7)
+- Fixed missing and misspelled data-test-id attributes with E2E test updates (Oct 8)
+- Fixed test assertions for accordion updates (Oct 8)
+- Fixed unit test for UTC dates after moment.js removal (Oct 30)
+
+## Monitoring & Analytics
+- Removed Unique User Metrics from Medications (Oct 23)
+
+---
+
+**Total commits**: 19
+**Date range**: October 7 - October 30, 2025

--- a/src/applications/mhv-medications/CHANGELOG.md
+++ b/src/applications/mhv-medications/CHANGELOG.md
@@ -1,44 +1,76 @@
 # Changelog: MHV Medications (Sept 30 - Nov 5, 2025)
 
 ## Refactoring & Code Quality
-- **#120943**: Removed moment.js dependency from medications, improved date handling consistency (Oct 30)
-- **#39285**: Moved pharmacy phone number logic to vets-api, added phone number formatting (Nov 3)
-- **RefillAlert → DelayedRefillAlert**: Refactored component naming and structure (Oct 21)
-- **RefillNotification refactor**: Improved component structure, added aria-labels, moved constants, created smaller sub-components (Oct 15)
+- [#120943][issue-120943]: Removed moment.js dependency from medications, improved date handling consistency ([#39617][pr-39617]) (Oct 30)
+- [#39285][pr-39285]: Moved pharmacy phone number logic to vets-api, added phone number formatting (Nov 3)
+- [#39245][pr-39245]: **RefillAlert → DelayedRefillAlert** - Refactored component naming and structure (Oct 21)
+- [#38897][pr-38897]: **RefillNotification refactor** - Improved component structure, added aria-labels, moved constants, created smaller sub-components (Oct 15)
 
 ## Accessibility Improvements
-- **#118720**: Enhanced screen reader messaging when sorting/filtering medications in list view (Oct 21)
-- **#121180**: Added aria-label to medications filter list for screen reader compatibility and fixed Firefox issues (Oct 16)
-- Fixed h2 not rendering in RefillAlert component (Oct 9)
+- [#118720][issue-118720]: Enhanced screen reader messaging when sorting/filtering medications in list view ([#39121][pr-39121]) (Oct 21)
+- [#121180][issue-121180]: Added aria-label to medications filter list for screen reader compatibility and fixed Firefox issues ([#39414][pr-39414]) (Oct 16)
+- [#39143][pr-39143]: Fixed h2 not rendering in RefillAlert component (Oct 9)
 
 ## PDF & TXT File Enhancements
-- **#122091**: Updated medication details PDF and TXT file content with edge case handling (Oct 27)
-- **#38787**: Added partial fill data to generated PDF and TXT files with unit tests (Oct 23)
-- **#118661**: Updated print/download dropdown to use filtered list instead of full list (Oct 9)
-- **#118663**: Updated PDF and TXT file content and format, refactored configs, improved recent Rx refill logic (Oct 20)
+- [#122091][issue-122091]: Updated medication details PDF and TXT file content with edge case handling ([#39595][pr-39595]) (Oct 27)
+- [#38787][pr-38787]: Added partial fill data to generated PDF and TXT files with unit tests (Oct 23)
+- [#118661][issue-118661]: Updated print/download dropdown to use filtered list instead of full list ([#39088][pr-39088]) (Oct 9)
+- [#118663][issue-118663]: Updated PDF and TXT file content and format, refactored configs, improved recent Rx refill logic ([#39426][pr-39426]) (Oct 20)
 
 ## Content & UI Updates
-- **#121896**: Refactored status descriptions for pending refills and renewals across PDF, TXT, Print, and Web views (Oct 22)
-- **#119115**: Updated content on details page for "Active: Refill in progress" medications to improve line formatting (Oct 10)
-- **#119376**: Updated small content change for the filter on the Medications list page (Oct 8)
+- [#121896][issue-121896]: Refactored status descriptions for pending refills and renewals across PDF, TXT, Print, and Web views ([#39328][pr-39328]) (Oct 22)
+- [#119115][issue-119115]: Updated content on details page for "Active: Refill in progress" medications to improve line formatting ([#39059][pr-39059]) (Oct 10)
+- [#119376][issue-119376]: Updated small content change for the filter on the Medications list page ([#39122][pr-39122]) (Oct 8)
 
 ## Feature Additions
-- **#119376**: Created new `NewCernerFacilityAlert` with va-alert-expandable when showNewFacilityAlert toggle is ON and user is associated with an Oracle Health Cerner facility (Oct 16)
+- [#119376][issue-119376]: Created new `NewCernerFacilityAlert` with va-alert-expandable when showNewFacilityAlert toggle is ON and user is associated with an Oracle Health Cerner facility ([#39302][pr-39302]) (Oct 16)
 
 ## Bug Fixes & Testing
-- **#119106**: Fixed PropType validation error - changed 'hasError' prop from object to boolean in PrintonlyPage (Oct 7)
-- Fixed missing and misspelled data-test-id attributes with E2E test updates (Oct 8)
-- Fixed test assertions for accordion updates (Oct 8)
+- [#119106][issue-119106]: Fixed PropType validation error - changed 'hasError' prop from object to boolean in PrintonlyPage ([#38704][pr-38704]) (Oct 7)
+- [#39108][pr-39108]: Fixed missing and misspelled data-test-id attributes with E2E test updates (Oct 8)
+- [#39223][pr-39223]: Fixed test assertions for accordion updates (Oct 8)
 - Fixed unit test for UTC dates after moment.js removal (Oct 30)
 
 ## Monitoring & Analytics
-- Removed Unique User Metrics from Medications (Oct 23)
+- [#39521][pr-39521]: Removed Unique User Metrics from Medications (Oct 23)
 
 ## Documentation
 - Added FEATURE_TOGGLES.md for mhv-medications (Nov 5)
-
 
 ---
 
 **Total commits**: 22
 **Date range**: October 7 - November 5, 2025
+
+<!-- Issue References -->
+[issue-120943]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/120943
+[issue-118720]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/118720
+[issue-121180]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/121180
+[issue-122091]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/122091
+[issue-118661]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/118661
+[issue-118663]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/118663
+[issue-121896]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/121896
+[issue-119115]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119115
+[issue-119376]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119376
+[issue-119106]: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119106
+
+<!-- PR References -->
+[pr-39617]: https://github.com/department-of-veterans-affairs/vets-website/pull/39617
+[pr-39285]: https://github.com/department-of-veterans-affairs/vets-website/pull/39285
+[pr-39245]: https://github.com/department-of-veterans-affairs/vets-website/pull/39245
+[pr-38897]: https://github.com/department-of-veterans-affairs/vets-website/pull/38897
+[pr-39121]: https://github.com/department-of-veterans-affairs/vets-website/pull/39121
+[pr-39414]: https://github.com/department-of-veterans-affairs/vets-website/pull/39414
+[pr-39143]: https://github.com/department-of-veterans-affairs/vets-website/pull/39143
+[pr-39595]: https://github.com/department-of-veterans-affairs/vets-website/pull/39595
+[pr-38787]: https://github.com/department-of-veterans-affairs/vets-website/pull/38787
+[pr-39088]: https://github.com/department-of-veterans-affairs/vets-website/pull/39088
+[pr-39426]: https://github.com/department-of-veterans-affairs/vets-website/pull/39426
+[pr-39328]: https://github.com/department-of-veterans-affairs/vets-website/pull/39328
+[pr-39059]: https://github.com/department-of-veterans-affairs/vets-website/pull/39059
+[pr-39122]: https://github.com/department-of-veterans-affairs/vets-website/pull/39122
+[pr-39302]: https://github.com/department-of-veterans-affairs/vets-website/pull/39302
+[pr-38704]: https://github.com/department-of-veterans-affairs/vets-website/pull/38704
+[pr-39108]: https://github.com/department-of-veterans-affairs/vets-website/pull/39108
+[pr-39223]: https://github.com/department-of-veterans-affairs/vets-website/pull/39223
+[pr-39521]: https://github.com/department-of-veterans-affairs/vets-website/pull/39521

--- a/src/applications/mhv-medications/CHANGELOG.md
+++ b/src/applications/mhv-medications/CHANGELOG.md
@@ -1,9 +1,10 @@
-# Changelog: MHV Medications (Sept 30 - Nov 3, 2025)
+# Changelog: MHV Medications (Sept 30 - Nov 5, 2025)
 
 ## Refactoring & Code Quality
 - **#120943**: Removed moment.js dependency from medications, improved date handling consistency (Oct 30)
+- **#39285**: Moved pharmacy phone number logic to vets-api, added phone number formatting (Nov 3)
 - **RefillAlert → DelayedRefillAlert**: Refactored component naming and structure (Oct 21)
-- **RefillNotification refactor**: Improved component structure, added aria-labels, moved constants, created smaller sub-components (Oct 15) -- aria labels?
+- **RefillNotification refactor**: Improved component structure, added aria-labels, moved constants, created smaller sub-components (Oct 15)
 
 ## Accessibility Improvements
 - **#118720**: Enhanced screen reader messaging when sorting/filtering medications in list view (Oct 21)
@@ -22,7 +23,7 @@
 - **#119376**: Updated small content change for the filter on the Medications list page (Oct 8)
 
 ## Feature Additions
-- **#119376**: Created new `NewCernerFacilityAlert` Alert with va-alert-expandable when showNewFacilityAlert toggle is ON and user has transitional facility (Oct 16)
+- **#119376**: Created new `NewCernerFacilityAlert` with va-alert-expandable when showNewFacilityAlert toggle is ON and user is associated with an Oracle Health Cerner facility (Oct 16)
 
 ## Bug Fixes & Testing
 - **#119106**: Fixed PropType validation error - changed 'hasError' prop from object to boolean in PrintonlyPage (Oct 7)
@@ -33,7 +34,11 @@
 ## Monitoring & Analytics
 - Removed Unique User Metrics from Medications (Oct 23)
 
+## Documentation
+- Added FEATURE_TOGGLES.md for mhv-medications (Nov 5)
+
+
 ---
 
-**Total commits**: 19
-**Date range**: October 7 - October 30, 2025
+**Total commits**: 22
+**Date range**: October 7 - November 5, 2025

--- a/src/applications/mhv-medications/FEATURE_TOGGLES.md
+++ b/src/applications/mhv-medications/FEATURE_TOGGLES.md
@@ -58,3 +58,27 @@ Enable/disable counting times IPE has been hidden. [source](https://github.com/d
 - [ ] `mhv_medications_remove_landing_page` `mhvMedicationsRemoveLandingPage`
 - [ ] `mhv_medications_show_ipe_content` `mhvMedicationsShowIpeContent`
 - [ ] `mhv_medications_to_va_gov_release` `mhvMedicationsToVaGovRelease`
+
+
+```
+# dev/sandbox
+vets-api(prod)> Flipper.remove(:mhv_medications_display_filter)
+=> true
+vets-api(prod)> Flipper.remove(:mhv_medications_display_grouping)
+=> true
+vets-api(prod)> Flipper.remove(:mhv_medications_display_refill_content)
+=> true
+vets-api(prod)> Flipper.remove(:mhv_medications_remove_landing_page)
+=> true
+vets-api(prod)> Flipper.remove(:mhv_medications_show_ipe_content)
+=> true
+vets-api(prod)> Flipper.remove(:mhv_medications_to_va_gov_release)
+=> true
+
+# staging -- no access via argocd
+$ bundle exec rails c
+Enter PEM pass phrase:
+
+# prod -- no access via argocd
+Terminal Connection Error: Internal error
+```

--- a/src/applications/mhv-medications/FEATURE_TOGGLES.md
+++ b/src/applications/mhv-medications/FEATURE_TOGGLES.md
@@ -1,0 +1,61 @@
+# Feature Toggles: MHV Medications
+
+## Report for 20251105
+
+- [vets-api | flipper (staging)](https://staging-api.va.gov/flipper/features)
+- [vets-api | flipper (production)](https://api.va.gov/flipper/features)
+
+Name | staging | production
+---- | ------- | ----------
+`mhvMedicationsDisplayAllergies`    | `true` | `true` |
+`mhv_medications_display_allergies` | `true` | `true` |
+`mhvMedicationsDisplayDocumentationContent`     | `true` |
+`mhv_medications_display_documentation_content` | `true` |
+`mhvMedicationsDisplayPendingMeds`     | `true` | `false` |
+`mhv_medications_display_pending_meds` | `true` | `false` |
+`mhvMedicationsDisplayRefillProgress`     | `true` | `true` |
+`mhv_medications_display_refill_progress` | `true` | `true` |
+`mhvMedicationsPartialFillContent`     | `true` | `false` |
+`mhv_medications_partial_fill_content` | `true` | `false` |
+`mhvMedicationsDontIncrementIpeCount`      | `true` | `false` |
+`mhv_medications_dont_increment_ipe_count` | `true` | `false` |
+`mhvBypassDowntimeNotification`    | `1 actor` | `false` |
+`mhv_bypass_downtime_notification` | `1 actor` | `false` |
+`mhvMedicationsDisplayNewCernerFacilityAlert`       | `1 actor` | `n/a` |
+`mhv_medications_display_new_cerner_facility_alert` | `1 actor` | `n/a` |
+
+
+### `mhv_medications_display_pending_meds`
+
+Show/hide Print-only content. [source](https://github.com/department-of-veterans-affairs/vets-website/blob/mhv-medications-changelog-oct/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx#L170-L177)
+
+```jsx
+{!showPendingMedsContent && (
+  <p>
+    <strong>
+      Request refills by this prescription expiration date:
+    </strong>{' '}
+    {dateFormat(rx.expirationDate, DATETIME_FORMATS.longMonthDate)}
+  </p>
+)}
+```
+
+### `mhv_medications_partial_fill_content`
+
+Show/hide partial fill information in refill history. [source](https://github.com/department-of-veterans-affairs/vets-website/blob/mhv-medications-changelog-oct/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx#L441-L555)
+
+
+### `mhv_medications_dont_increment_ipe_count`
+
+Enable/disable counting times IPE has been hidden. [source](https://github.com/department-of-veterans-affairs/vets-website/blob/mhv-medications-changelog-oct/src/applications/mhv-medications/components/MedicationsList/InProductionEducationFiltering.jsx)
+
+### Slated for removal
+
+- [ ] `mhv_medications_cerner_pilot` `mhvMedicationsCernerPilot`
+- [ ] `mhv_medications_display_filter` `mhvMedicationsDisplayFilter`
+- [ ] `mhv_medications_display_grouping` `mhvMedicationsDisplayGrouping`
+- [ ] `mhv_medications_display_refill_content` `mhvMedicationsDisplayRefillContent`
+- [ ] `mhv_medications_new_policy` `mhvMedicationsNewPolicy`
+- [ ] `mhv_medications_remove_landing_page` `mhvMedicationsRemoveLandingPage`
+- [ ] `mhv_medications_show_ipe_content` `mhvMedicationsShowIpeContent`
+- [ ] `mhv_medications_to_va_gov_release` `mhvMedicationsToVaGovRelease`

--- a/src/applications/mhv-medications/FEATURE_TOGGLES.md
+++ b/src/applications/mhv-medications/FEATURE_TOGGLES.md
@@ -9,8 +9,8 @@ Name | staging | production
 ---- | ------- | ----------
 `mhvMedicationsDisplayAllergies`    | `true` | `true` |
 `mhv_medications_display_allergies` | `true` | `true` |
-`mhvMedicationsDisplayDocumentationContent`     | `true` |
-`mhv_medications_display_documentation_content` | `true` |
+`mhvMedicationsDisplayDocumentationContent`     | `true` | `true` |
+`mhv_medications_display_documentation_content` | `true` | `true` |
 `mhvMedicationsDisplayPendingMeds`     | `true` | `false` |
 `mhv_medications_display_pending_meds` | `true` | `false` |
 `mhvMedicationsDisplayRefillProgress`     | `true` | `true` |

--- a/src/applications/mhv-medications/FEATURE_TOGGLES.md
+++ b/src/applications/mhv-medications/FEATURE_TOGGLES.md
@@ -51,7 +51,6 @@ Enable/disable counting times IPE has been hidden. [source](https://github.com/d
 
 ### Slated for removal
 
-- [ ] `mhv_medications_cerner_pilot` `mhvMedicationsCernerPilot`
 - [ ] `mhv_medications_display_filter` `mhvMedicationsDisplayFilter`
 - [ ] `mhv_medications_display_grouping` `mhvMedicationsDisplayGrouping`
 - [ ] `mhv_medications_display_refill_content` `mhvMedicationsDisplayRefillContent`


### PR DESCRIPTION
## Summary

- Adds mhv-medications CHANGELOG.md for October 2025

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#124414

## Testing done

- Verified functional changes locally using mocks, staging using test accounts