### PR TITLE
[ARC/114648] - fixing error state showing up before user uploads anything

### DIFF
--- a/src/applications/representative-form-upload/pages/upload.jsx
+++ b/src/applications/representative-form-upload/pages/upload.jsx
@@ -46,7 +46,7 @@ export const uploadPage = {
         formNumber,
         required: () => true,
         // Disallow uploads greater than 25 MB
-        maxFileSize: 25000000,
+        maxFileSize: 26214400, // 25MB in bytes
         updateUiSchema: formData => {
           return {
             'ui:title': warningsPresent(formData)
@@ -55,22 +55,6 @@ export const uploadPage = {
           };
         },
       }),
-      'ui:validations': [
-        (errors, data) => {
-          if (!(data?.confirmationCode && data?.name && data?.size)) {
-            errors.addError(`Upload a completed VA Form ${formNumber}`);
-          }
-          if (data?.name) {
-            const ext = data.name
-              .split('.')
-              .pop()
-              .toLowerCase();
-            if (ext !== 'pdf' && !window.Cypress) {
-              errors.addError('Your file must be .pdf format');
-            }
-          }
-        },
-      ],
     },
     'ui:objectViewField': SupportingEvidenceViewField,
     ...supportingEvidenceTitleAndDescription,

--- a/src/applications/representative-form-upload/tests/e2e/form-upload.cypress.spec.js
+++ b/src/applications/representative-form-upload/tests/e2e/form-upload.cypress.spec.js
@@ -238,11 +238,9 @@ describe('Representative Form Upload', () => {
           // eslint-disable-next-line cypress/no-unnecessary-waiting
           cy.wait(1000);
 
-          cy.get('[name="root_supportingDocuments-0"]').selectFile(
-            uploadImgPath,
-            {
-              force: true,
-            },
+          cy.fillVaFileInputMultiple(
+            'root_supportingDocuments',
+            uploadImgDetails,
           );
 
           // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/src/applications/representative-form-upload/tests/unit/pages/UploadPage.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/pages/UploadPage.unit.spec.jsx
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { uploadPage, warningsPresent } from '../../../pages/upload';
 import { createPayload, parseResponse } from '../../../helpers';
 
@@ -21,7 +20,7 @@ describe('uploadPage', () => {
     const { uploadedFile } = uiSchema;
 
     it('has maxFileSize of 25MB', () => {
-      expect(uploadedFile['ui:options'].maxFileSize).to.equal(25000000);
+      expect(uploadedFile['ui:options'].maxFileSize).to.equal(26214400);
     });
 
     it('updates the title when no warnings', () => {
@@ -50,56 +49,6 @@ describe('uploadPage', () => {
       const result = uploadedFile['ui:options'].updateUiSchema(formData);
       expect(result).to.deep.equal({
         'ui:title': 'Select a file to upload',
-      });
-    });
-
-    describe('ui:validations', () => {
-      const validationFn = uploadedFile['ui:validations'][0];
-
-      it('adds error if required fields are missing', () => {
-        const errors = { addError: sinon.spy() };
-        validationFn(errors, {});
-        expect(errors.addError.calledOnce).to.be.true;
-        expect(errors.addError.firstCall.args[0]).to.include(
-          'Upload a completed VA Form',
-        );
-      });
-
-      it('adds error if file extension is not pdf', () => {
-        const errors = { addError: sinon.spy() };
-        validationFn(errors, {
-          name: 'file.txt',
-          confirmationCode: 'abc',
-          size: 123,
-        });
-        expect(errors.addError.calledWith('Your file must be .pdf format')).to
-          .be.true;
-      });
-
-      it('does not add error if all required fields are present and file is a pdf', () => {
-        const errors = { addError: sinon.spy() };
-        validationFn(errors, {
-          name: 'file.pdf',
-          confirmationCode: 'abc',
-          size: 123,
-        });
-        expect(errors.addError.notCalled).to.be.true;
-      });
-
-      it('skips pdf extension validation in Cypress', () => {
-        const originalCypress = window.Cypress;
-        window.Cypress = true;
-
-        const errors = { addError: sinon.spy() };
-        validationFn(errors, {
-          name: 'file.jpg',
-          confirmationCode: 'abc',
-          size: 123,
-        });
-
-        expect(errors.addError.notCalled).to.be.true;
-
-        window.Cypress = originalCypress;
       });
     });
   });


### PR DESCRIPTION
Error state appears before user has a chance to select a file and upload, see ticket from staging review for video of original issue:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/114648

I removed tests that are no longer relevant, and updated the max file size to match max file size of 25mb instead of 23.8mb

<img width="658" height="414" alt="Screenshot 2025-11-05 at 10 59 15 AM" src="https://github.com/user-attachments/assets/7c656183-9503-4879-9c05-556b85772203" />
<img width="586" height="371" alt="Screenshot 2025-11-05 at 10 59 46 AM" src="https://github.com/user-attachments/assets/86921d1c-3caa-4f0e-8c1c-4c51d2890ded" />
i 