### PR TITLE
Dbc/confirmation page.retirement pay

### DIFF
--- a/src/applications/disability-benefits/all-claims/local-dev-mock-api/formData2.json
+++ b/src/applications/disability-benefits/all-claims/local-dev-mock-api/formData2.json
@@ -113,7 +113,7 @@
         ],
         "view:newDisabilityErrors": {},
         "hasTrainingPay": false,
-        "view:hasMilitaryRetiredPay": false,
+        "hasMilitaryRetiredPay": false,
         "hasSeparationPay": false,
         "serviceInformation": {
             "servicePeriods": [

--- a/src/applications/disability-benefits/all-claims/migrations/11-update-hasMilitaryRetiredPay.js
+++ b/src/applications/disability-benefits/all-claims/migrations/11-update-hasMilitaryRetiredPay.js
@@ -1,0 +1,18 @@
+const oldPropertyName = 'view:hasMilitaryRetiredPay';
+const newPropertyName = 'hasMilitaryRetiredPay';
+
+const update = formData => {
+  /* eslint-disable no-param-reassign */
+  if (!(oldPropertyName in formData)) return;
+
+  if (!(newPropertyName in formData))
+    formData[newPropertyName] = formData[oldPropertyName];
+
+  delete formData[oldPropertyName];
+  /* eslint-enable no-param-reassign */
+};
+
+export default savedData => {
+  update(savedData.formData);
+  return savedData;
+};

--- a/src/applications/disability-benefits/all-claims/migrations/index.js
+++ b/src/applications/disability-benefits/all-claims/migrations/index.js
@@ -8,6 +8,7 @@ import mapServiceBranches from './07-map-service-branches';
 import reorderHousingIllnessRemoveFdc from './08-paper-sync';
 import addDisabilitiesRedirect from './09-addDisabilities-redirect';
 import addDisabilitiesRedirectAdd3 from './10-addDisabilities-redirect-add-3';
+import updateHasMilitaryRetiredPay from './11-update-hasMilitaryRetiredPay';
 
 // We launched at version 1 and not version 0, so the first _real_ migration is at
 //  migrations[1]
@@ -26,6 +27,7 @@ const migrations = [
   reorderHousingIllnessRemoveFdc,
   addDisabilitiesRedirect,
   addDisabilitiesRedirectAdd3,
+  updateHasMilitaryRetiredPay,
 ];
 
 export default migrations;

--- a/src/applications/disability-benefits/all-claims/pages/retirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/retirementPay.js
@@ -1,4 +1,6 @@
 import set from 'platform/utilities/data/set';
+import { yesNoUI } from 'platform/forms-system/src/js/web-component-patterns';
+
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { hasMilitaryRetiredPay } from '../validations';
 import { getBranches } from '../utils/serviceBranches';
@@ -8,16 +10,23 @@ const {
 } = fullSchema.properties;
 
 export const uiSchema = {
-  'view:hasMilitaryRetiredPay': {
-    'ui:title': 'Have you ever received military retirement pay?',
-    'ui:widget': 'yesNo',
-    'ui:options': {},
-  },
+  /**
+   * Local-only UX field. It mirrors `militaryRetiredPayBranch`:
+   *   - no branch ⇔ "no"
+   *   - any branch ⇔ "yes"
+   *
+   * We avoid making this a `view:` field because the confirmation page hides
+   * all `view:` fields and we want it visible there. The field is removed
+   * before submission upstream.
+   */
+  hasMilitaryRetiredPay: yesNoUI({
+    title: 'Have you ever received military retirement pay?',
+  }),
   militaryRetiredPayBranch: {
     'ui:title':
       'Please choose the branch of service that gave you military retired pay ',
     'ui:options': {
-      expandUnder: 'view:hasMilitaryRetiredPay',
+      expandUnder: 'hasMilitaryRetiredPay',
       updateSchema: (_formData, schema) => {
         if (!schema.enum?.length) {
           const options = getBranches();
@@ -32,9 +41,9 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
-  required: ['view:hasMilitaryRetiredPay'],
+  required: ['hasMilitaryRetiredPay'],
   properties: {
-    'view:hasMilitaryRetiredPay': {
+    hasMilitaryRetiredPay: {
       type: 'boolean',
     },
     militaryRetiredPayBranch: militaryRetiredPayBranchSchema,

--- a/src/applications/disability-benefits/all-claims/reviewErrors.js
+++ b/src/applications/disability-benefits/all-claims/reviewErrors.js
@@ -18,7 +18,7 @@ export default {
       index + 1,
     )} section, enter a condition or select one from the list)`,
   cause: 'What caused this condition? (select from the list of causes)',
-  'view:hasMilitaryRetiredPay':
+  hasMilitaryRetiredPay:
     'Have you ever received military retirement pay? (select yes or no)',
   hasTrainingPay:
     'Do you expect to receive active or inactive duty training pay? (select yes or no)',

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -264,6 +264,13 @@ export function transform(formConfig, form) {
     return formData;
   };
 
+  const removeRedundantRetirementPayQuestion = formData => {
+    /* eslint-disable no-param-reassign */
+    delete formData.hasMilitaryRetiredPay;
+    /* eslint-enable no-param-reassign */
+    return formData;
+  };
+
   // End transformation definitions
 
   // Apply the transformations
@@ -294,6 +301,7 @@ export function transform(formConfig, form) {
     addForm8940,
     addFileAttachments,
     fullyDevelopedClaim,
+    removeRedundantRetirementPayQuestion,
   ].reduce(
     (formData, transformer) => transformer(formData),
     _.cloneDeep(form.data),

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -9,6 +9,7 @@
     "isVaEmployee": true,
     "isTerminallyIll": false,
     "homelessOrAtRisk": "homeless",
+    "hasMilitaryRetiredPay": false,
     "view:isHomeless": {
       "homelessHousingSituation": "other",
       "otherHomelessHousing": "Under a bridge",

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-skip-781.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-skip-781.json
@@ -20,7 +20,7 @@
     }],
     "view:newDisabilityErrors": {},
     "hasTrainingPay": false,
-    "view:hasMilitaryRetiredPay": false,
+    "hasMilitaryRetiredPay": false,
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": false,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/newOnly-test.json
@@ -30,7 +30,7 @@
     "view:powStatus": false,
     "view:disabilitiesClarification": {},
     "hasTrainingPay": true,
-    "view:hasMilitaryRetiredPay": true,
+    "hasMilitaryRetiredPay": true,
     "militaryRetiredPayBranch": "Air Force",
     "hasSeparationPay": true,
     "view:separationPayDetails": {

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.jsx
@@ -9,6 +9,7 @@ import mapServiceBranches from '../../migrations/07-map-service-branches';
 import reorderHousingIllnessRemoveFdc from '../../migrations/08-paper-sync';
 import addDisabilitiesRedirect from '../../migrations/09-addDisabilities-redirect';
 import addDisabilitiesRedirectAdd3 from '../../migrations/10-addDisabilities-redirect-add-3';
+import updateHasMilitaryRetiredPay from '../../migrations/11-update-hasMilitaryRetiredPay';
 
 import formConfig from '../../config/form';
 import { MAX_HOUSING_STRING_LENGTH } from '../../constants';
@@ -367,6 +368,17 @@ describe('526 v2 migrations', () => {
       expect(migratedData.metadata.returnUrl).to.equal(
         '/new-disabilities/follow-up',
       );
+    });
+  });
+
+  describe('11-update-hasMilitaryRetiredPay', () => {
+    it('should migrate view:hasMilitaryRetiredPay to hasMilitaryRetiredPay', () => {
+      const data = updateHasMilitaryRetiredPay({
+        formData: { 'view:hasMilitaryRetiredPay': true, test: true },
+        metadata: { version: 1 },
+      });
+      expect(data.formData['view:hasMilitaryRetiredPay']).to.be.undefined;
+      expect(data.formData.hasMilitaryRetiredPay).to.be.true;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
@@ -24,7 +24,8 @@ describe('Retirement Pay', () => {
       />,
     );
 
-    expect(form.find('input[type="radio"]').length).to.equal(2);
+    expect(form.find('VaRadio').length).to.equal(1);
+    expect(form.find('va-radio-option').length).to.equal(2);
     form.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('Retirement Pay', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
-        data={{ 'view:hasMilitaryRetiredPay': false }}
+        data={{ hasMilitaryRetiredPay: false }}
         formData={{}}
         onSubmit={onSubmit}
       />,
@@ -55,7 +55,7 @@ describe('Retirement Pay', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
-        data={{ 'view:hasMilitaryRetiredPay': true }}
+        data={{ hasMilitaryRetiredPay: true }}
         formData={{}}
         onSubmit={onSubmit}
       />,
@@ -78,7 +78,7 @@ describe('Retirement Pay', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          'view:hasMilitaryRetiredPay': true,
+          hasMilitaryRetiredPay: true,
           militaryRetiredPayBranch: 'Army',
         }}
         formData={{}}

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx
@@ -26,7 +26,6 @@ import {
   title10BeforeRad,
   validateTitle10StartDate,
   requireRatedDisability,
-  hasTrainingPay,
   isValidZIP,
   validateZIP,
   limitNewDisabilities,
@@ -40,19 +39,6 @@ const formatDate = date => format(date, 'yyyy-MM-dd');
 const daysFromToday = days => formatDate(add(new Date(), { days }));
 
 describe('526 All Claims validations', () => {
-  describe('hasTrainingPay', () => {
-    it('returns true when form data has training pay', () => {
-      const formData = {
-        'view:hasTrainingPay': true,
-      };
-      expect(hasTrainingPay(formData)).to.be.true;
-    });
-
-    it('returns false when form data does not have training pay', () => {
-      expect(hasTrainingPay({})).to.be.false;
-    });
-  });
-
   describe('isValidZIP', () => {
     it('returns true for valid 5 digit zip', () => {
       expect(isValidZIP(12345)).to.be.true;

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -37,13 +37,6 @@ export const hasMilitaryRetiredPay = data =>
   _.get('hasMilitaryRetiredPay', data, false);
 
 /**
- * Checks if the user expects to receive training pay
- * @param {Object} data - Form data
- * @returns true if the user expects to receive training pay, false otherwise
- */
-export const hasTrainingPay = data => _.get('view:hasTrainingPay', data, false);
-
-/**
  * Checks if a zip code is in a valid 5 or 9 digit format
  * @param {string} value - Zip code
  * @returns true if the zip code is in a valid format, false otherwise

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -34,7 +34,7 @@ import {
  * @returns true if the user has received military retired pay, false otherwise
  */
 export const hasMilitaryRetiredPay = data =>
-  _.get('view:hasMilitaryRetiredPay', data, false);
+  _.get('hasMilitaryRetiredPay', data, false);
 
 /**
  * Checks if the user expects to receive training pay


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/122800

```js
/**
* Local-only UX field. It mirrors `militaryRetiredPayBranch`:
*   - no branch ⇔ "no"
*   - any branch ⇔ "yes"
*
* We avoid making this a `view:` field because the confirmation page hides
* all `view:` fields and we want it visible there. The field is removed
* before submission upstream.
*/
```

Also, note that a form migration is added so that the corresponding prior in-progress form state doesn't stop getting represented in the client-side form state. That lifecycle was tested manually locally.

Another note: I don't see that there is a great place to exercise lots of the details of confirmation page appearance. In particular, I don't have a test that makes any assertion about the bug that I fixed! Potentially we could make a component spec that renders an unwrapped `ChapterSectionCollection`. Or maybe just put more of this testing in the `ConfirmationPage` spec? Should we ignore it for now?