### PR TITLE
0969 | Post MVP - Discontinued income pages udpates

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
@@ -593,8 +593,6 @@ const incomeAmountPage = {
       title:
         'What was the gross annual amount reported to the IRS for this income?',
       hint: 'Gross income is income before taxes and any other deductions.',
-      labelHeaderLevel: '2',
-      labelHeaderLevelStyle: '3',
     }),
   },
   schema: {

--- a/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
@@ -25,9 +25,9 @@ import {
   fullNameUIHelper,
   generateDeleteDescription,
   isDefined,
-  isRecipientInfoIncomplete,
+  updatedIsRecipientInfoIncomplete,
   otherRecipientRelationshipTypeUI,
-  recipientNameRequired,
+  updatedRecipientNameRequired,
   requireExpandedArrayField,
   resolveRecipientFullName,
   sharedRecipientRelationshipBase,
@@ -54,7 +54,7 @@ export const options = {
   nounPlural: 'discontinued income',
   required: false,
   isItemIncomplete: item =>
-    isRecipientInfoIncomplete(item) ||
+    updatedIsRecipientInfoIncomplete(item) ||
     !isDefined(item.payer) ||
     !isDefined(item?.incomeType) ||
     (!isDefined(item?.['view:otherIncomeType']) &&
@@ -263,6 +263,11 @@ const parentSummaryPage = {
   },
 };
 
+const updatedSharedRecipientRelationshipBase = {
+  ...sharedRecipientRelationshipBase,
+  title: 'Who received this income?',
+};
+
 /** @returns {PageSchema} */
 const veteranIncomeRecipientPage = {
   uiSchema: {
@@ -271,7 +276,7 @@ const veteranIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      ...sharedRecipientRelationshipBase,
+      ...updatedSharedRecipientRelationshipBase,
       labels: Object.fromEntries(
         Object.entries(relationshipLabels).filter(
           ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
@@ -308,7 +313,7 @@ const spouseIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      ...sharedRecipientRelationshipBase,
+      ...updatedSharedRecipientRelationshipBase,
       labels: spouseRelationshipLabels,
       descriptions: Object.fromEntries(
         Object.entries(relationshipLabelDescriptions).filter(
@@ -341,7 +346,7 @@ const custodianIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      ...sharedRecipientRelationshipBase,
+      ...updatedSharedRecipientRelationshipBase,
       labels: custodianRelationshipLabels,
       descriptions: Object.fromEntries(
         Object.entries(relationshipLabelDescriptions).filter(
@@ -376,7 +381,7 @@ const parentIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      ...sharedRecipientRelationshipBase,
+      ...updatedSharedRecipientRelationshipBase,
       labels: parentRelationshipLabels,
       descriptions: {
         SPOUSE: 'The Veteran’s other parent should file a separate claim',
@@ -588,6 +593,8 @@ const incomeAmountPage = {
       title:
         'What was the gross annual amount reported to the IRS for this income?',
       hint: 'Gross income is income before taxes and any other deductions.',
+      labelHeaderLevel: '2',
+      labelHeaderLevelStyle: '3',
     }),
   },
   schema: {
@@ -701,11 +708,36 @@ export const discontinuedIncomePages = arrayBuilderPages(
       uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
       schema: nonVeteranIncomeRecipientPage.schema,
     }),
+    // When claimantType is 'CHILD' we skip showing the recipient page entirely
+    // To preserve required data, we auto-set recipientRelationship to 'CHILD'
+    discontinuedIncomeChildRecipientNamePage: pageBuilder.itemPage({
+      title: 'Discontinued income recipient name',
+      path: 'discontinued-income/:index/recipient-name-updated',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CHILD',
+      uiSchema: {
+        ...recipientNamePage.uiSchema,
+        'ui:options': {
+          updateSchema: (formData, formSchema, _uiSchema, index) => {
+            const arrayData = formData?.discontinuedIncomes || [];
+            const item = arrayData[index];
+            if (formData.claimantType === 'CHILD' && item) {
+              item.recipientRelationship = 'CHILD';
+            }
+            return {
+              ...formSchema,
+            };
+          },
+        },
+      },
+      schema: recipientNamePage.schema,
+    }),
     discontinuedIncomeRecipientNamePage: pageBuilder.itemPage({
       title: 'Discontinued income recipient name',
       path: 'discontinued-income/:index/recipient-name',
       depends: (formData, index) =>
-        recipientNameRequired(formData, index, 'discontinuedIncomes'),
+        (!showUpdatedContent() || formData.claimantType !== 'CHILD') &&
+        updatedRecipientNameRequired(formData, index, 'discontinuedIncomes'),
       uiSchema: recipientNamePage.uiSchema,
       schema: recipientNamePage.schema,
     }),


### PR DESCRIPTION
### Summary of Changes
This update applies **Post-MVP Design QA feedback** to the **Discontinued Income** chapter of the 0969 form.  
The changes include refined text and alignment with the design spec. These updates ensure consistency across the Post-MVP income-related chapters.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116446

### How to Set Up in Local Environment
1. Start the local environment
2. Navigate to the 0969 form:  
   http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/

### How to Test
1. Go to the **Discontinued Incomes** chapter.  
2. Use a `claimantType` such as **Veteran** or **Parent** to verify the updated pages.  
3. Review the **name** and **information pages** conditional logic based on 'cliamantType'.  
4. Confirm there are no regressions in navigation, schema validation, or accessibility.

### Feature Flag Note
- These updates are included under the Post-MVP feature flag for the 0969 form:
  - `income_and_assets_content_updates`

### Acceptance Criteria
- [x] Updated text and layout per Design QA feedback.  
- [x] Name and information pages match the design spec.  
- [x] No accessibility or validation regressions.  
- [x] Verified behind the Post-MVP feature flag.

### Definition of Done
- [ ] Code reviewed and approved.  
- [ ] Verified locally and on staging.  
- [x] Automated tests passing.  
- [x] Aligned with design system typography and spacing standards.