### PR TITLE
Identity 864 | Create VHA interstitial landing page

### DIFF
--- a/src/applications/login/components/VHAPortalRemovalNotice.jsx
+++ b/src/applications/login/components/VHAPortalRemovalNotice.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export default function VHAPortalRemovalNotice() {
+  return (
+    <section className="container row login vads-u-padding--3">
+      <div className="columns small-12 vads-u-margin-y--2">
+        <h1>Manage your health care for all VA facilities on VA.gov</h1>
+        <p>
+          We’ve brought all your VA health care data together so you can manage
+          your care in one place.
+        </p>
+        <p>
+          You can now manage your care for all facilities through My HealtheVet
+          on VA.gov
+        </p>
+        <ul>
+          <li>Refill your VA prescriptions and manage your medications</li>
+          <li>Schedule and manage some VA health appointments</li>
+          <li>Send secure messages to your VA health care team</li>
+          <li>Review your medical records, including lab and test results</li>
+          <li>Order some medical supplies</li>
+          <li>File travel reimbursement claims</li>
+        </ul>
+        <va-link-action
+          text="Go to My HealtheVet on VA.gov"
+          label="Go to My HealtheVet on VA.gov"
+          type="primary"
+          // href=""
+        />
+        <h2>Still want to use My VA Health for now?</h2>
+        <p>
+          You can still access your health information through the My VA Health
+          portal if you’d like.
+        </p>
+        <va-link-action
+          text="Go to My VA Health"
+          label="Go to My VA Health"
+          type="secondary"
+          // href=""
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/applications/login/components/VHAPortalRemovalNotice.jsx
+++ b/src/applications/login/components/VHAPortalRemovalNotice.jsx
@@ -25,7 +25,7 @@ export default function VHAPortalRemovalNotice() {
           text="Go to My HealtheVet on VA.gov"
           label="Go to My HealtheVet on VA.gov"
           type="primary"
-          // href=""
+          href="/my-health"
         />
         <h2>Still want to use My VA Health for now?</h2>
         <p>
@@ -36,7 +36,7 @@ export default function VHAPortalRemovalNotice() {
           text="Go to My VA Health"
           label="Go to My VA Health"
           type="secondary"
-          // href=""
+          href="patientportal.myhealth.va.gov"
         />
       </div>
     </section>

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -4,6 +4,7 @@ import SignInWrapper from './components/SignInWrapper';
 import MockAuth from './containers/MockAuth';
 import ProdTestAccess from './containers/ProdTestAccess';
 import MhvTemporaryAccess from './containers/MhvTemporaryAccess';
+import VHAPortalRemovalNotice from './components/VHAPortalRemovalNotice';
 
 const routes = {
   path: '/',
@@ -24,6 +25,11 @@ const routes = {
             path: 'mhv',
             component: MhvTemporaryAccess,
           },
+          // TODO: Temporary route 'vha-portal-removal-notice' - remove after new app initialization
+          {
+            path: 'vha-portal-removal-notice',
+            component: VHAPortalRemovalNotice,
+          },
         ]
       : [
           {
@@ -33,6 +39,10 @@ const routes = {
           {
             path: 'mhv',
             component: MhvTemporaryAccess,
+          },
+          {
+            path: 'vha-portal-removal-notice',
+            component: VHAPortalRemovalNotice,
           },
         ],
 };

--- a/src/applications/login/tests/components/VHAPortalRemovalNotice.unit.spec.jsx
+++ b/src/applications/login/tests/components/VHAPortalRemovalNotice.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import VHAPortalRemovalNotice from '../../components/VHAPortalRemovalNotice';
 
 describe('VHAPortalRemovalNotice Component', () => {
@@ -100,31 +99,39 @@ describe('VHAPortalRemovalNotice Component', () => {
     });
   });
 
-  // describe("Action Links", () => {
-  // 	it("should render primary va-link-action with correct attributes", () => {
-  // 		const { container } = render(<VHAPortalRemovalNotice />);
-  // 		const primaryLink = container.querySelector('va-link-action[type="primary"]');
-  // 		expect(primaryLink).to.exist;
-  // 		expect(primaryLink.getAttribute("text")).to.equal(
-  // 			"Go to My HealtheVet on VA.gov"
-  // 		);
-  // 		expect(primaryLink.getAttribute("label")).to.equal(
-  // 			"Go to My HealtheVet on VA.gov"
-  // 		);
-  // 		expect(primaryLink.getAttribute("type")).to.equal("primary");
-  // 		expect(primaryLink.getAttribute("href")).to.exist;
-  // 		expect(primaryLink.getAttribute("href")).to.equal("");
-  // 	});
+  describe('Action Links', () => {
+    it('should render primary va-link-action with correct attributes', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const primaryLink = container.querySelector(
+        'va-link-action[type="primary"]',
+      );
+      expect(primaryLink).to.exist;
+      expect(primaryLink.getAttribute('text')).to.equal(
+        'Go to My HealtheVet on VA.gov',
+      );
+      expect(primaryLink.getAttribute('label')).to.equal(
+        'Go to My HealtheVet on VA.gov',
+      );
+      expect(primaryLink.getAttribute('type')).to.equal('primary');
+      expect(primaryLink.getAttribute('href')).to.exist;
+      expect(primaryLink.getAttribute('href')).to.equal('/my-health');
+    });
 
-  // 	it("should render secondary va-link-action with correct attributes", () => {
-  // 		const { container } = render(<VHAPortalRemovalNotice />);
-  // 		const secondaryLink = container.querySelector('va-link-action[type="secondary"]');
-  // 		expect(secondaryLink).to.exist;
-  // 		expect(secondaryLink.getAttribute("text")).to.equal("Go to My VA Health");
-  // 		expect(secondaryLink.getAttribute("label")).to.equal("Go to My VA Health");
-  // 		expect(secondaryLink.getAttribute("type")).to.equal("secondary");
-  // 		expect(secondaryLink.getAttribute("href")).to.exist;
-  // 		expect(secondaryLink.getAttribute("href")).to.equal("");
-  // 	});
-  // });
+    it('should render secondary va-link-action with correct attributes', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const secondaryLink = container.querySelector(
+        'va-link-action[type="secondary"]',
+      );
+      expect(secondaryLink).to.exist;
+      expect(secondaryLink.getAttribute('text')).to.equal('Go to My VA Health');
+      expect(secondaryLink.getAttribute('label')).to.equal(
+        'Go to My VA Health',
+      );
+      expect(secondaryLink.getAttribute('type')).to.equal('secondary');
+      expect(secondaryLink.getAttribute('href')).to.exist;
+      expect(secondaryLink.getAttribute('href')).to.equal(
+        'patientportal.myhealth.va.gov',
+      );
+    });
+  });
 });

--- a/src/applications/login/tests/components/VHAPortalRemovalNotice.unit.spec.jsx
+++ b/src/applications/login/tests/components/VHAPortalRemovalNotice.unit.spec.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import VHAPortalRemovalNotice from '../../components/VHAPortalRemovalNotice';
+
+describe('VHAPortalRemovalNotice Component', () => {
+  describe('H1 Heading', () => {
+    it('should render the h1 heading', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const h1 = container.querySelector('h1');
+      expect(h1).to.exist;
+    });
+
+    it('should render h1 with correct text', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const h1 = container.querySelector('h1');
+      expect(h1.textContent).to.equal(
+        'Manage your health care for all VA facilities on VA.gov',
+      );
+    });
+  });
+
+  describe('Paragraphs', () => {
+    it('should render 3 paragraphs', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const paragraphs = container.querySelectorAll('p');
+      expect(paragraphs).to.have.lengthOf(3);
+    });
+
+    it('should render first paragraph with correct text', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const paragraphs = container.querySelectorAll('p');
+      expect(paragraphs[0].textContent).to.equal(
+        'We’ve brought all your VA health care data together so you can manage your care in one place.',
+      );
+    });
+
+    it('should render second paragraph with correct text', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const paragraphs = container.querySelectorAll('p');
+      expect(paragraphs[1].textContent).to.equal(
+        'You can now manage your care for all facilities through My HealtheVet on VA.gov',
+      );
+    });
+
+    it('should render third paragraph with correct text', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const paragraphs = container.querySelectorAll('p');
+      expect(paragraphs[2].textContent).to.equal(
+        'You can still access your health information through the My VA Health portal if you’d like.',
+      );
+    });
+  });
+
+  describe('Unordered List', () => {
+    it('should render a ul element', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const list = container.querySelector('ul');
+      expect(list).to.exist;
+    });
+
+    it('should render 6 list items', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const listItems = container.querySelectorAll('li');
+      expect(listItems).to.have.lengthOf(6);
+    });
+
+    it('should render list items with correct content', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const listItems = container.querySelectorAll('li');
+      const expectedTexts = [
+        'Refill your VA prescriptions and manage your medications',
+        'Schedule and manage some VA health appointments',
+        'Send secure messages to your VA health care team',
+        'Review your medical records, including lab and test results',
+        'Order some medical supplies',
+        'File travel reimbursement claims',
+      ];
+
+      listItems.forEach((item, index) => {
+        expect(item.textContent).to.equal(expectedTexts[index]);
+      });
+    });
+  });
+
+  describe('H2 Heading', () => {
+    it('should render the h2 heading', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const h2 = container.querySelector('h2');
+      expect(h2).to.exist;
+    });
+
+    it('should render h2 with correct text', () => {
+      const { container } = render(<VHAPortalRemovalNotice />);
+      const h2 = container.querySelector('h2');
+      expect(h2.textContent).to.equal(
+        'Still want to use My VA Health for now?',
+      );
+    });
+  });
+
+  // describe("Action Links", () => {
+  // 	it("should render primary va-link-action with correct attributes", () => {
+  // 		const { container } = render(<VHAPortalRemovalNotice />);
+  // 		const primaryLink = container.querySelector('va-link-action[type="primary"]');
+  // 		expect(primaryLink).to.exist;
+  // 		expect(primaryLink.getAttribute("text")).to.equal(
+  // 			"Go to My HealtheVet on VA.gov"
+  // 		);
+  // 		expect(primaryLink.getAttribute("label")).to.equal(
+  // 			"Go to My HealtheVet on VA.gov"
+  // 		);
+  // 		expect(primaryLink.getAttribute("type")).to.equal("primary");
+  // 		expect(primaryLink.getAttribute("href")).to.exist;
+  // 		expect(primaryLink.getAttribute("href")).to.equal("");
+  // 	});
+
+  // 	it("should render secondary va-link-action with correct attributes", () => {
+  // 		const { container } = render(<VHAPortalRemovalNotice />);
+  // 		const secondaryLink = container.querySelector('va-link-action[type="secondary"]');
+  // 		expect(secondaryLink).to.exist;
+  // 		expect(secondaryLink.getAttribute("text")).to.equal("Go to My VA Health");
+  // 		expect(secondaryLink.getAttribute("label")).to.equal("Go to My VA Health");
+  // 		expect(secondaryLink.getAttribute("type")).to.equal("secondary");
+  // 		expect(secondaryLink.getAttribute("href")).to.exist;
+  // 		expect(secondaryLink.getAttribute("href")).to.equal("");
+  // 	});
+  // });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Creates interstitial landing page
- Temprorarily located in `src/applications/login` until the new application is created

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/864

## Testing done

- Manual / Unit

## Screenshots

<img width="1266" height="1143" alt="image" src="https://github.com/user-attachments/assets/3764870b-fe83-495c-93d2-8a7329c88dd7" />


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
