### PR TITLE
[CVE-2135] record tsa letter downloads

### DIFF
--- a/src/applications/letters/components/DownloadTsaLetter.jsx
+++ b/src/applications/letters/components/DownloadTsaLetter.jsx
@@ -83,6 +83,11 @@ export const DownloadTsaLetter = ({ letter }) => {
 
   const loading = !hasFetched;
   const letterTitle = 'TSA PreCheck Application Fee Waiver Letter';
+  const handleClick = () =>
+    recordEvent({
+      event: 'letter-download',
+      'letter-type': letterTitle,
+    });
 
   return (
     <va-accordion-item key="tsa-letter" ref={ref}>
@@ -112,6 +117,7 @@ export const DownloadTsaLetter = ({ letter }) => {
             filename={`${letterTitle}.pdf`}
             text={`Download ${letterTitle}`}
             download
+            onClick={handleClick}
           />
         </div>
       )}

--- a/src/applications/letters/tests/components/DownloadTsaLetter.unit.spec.jsx
+++ b/src/applications/letters/tests/components/DownloadTsaLetter.unit.spec.jsx
@@ -212,4 +212,25 @@ describe('DownloadTsaLetter', () => {
     accordion.setAttribute('open', '');
     expect(apiRequestStub.calledOnce).to.be.true;
   });
+
+  it('records download event when link is clicked', async () => {
+    apiRequestStub.resolves(mockResponse);
+    const { container } = render(<DownloadTsaLetter letter={mockLetter} />);
+    const accordion = container.querySelector('va-accordion-item');
+    accordion.setAttribute('open', '');
+    if (observerCallback) {
+      observerCallback();
+    }
+    await waitFor(() => {
+      expect(apiRequestStub.calledOnce).to.be.true;
+    });
+    const link = container.querySelector('va-link');
+    link.click();
+    expect(
+      recordEventStub.calledWith({
+        event: 'letter-download',
+        'letter-type': 'TSA PreCheck Application Fee Waiver Letter',
+      }),
+    ).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary

- _Records event when TSA letter is downloaded_

## Related issue(s)

- _https://github.com/department-of-veterans-affairs/va-iir/issues/2135_


## Testing done

- _Added unit test_


## What areas of the site does it impact?

Unit tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
