### PR TITLE
Removes mhvMedicationsRemoveLandingPage feature toggle

### DIFF
--- a/src/applications/mhv-medications/tests/e2e/fixtures/togggle-no-progress-tracker.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/togggle-no-progress-tracker.json
@@ -13,10 +13,6 @@
             {
                 "name": "mhv_medications_display_refill_progress",
                 "value": false
-            },
-            {
-                "name": "mhv_medications_remove_landing_page",
-                "value": true
             }
         ]
     }

--- a/src/applications/mhv-medications/tests/e2e/fixtures/toggles-response.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/toggles-response.json
@@ -15,10 +15,6 @@
                 "value": true
             },
             {
-                "name": "mhv_medications_remove_landing_page",
-                "value": true
-            },
-            {
                 "name": "mhv_medications_partial_fill_content",
                 "value": true
             },


### PR DESCRIPTION
After removal, searching vets-api/vets-website for `mhvMedicationsRemoveLandingPage` and `mhv_medications_remove_landing_page` yields no results.