### PR TITLE
[#124445] Travel Pay, Complex claims unsupported mileage page

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -68,10 +68,7 @@ const Mileage = () => {
       departureAddress === 'another-address' ||
       tripType === TRIP_TYPES.ONE_WAY.value
     ) {
-      // eslint-disable-next-line no-console
-      console.log(
-        'Special case detected - would redirect to "not supported" page',
-      );
+      navigate(`/file-new-claim/${apptId}/${claimId}/unsupported`);
     } else {
       try {
         if (expenseId) {

--- a/src/applications/travel-pay/components/complex-claims/pages/UnsupportedMileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/UnsupportedMileage.jsx
@@ -6,16 +6,17 @@ import { BTSSS_PORTAL_URL } from '../../../constants';
 
 const UnsupportedMileage = () => {
   const navigate = useNavigate();
+
   return (
     <>
       <h1>You’ll need to file this claim in another tool</h1>
       <p>
         Right now you can only file travel reimbursement claims on VA.gov if you
-        departed from the address we have on file and traveled roundtrip.
+        departed from the address we have on file and traveled round trip.
       </p>
       <p>
-        To file a one-way claim from another address, use the Beneficiary Travel
-        Self Service System (BTSSS).
+        To file a one-way claim or a claim from another address, use the
+        Beneficiary Travel Self Service System (BTSSS).
       </p>
       <va-link
         href={BTSSS_PORTAL_URL}

--- a/src/applications/travel-pay/components/complex-claims/pages/UnsupportedMileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/UnsupportedMileage.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import { BTSSS_PORTAL_URL } from '../../../constants';
+
+const UnsupportedMileage = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <h1>You’ll need to file this claim in another tool</h1>
+      <p>
+        Right now you can only file travel reimbursement claims on VA.gov if you
+        departed from the address we have on file and traveled roundtrip.
+      </p>
+      <p>
+        To file a one-way claim from another address, use the Beneficiary Travel
+        Self Service System (BTSSS).
+      </p>
+      <va-link
+        href={BTSSS_PORTAL_URL}
+        text="Continue this claim on BTSSS"
+        external
+      />
+      <VaButton
+        back
+        text="Back"
+        className="vads-u-display--flex vads-u-margin-y--2"
+        onClick={() => navigate(-1)}
+      />
+    </>
+  );
+};
+
+export default UnsupportedMileage;

--- a/src/applications/travel-pay/routes.jsx
+++ b/src/applications/travel-pay/routes.jsx
@@ -17,6 +17,7 @@ import SubmitFlowWrapper from './containers/SubmitFlowWrapper';
 import ComplexClaimSubmitFlowWrapper from './containers/ComplexClaimSubmitFlowWrapper';
 import ReviewPage from './components/complex-claims/pages/ReviewPage';
 import IntroductionPage from './components/complex-claims/pages/IntroductionPage';
+import UnsupportedMileage from './components/complex-claims/pages/UnsupportedMileage';
 import App from './containers/App';
 
 // Function that returns routes based on feature toggle
@@ -39,6 +40,7 @@ const getRoutes = () => {
           <Route path="review" element={<ReviewPage />} />
           <Route path="travel-agreement" element={<AgreementPage />} />
           <Route path="confirmation" element={<ConfirmationPage />} />
+          <Route path="unsupported" element={<UnsupportedMileage />} />
         </Route>
       </Route>
     ) : (

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/UnsupportedMileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/UnsupportedMileage.unit.spec.jsx
@@ -81,7 +81,7 @@ describe('Travel Pay – UnsupportedMileage', () => {
 
   it('should render the unsupported mileage page correctly', () => {
     const screen = renderWithStoreAndRouter(
-      <MemoryRouter initialEntries={['/unsupported-mileage']}>
+      <MemoryRouter initialEntries={['/unsupported']}>
         <UnsupportedMileage />
       </MemoryRouter>,
       {
@@ -126,7 +126,7 @@ describe('Travel Pay – UnsupportedMileage', () => {
 
   it('should have correct BTSSS portal URL', () => {
     renderWithStoreAndRouter(
-      <MemoryRouter initialEntries={['/unsupported-mileage']}>
+      <MemoryRouter initialEntries={['/unsupported']}>
         <UnsupportedMileage />
       </MemoryRouter>,
       {
@@ -144,10 +144,10 @@ describe('Travel Pay – UnsupportedMileage', () => {
 
   it('should navigate back when back button is clicked', () => {
     const screen = renderWithStoreAndRouter(
-      <MemoryRouter initialEntries={['/previous-page', '/unsupported-mileage']}>
+      <MemoryRouter initialEntries={['/previous-page', '/unsupported']}>
         <Routes>
           <Route path="/previous-page" element={<div>Previous Page</div>} />
-          <Route path="/unsupported-mileage" element={<UnsupportedMileage />} />
+          <Route path="/unsupported" element={<UnsupportedMileage />} />
         </Routes>
         <LocationDisplay />
       </MemoryRouter>,
@@ -159,7 +159,7 @@ describe('Travel Pay – UnsupportedMileage', () => {
 
     // Verify we're on the unsupported mileage page
     expect(screen.getByTestId('location-display').textContent).to.equal(
-      '/unsupported-mileage',
+      '/unsupported',
     );
 
     // Click the back button

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/UnsupportedMileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/UnsupportedMileage.unit.spec.jsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { expect } from 'chai';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { fireEvent } from '@testing-library/react';
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  useLocation,
+} from 'react-router-dom-v5-compat';
+import UnsupportedMileage from '../../../../components/complex-claims/pages/UnsupportedMileage';
+import { BTSSS_PORTAL_URL } from '../../../../constants';
+import reducer from '../../../../redux/reducer';
+
+describe('Travel Pay – UnsupportedMileage', () => {
+  const LocationDisplay = () => {
+    const location = useLocation();
+    return <div data-testid="location-display">{location.pathname}</div>;
+  };
+
+  const getData = () => ({
+    travelPay: {
+      travelClaims: {
+        isLoading: false,
+        claims: {},
+      },
+      claimDetails: {
+        isLoading: false,
+        error: null,
+        data: {},
+      },
+      appointment: {
+        isLoading: false,
+        error: null,
+        data: null,
+      },
+      claimSubmission: {
+        isSubmitting: false,
+        error: null,
+        data: null,
+      },
+      complexClaim: {
+        claim: {
+          creation: {
+            isLoading: false,
+            error: null,
+          },
+          submission: {
+            id: '',
+            isSubmitting: false,
+            error: null,
+            data: null,
+          },
+          fetch: {
+            isLoading: false,
+            error: null,
+          },
+          data: null,
+        },
+        expenses: {
+          creation: {
+            isLoading: false,
+            error: null,
+          },
+          update: {
+            id: '',
+            isLoading: false,
+            error: null,
+          },
+          delete: {
+            id: '',
+            isLoading: false,
+            error: null,
+          },
+          data: [],
+        },
+      },
+    },
+  });
+
+  it('should render the unsupported mileage page correctly', () => {
+    const screen = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={['/unsupported-mileage']}>
+        <UnsupportedMileage />
+      </MemoryRouter>,
+      {
+        initialState: getData(),
+        reducers: reducer,
+      },
+    );
+
+    // Check main heading
+    expect(
+      screen.getByRole('heading', {
+        name: 'You’ll need to file this claim in another tool',
+      }),
+    ).to.exist;
+
+    // Check explanatory text
+    expect(
+      screen.getByText(
+        /Right now you can only file travel reimbursement claims on VA.gov if you departed from the address we have on file and traveled roundtrip/i,
+      ),
+    ).to.exist;
+
+    expect(
+      screen.getByText(
+        /To file a one-way claim from another address, use the Beneficiary Travel Self Service System \(BTSSS\)/i,
+      ),
+    ).to.exist;
+
+    // Check BTSSS link
+    const btsssLink = $('va-link[text="Continue this claim on BTSSS"]');
+    expect(btsssLink).to.exist;
+    expect(btsssLink).to.have.attribute('href', BTSSS_PORTAL_URL);
+    expect(btsssLink).to.have.attribute('external');
+
+    // Check back button
+    const backButton = $('va-button[text="Back"]');
+    expect(backButton).to.exist;
+    expect(backButton).to.have.attribute('back');
+    expect(backButton).to.have.class('vads-u-display--flex');
+    expect(backButton).to.have.class('vads-u-margin-y--2');
+  });
+
+  it('should have correct BTSSS portal URL', () => {
+    renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={['/unsupported-mileage']}>
+        <UnsupportedMileage />
+      </MemoryRouter>,
+      {
+        initialState: getData(),
+        reducers: reducer,
+      },
+    );
+
+    const btsssLink = $('va-link[text="Continue this claim on BTSSS"]');
+    expect(btsssLink).to.have.attribute(
+      'href',
+      'https://dvagov-btsss.dynamics365portals.us/',
+    );
+  });
+
+  it('should navigate back when back button is clicked', () => {
+    const screen = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={['/previous-page', '/unsupported-mileage']}>
+        <Routes>
+          <Route path="/previous-page" element={<div>Previous Page</div>} />
+          <Route path="/unsupported-mileage" element={<UnsupportedMileage />} />
+        </Routes>
+        <LocationDisplay />
+      </MemoryRouter>,
+      {
+        initialState: getData(),
+        reducers: reducer,
+      },
+    );
+
+    // Verify we're on the unsupported mileage page
+    expect(screen.getByTestId('location-display').textContent).to.equal(
+      '/unsupported-mileage',
+    );
+
+    // Click the back button
+    const backButton = $('va-button[text="Back"]');
+    expect(backButton).to.exist;
+    fireEvent.click(backButton);
+
+    // Check that we navigated back to the previous page
+    expect(screen.getByTestId('location-display').textContent).to.equal(
+      '/previous-page',
+    );
+  });
+
+  it('should render all informational content', () => {
+    const screen = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={['/unsupported-mileage']}>
+        <UnsupportedMileage />
+      </MemoryRouter>,
+      {
+        initialState: getData(),
+        reducers: reducer,
+      },
+    );
+
+    // Check that all paragraphs are present
+    const paragraphs = screen.container.querySelectorAll('p');
+    expect(paragraphs).to.have.length(2);
+
+    // Check first paragraph content
+    expect(paragraphs[0].textContent).to.include(
+      'Right now you can only file travel reimbursement claims on VA.gov if you departed from the address we have on file and traveled roundtrip',
+    );
+
+    // Check second paragraph content
+    expect(paragraphs[1].textContent).to.include(
+      'To file a one-way claim from another address, use the Beneficiary Travel Self Service System (BTSSS)',
+    );
+  });
+});

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/UnsupportedMileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/UnsupportedMileage.unit.spec.jsx
@@ -100,13 +100,13 @@ describe('Travel Pay – UnsupportedMileage', () => {
     // Check explanatory text
     expect(
       screen.getByText(
-        /Right now you can only file travel reimbursement claims on VA.gov if you departed from the address we have on file and traveled roundtrip/i,
+        /Right now you can only file travel reimbursement claims on VA.gov if you departed from the address we have on file and traveled round trip./i,
       ),
     ).to.exist;
 
     expect(
       screen.getByText(
-        /To file a one-way claim from another address, use the Beneficiary Travel Self Service System \(BTSSS\)/i,
+        /To file a one-way claim or a claim from another address, use the Beneficiary Travel Self Service System \(BTSSS\)./i,
       ),
     ).to.exist;
 
@@ -170,32 +170,6 @@ describe('Travel Pay – UnsupportedMileage', () => {
     // Check that we navigated back to the previous page
     expect(screen.getByTestId('location-display').textContent).to.equal(
       '/previous-page',
-    );
-  });
-
-  it('should render all informational content', () => {
-    const screen = renderWithStoreAndRouter(
-      <MemoryRouter initialEntries={['/unsupported-mileage']}>
-        <UnsupportedMileage />
-      </MemoryRouter>,
-      {
-        initialState: getData(),
-        reducers: reducer,
-      },
-    );
-
-    // Check that all paragraphs are present
-    const paragraphs = screen.container.querySelectorAll('p');
-    expect(paragraphs).to.have.length(2);
-
-    // Check first paragraph content
-    expect(paragraphs[0].textContent).to.include(
-      'Right now you can only file travel reimbursement claims on VA.gov if you departed from the address we have on file and traveled roundtrip',
-    );
-
-    // Check second paragraph content
-    expect(paragraphs[1].textContent).to.include(
-      'To file a one-way claim from another address, use the Beneficiary Travel Self Service System (BTSSS)',
     );
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add unsupported mileage page for complex claims

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/124445

## Testing done

Tested route from mileage expense for "other address" and "one way" selections. Tested back functionality.

## Screenshots

| Mobile  |  Desktop  |
| ------ | ----- |
| <img width="750" height="1421" alt="mobile" src="https://github.com/user-attachments/assets/635d6393-d7f6-4b60-ada5-d6215f72c0e7" /> | <img width="1106" height="713" alt="Screenshot 2025-11-05 at 10 03 42 AM" src="https://github.com/user-attachments/assets/2112b62b-34ba-47e7-8466-02fbb53629b2" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user