### PR TITLE
VEBT-3479: 22-10275 - Update application TYPE verbiage for SIP authentication

### DIFF
--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
@@ -113,7 +113,7 @@ const ApplicationsInProgress = ({
         {hasForms && (
           <div>
             {allForms.map(form => {
-              const formArrays = ['22-10297'];
+              const formArrays = ['22-10275', '22-10297'];
 
               const formId = form.form;
               const formStatus = form.status;
@@ -122,14 +122,16 @@ const ApplicationsInProgress = ({
               // otherwise use "VA Form {formId}" for non-SiP forms
               const formMeta = MY_VA_SIP_FORMS.find(e => e.id === formId);
               const hasBenefit = !!formMeta?.benefit;
+              const isForm = formArrays.includes(formId);
               // Temporary custom label for 21-4142 via 526 claim
               // and for 686C-674-v2 so they can be user-friendly
               let formIdLabel;
               if (formId === 'form526_form4142') {
                 formIdLabel = '21-4142 submitted with VA Form 21-526EZ';
-              } else if (formId === '22-10297') {
-                formIdLabel =
-                  '22-10297 (Apply for VET TEC 2.0 (high-tech program))';
+              } else if (isForm) {
+                formIdLabel = formMeta?.title
+                  ? `${formId} (${formMeta.title})`
+                  : formId;
               } else if (formId === 'form0995_form4142') {
                 formIdLabel = '21-4142 submitted with VA Form 20-0995';
               } else {
@@ -153,7 +155,6 @@ const ApplicationsInProgress = ({
                   'MMMM d, yyyy',
                 );
                 const continueUrl = `${getFormLink(formId)}resume`;
-                const isForm = formArrays.includes(formId);
                 // TODO: consider combining all "Application Cards" into single component
                 return (
                   <DraftCard

--- a/src/applications/personalization/dashboard/tests/components/benefit-applications/ApplicationsInProgress.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/benefit-applications/ApplicationsInProgress.unit.spec.jsx
@@ -258,9 +258,29 @@ describe('ApplicationsInProgress component', () => {
     );
     expect(view.getByTestId('missing-application-help')).to.exist;
   });
+
   describe('Custom form labels', () => {
     it('renders custom label for 22-10297 (VET TEC 2.0)', () => {
       const customSavedForms = [
+        {
+          form: '22-10275',
+          metadata: {
+            version: 1,
+            returnUrl: '/10275',
+            savedAt: dayAgo,
+            submission: {
+              status: false,
+              errorMessage: false,
+              id: false,
+              timestamp: false,
+              hasAttemptedSubmit: false,
+            },
+            expiresAt: weekFromNow / 1000,
+            lastUpdated: dayAgo / 1000,
+            inProgressFormId: 5179,
+          },
+          lastUpdated: dayAgo / 1000,
+        },
         {
           form: '22-10297',
           metadata: {
@@ -304,6 +324,14 @@ describe('ApplicationsInProgress component', () => {
         </Provider>,
       );
 
+      expect(
+        view.getByText(
+          '22-10275 (Commit to the Principles of Excellence for educational institutions)',
+          {
+            exact: false,
+          },
+        ),
+      ).to.exist;
       expect(
         view.getByText('22-10297 (Apply for VET TEC 2.0 (high-tech program))', {
           exact: false,

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -834,7 +834,7 @@ export const MY_VA_SIP_FORMS = [
   },
   {
     id: VA_FORM_IDS.FORM_22_10297,
-    title: 'Apply for VET TEC 2.0 (high-tech program) (22-10297)',
+    title: 'Apply for VET TEC 2.0 (high-tech program)',
     description:
       'Application for High Technology Veterans Education, Training, and Skills (VA Form 22-10297)',
     trackingPrefix: 'edu-10297-',
@@ -851,10 +851,8 @@ export const MY_VA_SIP_FORMS = [
   },
   {
     id: VA_FORM_IDS.FORM_22_10275,
-    benefit:
-      'Commit to the Principles of Excellence for educational institutions',
     title:
-      'Commit to the Principles of Excellence for educational institutions (22-10275)',
+      'Commit to the Principles of Excellence for educational institutions',
     description:
       'Principles of Excellence for educational institutions (VA Form 22-10275)',
     trackingPrefix: 'edu-10275-',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- The verbiage for the 22-10275 Form has been updated to use `form` where applicable as opposed to `application`

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-3479

**Given:** (The initial context or precondition of the scenario)

I am a user of the 22-10275 form

**When:** (The action performed by the user or the system)

Update "form" vs "application" verbiage for SIP authentication 

**Then:** (The expected outcome or result)

Form remains consistent

**Acceptance Criteria**

- AC1: Instead of Application for education benefits it should grab the application name itself for each form. In this case excellence. 
- Changing the "application" language to "form" language so instead of reading application, it will read as form. 

## Testing done

- Local testing with authenticated user to verify the draft card component renders properly with `form`
- Unit tests updated for `ApplicationsInProgress` component

<img width="1917" height="272" alt="Unit Test Coverage" src="https://github.com/user-attachments/assets/d4bbb05b-df01-442c-9a91-ca0a55a5db79" />

## Screenshots

**Before:**

<img width="480" height="303" alt="Draft Card (Before)" src="https://github.com/user-attachments/assets/3c509f0e-c216-4e9b-af4c-85bfba0a15c2" />

**After:**

<img width="479" height="278" alt="Draft Card (After)" src="https://github.com/user-attachments/assets/bf751ff4-75e0-4f61-8d2e-c7c8d328c3c2" />

## What areas of the site does it impact?

- MyVA Dashboard | Form 22-10275 SiP Cards

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A