### PR TITLE
Add GA4 event to track the number of clinics displayed

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import FormButtons from '../../../components/FormButtons';
 import RequestEligibilityMessage from './RequestEligibilityMessage';
@@ -19,7 +20,7 @@ import {
   selectEligibility,
 } from '../../redux/selectors';
 import useClinicFormState from './useClinicFormState';
-import { TYPE_OF_CARE_IDS } from '../../../utils/constants';
+import { GA_PREFIX, TYPE_OF_CARE_IDS } from '../../../utils/constants';
 import { getPageTitle } from '../../newAppointmentFlow';
 import { selectFeatureMentalHealthHistoryFiltering } from '../../../redux/selectors';
 
@@ -69,6 +70,10 @@ export default function ClinicChoicePage() {
   useEffect(
     () => {
       document.title = `${pageTitle} | Veterans Affairs`;
+      recordEvent({
+        event: `${GA_PREFIX}-clinic-choice-count`,
+        'clinic-count': schema.properties.clinicId.enum.length - 1,
+      });
       dispatch(startDirectScheduleFlow({ isRecordEvent: false }));
     },
     [dispatch],


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We are adding a new event `vaos-clinic-choice-count` with the payload field `clinic-count` to track the actual number of filtered clinics shown to the user on the Clinic choice page. This will help us evaluate upcoming changes on this page.
- United Appointments Experience
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121414

## Testing done

- Tested locally see screenshot of new event in diagnostics console

## Screenshots

<img width="1558" height="554" alt="image" src="https://github.com/user-attachments/assets/ff3c6a3c-1596-4516-9459-91177edabf15" />


## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

