### PR TITLE
Removes mhvMedicationsShowIpeContent feature toggle

### DIFF
--- a/src/applications/mhv-medications/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-medications/mocks/api/feature-toggles/index.js
@@ -4,7 +4,6 @@ const generateFeatureToggles = (toggles = {}) => {
     mhvMedicationsDisplayDocumentationContent = true,
     mhvMedicationsDisplayPendingMeds = true,
     mhvMedicationsDisplayRefillProgress = true,
-    mhvMedicationsShowIpeContent = true,
     mhvMedicationsPartialFillContent = true,
     mhvMedicationsDontIncrementIpeCount = true,
     mhvMedicationsDisplayNewCernerFacilityAlert = true,
@@ -29,10 +28,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medications_display_refill_progress',
           value: mhvMedicationsDisplayRefillProgress,
-        },
-        {
-          name: 'mhv_medications_show_ipe_content',
-          value: mhvMedicationsShowIpeContent,
         },
         {
           name: 'mhv_medications_partial_fill_content',

--- a/src/platform/mhv/api/mocks/feature-toggles/index.js
+++ b/src/platform/mhv/api/mocks/feature-toggles/index.js
@@ -9,7 +9,6 @@ const generateFeatureToggles = (toggles = {}) => {
     mhvMedicationsDisplayGrouping = true,
     mhvMedicationsDisplayPendingMeds = true,
     mhvMedicationsDisplayRefillProgress = true,
-    mhvMedicationsShowIpeContent = true,
     mhvMedicationsPartialFillContent,
     mhvMedicationsDontIncrementIpeCount,
 
@@ -99,10 +98,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medications_display_refill_progress',
           value: mhvMedicationsDisplayRefillProgress,
-        },
-        {
-          name: 'mhv_medications_show_ipe_content',
-          value: mhvMedicationsShowIpeContent,
         },
         {
           name: 'mhv_medications_partial_fill_content',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -179,7 +179,6 @@
   "mhvMedicationsDisplayRefillContent": "mhv_medications_display_refill_content",
   "mhvMedicationsDisplayPendingMeds": "mhv_medications_display_pending_meds",
   "mhvMedicationsDisplayRefillProgress": "mhv_medications_display_refill_progress",
-  "mhvMedicationsShowIpeContent": "mhv_medications_show_ipe_content",
   "mhvMedicationsPartialFillContent": "mhv_medications_partial_fill_content",
   "mhvMedicationsDontIncrementIpeCount": "mhv_medications_dont_increment_ipe_count",
   "mhvMilestone2ChangesEnabled": "mhv_milestone_2_changes_enabled",


### PR DESCRIPTION
After removal, searching vets-api/vets-website for `mhvMedicationsShowIpeContent` and `mhv_medications_show_ipe_content` yields no results.