### PR TITLE
[#123362] Travel Pay, Check for appointment claim ID for Complex claims intro page routing

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -19,10 +19,7 @@ const IntroductionPage = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  // Get appointment data from the store
   const { data: appointment } = useSelector(selectAppointment);
-
-  // Get the complex claim data from the store
   const complexClaim = useSelector(selectComplexClaim);
 
   const apptId = appointment?.id;
@@ -33,7 +30,9 @@ const IntroductionPage = () => {
     }
 
     // If claim already exists, navigate directly
-    const existingClaimId = complexClaim?.data?.claimId;
+    const existingClaimId =
+      complexClaim?.data?.claimId || appointment?.travelPayClaim?.claim?.id;
+
     if (existingClaimId) {
       navigate(`/file-new-claim/${apptId}/${existingClaimId}/choose-expense`);
       return;

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
@@ -237,4 +237,66 @@ describe('Travel Pay – IntroductionPage', () => {
 
     expect(getByTestId('introduction-page')).to.exist;
   });
+
+  it('navigates using appointment claim ID when complexClaim data is null', async () => {
+    // Set up state with claim ID on appointment but null complexClaim data
+    const stateWithAppointmentClaim = {
+      ...getData(),
+      travelPay: {
+        ...getData().travelPay,
+        appointment: {
+          ...getData().travelPay.appointment,
+          data: {
+            id: '12345',
+            facilityName: 'Test Facility',
+            travelPayClaim: {
+              claim: {
+                id: '99999',
+              },
+            },
+          },
+        },
+        complexClaim: {
+          ...getData().travelPay.complexClaim,
+          claim: {
+            ...getData().travelPay.complexClaim.claim,
+            data: null,
+          },
+        },
+      },
+    };
+
+    const { getByTestId, container } = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <Routes>
+          <Route
+            path="/file-new-claim/:apptId"
+            element={<IntroductionPage />}
+          />
+          <Route
+            path="/file-new-claim/:apptId/:claimId/choose-expense"
+            element={<ChooseExpenseType />}
+          />
+        </Routes>
+        <LocationDisplay />
+      </MemoryRouter>,
+      {
+        initialState: stateWithAppointmentClaim,
+        reducers: reducer,
+      },
+    );
+
+    const startButton = $(
+      'va-link-action[text="Start your travel reimbursement claim"]',
+      container,
+    );
+    expect(startButton).to.exist;
+    startButton.click();
+
+    await waitFor(() => {
+      expect(getByTestId('location-display').textContent).to.equal(
+        '/file-new-claim/12345/99999/choose-expense',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added check for `appointment?.travelPayClaim?.claim?.id` as a fallback when `complexClaim.data` is null
- Added comprehensive unit test to verify the new fallback behavior

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/123362

## Testing done

### Old Behavior
- When a user clicked "Start your travel reimbursement claim", the component only checked the Redux `complexClaim.data.claimId` to determine if a claim already existed
- If the appointment object contained a `travelPayClaim.claim.id` but `complexClaim.data` was null, a new claim would be created unnecessarily

### New Behavior
- The component now checks both sources for an existing claim ID:
  1. `complexClaim?.data?.claimId` (from newly created claims)
  2. `appointment?.travelPayClaim?.claim?.id` (from claims already associated with the appointment)

### Testing Completed
- Added new unit test `navigates using appointment claim ID when complexClaim data is null` that verifies:
  - When `complexClaim.data` is null but `appointment.travelPayClaim.claim.id` exists
  - Clicking the start button navigates to the correct route with the appointment's claim ID
- Existing unit tests pass, including navigation test when `complexClaim.data.claimId` exists
- Manually tested in local environment with mock API

## Screenshots

This is a logic change with no UI modifications.

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A - no documentation needed for this internal logic change)
- [ ] Screenshot of the developed feature is added (N/A - no UI changes)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - no new events added)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - uses existing monitoring)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user