### PR TITLE
Pension - Disable introduction page disability rating alert

### DIFF
--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
-import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import DisabilityRatingAlert from './DisabilityRatingAlert';
 import { FormReactivationAlert } from './FormAlerts';
 
 const IntroductionPage = props => {
   const { route } = props;
   const { formConfig, pageList } = route;
-  const loggedIn = useSelector(isLoggedIn);
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const pbbFormsRequireLoa3 = useToggleValue(TOGGLE_NAMES.pbbFormsRequireLoa3);
@@ -22,7 +18,6 @@ const IntroductionPage = props => {
         title="Apply for Veterans Pension benefits"
         subTitle="Application for Veterans Pension (VA Form 21P-527EZ)"
       />
-      {loggedIn && <DisabilityRatingAlert />}
       <p className="va-introtext">
         Use our online tool to fill out and submit your application for Veterans
         Pension benefits. If you’re a wartime Veteran and you’re at least 65

--- a/src/applications/pensions/tests/e2e/pensions-disability-rating.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions-disability-rating.cypress.spec.js
@@ -56,7 +56,7 @@ const cypressSetup = ({
   cy.visit(TEST_URL);
 };
 
-describe('Pensions — Disability Rating Alert', () => {
+describe.skip('Pensions — Disability Rating Alert', () => {
   before(() => {
     cypressBeforeAllSetup();
   });


### PR DESCRIPTION
### Summary of Changes
This update removes the **Disability Rating Alert** from the **Introduction** page of the Pension Benefits (21P-527EZ) form. The alert has been temporarily removed from **all environments** until it is approved by VBA for production.  
Additionally, associated Cypress tests have been skipped to prevent test failures while the alert is disabled.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118306

### How to Set Up in Local Environment
1. Enable form via feature toggle
2. Run the local environment
3. Navigate to the Pension Benefits form:  
   http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/introduction

### How to Test
1. Go to the **Introduction** page for the Pension Benefits form.  
2. Verify that the **Disability Rating Alert** is **no longer displayed**.
3. Verify there isn't a network call for authenticated users
4. Confirm that there are no layout or accessibility regressions.  
5. Run Cypress tests and confirm that the skipped tests related to the alert do not block other suites.

### Feature Flag Note
- No feature flags are required. This update applies globally across environments.

### Acceptance Criteria
- [ ] Disability Rating Alert is removed from the Introduction page.  
- [ ] Cypress tests related to the alert are skipped.  
- [ ] No console warnings or accessibility regressions.  
- [ ] Verified in local and staging environments.

### Definition of Done
- [ ] Code reviewed and approved.  
- [ ] Verified in all environments.  
- [ ] All tests pass or are intentionally skipped as part of this change.  
- [ ] Change coordinated with VBA approval timeline.
