### PR TITLE
Fix breadcrumb back link clickable area by removing nav wrapper and a…

### DIFF
--- a/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -450,38 +450,31 @@ const SmBreadcrumbs = () => {
     ],
   );
 
-  return (
-    <div>
-      {shortenBreadcrumb ? (
-        <nav
-          aria-label="Breadcrumb"
-          className="breadcrumbs vads-u-padding-y--4"
-        >
-          <va-link
-            back
-            text="Back"
-            href={backLinkHref}
-            onClick={e => {
-              e.preventDefault();
-              navigateBack();
-            }}
-            data-testid="sm-breadcrumbs-back"
-            data-dd-action-name="Breadcrumb - Back"
-          />
-        </nav>
-      ) : (
-        <VaBreadcrumbs
-          breadcrumbList={newCrumbsList}
-          label="Breadcrumb"
-          home-veterans-affairs
-          onRouteChange={handleRouteChange}
-          className="mobile-lg:vads-u-margin-y--2"
-          dataTestid="sm-breadcrumbs"
-          data-dd-action-name="Breadcrumb"
-          uswds
-        />
-      )}
+  return shortenBreadcrumb ? (
+    <div className="vads-u-padding-y--4 vads-u-display--inline-block">
+      <va-link
+        back
+        text="Back"
+        href={backLinkHref}
+        onClick={e => {
+          e.preventDefault();
+          navigateBack();
+        }}
+        data-testid="sm-breadcrumbs-back"
+        data-dd-action-name="Breadcrumb - Back"
+      />
     </div>
+  ) : (
+    <VaBreadcrumbs
+      breadcrumbList={newCrumbsList}
+      label="Breadcrumb"
+      home-veterans-affairs
+      onRouteChange={handleRouteChange}
+      className="mobile-lg:vads-u-margin-y--2"
+      dataTestid="sm-breadcrumbs"
+      data-dd-action-name="Breadcrumb"
+      uswds
+    />
   );
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
This pull request refactors the rendering logic for the `SmBreadcrumbs` component to remove the unnecessary wrapper elements that caused the back button to have extra clickable whitespace.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120574#issuecomment-3488079659

- _Describe what the old behavior was prior to the change_
clickable whitespace of the back link spanned the width of the page.
- _Describe the steps required to verify your changes are working as expected_
tested manually that this it no longer the case – the clickable area of the back link only spans the with of the text.
- _Describe the tests completed and the results_
All related unit and E2E tests are passing. 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | https://github.com/user-attachments/assets/1f4e4291-eaa4-4425-a8e8-8a9247b6f54c  | https://github.com/user-attachments/assets/c18993b3-5ff3-41a6-9dfe-94eba2547f8b  |

## What areas of the site does it impact?
Secure Messaging

## Acceptance criteria
That only the actually link is clickable, and not the surrounding white space.