### PR TITLE
Update manifest generator to not check node_modules

### DIFF
--- a/script/generate-manifest-catalog.js
+++ b/script/generate-manifest-catalog.js
@@ -14,12 +14,16 @@ const path = require('path');
 function findManifestFiles(dir, manifestFiles = []) {
   const files = fs.readdirSync(dir);
 
+  const skipDirectories = ['node_modules', 'dist', 'build', 'coverage', '.git'];
+
   for (const file of files) {
     const filePath = path.join(dir, file);
     const stat = fs.statSync(filePath);
 
     if (stat.isDirectory()) {
-      findManifestFiles(filePath, manifestFiles);
+      if (!skipDirectories.includes(file)) {
+        findManifestFiles(filePath, manifestFiles);
+      }
     } else if (file === 'manifest.json') {
       manifestFiles.push(filePath);
     }


### PR DESCRIPTION
## Summary

If a `src/application` has their own `node_modules`, the manifest generator will unintentionally also recursively check those and add any `manifest.json` files to the `manifest-catalog.json` as seen in this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39864/files#diff-074973465ba02b2dcc52085357cb6e2b622e3dfe2e0fc5382058c3c717e048d1R162-R167)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5148

## Testing done

- manifest-catalog.json still generates correctly

## Screenshots

n/a

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
