### PR TITLE
Removes mhvMedicationsDisplayFilter feature toggle

### DIFF
--- a/src/platform/mhv/api/mocks/feature-toggles/index.js
+++ b/src/platform/mhv/api/mocks/feature-toggles/index.js
@@ -5,7 +5,6 @@ const generateFeatureToggles = (toggles = {}) => {
 
     // medications
     mhvMedicationsDisplayDocumentationContent = true,
-    mhvMedicationsDisplayFilter = true,
     mhvMedicationsDisplayGrouping = true,
     mhvMedicationsDisplayPendingMeds = true,
     mhvMedicationsDisplayRefillProgress = true,
@@ -83,10 +82,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medications_display_documentation_content',
           value: mhvMedicationsDisplayDocumentationContent,
-        },
-        {
-          name: 'mhv_medications_display_filter',
-          value: mhvMedicationsDisplayFilter,
         },
         {
           name: 'mhv_medications_display_grouping',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -173,7 +173,6 @@
   "mhvMedicalRecordsSupportBackendPaginationVital": "mhv_medical_records_support_backend_pagination_vital",
   "mhvMedicationsDisplayAllergies": "mhv_medications_display_allergies",
   "mhvMedicationsDisplayDocumentationContent": "mhv_medications_display_documentation_content",
-  "mhvMedicationsDisplayFilter": "mhv_medications_display_filter",
   "mhvMedicationsDisplayGrouping": "mhv_medications_display_grouping",
   "mhvMedicationsDisplayNewCernerFacilityAlert": "mhv_medications_display_new_cerner_facility_alert",
   "mhvMedicationsDisplayRefillContent": "mhv_medications_display_refill_content",


### PR DESCRIPTION
After removal, searching vets-website/vets-api shows no results:

```
radavis@DavisR-119:~/va/vets-api$ ag mhv_medications_display_filter
radavis@DavisR-119:~/va/vets-api$ cd ../vets-website
radavis@DavisR-119:~/va/vets-website$ ag mhv_medications_display_filter
radavis@DavisR-119:~/va/vets-website$ ag mhvMedicationsDisplayFilter
```