### PR TITLE
[DBC] Confirmation Page -> Separation Location (Option A)

### DIFF
--- a/src/platform/forms-system/src/js/definitions/autosuggest.js
+++ b/src/platform/forms-system/src/js/definitions/autosuggest.js
@@ -33,6 +33,7 @@ export function uiSchema(label, getOptions, options = {}) {
   return merge(
     {},
     {
+      label: {},
       'ui:title': label,
       'ui:field': AutosuggestField,
       'ui:validations': validations,


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/122801

`autosuggest.js` generates form data that looks like `{ id: 1, label: 'Some Label' }` (code [here](https://github.com/department-of-veterans-affairs/vets-website/blob/b66af3f87635a2c738617ff177b69fd0138abbdf/src/platform/forms-system/src/js/fields/AutosuggestField.jsx#L130)). But the `uiSchema` it defines does not contain keys that correspond to that form data. This is why this datapoint does not automatically render on the confirmation view (code [here](https://github.com/department-of-veterans-affairs/vets-website/blob/b66af3f87635a2c738617ff177b69fd0138abbdf/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx#L192)).

Also, `autosuggest.js` allows for this same customization to be passed in by us at the call site if that turns out to be our favorite approach:
```js
// src/applications/disability-benefits/all-claims/pages/separationLocation.js
autosuggest.uiSchema(
  'Enter a location',
  getSeparationLocations,
  {
    label: {},
    'ui:required': () => true,
    'ui:validations': [requireSeparationLocation],
  },
)
```

Here's a screenshot. Notice that neither the parent nor child `ui:title` (`Place of anticipated separation` and `Enter a location` respectively) show up as a header in this solution.

<img width="688" height="1155" alt="Screenshot 2025-11-12 at 4 26 12 PM" src="https://github.com/user-attachments/assets/a6cd7998-4ee9-4335-8580-1aad27c0435b" />