### PR TITLE
[#2716] Add character limit with indicator to Chatbot

### DIFF
--- a/src/applications/virtual-agent/components/WebChat.jsx
+++ b/src/applications/virtual-agent/components/WebChat.jsx
@@ -9,6 +9,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 // Hooks
 import useDirectLine from '../hooks/useDirectline';
 import useWebChatStore from '../hooks/useWebChatStore';
+import useCharacterLimit from '../hooks/useCharacterLimit';
 
 // Event Listeners
 import clearBotSessionStorageEventListener from '../event-listeners/clearBotSessionStorageEventListener';
@@ -77,6 +78,10 @@ const WebChat = ({ code, webChatFramework }) => {
     TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled,
   );
 
+  const isAIDisclaimerEnabled = useToggleValue(
+    TOGGLE_NAMES.virtualAgentShowAiDisclaimer,
+  );
+
   const store = useWebChatStore({
     createStore,
     code,
@@ -104,6 +109,8 @@ const WebChat = ({ code, webChatFramework }) => {
   );
 
   const directLine = useDirectLine(createDirectLine);
+
+  useCharacterLimit(isAIDisclaimerEnabled);
 
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>

--- a/src/applications/virtual-agent/hooks/useCharacterLimit.js
+++ b/src/applications/virtual-agent/hooks/useCharacterLimit.js
@@ -1,0 +1,226 @@
+import { useEffect } from 'react';
+
+// Character limit constant - should match the limit in useWebChatStore.js
+const CHARACTER_LIMIT = 400;
+// Threshold for turning counter red
+const RED_THRESHOLD = 390;
+
+/**
+ * Finds the WebChat input element
+ * @returns {HTMLInputElement|null} The input element or null if not found
+ */
+export function getInputElement() {
+  return document.querySelector('input.webchat__send-box-text-box__input');
+}
+
+/**
+ * Finds the character counter element
+ * @returns {HTMLDivElement|null} The counter element or null if not found
+ */
+export function getCounterElement() {
+  return document.querySelector('.webchat-character-counter');
+}
+
+/**
+ * Updates the character counter text and warning state
+ * @param {HTMLDivElement} counterElement - The counter element
+ * @param {HTMLInputElement} inputElement - The input element
+ * @param {number} characterLimit - Maximum number of characters allowed
+ * @param {number} redThreshold - Character count at which to show warning (red)
+ */
+export function updateCounter(
+  counterElement,
+  inputElement,
+  characterLimit,
+  redThreshold,
+) {
+  const currentLength = inputElement.value.length;
+  const charactersLeft = characterLimit - currentLength;
+  const isNearLimit = currentLength >= redThreshold;
+
+  // Update counter text to show "x characters left"
+  const element = counterElement;
+  element.textContent = `${charactersLeft} characters left`;
+  // Turn red when approaching limit using CSS class
+  if (isNearLimit) {
+    element.classList.add('warning');
+  } else {
+    element.classList.remove('warning');
+  }
+}
+
+/**
+ * Creates or finds the character counter element and appends it to the DOM
+ * @returns {HTMLDivElement} The counter element
+ */
+export function createCounterElement() {
+  // Check if counter already exists
+  let counterElement = getCounterElement();
+  if (counterElement) {
+    return counterElement;
+  }
+
+  const formElement = document.querySelector('form.webchat__send-box-text-box');
+  const sendButton = document.querySelector('button.webchat__send-button');
+
+  // Create the character counter element
+  counterElement = document.createElement('div');
+  counterElement.className = 'webchat-character-counter';
+  // Make it focusable for accessibility (tab order: input -> counter -> send button)
+  counterElement.setAttribute('tabindex', '0');
+
+  // Insert counter after the form element but before the send button
+  formElement.parentElement.insertBefore(counterElement, sendButton);
+
+  return counterElement;
+}
+
+/**
+ * Sets up character limit enforcement and indicator on the input element
+ * @param {number} characterLimit - Maximum number of characters allowed
+ * @param {number} redThreshold - Character count at which to show warning (red)
+ * @returns {Function|undefined} Cleanup function, or undefined if input not found
+ */
+export function setupCharacterLimit(characterLimit, redThreshold) {
+  const inputElement = getInputElement();
+
+  if (!inputElement) {
+    return undefined;
+  }
+
+  // Set the maxLength attribute to prevent typing beyond the limit
+  inputElement.setAttribute('maxLength', characterLimit.toString());
+
+  // Create or find the character counter element
+  const counterElement = createCounterElement();
+
+  // Initial counter update
+  updateCounter(counterElement, inputElement, characterLimit, redThreshold);
+
+  // Update the counter on input
+  const handleInput = () =>
+    updateCounter(counterElement, inputElement, characterLimit, redThreshold);
+  inputElement.addEventListener('input', handleInput);
+
+  return () => {
+    inputElement.removeEventListener('input', handleInput);
+    if (counterElement && counterElement.parentElement) {
+      counterElement.parentElement.removeChild(counterElement);
+    }
+  };
+}
+
+/**
+ * Checks if input was cleared and resets counter
+ * @param {HTMLInputElement} inputElement - The input element
+ * @param {string} previousValue - The previous input value
+ * @param {number} characterLimit - Maximum number of characters allowed
+ * @param {number} redThreshold - Character count at which to show warning (red)
+ * @returns {string} The current input value
+ */
+export function checkAndResetCounterIfCleared(
+  inputElement,
+  previousValue,
+  characterLimit,
+  redThreshold,
+) {
+  const currentValue = inputElement.value || '';
+  if (previousValue !== '' && currentValue === '') {
+    // Input was cleared after having content - reset counter
+    const counterElement = getCounterElement();
+    if (counterElement) {
+      updateCounter(counterElement, inputElement, characterLimit, redThreshold);
+    }
+  }
+  return currentValue;
+}
+
+/**
+ * Creates a MutationObserver callback function to setup the character
+ * limit when the input is added to the DOM
+ * @param {Object} refs - Object with cleanupRef and stateRef properties
+ * @param {number} characterLimit - Maximum number of characters allowed
+ * @param {number} redThreshold - Character count at which to show warning (red)
+ * @returns {Function} The MutationObserver callback function
+ */
+export function createMutationObserverCallback(
+  refs,
+  characterLimit,
+  redThreshold,
+) {
+  return () => {
+    const inputElement = getInputElement();
+    const counterExists = getCounterElement() !== null;
+
+    if (inputElement && !counterExists) {
+      // If input exists but counter doesn't, setup the character limit
+      const cleanupRefObj = refs.cleanupRef;
+      const stateRefObj = refs.stateRef;
+      if (cleanupRefObj.current) {
+        cleanupRefObj.current();
+      }
+      const newCleanup = setupCharacterLimit(characterLimit, redThreshold);
+      cleanupRefObj.current = newCleanup;
+      stateRefObj.current.previousInputValue = inputElement.value || '';
+    } else if (inputElement && counterExists) {
+      // Check if input value changed from non-empty to empty (message was sent)
+      const stateRefObj = refs.stateRef;
+      stateRefObj.current.previousInputValue = checkAndResetCounterIfCleared(
+        inputElement,
+        stateRefObj.current.previousInputValue,
+        characterLimit,
+        redThreshold,
+      );
+    }
+  };
+}
+
+/**
+ * Hook that adds a character counter and enforces character limit
+ * @param {boolean} isEnabled - Whether to enable the character limit feature
+ */
+export default function useCharacterLimit(isEnabled) {
+  useEffect(
+    () => {
+      // Only enable character limit if the feature toggle is true
+      if (!isEnabled) {
+        return () => {};
+      }
+
+      // Setup the character limit on pgae load
+      const initialCleanup = setupCharacterLimit(
+        CHARACTER_LIMIT,
+        RED_THRESHOLD,
+      );
+
+      // Track previous input value to detect when it becomes empty (after message sent)
+      const cleanupRef = { current: initialCleanup };
+      const stateRef = { current: { previousInputValue: '' } };
+
+      // Setup a MutationObserver to watch for when the input is added to the DOM
+      const observerCallback = createMutationObserverCallback(
+        { cleanupRef, stateRef },
+        CHARACTER_LIMIT,
+        RED_THRESHOLD,
+      );
+      const observer = new MutationObserver(observerCallback);
+
+      // Observe the document body for changes in the webchat area
+      const observeTarget = document.querySelector('[data-testid="webchat"]');
+      observer.observe(observeTarget, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['value'],
+      });
+
+      return () => {
+        observer.disconnect();
+        if (cleanupRef.current) {
+          cleanupRef.current();
+        }
+      };
+    },
+    [isEnabled],
+  );
+}

--- a/src/applications/virtual-agent/sass/virtual-agent.scss
+++ b/src/applications/virtual-agent/sass/virtual-agent.scss
@@ -28,6 +28,37 @@
   margin: 0;
 }
 
+// Ensure the send box main container allows wrapping so counter appears on new line
+.webchat__send-box__main {
+  flex-wrap: wrap !important;
+}
+
+.webchat-character-counter {
+  font-size: 16px;
+  color: rgb(0, 0, 0);
+  text-align: left;
+  padding: 0 0 8px 10px;
+  margin: 0;
+  display: block;
+  width: 100%;
+  flex-basis: 100%;
+  flex-shrink: 0;
+  min-width: 100%;
+  max-width: 100%;
+  order: 2;
+  clear: both;
+  background-color: transparent !important;
+  background: none !important;
+  transition: color 0.2s ease;
+
+  // Turn red when approaching or over limit
+  &.warning {
+    color: rgb(211, 47, 47);
+    background-color: transparent !important;
+    background: none !important;
+  }
+}
+
 .webchat__suggested-actions__stack {
   margin-bottom: 1em !important;
   overflow-y: hidden !important;

--- a/src/applications/virtual-agent/sass/virtual-agent.scss
+++ b/src/applications/virtual-agent/sass/virtual-agent.scss
@@ -53,7 +53,8 @@
 
   // Turn red when approaching or over limit
   &.warning {
-    color: rgb(211, 47, 47);
+    color: rgb(181, 9, 9);
+    font-weight: bold;
     background-color: transparent !important;
     background: none !important;
   }
@@ -136,4 +137,17 @@ button.webchat__suggested-actions__button:active {
 
 div.ac-container[style*="rgb(255, 226, 178)"]{
   background-color: rgb(250, 243, 209) !important
+}
+
+// Screen reader only class - visually hides content but keeps it accessible to screen readers
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }

--- a/src/applications/virtual-agent/tests/hooks/useCharacterLimit.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useCharacterLimit.unit.spec.jsx
@@ -1,0 +1,626 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { renderHook } from '@testing-library/react-hooks';
+import useCharacterLimit, {
+  getInputElement,
+  getCounterElement,
+  createCounterElement,
+  updateCounter,
+  setupCharacterLimit,
+  checkAndResetCounterIfCleared,
+  createMutationObserverCallback,
+} from '../../hooks/useCharacterLimit';
+
+// Helper function to set up querySelector stub with common selectors
+function setupQuerySelectorStub(sandbox, options = {}) {
+  const {
+    inputElement = null,
+    counterElement = null,
+    formElement = null,
+    sendButton = null,
+    webchatContainer = null,
+  } = options;
+
+  return sandbox.stub(document, 'querySelector').callsFake(selector => {
+    if (selector.includes('input.webchat__send-box-text-box__input')) {
+      return inputElement;
+    }
+    if (selector.includes('.webchat-character-counter')) {
+      return counterElement;
+    }
+    if (selector.includes('form.webchat__send-box-text-box')) {
+      return formElement;
+    }
+    if (selector.includes('button.webchat__send-button')) {
+      return sendButton;
+    }
+    if (selector.includes('[data-testid="webchat"]')) {
+      return webchatContainer;
+    }
+    return null;
+  });
+}
+
+describe('useCharacterLimit', () => {
+  let sandbox;
+  let mockInputElement;
+  let mockCounterElement;
+  let mockParentElement;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    mockInputElement = {
+      value: '',
+      setAttribute: sandbox.stub(),
+      addEventListener: sandbox.stub(),
+      removeEventListener: sandbox.stub(),
+      closest: sandbox.stub(),
+      parentElement: null,
+      dispatchEvent: sandbox.stub(),
+    };
+
+    mockCounterElement = {
+      textContent: '',
+      classList: {
+        add: sandbox.stub(),
+        remove: sandbox.stub(),
+      },
+      parentElement: null,
+      setAttribute: sandbox.stub(),
+      getAttribute: sandbox.stub(),
+    };
+
+    mockParentElement = {
+      appendChild: sandbox.stub(),
+      removeChild: sandbox.stub(),
+    };
+
+    mockInputElement.parentElement = mockParentElement;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getInputElement', () => {
+    it('should find input element by class selector', () => {
+      sandbox.stub(document, 'querySelector').returns(mockInputElement);
+
+      const result = getInputElement();
+
+      expect(result).to.equal(mockInputElement);
+      expect(
+        document.querySelector.calledWith(
+          'input.webchat__send-box-text-box__input',
+        ),
+      ).to.be.true;
+    });
+
+    it('should return null if input element is not found', () => {
+      sandbox.stub(document, 'querySelector').returns(null);
+
+      const result = getInputElement();
+
+      expect(result).to.be.null;
+    });
+  });
+
+  describe('getCounterElement', () => {
+    it('should find counter element by class selector', () => {
+      sandbox.stub(document, 'querySelector').returns(mockCounterElement);
+
+      const result = getCounterElement();
+
+      expect(result).to.equal(mockCounterElement);
+      expect(document.querySelector.calledWith('.webchat-character-counter')).to
+        .be.true;
+    });
+
+    it('should return null if counter element is not found', () => {
+      sandbox.stub(document, 'querySelector').returns(null);
+
+      const result = getCounterElement();
+
+      expect(result).to.be.null;
+    });
+  });
+
+  describe('updateCounter', () => {
+    it('should update counter text with current length', () => {
+      mockInputElement.value = 'test';
+      const characterLimit = 400;
+      const redThreshold = 350;
+
+      updateCounter(
+        mockCounterElement,
+        mockInputElement,
+        characterLimit,
+        redThreshold,
+      );
+
+      expect(mockCounterElement.textContent).to.equal('396 characters left');
+      expect(mockCounterElement.classList.add.called).to.be.false;
+      expect(mockCounterElement.classList.remove.called).to.be.true;
+    });
+
+    it('should add warning class when near limit', () => {
+      mockInputElement.value = 'a'.repeat(350);
+      const characterLimit = 400;
+      const redThreshold = 350;
+
+      updateCounter(
+        mockCounterElement,
+        mockInputElement,
+        characterLimit,
+        redThreshold,
+      );
+
+      expect(mockCounterElement.textContent).to.equal('50 characters left');
+      expect(mockCounterElement.classList.add.calledWith('warning')).to.be.true;
+    });
+
+    it('should add warning class when at limit', () => {
+      mockInputElement.value = 'a'.repeat(400);
+      const characterLimit = 400;
+      const redThreshold = 350;
+
+      updateCounter(
+        mockCounterElement,
+        mockInputElement,
+        characterLimit,
+        redThreshold,
+      );
+
+      expect(mockCounterElement.textContent).to.equal('0 characters left');
+      expect(mockCounterElement.classList.add.calledWith('warning')).to.be.true;
+    });
+
+    it('should remove warning class when below threshold', () => {
+      mockInputElement.value = 'a'.repeat(349);
+      const characterLimit = 400;
+      const redThreshold = 350;
+
+      updateCounter(
+        mockCounterElement,
+        mockInputElement,
+        characterLimit,
+        redThreshold,
+      );
+
+      expect(mockCounterElement.textContent).to.equal('51 characters left');
+      expect(mockCounterElement.classList.remove.calledWith('warning')).to.be
+        .true;
+    });
+  });
+
+  describe('createCounterElement', () => {
+    let mockFormElement;
+    let mockSendButton;
+    let mockCounterParentElement;
+
+    beforeEach(() => {
+      mockFormElement = {
+        parentElement: null,
+      };
+      mockSendButton = {};
+      mockCounterParentElement = {
+        insertBefore: sandbox.stub(),
+      };
+      mockFormElement.parentElement = mockCounterParentElement;
+    });
+
+    it('should return existing counter element if it exists', () => {
+      const createElementStub = sandbox.stub(document, 'createElement');
+      sandbox.stub(document, 'querySelector').returns(mockCounterElement);
+
+      const result = createCounterElement();
+
+      expect(result).to.equal(mockCounterElement);
+      expect(createElementStub.called).to.be.false;
+    });
+
+    it('should create and insert counter element if it does not exist', () => {
+      sandbox
+        .stub(document, 'querySelector')
+        .onFirstCall()
+        .returns(null) // getCounterElement - counter doesn't exist
+        .onSecondCall()
+        .returns(mockFormElement) // form.webchat__send-box-text-box
+        .onThirdCall()
+        .returns(mockSendButton); // button.webchat__send-button
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      const result = createCounterElement();
+
+      expect(result).to.equal(mockCounterElement);
+      expect(document.createElement.calledWith('div')).to.be.true;
+      expect(mockCounterElement.className).to.equal(
+        'webchat-character-counter',
+      );
+      expect(mockCounterElement.setAttribute.calledWith('tabindex', '0')).to.be
+        .true;
+      expect(
+        mockCounterParentElement.insertBefore.calledWith(
+          mockCounterElement,
+          mockSendButton,
+        ),
+      ).to.be.true;
+    });
+  });
+
+  describe('setupCharacterLimit', () => {
+    let mockFormElement;
+    let mockSendButton;
+    let mockCounterParentElement;
+
+    beforeEach(() => {
+      mockInputElement.value = '';
+      mockFormElement = {
+        parentElement: null,
+      };
+      mockSendButton = {};
+      mockCounterParentElement = {
+        insertBefore: sandbox.stub(),
+      };
+      mockFormElement.parentElement = mockCounterParentElement;
+    });
+
+    it('should return undefined if input element is not found', () => {
+      sandbox.stub(document, 'querySelector').returns(null);
+
+      const result = setupCharacterLimit(400, 350);
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should set maxLength attribute on input element', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      setupCharacterLimit(400, 350);
+
+      expect(mockInputElement.setAttribute.calledWith('maxLength', '400')).to.be
+        .true;
+    });
+
+    it('should create counter element', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      setupCharacterLimit(400, 350);
+
+      expect(document.createElement.calledWith('div')).to.be.true;
+    });
+
+    it('should add input event listener', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      setupCharacterLimit(400, 350);
+
+      expect(mockInputElement.addEventListener.calledWith('input')).to.be.true;
+      expect(mockInputElement.addEventListener.calledWith('paste')).to.be.false;
+    });
+
+    it('should call updateCounter when input event is triggered', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+      mockInputElement.value = 'test';
+
+      setupCharacterLimit(400, 350);
+
+      // Get the handler that was added
+      const addEventListenerCalls = mockInputElement.addEventListener.getCalls();
+      const inputHandler = addEventListenerCalls.find(
+        call => call.args[0] === 'input',
+      )?.args[1];
+
+      // Reset counter textContent to track changes
+      mockCounterElement.textContent = 'initial';
+
+      // Simulate input event by calling the handler
+      inputHandler();
+
+      // Verify updateCounter was called (counter textContent should be updated)
+      expect(mockCounterElement.textContent).to.equal('396 characters left');
+    });
+
+    it('should return cleanup function', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+      mockCounterElement.parentElement = mockCounterParentElement;
+      mockCounterParentElement.removeChild = sandbox.stub();
+
+      const cleanup = setupCharacterLimit(400, 350);
+
+      expect(cleanup).to.be.a('function');
+
+      cleanup();
+
+      expect(mockInputElement.removeEventListener.calledWith('input')).to.be
+        .true;
+    });
+
+    it('should remove counter element on cleanup', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+      mockCounterElement.parentElement = mockCounterParentElement;
+      mockCounterParentElement.removeChild = sandbox.stub();
+
+      const cleanup = setupCharacterLimit(400, 350);
+
+      cleanup();
+
+      expect(
+        mockCounterParentElement.removeChild.calledWith(mockCounterElement),
+      ).to.be.true;
+    });
+  });
+
+  describe('checkAndResetCounterIfCleared', () => {
+    it('should reset counter when input is cleared (changed from non-empty to empty)', () => {
+      mockInputElement.value = '';
+      sandbox.stub(document, 'querySelector').returns(mockCounterElement);
+
+      const result = checkAndResetCounterIfCleared(
+        mockInputElement,
+        'previous text',
+        400,
+        350,
+      );
+
+      expect(result).to.equal('');
+      expect(mockCounterElement.textContent).to.equal('400 characters left');
+      expect(mockCounterElement.classList.add.called).to.be.false;
+      expect(mockCounterElement.classList.remove.called).to.be.true;
+    });
+
+    it('should not reset counter when input was already empty', () => {
+      mockInputElement.value = '';
+      mockCounterElement.textContent = 'initial';
+      sandbox.stub(document, 'querySelector').returns(mockCounterElement);
+
+      const result = checkAndResetCounterIfCleared(
+        mockInputElement,
+        '',
+        400,
+        350,
+      );
+
+      expect(result).to.equal('');
+      expect(mockCounterElement.textContent).to.equal('initial');
+    });
+
+    it('should not reset counter when input still has content', () => {
+      mockInputElement.value = 'some text';
+      mockCounterElement.textContent = 'initial';
+      sandbox.stub(document, 'querySelector').returns(mockCounterElement);
+
+      const result = checkAndResetCounterIfCleared(
+        mockInputElement,
+        'previous text',
+        400,
+        350,
+      );
+
+      expect(result).to.equal('some text');
+      expect(mockCounterElement.textContent).to.equal('initial');
+    });
+
+    it('should not reset counter when counter element does not exist', () => {
+      mockInputElement.value = '';
+      sandbox.stub(document, 'querySelector').returns(null);
+
+      const result = checkAndResetCounterIfCleared(
+        mockInputElement,
+        'previous text',
+        400,
+        350,
+      );
+
+      expect(result).to.equal('');
+    });
+  });
+
+  describe('createMutationObserverCallback', () => {
+    it('should return a function', () => {
+      const refs = {
+        cleanupRef: { current: null },
+        stateRef: { current: { previousInputValue: '' } },
+      };
+
+      const callback = createMutationObserverCallback(refs, 400, 350);
+
+      expect(callback).to.be.a('function');
+    });
+
+    it('should setup character limit when input exists but counter does not', () => {
+      const refs = {
+        cleanupRef: { current: null },
+        stateRef: { current: { previousInputValue: '' } },
+      };
+      mockInputElement.value = 'test';
+      const mockFormElement = {
+        parentElement: { insertBefore: sandbox.stub() },
+      };
+      const mockSendButton = {};
+
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      const callback = createMutationObserverCallback(refs, 400, 350);
+      callback();
+
+      expect(mockInputElement.setAttribute.calledWith('maxLength', '400')).to.be
+        .true;
+      expect(refs.stateRef.current.previousInputValue).to.equal('test');
+      expect(refs.cleanupRef.current).to.be.a('function');
+    });
+
+    it('should call existing cleanup before setting up character limit', () => {
+      const mockCleanup = sandbox.stub();
+      const refs = {
+        cleanupRef: { current: mockCleanup },
+        stateRef: { current: { previousInputValue: '' } },
+      };
+      mockInputElement.value = 'test';
+      const mockFormElement = {
+        parentElement: { insertBefore: sandbox.stub() },
+      };
+      const mockSendButton = {};
+
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      const callback = createMutationObserverCallback(refs, 400, 350);
+      callback();
+
+      expect(mockCleanup.called).to.be.true;
+      expect(mockInputElement.setAttribute.calledWith('maxLength', '400')).to.be
+        .true;
+    });
+
+    it('should check and reset counter when input exists and counter exists', () => {
+      const refs = {
+        cleanupRef: { current: null },
+        stateRef: { current: { previousInputValue: 'previous text' } },
+      };
+      mockInputElement.value = '';
+
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        counterElement: mockCounterElement,
+      });
+
+      const callback = createMutationObserverCallback(refs, 400, 350);
+      callback();
+
+      expect(mockCounterElement.textContent).to.equal('400 characters left');
+      expect(refs.stateRef.current.previousInputValue).to.equal('');
+    });
+
+    it('should do nothing when input does not exist', () => {
+      const refs = {
+        cleanupRef: { current: null },
+        stateRef: { current: { previousInputValue: '' } },
+      };
+
+      sandbox.stub(document, 'querySelector').returns(null);
+
+      const callback = createMutationObserverCallback(refs, 400, 350);
+      callback();
+
+      expect(mockInputElement.setAttribute.called).to.be.false;
+      expect(refs.stateRef.current.previousInputValue).to.equal('');
+    });
+  });
+
+  describe('useCharacterLimit', () => {
+    let mockFormElement;
+    let mockSendButton;
+    let mockCounterParentElement;
+
+    beforeEach(() => {
+      mockFormElement = {
+        parentElement: null,
+      };
+      mockSendButton = {};
+      mockCounterParentElement = {
+        insertBefore: sandbox.stub(),
+      };
+      mockFormElement.parentElement = mockCounterParentElement;
+    });
+
+    it('should enforce character limit when enabled', () => {
+      sandbox
+        .stub(document, 'querySelector')
+        .onFirstCall()
+        .returns(mockInputElement) // getInputElement
+        .onSecondCall()
+        .returns(null) // getCounterElement - counter doesn't exist
+        .onThirdCall()
+        .returns(mockFormElement) // form.webchat__send-box-text-box
+        .onCall(3)
+        .returns(mockSendButton) // button.webchat__send-button
+        .onCall(4)
+        .returns(null); // [data-testid="webchat"] - webchat container
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+
+      renderHook(() => useCharacterLimit(true));
+
+      expect(mockInputElement.setAttribute.calledWith('maxLength', '400')).to.be
+        .true;
+    });
+
+    it('should do nothing when disabled', () => {
+      const createElementStub = sandbox.stub(document, 'createElement');
+      sandbox.stub(document, 'querySelector').returns(null);
+
+      renderHook(() => useCharacterLimit(false));
+
+      expect(mockInputElement.setAttribute.called).to.be.false;
+      expect(createElementStub.called).to.be.false;
+    });
+
+    it('should cleanup on unmount', () => {
+      setupQuerySelectorStub(sandbox, {
+        inputElement: mockInputElement,
+        formElement: mockFormElement,
+        sendButton: mockSendButton,
+        webchatContainer: document.body,
+      });
+      sandbox.stub(document, 'createElement').returns(mockCounterElement);
+      mockCounterElement.parentElement = mockCounterParentElement;
+      mockCounterParentElement.removeChild = sandbox.stub();
+
+      const { unmount } = renderHook(() => useCharacterLimit(true));
+
+      expect(mockInputElement.addEventListener.calledWith('input')).to.be.true;
+
+      // Get the handler that was added
+      const addEventListenerCalls = mockInputElement.addEventListener.getCalls();
+      const inputHandler = addEventListenerCalls.find(
+        call => call.args[0] === 'input',
+      )?.args[1];
+
+      unmount();
+
+      expect(
+        mockInputElement.removeEventListener.calledWith('input', inputHandler),
+      ).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


## Summary

- Summary: Added a character limit 
- _(Which team do you work for, does your team own the maintenance of this component?)_
- Using the virtual agent AI disclaimer flipper but this has no known end date yet since it depends on our release to prod.

## Testing done

- Old behavior: No character limit indicator. Users could type as many characters as they wanted.
- Enable the virtual agent AI disclaimer flipper, go to the chatbot and click start chat. The indicator will be under the text box.
- Unit tests added. Ran locally and verified functionality.

## Screenshots
Before:
<img width="404" height="634" alt="Screenshot 2025-11-12 at 4 34 59 PM" src="https://github.com/user-attachments/assets/4a69d285-6621-4ed3-a6dd-06dabb70fb5a" />

After:
<img width="410" height="635" alt="Screenshot 2025-11-12 at 4 34 17 PM" src="https://github.com/user-attachments/assets/e2be4f42-3fe1-4cad-ab27-0fac79f82b41" />
<img width="411" height="642" alt="Screenshot 2025-11-12 at 4 34 34 PM" src="https://github.com/user-attachments/assets/8af016a7-629b-471e-82bc-8791ede9a4a4" />

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

