### PR TITLE
0969 | Post MVP - Add waived income recipient pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/06-asset-transfers/assetTransferPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/06-asset-transfers/assetTransferPages.js
@@ -671,7 +671,7 @@ export const assetTransferPages = arrayBuilderPages(options, pageBuilder => ({
     schema: parentIncomeRecipientPage.schema,
   }),
   assetTransferNonVeteranRecipientPage: pageBuilder.itemPage({
-    title: 'Asset transfer relationship information',
+    title: incomeRecipientPageTitle,
     path: 'asset-transfers/:index/income-recipient',
     depends: () => !showUpdatedContent(),
     uiSchema: nonVeteranIncomeRecipientPage.uiSchema,

--- a/src/applications/income-and-asset-statement/config/chapters/11-income-receipt-waivers/incomeReceiptWaiverPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/11-income-receipt-waivers/incomeReceiptWaiverPages.js
@@ -19,7 +19,6 @@ import {
 } from '~/platform/forms-system/src/js/web-component-patterns';
 import VaMemorableDateField from 'platform/forms-system/src/js/web-component-fields/VaMemorableDateField';
 import { validateDate } from 'platform/forms-system/src/js/validation';
-import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
@@ -27,15 +26,23 @@ import {
   generateDeleteDescription,
   isDefined,
   isRecipientInfoIncomplete,
-  otherRecipientRelationshipExplanationRequired,
+  otherRecipientRelationshipTypeUI,
   recipientNameRequired,
   requireExpandedArrayField,
   resolveRecipientFullName,
+  sharedRecipientRelationshipBase,
   sharedYesNoOptionsBase,
   showUpdatedContent,
 } from '../../../helpers';
-import { relationshipLabels } from '../../../labels';
+import {
+  custodianRelationshipLabels,
+  parentRelationshipLabels,
+  relationshipLabelDescriptions,
+  relationshipLabels,
+  spouseRelationshipLabels,
+} from '../../../labels';
 import { WaivedIncomeSummaryDescription } from '../../../components/SummaryDescriptions';
+import { DependentDescription } from '../../../components/DependentDescription';
 
 /** @type {ArrayBuilderOptions} */
 export const options = {
@@ -103,6 +110,7 @@ const updatedTitleNoItems =
   'Do you or your dependents plan to waive any income in the next 12 months?';
 const updatedTitleWithItems = 'Do you have more waived income to report?';
 const summaryPageTitle = 'Waived income';
+const incomeRecipientPageTitle = 'Waived income relationship';
 const yesNoOptionLabels = {
   Y: 'Yes, I have waived income to report',
   N: 'No, I don’t have waived income to report',
@@ -234,32 +242,162 @@ const parentSummaryPage = {
   },
 };
 
+const updatedSharedRecipientRelationshipBase = {
+  ...sharedRecipientRelationshipBase,
+  title: 'Who has waived income to report?',
+};
+
 /** @returns {PageSchema} */
-const relationshipPage = {
+const veteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Waived income relationship',
+      title: incomeRecipientPageTitle,
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: Object.fromEntries(
+        Object.entries(relationshipLabels).filter(
+          ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      descriptions: relationshipLabelDescriptions,
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'incomeReceiptWaivers',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(relationshipLabels).filter(
+          key => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const spouseIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: incomeRecipientPageTitle,
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: spouseRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key === 'CHILD',
+        ),
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'incomeReceiptWaivers',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(Object.keys(spouseRelationshipLabels)),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const custodianIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: incomeRecipientPageTitle,
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: custodianRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key !== 'CHILD',
+        ),
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'incomeReceiptWaivers',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(custodianRelationshipLabels),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const parentIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: incomeRecipientPageTitle,
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...updatedSharedRecipientRelationshipBase,
+      labels: parentRelationshipLabels,
+      descriptions: {
+        SPOUSE: 'The Veteran’s other parent should file a separate claim',
+      },
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'incomeReceiptWaivers',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(Object.keys(parentRelationshipLabels)),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const nonVeteranIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: incomeRecipientPageTitle,
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
       title: 'Who has waived income to report?',
+      ...sharedYesNoOptionsBase,
       labels: relationshipLabels,
     }),
-    otherRecipientRelationshipType: {
-      'ui:title': 'Describe their relationship to the Veteran',
-      'ui:webComponentField': VaTextInputField,
-      'ui:options': {
-        expandUnder: 'recipientRelationship',
-        expandUnderCondition: 'OTHER',
-        expandedContentFocus: true,
-      },
-      'ui:required': (formData, index) =>
-        otherRecipientRelationshipExplanationRequired(
-          formData,
-          index,
-          'incomeReceiptWaivers',
-        ),
-    },
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'incomeReceiptWaivers',
+    ),
     'ui:options': {
       ...requireExpandedArrayField('otherRecipientRelationshipType'),
     },
@@ -427,11 +565,56 @@ export const incomeReceiptWaiverPages = arrayBuilderPages(
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
-    incomeReceiptWaiverRelationshipPage: pageBuilder.itemPage({
-      title: 'Waived income relationship',
+    incomeReceiptWaiverVeteranRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="VETERAN" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'waived-income/:index/veteran-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'VETERAN',
+      uiSchema: veteranIncomeRecipientPage.uiSchema,
+      schema: veteranIncomeRecipientPage.schema,
+    }),
+    incomeReceiptWaiverSpouseRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="SPOUSE" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'waived-income/:index/spouse-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'SPOUSE',
+      uiSchema: spouseIncomeRecipientPage.uiSchema,
+      schema: spouseIncomeRecipientPage.schema,
+    }),
+    incomeReceiptWaiverCustodianRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="CUSTODIAN" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'waived-income/:index/custodian-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+      uiSchema: custodianIncomeRecipientPage.uiSchema,
+      schema: custodianIncomeRecipientPage.schema,
+    }),
+    incomeReceiptWaiverParentRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="PARENT" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'waived-income/:index/parent-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'PARENT',
+      uiSchema: parentIncomeRecipientPage.uiSchema,
+      schema: parentIncomeRecipientPage.schema,
+    }),
+    incomeReceiptWaiverNonVeteranRecipientPage: pageBuilder.itemPage({
+      title: incomeRecipientPageTitle,
       path: 'waived-income/:index/relationship',
-      uiSchema: relationshipPage.uiSchema,
-      schema: relationshipPage.schema,
+      depends: () => !showUpdatedContent(),
+      uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
+      schema: nonVeteranIncomeRecipientPage.schema,
     }),
     incomeReceiptWaiverRecipientNamePage: pageBuilder.itemPage({
       title: 'Waived income recipient name',

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
@@ -42,6 +42,11 @@ describe('income receipt waiver list and loop pages', () => {
     incomeReceiptWaiverPagesChildSummary,
     incomeReceiptWaiverPagesCustodianSummary,
     incomeReceiptWaiverPagesParentSummary,
+    incomeReceiptWaiverVeteranRecipientPage,
+    incomeReceiptWaiverSpouseRecipientPage,
+    incomeReceiptWaiverCustodianRecipientPage,
+    incomeReceiptWaiverParentRecipientPage,
+    incomeReceiptWaiverNonVeteranRecipientPage,
   } = incomeReceiptWaiverPages;
 
   describe('isItemIncomplete function', () => {
@@ -334,13 +339,13 @@ describe('income receipt waiver list and loop pages', () => {
     });
   });
 
-  describe('relationship page', () => {
+  describe('MVP income recipient page', () => {
     const schema =
-      incomeReceiptWaiverPages.incomeReceiptWaiverRelationshipPage.schema
-        .properties.incomeReceiptWaivers.items;
-    const uiSchema =
-      incomeReceiptWaiverPages.incomeReceiptWaiverRelationshipPage.uiSchema
+      incomeReceiptWaiverNonVeteranRecipientPage.schema.properties
         .incomeReceiptWaivers.items;
+    const uiSchema =
+      incomeReceiptWaiverNonVeteranRecipientPage.uiSchema.incomeReceiptWaivers
+        .items;
 
     testNumberOfFieldsByType(
       formConfig,
@@ -371,6 +376,73 @@ describe('income receipt waiver list and loop pages', () => {
       'relationship',
       'root_otherRecipientRelationshipType',
     );
+
+    describe('Non-Veteran recipient page', () => {
+      it('should display when showUpdatedContent is false', () => {
+        const formData = { ...testData.data, claimantType: 'SPOUSE' };
+        const { depends } = incomeReceiptWaiverNonVeteranRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+  });
+
+  describe('Updated recipient pages', () => {
+    beforeEach(() => {
+      showUpdatedContentStub.returns(true);
+    });
+
+    describe('Veteran recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'VETERAN' };
+
+      it('should display when showUpdatedContent is true and claimantType is VETERAN', () => {
+        const { depends } = incomeReceiptWaiverVeteranRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Spouse recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'SPOUSE' };
+
+      it('should display when showUpdatedContent is true and claimantType is SPOUSE', () => {
+        const { depends } = incomeReceiptWaiverSpouseRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Custodian recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'CUSTODIAN' };
+
+      it('should display when showUpdatedContent is true and claimantType is CUSTODIAN', () => {
+        const { depends } = incomeReceiptWaiverCustodianRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Parent recipient page', () => {
+      const formData = { ...testData.data, claimantType: 'PARENT' };
+
+      it('should display when showUpdatedContent is true and claimantType is PARENT', () => {
+        const { depends } = incomeReceiptWaiverParentRecipientPage;
+        expect(depends(formData)).to.be.true;
+      });
+    });
+
+    describe('Income recipient pages', () => {
+      const formData = { ...testData.data, claimantType: 'CHILD' };
+
+      it('should NOT display any recipient pages when claimantType is CHILD', () => {
+        expect(incomeReceiptWaiverNonVeteranRecipientPage.depends(formData)).to
+          .be.false;
+        expect(incomeReceiptWaiverVeteranRecipientPage.depends(formData)).to.be
+          .false;
+        expect(incomeReceiptWaiverSpouseRecipientPage.depends(formData)).to.be
+          .false;
+        expect(incomeReceiptWaiverCustodianRecipientPage.depends(formData)).to
+          .be.false;
+        expect(incomeReceiptWaiverParentRecipientPage.depends(formData)).to.be
+          .false;
+      });
+    });
   });
 
   describe('recipient name page', () => {


### PR DESCRIPTION
## Summary

This PR adds the **“Relationship to the Veteran”** recipient pages to the **Waived Income** chapter for **Post-MVP** updates in the **VA Form 21P-0969** (Income and Asset Statement).  

These pages introduce claimant-specific recipient relationship logic, aligning with the latest **Post-MVP array builder patterns** used across other income-related chapters.

The implementation ensures consistent page structure, content, and accessibility across all claimant types.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111739

## How to Test

1. Enable the Post-MVP feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`
2. Launch the form locally:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`
3. Proceed to the **Waived Income** chapter.
4. Add a waived income entry for each claimant type.
5. Verify:
   - The **“Waived income relationship”** page renders correctly.
   - Page content updates dynamically based on the claimant type.
   - Navigation and data persistence work correctly through the list-and-loop sequence.
  6. Verify no MVP regressions

## Areas Impacted

- **Waived Income** chapter (relationship to veteran pages)  
- **Array Builder utilities** for claimant-type page handling

## Feature Toggle

- `income_and_assets_content_updates`

## Screenshots

| Before | After |
|--------|--------|
| No relationship recipient pages for waived income | Added recipient relationship pages with Post-MVP logic and consistent design |

## Quality Assurance & Testing

- [x] Unit and E2E tests updated or added where applicable.  
- [x] Verified dynamic claimant-type content rendering.  
- [x] Accessibility tests confirm proper heading and label associations.  
- [x] Linting and CI checks pass.  
- [x] No PII/PHI data in logs or tests.

## Definition of Done

- Recipient relationship pages implemented for all claimant types.  
- Functionality and navigation match Post-MVP standards.  
- Gated behind the feature toggle.  
- Tested across claimant types for accuracy and completeness.

## Requested Feedback

Please confirm:
- Relationship to Veteran pages follow expected structure and logic.  
- Content and labels accurately reflect claimant context.  
- Integration with the Post-MVP toggle behaves as expected.