### PR TITLE
10-10dx | Bugfix Medicare plan type age logic

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -236,7 +236,14 @@ const medicarePlanTypes = {
       ...radioUI({
         title: 'Which Medicare plan does this applicant have?',
         labels: MEDICARE_TYPE_LABELS,
-        updateSchema: ({ applicants, medicare }, schema, _uiSchema, index) => {
+        updateSchema: (
+          _formData,
+          schema,
+          _uiSchema,
+          index,
+          _fields,
+          { applicants, medicare } = {},
+        ) => {
           const isUnder65 = getIsUnder65(applicants, medicare, index);
           const keys = getPlanKeys(isUnder65);
           return set('enum', keys, schema);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR changes the argument form data is pulled from in an `updateSchema` schema for the Medicare plan type page. The radio options change based on whether the applicant is age 65 and over or not.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#117943
department-of-veterans-affairs/va.gov-team#125014

## Testing done

- Prior to the change, the arg for data changed whether you were in add or edit mode within the array loop. In edit mode the dataset is limited to only the current array item, not the full form data. The associated arrays we were checking were undefined in edit mode, so all options were displayed to users.
- After the change, we are using an arg that passes the full dataset, allowing for the options to be filtered correctly.

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="538" height="414" alt="Screenshot 2025-11-12 at 14 42 42" src="https://github.com/user-attachments/assets/bbcc8620-7bb7-4313-aaa5-c66e823901cc" /> | <img width="538" height="394" alt="Screenshot 2025-11-12 at 14 42 05" src="https://github.com/user-attachments/assets/63a65aa3-e8a7-4d23-99ed-5b0f14897d9a" /> |

## Acceptance criteria

 - Age-based logic is correct in all array modes

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user