### PR TITLE
Removes mhvMedicationsDisplayGrouping feature toggle

### DIFF
--- a/src/platform/mhv/api/mocks/feature-toggles/index.js
+++ b/src/platform/mhv/api/mocks/feature-toggles/index.js
@@ -6,7 +6,6 @@ const generateFeatureToggles = (toggles = {}) => {
     // medications
     mhvMedicationsDisplayDocumentationContent = true,
     mhvMedicationsDisplayFilter = true,
-    mhvMedicationsDisplayGrouping = true,
     mhvMedicationsDisplayPendingMeds = true,
     mhvMedicationsDisplayRefillProgress = true,
     mhvMedicationsPartialFillContent,
@@ -86,10 +85,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medications_display_filter',
           value: mhvMedicationsDisplayFilter,
-        },
-        {
-          name: 'mhv_medications_display_grouping',
-          value: mhvMedicationsDisplayGrouping,
         },
         {
           name: 'mhv_medications_display_pending_meds',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -181,7 +181,6 @@
   "mhvMedicationsDisplayAllergies": "mhv_medications_display_allergies",
   "mhvMedicationsDisplayDocumentationContent": "mhv_medications_display_documentation_content",
   "mhvMedicationsDisplayFilter": "mhv_medications_display_filter",
-  "mhvMedicationsDisplayGrouping": "mhv_medications_display_grouping",
   "mhvMedicationsDisplayRefillContent": "mhv_medications_display_refill_content",
   "mhvMedicationsDisplayPendingMeds": "mhv_medications_display_pending_meds",
   "mhvMedicationsDisplayRefillProgress": "mhv_medications_display_refill_progress",


### PR DESCRIPTION
After removal, no instances of `mhvMedicationsDisplayGrouping` or `mhv_medications_display_grouping` are found in vets-website or vets-api