### PR TITLE
Removes mhvMedicationsToVaGovRelease feature toggle

### DIFF
--- a/src/applications/mhv-medical-records/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-medical-records/mocks/api/feature-toggles/index.js
@@ -5,7 +5,6 @@ const APPLICATION_FEATURE_TOGGLES = Object.freeze({
   // medical records
 
   // OH integration work
-  mhvMedicationsToVaGovRelease: true,
   mhvAcceleratedDeliveryEnabled: true,
   mhvAcceleratedDeliveryAllergiesEnabled: true,
   mhvAcceleratedDeliveryConditionsEnabled: true,


### PR DESCRIPTION
After removal, searching vets-api/vets-website for `mhvMedicationsToVaGovRelease` and `mhv_medications_to_va_gov_release` yields no results.