### PR TITLE
Added user-dismissible token expiry alert with chat freeze and deferred refresh

### DIFF
--- a/src/applications/virtual-agent/components/App.jsx
+++ b/src/applications/virtual-agent/components/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import useWebChat from '../hooks/useWebChat';
 import { COMPLETE, ERROR, LOADING } from '../utils/loadingStatus';
@@ -8,9 +8,41 @@ import WebChat from './WebChat';
 export default function App(props) {
   // Default to complete because when feature toggles are loaded we assume paramLoadingStatus is complete and will error out otherwise
   const [paramLoadingStatus, setParamLoadingStatus] = useState(COMPLETE);
-  const { token, code, webChatFramework, loadingStatus } = useWebChat(
+  const { token, code, expired, webChatFramework, loadingStatus } = useWebChat(
     props,
     paramLoadingStatus,
+  );
+
+  // UX: keep alert visible until the user closes it, then remount WebChat
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [webchatKey, setWebchatKey] = useState(0);
+  const alertRef = useRef(null);
+
+  useEffect(
+    () => {
+      if (expired) setAlertOpen(true);
+    },
+    [expired],
+  );
+
+  useEffect(
+    () => {
+      if (!alertOpen) return undefined;
+      const el = alertRef.current;
+      if (!el) return undefined;
+      const onClose = () => {
+        setAlertOpen(false);
+        try {
+          window.dispatchEvent(new Event('va-chatbot-reset'));
+        } catch (e) {
+          // no-op
+        }
+        setWebchatKey(k => k + 1);
+      };
+      el.addEventListener('closeEvent', onClose);
+      return () => el.removeEventListener('closeEvent', onClose);
+    },
+    [alertOpen],
   );
 
   switch (loadingStatus) {
@@ -20,12 +52,27 @@ export default function App(props) {
       return <va-loading-indicator message="Loading Chatbot" />;
     case COMPLETE:
       return (
-        <WebChat
-          token={token}
-          code={code}
-          webChatFramework={webChatFramework}
-          setParamLoadingStatus={setParamLoadingStatus}
-        />
+        <>
+          {alertOpen && (
+            <div style={{ marginBottom: '1rem' }}>
+              <va-alert status="info" uswds closeable ref={alertRef}>
+                <h3 slot="headline">Your chat session has expired</h3>
+                <p>
+                  Your chat session has expired. Close this alert to start a new
+                  conversation.
+                </p>
+              </va-alert>
+            </div>
+          )}
+          <WebChat
+            token={token}
+            code={code}
+            webChatFramework={webChatFramework}
+            setParamLoadingStatus={setParamLoadingStatus}
+            key={webchatKey}
+            freeze={alertOpen}
+          />
+        </>
       );
     default:
       throw new Error(`Invalid loading status: ${loadingStatus}`);

--- a/src/applications/virtual-agent/components/WebChat.jsx
+++ b/src/applications/virtual-agent/components/WebChat.jsx
@@ -54,7 +54,22 @@ const styleOptions = {
 
 export const renderMarkdown = text => MarkdownRenderer.render(text);
 
-const WebChat = ({ code, webChatFramework }) => {
+/**
+ * WebChat component rendering BotFramework Web Chat.
+ *
+ * The `freeze` prop temporarily blocks outbound activities (e.g., send message,
+ * post activity) while keeping the existing transcript visible. This is used
+ * when the token-expiry alert is shown. The value is passed via ref to
+ * middleware in useWebChatStore so we can toggle blocking without recreating
+ * the store.
+ *
+ * @param {Object} props
+ * @param {string} props.token - Direct Line token
+ * @param {string} [props.code] - Optional auth code for STS flows
+ * @param {Object} props.webChatFramework - Factories and components from Web Chat
+ * @param {boolean} [props.freeze=false] - When true, outbound actions are blocked; transcript remains visible
+ */
+const WebChat = ({ token, code, webChatFramework, freeze = false }) => {
   const {
     createDirectLine,
     createStore,
@@ -79,6 +94,8 @@ const WebChat = ({ code, webChatFramework }) => {
 
   const store = useWebChatStore({
     createStore,
+    freeze,
+    token,
     code,
     isMobile,
     environment,
@@ -103,7 +120,7 @@ const WebChat = ({ code, webChatFramework }) => {
     [isLoggedIn],
   );
 
-  const directLine = useDirectLine(createDirectLine);
+  const directLine = useDirectLine(createDirectLine, token, freeze);
 
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
@@ -134,6 +151,7 @@ WebChat.propTypes = {
     }),
   }).isRequired,
   code: PropTypes.string,
+  freeze: PropTypes.bool,
 };
 
 export default WebChat;

--- a/src/applications/virtual-agent/hooks/useChatbotToken.js
+++ b/src/applications/virtual-agent/hooks/useChatbotToken.js
@@ -1,5 +1,5 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { COMPLETE, ERROR, LOADING } from '../utils/loadingStatus';
 import { logErrorToDatadog } from '../utils/logging';
@@ -10,9 +10,42 @@ import {
   getTokenKey,
   setConversationIdKey,
   setTokenKey,
+  getCodeKey,
+  setCodeKey,
+  getTokenExpiresAt,
+  setTokenExpiresAt,
 } from '../utils/sessionStorage';
+import {
+  parseTTLSeconds,
+  getAlertTargetTs,
+  shouldShowExpiryAlertAt,
+} from '../utils/expiry';
 
-async function getToken(setToken, setCode, setLoadingStatus, forceNew = false) {
+// Helpers moved to utils/expiry.js
+
+function clearSessionForNewConversation() {
+  try {
+    sessionStorage.removeItem('va-bot.token');
+    sessionStorage.removeItem('va-bot.conversationId');
+    sessionStorage.removeItem('va-bot.code');
+    sessionStorage.removeItem('va-bot.tokenExpiresAt');
+    sessionStorage.removeItem('va-bot.recentUtterances');
+    sessionStorage.removeItem('va-bot.isTrackingUtterances');
+    sessionStorage.removeItem('va-bot.skillEventValue');
+    sessionStorage.removeItem('va-bot.conversationToken');
+  } catch (e) {
+    // no-op
+  }
+}
+
+async function getToken(
+  setToken,
+  setCode,
+  setLoadingStatus,
+  forceNew = false,
+  setExpiresAtCb = null,
+  resetExpiredCb = null,
+) {
   try {
     const response = await retryOnce(() => {
       return apiRequest('/chatbot/token', {
@@ -30,8 +63,20 @@ async function getToken(setToken, setCode, setLoadingStatus, forceNew = false) {
     } else {
       setToken(existingToken);
     }
-    setCode(response.code);
+    if (response.code) {
+      setCode(response.code);
+      setCodeKey(response.code);
+    }
+    {
+      const ttl = parseTTLSeconds(
+        response && (response.expires_in ?? response.expiresIn),
+      );
+      const expiresAt = Date.now() + ttl * 1000;
+      setTokenExpiresAt(expiresAt);
+      if (typeof setExpiresAtCb === 'function') setExpiresAtCb(expiresAt);
+    }
     setLoadingStatus(COMPLETE);
+    if (typeof resetExpiredCb === 'function') resetExpiredCb(false);
   } catch (ex) {
     const error = new Error('Could not retrieve chatbot token');
     logErrorToDatadog(true, error.message, error);
@@ -43,6 +88,9 @@ export default function useChatbotToken() {
   const [token, setToken] = useState('');
   const [code, setCode] = useState('');
   const [loadingStatus, setLoadingStatus] = useState(LOADING);
+  const [expired, setExpired] = useState(false);
+  const [expiresAt, setExpiresAt] = useState(null);
+  const expiryTimerRef = useRef(null);
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const isSessionPersistenceEnabled = useToggleValue(
     TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled,
@@ -55,7 +103,14 @@ export default function useChatbotToken() {
 
       // When persistence is OFF, force fresh token/conversationId.
       if (!isSessionPersistenceEnabled) {
-        getToken(setToken, setCode, setLoadingStatus, true);
+        getToken(
+          setToken,
+          setCode,
+          setLoadingStatus,
+          true,
+          setExpiresAt,
+          setExpired,
+        );
         return;
       }
 
@@ -63,15 +118,138 @@ export default function useChatbotToken() {
       const existingConversationId = getConversationIdKey();
       const existingToken = getTokenKey();
       if (existingConversationId && existingToken) {
+        // 1) Check expiry first (expire only if we have a stored timestamp)
+        const storedExpiresAt = getTokenExpiresAt();
+        if (shouldShowExpiryAlertAt(storedExpiresAt)) {
+          setExpired(true);
+          // Preserve current token & transcript; do not auto-refresh
+          setToken(existingToken);
+          setLoadingStatus(COMPLETE);
+          return;
+        }
+
+        // If expiry missing, request it; also fetch code if missing. This does NOT force a new token/conversation.
+        const existingCode = getCodeKey();
+        const needsMeta = !storedExpiresAt || !existingCode;
+        if (needsMeta) {
+          getToken(
+            setToken,
+            setCode,
+            setLoadingStatus,
+            false,
+            setExpiresAt,
+            setExpired,
+          );
+        } else {
+          // Schedule with known expiry
+          setExpiresAt(storedExpiresAt);
+          setCode(existingCode);
+        }
+
+        // Not expired; ensure alert is hidden
+        setExpired(false);
         setToken(existingToken);
         setLoadingStatus(COMPLETE);
         return;
       }
 
-      getToken(setToken, setCode, setLoadingStatus);
+      getToken(
+        setToken,
+        setCode,
+        setLoadingStatus,
+        false,
+        setExpiresAt,
+        setExpired,
+      );
     },
     [isSessionPersistenceEnabled],
   );
 
-  return { token, code, loadingStatus };
+  // Fallback: if socket hits an unrecoverable error (e.g., 403), trigger refresh
+  useEffect(
+    () => {
+      function onConnErr() {
+        if (!isSessionPersistenceEnabled) return;
+        // Connection error often means expired token. Freeze UI and wait for user reset.
+        setExpired(true);
+      }
+      window.addEventListener('va-chatbot-connection-error', onConnErr);
+      return () =>
+        window.removeEventListener('va-chatbot-connection-error', onConnErr);
+    },
+    [isSessionPersistenceEnabled],
+  );
+
+  // Schedule or trigger expiry based on expiresAt
+  useEffect(
+    () => {
+      if (!isSessionPersistenceEnabled) return undefined;
+      const target = getAlertTargetTs(expiresAt || getTokenExpiresAt());
+      if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
+      if (!target) return undefined;
+
+      const now = Date.now();
+      if (now >= target) {
+        // Expired: show alert and freeze until user resets
+        setExpired(true);
+        return undefined;
+      }
+
+      const delay = Math.max(0, target - now);
+      expiryTimerRef.current = setTimeout(() => {
+        if (!isSessionPersistenceEnabled) return;
+        // Expired: show alert and freeze until user resets
+        setExpired(true);
+      }, delay);
+
+      return () => {
+        if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
+      };
+    },
+    [expiresAt, isSessionPersistenceEnabled],
+  );
+
+  // Ensure expiry handling triggers when tab regains focus or becomes visible (timers can be throttled)
+  useEffect(
+    () => {
+      if (!isSessionPersistenceEnabled) return undefined;
+      const checkExpiry = () => {
+        const target = getAlertTargetTs(getTokenExpiresAt());
+        if (target && Date.now() >= target) {
+          // Expired while tab hidden; set expired but do not auto-refresh
+          setExpired(true);
+        }
+      };
+      const onFocus = checkExpiry;
+      const onVisibilityChange = () => {
+        if (document.visibilityState === 'visible') checkExpiry();
+      };
+      window.addEventListener('focus', onFocus);
+      document.addEventListener('visibilitychange', onVisibilityChange);
+      return () => {
+        window.removeEventListener('focus', onFocus);
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      };
+    },
+    [isSessionPersistenceEnabled],
+  );
+
+  // Allow parent UI to request a full reset on alert close
+  useEffect(() => {
+    function onReset() {
+      clearSessionForNewConversation();
+      getToken(
+        setToken,
+        setCode,
+        setLoadingStatus,
+        true,
+        setExpiresAt,
+        setExpired,
+      );
+    }
+    window.addEventListener('va-chatbot-reset', onReset);
+    return () => window.removeEventListener('va-chatbot-reset', onReset);
+  }, []);
+
+  return { token, code, loadingStatus, expired };
 }

--- a/src/applications/virtual-agent/hooks/useDirectline.js
+++ b/src/applications/virtual-agent/hooks/useDirectline.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
-import { getConversationIdKey, getTokenKey } from '../utils/sessionStorage';
+import * as SessionStorage from '../utils/sessionStorage';
 
 const getDirectLineDomain = () =>
   process.env.USE_LOCAL_DIRECTLINE
@@ -18,7 +18,7 @@ export default function useDirectLine(
   tokenOverride,
   freeze = false,
 ) {
-  const token = tokenOverride || getTokenKey();
+  const token = tokenOverride || SessionStorage.getTokenKey();
   const domain = getDirectLineDomain();
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const isSessionPersistenceEnabled = useToggleValue(
@@ -28,13 +28,12 @@ export default function useDirectLine(
   // Always capture the conversationId from the token endpoint so the socket
   // attaches to the correct conversation. Replay remains gated by watermark
   // below.
-  const conversationId = getConversationIdKey();
+  const conversationId = SessionStorage.getConversationIdKey();
 
   const initialOptions = useMemo(
     () => {
       const opts = { token, domain };
-      const useLocal = !!process.env.USE_LOCAL_DIRECTLINE;
-      if (useLocal && isSessionPersistenceEnabled && conversationId) {
+      if (isSessionPersistenceEnabled && conversationId) {
         opts.conversationId = conversationId;
         opts.watermark = '0';
       }

--- a/src/applications/virtual-agent/hooks/useWebChat.js
+++ b/src/applications/virtual-agent/hooks/useWebChat.js
@@ -37,6 +37,7 @@ export default function useWebChat(props, paramLoadingStatus) {
   return {
     token: token.token,
     code: token.code,
+    expired: token.expired,
     webChatFramework: webChatFramework.webChatFramework,
     loadingStatus,
   };

--- a/src/applications/virtual-agent/hooks/useWebChatStore.js
+++ b/src/applications/virtual-agent/hooks/useWebChatStore.js
@@ -1,13 +1,42 @@
-import { useMemo } from 'react';
+import { useEffect, useRef } from 'react';
 import StartConvoAndTrackUtterances from '../utils/startConvoAndTrackUtterances';
 
-export default function useWebChatStore({ createStore, ...params }) {
-  return useMemo(() => {
-    return createStore(
+/**
+ * Create a Web Chat Redux store with middleware wired for Virtual Agent.
+ *
+ * The `freeze` flag is used to temporarily block outbound activities
+ * (e.g., when the token expiry alert is shown). It is passed via a ref
+ * into middleware so we can toggle blocking without re-creating the store.
+ *
+ * @param {Object} params
+ * @param {Function} params.createStore - Factory to create the Web Chat store
+ * @param {boolean} [params.freeze=false] - When true, blocks outbound actions
+ * @returns {import('redux').Store} Configured Web Chat Redux store
+ */
+export default function useWebChatStore({
+  createStore,
+  freeze = false,
+  ...params
+}) {
+  // Keep freeze reactive without recreating the store
+  const freezeRef = useRef(freeze);
+  useEffect(
+    () => {
+      freezeRef.current = freeze;
+    },
+    [freeze],
+  );
+
+  const storeRef = useRef();
+  if (!storeRef.current) {
+    storeRef.current = createStore(
       {},
       StartConvoAndTrackUtterances.makeBotStartConvoAndTrackUtterances({
         ...params,
+        freezeRef,
       }),
     );
-  }, []);
+  }
+
+  return storeRef.current;
 }

--- a/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
@@ -9,6 +9,7 @@ import { createStore } from 'redux';
 import TOGGLE_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import * as RetryOnce from '../../utils/retryOnce';
 import useChatbotToken from '../../hooks/useChatbotToken';
+import { EXPIRY_ALERT_BUFFER_MS } from '../../utils/expiry';
 import { COMPLETE } from '../../utils/loadingStatus';
 
 describe('useChatbotToken', () => {
@@ -71,7 +72,7 @@ describe('useChatbotToken', () => {
       expect(sessionStorage.getItem('va-bot.conversationId')).to.equal('c-new');
     });
 
-    it('should reuse existing token/conversationId and not fetch again', async () => {
+    it('should reuse existing token/conversationId; fetch meta but not overwrite token', async () => {
       // Pre-populate existing values
       sessionStorage.setItem('va-bot.token', 't-existing');
       sessionStorage.setItem('va-bot.conversationId', 'c-existing');
@@ -79,6 +80,8 @@ describe('useChatbotToken', () => {
       const retryStub = sandbox.stub(RetryOnce, 'default').resolves({
         token: 't-should-not-be-used',
         conversationId: 'c-should-not-be-used',
+        code: 'code-meta',
+        expiresIn: 3600,
       });
 
       let result;
@@ -90,12 +93,75 @@ describe('useChatbotToken', () => {
 
       expect(result.result.current.token).to.equal('t-existing');
       expect(result.result.current.loadingStatus).to.equal(COMPLETE);
-      expect(retryStub.called).to.be.false; // no fetch when values exist
-      // Ensure values not overwritten
+      expect(retryStub.called).to.be.true; // meta fetch occurs
+      // Ensure values not overwritten by meta fetch
       expect(sessionStorage.getItem('va-bot.token')).to.equal('t-existing');
       expect(sessionStorage.getItem('va-bot.conversationId')).to.equal(
         'c-existing',
       );
+    });
+
+    it('should set expired=true when within alert buffer window', async () => {
+      // Pre-populate existing values and expiry near buffer threshold
+      sessionStorage.setItem('va-bot.token', 't-existing');
+      sessionStorage.setItem('va-bot.conversationId', 'c-existing');
+      const expiresSoon = Date.now() + EXPIRY_ALERT_BUFFER_MS - 1000;
+      sessionStorage.setItem('va-bot.tokenExpiresAt', String(expiresSoon));
+
+      // Ensure no additional fetch occurs when within buffer
+      const retryStub = sandbox
+        .stub(RetryOnce, 'default')
+        .resolves({ token: 't-new', conversationId: 'c-new' });
+
+      let result;
+      await act(async () => {
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(true),
+        });
+      });
+
+      expect(result.result.current.token).to.equal('t-existing');
+      expect(result.result.current.loadingStatus).to.equal(COMPLETE);
+      expect(result.result.current.expired).to.equal(true);
+      expect(retryStub.called).to.be.false;
+    });
+
+    it('should clear session and fetch new token on va-chatbot-reset', async () => {
+      // Pre-populate existing
+      sessionStorage.setItem('va-bot.token', 't-existing');
+      sessionStorage.setItem('va-bot.conversationId', 'c-existing');
+      sessionStorage.setItem('va-bot.code', 'code-old');
+      sessionStorage.setItem(
+        'va-bot.tokenExpiresAt',
+        String(Date.now() + 300000),
+      );
+
+      const retryStub = sandbox.stub(RetryOnce, 'default').resolves({
+        token: 't-new',
+        conversationId: 'c-new',
+        code: 'code-new',
+        expiresIn: 3600,
+      });
+
+      let result;
+      await act(async () => {
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(true),
+        });
+      });
+      expect(result.result.current.token).to.equal('t-existing');
+
+      // Trigger reset
+      await act(async () => {
+        window.dispatchEvent(new Event('va-chatbot-reset'));
+      });
+
+      // Ensure token fetched and storage updated
+      expect(retryStub.called).to.be.true;
+      expect(sessionStorage.getItem('va-bot.token')).to.equal('t-new');
+      expect(sessionStorage.getItem('va-bot.conversationId')).to.equal('c-new');
+      expect(sessionStorage.getItem('va-bot.code')).to.equal('code-new');
+      expect(result.result.current.token).to.equal('t-new');
     });
 
     it('should run the effect only once on mount (no duplicate fetches)', async () => {
@@ -116,6 +182,94 @@ describe('useChatbotToken', () => {
       });
 
       expect(retryStub.calledOnce).to.be.true;
+    });
+
+    it('should flip expired to true after scheduled timer passes threshold', async () => {
+      // Persistence on with existing token
+      sessionStorage.setItem('va-bot.token', 't-existing');
+      sessionStorage.setItem('va-bot.conversationId', 'c-existing');
+      // Prevent meta fetch (code missing would trigger it)
+      sessionStorage.setItem('va-bot.code', 'code-existing');
+      // Set expiry so alert target is ~50ms from now
+      const now = Date.now();
+      const targetAlertMs = 50; // small, keep test fast
+      const expiresAt = now + EXPIRY_ALERT_BUFFER_MS + targetAlertMs;
+      sessionStorage.setItem('va-bot.tokenExpiresAt', String(expiresAt));
+
+      // No network fetch needed for this scenario
+      sandbox.stub(RetryOnce, 'default').resolves({});
+
+      let result;
+      await act(async () => {
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(true),
+        });
+      });
+
+      // Initially not expired
+      expect(result.result.current.expired).to.equal(false);
+      // Wait beyond the scheduled delay; give buffer for CI
+      await new Promise(res => setTimeout(res, targetAlertMs + 75));
+      // Re-read hook state
+      expect(result.result.current.expired).to.equal(true);
+    });
+
+    it('should set expired=true on focus event after threshold', async () => {
+      sessionStorage.setItem('va-bot.token', 't-existing');
+      sessionStorage.setItem('va-bot.conversationId', 'c-existing');
+      // Prevent meta fetch that would reset expiresAt
+      sessionStorage.setItem('va-bot.code', 'code-existing');
+      const realNow = Date.now();
+      const expiresAt = realNow + EXPIRY_ALERT_BUFFER_MS + 2000; // 2s beyond buffer
+      sessionStorage.setItem('va-bot.tokenExpiresAt', String(expiresAt));
+
+      sandbox.stub(RetryOnce, 'default').resolves({});
+
+      let result;
+      await act(async () => {
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(true),
+        });
+      });
+      expect(result.result.current.expired).to.equal(false);
+
+      // Jump time to after alert threshold using Date.now stub
+      const nowStub = sandbox.stub(Date, 'now').returns(
+        // just after alert target
+        expiresAt - EXPIRY_ALERT_BUFFER_MS + 50,
+      );
+      try {
+        // Trigger focus re-check
+        await act(async () => {
+          window.dispatchEvent(new Event('focus'));
+        });
+        expect(result.result.current.expired).to.equal(true);
+      } finally {
+        nowStub.restore();
+      }
+    });
+
+    it('should set expired=true on connection error event', async () => {
+      // Persistence on
+      sessionStorage.setItem('va-bot.token', 't-existing');
+      sessionStorage.setItem('va-bot.conversationId', 'c-existing');
+      const expiresAtFuture = Date.now() + 10 * 60 * 1000; // far in future
+      sessionStorage.setItem('va-bot.tokenExpiresAt', String(expiresAtFuture));
+
+      sandbox.stub(RetryOnce, 'default').resolves({});
+
+      let result;
+      await act(async () => {
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(true),
+        });
+      });
+      expect(result.result.current.expired).to.equal(false);
+
+      await act(async () => {
+        window.dispatchEvent(new Event('va-chatbot-connection-error'));
+      });
+      expect(result.result.current.expired).to.equal(true);
     });
   });
 });

--- a/src/applications/virtual-agent/tests/hooks/useWebChat.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useWebChat.unit.spec.jsx
@@ -41,6 +41,7 @@ describe('useWebChat', () => {
 
       expect(result).to.deep.equal({
         ...token,
+        expired: token.expired,
         webChatFramework: 'framework',
         loadingStatus: 'combinedStatus',
       });

--- a/src/applications/virtual-agent/tests/utils/expiry.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/utils/expiry.unit.spec.jsx
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import {
+  parseTTLSeconds,
+  shouldShowExpiryAlertAt,
+  getAlertTargetTs,
+  EXPIRY_ALERT_BUFFER_MS,
+} from '../../utils/expiry';
+
+describe('utils/expiry', () => {
+  describe('parseTTLSeconds', () => {
+    it('returns parsed number when valid positive', () => {
+      expect(parseTTLSeconds(3600)).to.equal(3600);
+      expect(parseTTLSeconds('1800')).to.equal(1800);
+    });
+
+    it('falls back to default when invalid or non-positive', () => {
+      expect(parseTTLSeconds(0)).to.equal(3600);
+      expect(parseTTLSeconds(-10)).to.equal(3600);
+      expect(parseTTLSeconds(undefined)).to.equal(3600);
+      expect(parseTTLSeconds('bad')).to.equal(3600);
+    });
+  });
+
+  describe('shouldShowExpiryAlertAt / getAlertTargetTs', () => {
+    it('returns false when expiresAt is nullish', () => {
+      expect(shouldShowExpiryAlertAt(null)).to.equal(false);
+      expect(shouldShowExpiryAlertAt(undefined)).to.equal(false);
+    });
+
+    it('returns false before buffer threshold and true after (using Date.now stub)', () => {
+      const realNow = Date.now();
+      const nowStub = sinon.stub(Date, 'now').returns(realNow);
+      try {
+        const expiresAt = realNow + EXPIRY_ALERT_BUFFER_MS + 50; // 50ms past the buffer window
+        // Before the alert threshold
+        expect(shouldShowExpiryAlertAt(expiresAt)).to.equal(false);
+
+        // Jump to just after the alert threshold
+        const afterThreshold = getAlertTargetTs(expiresAt) + 75;
+        nowStub.returns(afterThreshold);
+        expect(shouldShowExpiryAlertAt(expiresAt)).to.equal(true);
+      } finally {
+        nowStub.restore();
+      }
+    });
+  });
+});

--- a/src/applications/virtual-agent/tests/utils/startConvoAndTrackUtterances.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/utils/startConvoAndTrackUtterances.unit.spec.jsx
@@ -127,5 +127,59 @@ describe('startConvoAndTrackUtterances', () => {
       expect(processSendMessageActivityStub.notCalled).to.be.true;
       expect(nextSpy.calledOnce).to.be.true;
     });
+
+    it('should block WEB_CHAT/SEND_MESSAGE when frozen (no processing, no next)', async () => {
+      const store = { dispatch: 'fake-dispatch' };
+      const nextSpy = sinon.spy();
+      const action = { type: 'WEB_CHAT/SEND_MESSAGE' };
+
+      const processSendMessageActivityStub = sandbox.spy();
+      sandbox
+        .stub(
+          ActionHelpersModule,
+          ActionHelpersModule.processSendMessageActivity.name,
+        )
+        .returns(processSendMessageActivityStub);
+
+      const addActivityDataSpy = sandbox.spy(
+        ActionHelpersModule,
+        'addActivityData',
+      );
+
+      await StartConvoAndTrackUtterances.makeBotStartConvoAndTrackUtterances({
+        freezeRef: { current: true },
+      })(store)(nextSpy)(action);
+
+      expect(processSendMessageActivityStub.notCalled).to.be.true;
+      expect(addActivityDataSpy.notCalled).to.be.true;
+      expect(nextSpy.notCalled).to.be.true;
+    });
+
+    it('should block DIRECT_LINE/POST_ACTIVITY when frozen (no processing, no next)', async () => {
+      const store = { dispatch: 'fake-dispatch' };
+      const nextSpy = sinon.spy();
+      const action = { type: 'DIRECT_LINE/POST_ACTIVITY' };
+
+      const processIncomingActivityStub = sandbox.spy();
+      sandbox
+        .stub(
+          ActionHelpersModule,
+          ActionHelpersModule.processIncomingActivity.name,
+        )
+        .returns(processIncomingActivityStub);
+
+      const addActivityDataSpy = sandbox.spy(
+        ActionHelpersModule,
+        'addActivityData',
+      );
+
+      await StartConvoAndTrackUtterances.makeBotStartConvoAndTrackUtterances({
+        freezeRef: { current: true },
+      })(store)(nextSpy)(action);
+
+      expect(processIncomingActivityStub.notCalled).to.be.true;
+      expect(addActivityDataSpy.notCalled).to.be.true;
+      expect(nextSpy.notCalled).to.be.true;
+    });
   });
 });

--- a/src/applications/virtual-agent/utils/actionTypes.js
+++ b/src/applications/virtual-agent/utils/actionTypes.js
@@ -1,0 +1,14 @@
+// Action type constants to avoid magic strings and enable reuse across middleware
+// These values mirror the BotFramework Web Chat and DirectLine Redux action types.
+
+/** Web Chat: dispatched when user sends a message */
+export const WEB_CHAT_SEND_MESSAGE = 'WEB_CHAT/SEND_MESSAGE';
+
+/** Direct Line: dispatched when posting any activity to the bot */
+export const DIRECT_LINE_POST_ACTIVITY = 'DIRECT_LINE/POST_ACTIVITY';
+
+/** Direct Line: connection established */
+export const DIRECT_LINE_CONNECT_FULFILLED = 'DIRECT_LINE/CONNECT_FULFILLED';
+
+/** Direct Line: incoming activity received */
+export const DIRECT_LINE_INCOMING_ACTIVITY = 'DIRECT_LINE/INCOMING_ACTIVITY';

--- a/src/applications/virtual-agent/utils/expiry.js
+++ b/src/applications/virtual-agent/utils/expiry.js
@@ -1,0 +1,30 @@
+// Expiry helpers for chatbot token handling
+// Centralizes TTL parsing and alert-threshold calculations
+
+export const DEFAULT_TTL_SECONDS = 3600; // 1 hour
+export const EXPIRY_ALERT_BUFFER_MS = 2 * 60 * 1000; // 2 minutes
+
+/**
+ * Parse a TTL value (in seconds) from the backend.
+ * Falls back to DEFAULT_TTL_SECONDS when invalid.
+ */
+export function parseTTLSeconds(rawTtl) {
+  const n = Number(rawTtl);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TTL_SECONDS;
+}
+
+/**
+ * Compute the timestamp at which we should show the expiry alert.
+ * This is the token expiry minus a buffer to avoid racing with expiry.
+ */
+export function getAlertTargetTs(expiresAt) {
+  return expiresAt ? expiresAt - EXPIRY_ALERT_BUFFER_MS : null;
+}
+
+/**
+ * Determine if the expiry alert should be shown at the current moment.
+ */
+export function shouldShowExpiryAlertAt(expiresAt) {
+  const target = getAlertTargetTs(expiresAt);
+  return target !== null && Date.now() >= target;
+}

--- a/src/applications/virtual-agent/utils/sessionStorage.js
+++ b/src/applications/virtual-agent/utils/sessionStorage.js
@@ -6,6 +6,8 @@ const CONVERSATION_ID_KEY = `${BOT_SESSION_PREFIX}conversationId`;
 const IS_TRACKING_UTTERANCES = `${BOT_SESSION_PREFIX}isTrackingUtterances`;
 const TOKEN_KEY = `${BOT_SESSION_PREFIX}token`;
 const CODE_KEY = `${BOT_SESSION_PREFIX}code`;
+const TOKEN_EXPIRES_AT = `${BOT_SESSION_PREFIX}tokenExpiresAt`;
+const CONVERSATION_TOKEN_KEY = `${BOT_SESSION_PREFIX}conversationToken`;
 const FIRST_CONNECTION = `${BOT_SESSION_PREFIX}firstConnection`;
 const SKILL_EVENT_VALUE = `${BOT_SESSION_PREFIX}skillEventValue`;
 
@@ -19,7 +21,13 @@ function setStorageItem(key, value, json = false) {
 
 function getStorageItem(key, json = false) {
   if (json) {
-    return JSON.parse(sessionStorage.getItem(key));
+    const raw = sessionStorage.getItem(key);
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw);
+    } catch (e) {
+      return null;
+    }
   }
   return sessionStorage.getItem(key);
 }
@@ -88,6 +96,23 @@ export function setCodeKey(value) {
   setStorageItem(CODE_KEY, value);
 }
 
+export function getTokenExpiresAt() {
+  const val = getStorageItem(TOKEN_EXPIRES_AT);
+  return val ? Number(val) : null;
+}
+
+export function setTokenExpiresAt(value) {
+  setStorageItem(TOKEN_EXPIRES_AT, String(value));
+}
+
+export function getConversationTokenKey() {
+  return getStorageItem(CONVERSATION_TOKEN_KEY);
+}
+
+export function setConversationTokenKey(value) {
+  setStorageItem(CONVERSATION_TOKEN_KEY, value);
+}
+
 // First-connection helpers removed; key is still used to preserve the flag during session clears for backward compatibility
 
 export function clearBotSessionStorage(forceClear) {
@@ -107,6 +132,8 @@ export function clearBotSessionStorage(forceClear) {
     CONVERSATION_ID_KEY,
     TOKEN_KEY,
     CODE_KEY,
+    TOKEN_EXPIRES_AT,
+    CONVERSATION_TOKEN_KEY,
   ];
 
   // capture the canceled login scenarios [issue #479]

--- a/src/applications/virtual-agent/utils/startConvoAndTrackUtterances.js
+++ b/src/applications/virtual-agent/utils/startConvoAndTrackUtterances.js
@@ -4,7 +4,26 @@ import {
   processIncomingActivity,
   addActivityData,
 } from './actions';
+import {
+  WEB_CHAT_SEND_MESSAGE,
+  DIRECT_LINE_POST_ACTIVITY,
+  DIRECT_LINE_CONNECT_FULFILLED,
+  DIRECT_LINE_INCOMING_ACTIVITY,
+} from './actionTypes';
 
+/**
+ * Middleware factory for Virtual Agent Web Chat behavior.
+ *
+ * When `freezeRef.current` is true (e.g., token-expiry alert is open), this
+ * middleware blocks outbound activities to preserve the transcript while
+ * preventing new messages/events from being sent to the bot. Specifically it
+ * blocks:
+ * - WEB_CHAT/SEND_MESSAGE
+ * - DIRECT_LINE/POST_ACTIVITY
+ *
+ * The `freezeRef` is a mutable ref passed from useWebChatStore, allowing the
+ * UI to toggle blocking without recreating the Redux store or middleware.
+ */
 const StartConvoAndTrackUtterances = {
   makeBotStartConvoAndTrackUtterances: event => ({
     dispatch,
@@ -15,10 +34,20 @@ const StartConvoAndTrackUtterances = {
       ...event,
     };
 
+    // When frozen (expiry alert shown), prevent any new outbound messages or events
+    if (
+      options.freezeRef &&
+      options.freezeRef.current &&
+      (action.type === WEB_CHAT_SEND_MESSAGE ||
+        action.type === DIRECT_LINE_POST_ACTIVITY)
+    ) {
+      return undefined;
+    }
+
     const processActionType = {
-      'DIRECT_LINE/CONNECT_FULFILLED': processActionConnectFulfilled(options),
-      'DIRECT_LINE/INCOMING_ACTIVITY': processIncomingActivity(options),
-      'WEB_CHAT/SEND_MESSAGE': processSendMessageActivity(options),
+      [DIRECT_LINE_CONNECT_FULFILLED]: processActionConnectFulfilled(options),
+      [DIRECT_LINE_INCOMING_ACTIVITY]: processIncomingActivity(options),
+      [WEB_CHAT_SEND_MESSAGE]: processSendMessageActivity(options),
     };
 
     const canProcessAction = processActionType[action.type];


### PR DESCRIPTION
# PR Title

Chatbot token expiry: dismissible alert with chat freeze, 2‑min buffer, deferred refresh, and comprehensive tests

# PR Description

## What & Why
- **What**: Implement a user-dismissible token expiry alert that freezes the chat (blocks sending) but preserves the transcript until the user dismisses the alert; then clears stale session state and restarts fresh.
- **Why**: Prevent Direct Line 404s and stale-token errors, avoid premature reloads, and align with site-wide SSO TTL by alerting early and deferring refresh until user intent.

## UX/Behavior
- **Alert timing**: Shown 2 minutes (120,000 ms) before token expiration.
- **While alert is visible**:
  - Transcript remains visible.
  - Sending new messages is blocked (middleware freeze gating).
  - No auto-refresh or page reload is triggered.
- **On alert dismiss**:
  - All chatbot session storage keys are cleared and re-fetched to prevent stale data.
  - Chat is remounted with a fresh token and new conversation.

## Technical Changes
- **Hooks**
  - [useChatbotToken.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useChatbotToken.js:0:0-0:0)
    - Added early-alert buffer logic and scheduling.
    - Deferred token refresh until `va-chatbot-reset` triggered by alert dismissal.
    - Robust session storage interactions; no auto-refresh within buffer.
    - Listeners for `va-chatbot-connection-error` and `va-chatbot-reset`.
  - [useDirectline.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useDirectline.js:0:0-0:0)
    - Respect `freeze`: do not swap instances on connection error while frozen.
    - Dispatch `va-chatbot-connection-error` on status=4; create fallback instance only if not frozen.
  - [useWebChatStore.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useWebChatStore.js:0:0-0:0)
    - Pass `freezeRef` into middleware to gate outbound actions without recreating the store.
- **Components**
  - [App.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/components/App.jsx:0:0-0:0)
    - Removed route-scoped SSO suppression/keep-alive logic.
    - Dismissible alert drives `va-chatbot-reset` and remount.
  - [WebChat.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/components/WebChat.jsx:0:0-0:0)
    - Accepts `freeze` prop; passes through to store/middleware; preserves transcript.
- **Utils**
  - [utils/expiry.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/expiry.js:0:0-0:0)
    - New helpers: [parseTTLSeconds](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useChatbotToken.js:20:0-24:1), [getAlertTargetTs](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useChatbotToken.js:26:0-28:1), [shouldShowExpiryAlertAt](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useChatbotToken.js:30:0-33:1), plus TTL/alert buffer constants.
  - [utils/sessionStorage.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:0:0-0:0)
    - Safe JSON parsing; return `null` for malformed JSON instead of throwing.
  - [utils/actionTypes.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/actionTypes.js:0:0-0:0)
    - Action constants for Web Chat/DirectLine:
      - `WEB_CHAT/SEND_MESSAGE`
      - `DIRECT_LINE/POST_ACTIVITY`
      - `DIRECT_LINE/CONNECT_FULFILLED`
      - `DIRECT_LINE/INCOMING_ACTIVITY`
  - [utils/startConvoAndTrackUtterances.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/startConvoAndTrackUtterances.js:0:0-0:0)
    - Middleware gates outbound `SEND_MESSAGE` and `POST_ACTIVITY` when `freezeRef.current` is true.
    - JSDoc clarifying freeze behavior and purpose.
- **Session Storage keys cleared on dismiss**
  - `va-bot.token`
  - `va-bot.conversationId`
  - `va-bot.code`
  - `va-bot.tokenExpiresAt`
  - `va-bot.recentUtterances`
  - `va-bot.isTrackingUtterances`
  - `va-bot.skillEventValue`
  - `va-bot.conversationToken`

## Tests
- **New/updated unit tests**
  - [tests/utils/expiry.unit.spec.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/tests/utils/expiry.unit.spec.jsx:0:0-0:0): expiry helpers with stable `Date.now` stubs.
  - [tests/hooks/useChatbotToken.unit.spec.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx:0:0-0:0):
    - Timer-driven early expiry alert.
    - Focus re-check path.
    - Connection error event handling (no auto-refresh while frozen).
    - Reset event clearing and fresh boot.
    - No auto-refresh within buffer window.
  - [tests/utils/startConvoAndTrackUtterances.unit.spec.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/tests/utils/startConvoAndTrackUtterances.unit.spec.jsx:0:0-0:0):
    - Freeze gating blocks `WEB_CHAT/SEND_MESSAGE`.
    - Freeze gating blocks `DIRECT_LINE/POST_ACTIVITY`.
- **Stability improvements**
  - Replaced sinon fake timers with `Date.now` stubs to avoid JSDOM issues.
  - Pre-populated `code` to ensure meta fetch does not unexpectedly reset `expiresAt` during timing tests.

## How to Test Manually
1. Start the app and open the Virtual Agent.
2. Shorten token TTL in a test environment or mock expiry to be within the next few minutes.
3. Observe:
   - Alert appears ~2 minutes before expiry.
   - Transcript remains visible; sending is disabled.
4. Click “Dismiss”/Close on the alert:
   - Session storage keys listed above are cleared.
   - New token is fetched and chat remounts; sending is enabled again.
5. Simulate a Direct Line connection error:
   - While frozen, instance does not swap; `va-chatbot-connection-error` is dispatched for the hook to handle.

## Risk & Rollback
- **Risk**: Low. Feature is self-contained to Virtual Agent. Freeze only gates outbound actions.
- **Rollback**: Revert this PR; previous non-freeze behavior restored.

## Accessibility
- Alert is user-dismissible and non-blocking to reading the transcript.
- No keyboard traps; chat input disabled while frozen.

## Follow-ups (optional)
- Track alert display and dismiss events for analytics (if desired).
- Consider UX copy refinements for expiry messaging.

## Checklist
- [x] Dismissible alert with early buffer
- [x] Chat freeze gating blocks outbound messages
- [x] No auto-refresh or reload on expiry/connection error
- [x] Full session storage reset on dismiss
- [x] Comprehensive unit tests
- [x] JSDoc added for freeze and middleware