### PR TITLE
120142 - [ADE] 508 Audit Report for Digital Debt Dispute - 9/18/2025 (2 of 2)

### DIFF
--- a/src/applications/dispute-debt/components/DebtReviewPage.jsx
+++ b/src/applications/dispute-debt/components/DebtReviewPage.jsx
@@ -1,10 +1,14 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { currency } from '../utils';
+import { currency, setDocumentTitle } from '../utils';
 import { deductionCodes } from '../constants';
 
 const DebtReviewPage = ({ data, pagePerItemIndex, name, goToPath }) => {
   const debt = data?.selectedDebts?.[pagePerItemIndex];
+
+  useEffect(() => {
+    setDocumentTitle('Review your disputed debts');
+  }, []);
 
   const handleEdit = useCallback(
     () => {

--- a/src/applications/dispute-debt/containers/App.jsx
+++ b/src/applications/dispute-debt/containers/App.jsx
@@ -8,6 +8,7 @@ import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { DowntimeNotification } from 'platform/monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 import { fetchDebts } from '../actions';
+import useDocumentTitle from '../hooks/useDocumentTitle';
 
 export default function App({ children, location }) {
   const dispatch = useDispatch();
@@ -19,6 +20,9 @@ export default function App({ children, location }) {
   const { isDebtPending } = useSelector(state => state.availableDebts);
   const { useToggleLoadingValue } = useFeatureToggle();
   const isLoadingFeatures = useToggleLoadingValue();
+
+  const formData = useSelector(state => state.form?.data);
+  useDocumentTitle(location, formData);
 
   useEffect(
     () => {

--- a/src/applications/dispute-debt/containers/ConfirmationPage.jsx
+++ b/src/applications/dispute-debt/containers/ConfirmationPage.jsx
@@ -1,15 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-
 import {
   ConfirmationView,
   ChapterSectionCollection,
 } from 'platform/forms-system/src/js/components/ConfirmationView';
+import { setDocumentTitle } from '../utils';
+
 import NeedHelp from '../components/NeedHelp';
 
 export const ConfirmationPage = ({ route }) => {
   const { formConfig } = route;
+
+  useEffect(
+    () => {
+      setDocumentTitle('Confirmation Page - Dispute Debt');
+    },
+    [formConfig.title],
+  );
 
   const form = useSelector(state => state.form || {});
   const { submission } = form;

--- a/src/applications/dispute-debt/hooks/useDocumentTitle.jsx
+++ b/src/applications/dispute-debt/hooks/useDocumentTitle.jsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import formConfig from '../config/form';
+import { setDocumentTitle } from '../utils';
+
+const useDocumentTitle = (location, formData) => {
+  useEffect(
+    () => {
+      const pathSegments = location.pathname.split('/').filter(Boolean);
+      const lastSegment = pathSegments[pathSegments.length - 1];
+      const secondToLast = pathSegments[pathSegments.length - 2];
+      let title = null;
+
+      Object.values(formConfig.chapters).forEach(chapter => {
+        Object.values(chapter.pages).forEach(page => {
+          const pagePath = page.path;
+
+          // Check for exact match (static routes)
+          if (pagePath === lastSegment) {
+            const chapterTitle = chapter.title || '';
+            const pageTitle = page.title || '';
+            title =
+              chapterTitle === pageTitle
+                ? chapterTitle
+                : `${chapterTitle} - ${pageTitle}`;
+          }
+
+          // Check for dynamic route match (e.g., "dispute-reason/:index")
+          if (pagePath.includes(':index')) {
+            const basePattern = pagePath.split('/:index')[0];
+
+            if (secondToLast === basePattern) {
+              const chapterTitle = chapter.title || '';
+              let pageTitle = '';
+
+              // If page.title is a function, call it with formData and index
+              if (typeof page.title === 'function') {
+                const index = parseInt(lastSegment, 10);
+                if (!isNaN(index) && formData) {
+                  pageTitle = page.title(formData, { pagePerItemIndex: index });
+                } else {
+                  pageTitle = chapterTitle;
+                }
+              } else {
+                pageTitle = page.title || '';
+              }
+
+              title =
+                chapterTitle === pageTitle
+                  ? chapterTitle
+                  : `${chapterTitle} - ${pageTitle}`;
+            }
+          }
+        });
+      });
+
+      if (title && document.title !== title) {
+        setDocumentTitle(title);
+      }
+    },
+    [location.pathname, formData],
+  );
+};
+
+export default useDocumentTitle;

--- a/src/applications/dispute-debt/utils/index.js
+++ b/src/applications/dispute-debt/utils/index.js
@@ -102,3 +102,7 @@ export const getDebtPageTitle = (formData, { pagePerItemIndex } = {}) => {
 
   return `Debt ${debtNumber} of ${total}: ${currency(amount)} for ${debtTitle}`;
 };
+
+export const setDocumentTitle = title => {
+  document.title = `${title} | Veterans Affairs`;
+};


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update digital dispute to have dynamic titles per fsr.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#120142

## Testing done

Logged in with Aaron and determined titles were being displayed correctly and logged properly.

## Screenshots

<img width="1438" height="846" alt="image" src="https://github.com/user-attachments/assets/ebe4ff40-2d83-4f9a-9952-ca1e289435e2" />

## What areas of the site does it impact?

Digital Dispute

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
