### PR TITLE
arp/fix_flakey_character_references_test_time_stamp

### DIFF
--- a/src/applications/accreditation/21a/tests/e2e/21a-character-references.cypress.spec.js
+++ b/src/applications/accreditation/21a/tests/e2e/21a-character-references.cypress.spec.js
@@ -64,7 +64,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'seedUserWith21aSIP',
   (returnUrlRel = '/character-references') => {
-    const nowSec = Math.floor(Date.now() / 1000);
+    const nowSec = 4918241875; // Fixed timestamp: 2125-11-07 00:00:00 UTC
     cy.intercept('GET', '/accredited_representative_portal/v0/user', {
       statusCode: 200,
       headers: { 'cache-control': 'no-store' },
@@ -108,7 +108,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'stub21aFormDataExact',
   (returnUrlRel = '/character-references') => {
-    const nowSec = Math.floor(Date.now() / 1000);
+    const nowSec = 4918241875; // Fixed timestamp: 2125-11-07 00:00:00 UTC
     const nowMs = nowSec * 1000;
 
     cy.intercept(


### PR DESCRIPTION
## Summary

- Copilot prefers a hardcoded date. It doesn't like in the past so I made it 100 years in the future

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116777

## Testing done

- tried tests locally

## Screenshots

n/a

## What areas of the site does it impact?

representative/accreditation/attorney-claims-agent-form-21a/

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
