### PR TITLE
118766 - flipper dependent truncation - goes with removal of details and clinic info/location

### DIFF
--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
@@ -226,7 +226,13 @@ export default function AppointmentColumnLayout({
                       />
                     </span>
                   )}
-                  <span>{modalityText}</span>
+                  <span
+                    className={classNames({
+                      'vaos-appts__text--truncate': !featureListViewClinicInfo,
+                    })}
+                  >
+                    {modalityText}
+                  </span>
                 </span>
               </AppointmentColumn>
             </AppointmentRow>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Puts the removal of truncate behind the flipper
- Flipper used: `vaOnlineSchedulingListViewClinicInfo`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118766

## Testing done

- Tested locally with mock data for flipper on/off

## Screenshots

**flipper on - wrapped facility**
<img width="529" height="259" alt="Screenshot 2025-11-10 at 12 26 38 PM" src="https://github.com/user-attachments/assets/f5ec2ee8-05d9-4bf1-a885-a46fc23d1816" />

**flipper off - truncated facility**
<img width="535" height="218" alt="Screenshot 2025-11-10 at 12 27 04 PM" src="https://github.com/user-attachments/assets/d7b957c4-e0d6-4502-a04e-478efaa130c2" />


## What areas of the site does it impact?

Upcoming/Past appointments (requests was already behind the flipper)

## Acceptance criteria

1. When flipper off no change from prior state (shows details link, facility shows truncated with icon in line, clinic info/location not shown)
2. When flipper on Does not show details link, facility is wrapped, icon in line with first line, clinic info/location shown when available

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check upcoming/past appointments list with mocks or other data to show state when flipper on/off matches ACs.