### PR TITLE
MHV SM: 121972 invalid filterbox behavior

### DIFF
--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -1,4 +1,9 @@
-import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import React, {
+  forwardRef,
+  useRef,
+  useImperativeHandle,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import {
   VaDate,
@@ -7,6 +12,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { datadogRum } from '@datadog/browser-rum';
 import moment from 'moment';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { DateRangeOptions, SelectCategories } from '../../util/inputContants';
 import { ErrorMessages } from '../../util/constants';
 
@@ -26,6 +32,8 @@ const FilterBox = forwardRef((props, ref) => {
   const [toDateError, setToDateError] = useState('');
   const [formError, setFormError] = useState('');
   const [isItemExpanded, setIsItemExpanded] = useState(false);
+  const fromDateRef = useRef(null);
+  const toDateRef = useRef(null);
 
   const handleCategoryChange = e => {
     setCategory(SelectCategories.find(item => item?.value === e.detail.value));
@@ -47,19 +55,23 @@ const FilterBox = forwardRef((props, ref) => {
     const today = new Date();
     // TODO: add validation for ALL blank fields
     let formInvalid;
+    const invalidInputs = [];
     if (dateRange === 'custom') {
       if (!fromDate) {
         formInvalid = true;
         setFromDateError(ErrorMessages.SearchForm.START_DATE_REQUIRED);
+        invalidInputs.push(fromDateRef);
       }
       if (!toDate) {
         formInvalid = true;
         setToDateError(ErrorMessages.SearchForm.END_DATE_REQUIRED);
+        invalidInputs.push(toDateRef);
       }
       if (fromDate && toDate && moment(toDate).isBefore(fromDate)) {
         formInvalid = true;
         setFromDateError(ErrorMessages.SearchForm.START_DATE_AFTER_END_DATE);
         setToDateError(ErrorMessages.SearchForm.END_DATE_BEFORE_START_DATE);
+        invalidInputs.push(fromDateRef);
       }
       if (fromDate && toDate && moment(fromDate).isBefore(toDate)) {
         formInvalid = false;
@@ -71,7 +83,12 @@ const FilterBox = forwardRef((props, ref) => {
         setToDateError(
           ErrorMessages.SearchForm.END_YEAR_GREATER_THAN_CURRENT_YEAR,
         );
+        invalidInputs.push(toDateRef);
       }
+      setIsItemExpanded(true);
+      setTimeout(() => {
+        focusElement(invalidInputs[0]?.current);
+      }, 100);
     } else {
       formInvalid = false;
     }
@@ -177,6 +194,7 @@ const FilterBox = forwardRef((props, ref) => {
                     required
                     error={fromDateError}
                     data-testid="date-start"
+                    ref={fromDateRef}
                   />
                   <VaDate
                     label="End date"
@@ -187,6 +205,7 @@ const FilterBox = forwardRef((props, ref) => {
                     required
                     error={toDateError}
                     data-testid="date-end"
+                    ref={toDateRef}
                   />
                 </div>
               </div>

--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -34,6 +34,7 @@ const FilterBox = forwardRef((props, ref) => {
   const [isItemExpanded, setIsItemExpanded] = useState(false);
   const fromDateRef = useRef(null);
   const toDateRef = useRef(null);
+  const filterRef = useRef(null);
 
   const handleCategoryChange = e => {
     setCategory(SelectCategories.find(item => item?.value === e.detail.value));
@@ -85,10 +86,15 @@ const FilterBox = forwardRef((props, ref) => {
         );
         invalidInputs.push(toDateRef);
       }
-      setIsItemExpanded(true);
-      setTimeout(() => {
-        focusElement(invalidInputs[0]?.current);
-      }, 100);
+
+      if (formInvalid) {
+        if (!isItemExpanded) {
+          setIsItemExpanded(true);
+        }
+        setTimeout(() => {
+          focusElement(invalidInputs[0]?.current);
+        }, 100);
+      }
     } else {
       formInvalid = false;
     }
@@ -99,7 +105,22 @@ const FilterBox = forwardRef((props, ref) => {
     checkFormValidity() {
       return checkFormValidity();
     },
+    clearDateErrors() {
+      setFromDateError('');
+      setToDateError('');
+    },
   }));
+
+  const handleToggle = target => {
+    if (
+      target === filterRef.current ||
+      target.tagName === 'VA-ACCORDION-ITEM'
+    ) {
+      return setIsItemExpanded(!isItemExpanded);
+    }
+    // If text is not defined, null
+    return null;
+  };
 
   return (
     <div className="advanced-search-form filter-box">
@@ -130,21 +151,10 @@ const FilterBox = forwardRef((props, ref) => {
         <va-accordion-item
           data-testid="accordion-item-filter"
           id="additional-filter-accordion"
-          onClick={e => {
-            const isOpen = e.target?.getAttribute('open') === 'true';
-            const text = e.target?.shadowRoot?.querySelector('button')
-              ?.innerText;
-
-            // Only proceed if text is defined
-            if (text !== undefined) {
-              return setIsItemExpanded(isOpen && text !== undefined);
-            }
-            // If text is not defined, null
-            return null;
-          }}
+          onClick={e => handleToggle(e.target)}
           open={isItemExpanded}
         >
-          <h3 slot="headline" className="headline-text">
+          <h3 slot="headline" className="headline-text" ref={filterRef}>
             {isItemExpanded ? 'Hide filters' : 'Show filters'}
           </h3>
           <div className="filter-content">

--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -1,5 +1,6 @@
 import React, {
   forwardRef,
+  useCallback,
   useRef,
   useImperativeHandle,
   useState,
@@ -111,16 +112,19 @@ const FilterBox = forwardRef((props, ref) => {
     },
   }));
 
-  const handleToggle = target => {
-    if (
-      target === filterRef.current ||
-      target.tagName === 'VA-ACCORDION-ITEM'
-    ) {
-      return setIsItemExpanded(!isItemExpanded);
-    }
-    // If text is not defined, null
-    return null;
-  };
+  const handleToggle = useCallback(
+    target => {
+      if (
+        target === filterRef.current ||
+        target.tagName === 'VA-ACCORDION-ITEM'
+      ) {
+        return setIsItemExpanded(!isItemExpanded);
+      }
+      // If text is not defined, null
+      return null;
+    },
+    [filterRef, isItemExpanded],
+  );
 
   return (
     <div className="advanced-search-form filter-box">

--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -93,7 +93,7 @@ const FilterBox = forwardRef((props, ref) => {
         }
         setTimeout(() => {
           focusElement(invalidInputs[0]?.current);
-        }, 100);
+        }, 10);
       }
     } else {
       formInvalid = false;

--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -101,6 +101,7 @@ const SearchForm = props => {
     if (searchTerm === '' && customFilter === false) {
       setSearchTermError(null);
       setSearchTermError(ErrorMessages.SearchForm.SEARCH_TERM_REQUIRED);
+      focusElement(filterInputRef.current);
       return;
     }
     setSearchTermError(null);
@@ -124,6 +125,7 @@ const SearchForm = props => {
     dispatch(clearSearchResults());
     setFiltersCleared(true);
     setSearchTerm('');
+    setSearchTermError(null);
     focusElement(filterFormTitleRef.current);
     setCategory('');
     setDateRange('any');

--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -73,7 +73,10 @@ const SearchForm = props => {
 
   const handleSearch = () => {
     setFiltersCleared(false);
-    if (filterBoxRef.current.checkFormValidity()) return;
+    if (filterBoxRef.current.checkFormValidity()) {
+      setSearchTermError(null);
+      return;
+    }
 
     let relativeToDate;
     let relativeFromDate;
@@ -105,6 +108,7 @@ const SearchForm = props => {
       return;
     }
     setSearchTermError(null);
+    filterBoxRef.current.clearDateErrors();
 
     dispatch(
       runAdvancedSearch(

--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -126,6 +126,7 @@ const SearchForm = props => {
     setFiltersCleared(true);
     setSearchTerm('');
     setSearchTermError(null);
+    filterBoxRef.current.clearDateErrors();
     focusElement(filterFormTitleRef.current);
     setCategory('');
     setDateRange('any');

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientFilterPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientFilterPage.js
@@ -22,6 +22,10 @@ class PatientFilterSortPage {
     cy.findByText('Show filters', { selector: 'h3' }).click();
   };
 
+  closeAdditionalFilter = () => {
+    cy.findByText('Hide filters', { selector: 'h3' }).click();
+  };
+
   // This method will access the input field and enters the text that will be used for search.
   inputFilterData = text => {
     cy.get(Locators.KEYWORD_SEARCH)
@@ -308,6 +312,13 @@ class PatientFilterSortPage {
       .get(selector)
       .find(`#error-message`)
       .should(`be.visible`);
+  };
+
+  verifyNoFieldErrors = selector => {
+    return cy
+      .get(selector)
+      .find(`#error-message`)
+      .should(`not.exist`);
   };
 
   // retrieveMessages = function (folderID) {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-folders.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-folders.cypress.spec.js
@@ -3,7 +3,7 @@ import SecureMessagingSite from './sm_site/SecureMessagingSite';
 import FolderLoadPage from './pages/FolderLoadPage';
 import { AXE_CONTEXT } from './utils/constants';
 import PatientInboxPage from './pages/PatientInboxPage';
-import PatentMessageSentPage from './pages/PatientMessageSentPage';
+import PatientMessageSentPage from './pages/PatientMessageSentPage';
 import SharedComponents from './pages/SharedComponents';
 
 describe(manifest.appName, () => {
@@ -20,7 +20,7 @@ describe(manifest.appName, () => {
   });
 
   it('Check the Sent folder', () => {
-    PatentMessageSentPage.loadMessages();
+    PatientMessageSentPage.loadMessages();
     FolderLoadPage.verifyFolderHeaderText('Messages: Sent');
     FolderLoadPage.verifyBreadCrumbsLength(3);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js
@@ -43,6 +43,8 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -74,6 +76,35 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`include.text`, Alerts.DATE_FILTER.INVALID_END_DATE);
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('focuses on the first filter error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('opens closed accordion on relevant error', () => {
+    PatientFilterPage.closeAdditionalFilter();
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears start and end date errors on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.CLEAR_FILTERS).click();
+    PatientFilterPage.selectDateRange('Custom');
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_START_DATE);
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_END_DATE);
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js
@@ -43,8 +43,6 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -64,6 +62,10 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`have.text`, Alerts.DATE_FILTER.EMPTY_END_DATE);
 
+    cy.get(Locators.BLOCKS.FILTER_START_DATE)
+      .find('[name="discharge-dateMonth"]')
+      .should('not.be.disabled');
+
     PatientFilterPage.selectStartMonth('April');
     PatientFilterPage.selectEndMonth('February');
     cy.get(Locators.BUTTONS.FILTER).click();
@@ -82,8 +84,6 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
 
   it('focuses on the first filter error', () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
@@ -92,8 +92,6 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
   it('opens closed accordion on relevant error', () => {
     PatientFilterPage.closeAdditionalFilter();
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-drafts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-drafts.cypress.spec.js
@@ -42,8 +42,6 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -63,6 +61,10 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`have.text`, Alerts.DATE_FILTER.EMPTY_END_DATE);
 
+    cy.get(Locators.BLOCKS.FILTER_START_DATE)
+      .find('[name="discharge-dateMonth"]')
+      .should('not.be.disabled');
+
     PatientFilterPage.selectStartMonth('April');
     PatientFilterPage.selectEndMonth('February');
     cy.get(Locators.BUTTONS.FILTER).click();
@@ -81,8 +83,6 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
 
   it('focuses on the first filter error', () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
@@ -91,8 +91,6 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
   it('opens closed accordion on relevant error', () => {
     PatientFilterPage.closeAdditionalFilter();
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-drafts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-drafts.cypress.spec.js
@@ -42,6 +42,8 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -73,6 +75,35 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`include.text`, Alerts.DATE_FILTER.INVALID_END_DATE);
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('focuses on the first filter error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('opens closed accordion on relevant error', () => {
+    PatientFilterPage.closeAdditionalFilter();
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears start and end date errors on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.CLEAR_FILTERS).click();
+    PatientFilterPage.selectDateRange('Custom');
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_START_DATE);
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_END_DATE);
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
@@ -39,8 +39,6 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -60,6 +58,10 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`have.text`, Alerts.DATE_FILTER.EMPTY_END_DATE);
 
+    cy.get(Locators.BLOCKS.FILTER_START_DATE)
+      .find('[name="discharge-dateMonth"]')
+      .should('not.be.disabled');
+
     PatientFilterPage.selectStartMonth('April');
     PatientFilterPage.selectEndMonth('February');
     cy.get(Locators.BUTTONS.FILTER).click();
@@ -78,8 +80,6 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
 
   it('focuses on the first filter error', () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
@@ -88,8 +88,6 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
   it('opens closed accordion on relevant error', () => {
     PatientFilterPage.closeAdditionalFilter();
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
@@ -39,6 +39,8 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -70,6 +72,35 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`include.text`, Alerts.DATE_FILTER.INVALID_END_DATE);
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('focuses on the first filter error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('opens closed accordion on relevant error', () => {
+    PatientFilterPage.closeAdditionalFilter();
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears start and end date errors on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.CLEAR_FILTERS).click();
+    PatientFilterPage.selectDateRange('Custom');
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_START_DATE);
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_END_DATE);
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-sent.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-sent.cypress.spec.js
@@ -3,7 +3,7 @@ import PatientInboxPage from '../pages/PatientInboxPage';
 import { AXE_CONTEXT, Locators, Alerts } from '../utils/constants';
 import PatientFilterPage from '../pages/PatientFilterPage';
 import FolderLoadPage from '../pages/FolderLoadPage';
-import PatentMessageSentPage from '../pages/PatientMessageSentPage';
+import PatientMessageSentPage from '../pages/PatientMessageSentPage';
 import GeneralFunctionsPage from '../pages/GeneralFunctionsPage';
 
 describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
@@ -11,7 +11,7 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
     SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
-    PatentMessageSentPage.loadMessages();
+    PatientMessageSentPage.loadMessages();
     PatientFilterPage.openAdditionalFilter();
     PatientFilterPage.selectDateRange('Custom');
   });
@@ -43,6 +43,8 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -74,6 +76,35 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`include.text`, Alerts.DATE_FILTER.INVALID_END_DATE);
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('focuses on the first filter error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('opens closed accordion on relevant error', () => {
+    PatientFilterPage.closeAdditionalFilter();
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears start and end date errors on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.CLEAR_FILTERS).click();
+    PatientFilterPage.selectDateRange('Custom');
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_START_DATE);
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_END_DATE);
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-sent.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-sent.cypress.spec.js
@@ -43,8 +43,6 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -64,6 +62,10 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`have.text`, Alerts.DATE_FILTER.EMPTY_END_DATE);
 
+    cy.get(Locators.BLOCKS.FILTER_START_DATE)
+      .find('[name="discharge-dateMonth"]')
+      .should('not.be.disabled');
+
     PatientFilterPage.selectStartMonth('April');
     PatientFilterPage.selectEndMonth('February');
     cy.get(Locators.BUTTONS.FILTER).click();
@@ -82,8 +84,6 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
 
   it('focuses on the first filter error', () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
@@ -92,8 +92,6 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
   it('opens closed accordion on relevant error', () => {
     PatientFilterPage.closeAdditionalFilter();
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-trash.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-trash.cypress.spec.js
@@ -42,8 +42,6 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -63,6 +61,10 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`have.text`, Alerts.DATE_FILTER.EMPTY_END_DATE);
 
+    cy.get(Locators.BLOCKS.FILTER_START_DATE)
+      .find('[name="discharge-dateMonth"]')
+      .should('not.be.disabled');
+
     PatientFilterPage.selectStartMonth('April');
     PatientFilterPage.selectEndMonth('February');
     cy.get(Locators.BUTTONS.FILTER).click();
@@ -81,8 +83,6 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
 
   it('focuses on the first filter error', () => {
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
@@ -91,8 +91,6 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
   it('opens closed accordion on relevant error', () => {
     PatientFilterPage.closeAdditionalFilter();
     cy.get(Locators.BUTTONS.FILTER).click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200);
     cy.findByTestId('date-start').should('be.focused');
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-trash.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-trash.cypress.spec.js
@@ -42,6 +42,8 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
 
   it(`verify errors`, () => {
     cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
 
     cy.get(Locators.FROM_TO_DATES_CONTAINER)
       .find('legend')
@@ -73,6 +75,35 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
       Locators.BLOCKS.FILTER_END_DATE,
     ).should(`include.text`, Alerts.DATE_FILTER.INVALID_END_DATE);
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('focuses on the first filter error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('opens closed accordion on relevant error', () => {
+    PatientFilterPage.closeAdditionalFilter();
+    cy.get(Locators.BUTTONS.FILTER).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
+    cy.findByTestId('date-start').should('be.focused');
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears start and end date errors on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.CLEAR_FILTERS).click();
+    PatientFilterPage.selectDateRange('Custom');
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_START_DATE);
+    PatientFilterPage.verifyNoFieldErrors(Locators.BLOCKS.FILTER_END_DATE);
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-folder.cypress.spec.js
@@ -1,7 +1,7 @@
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import PatientInboxPage from '../pages/PatientInboxPage';
 import mockSingleThreadResponse from '../fixtures/customResponse/custom-single-thread-response.json';
-import { AXE_CONTEXT, Data } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Data, Alerts } from '../utils/constants';
 import PatientMessageCustomFolderPage from '../pages/PatientMessageCustomFolderPage';
 import FolderLoadPage from '../pages/FolderLoadPage';
 import PatientFilterPage from '../pages/PatientFilterPage';
@@ -108,6 +108,44 @@ describe('SM CUSTOM FOLDER ADD FILTER FIXED DATE RANGE', () => {
       Data.DATE_RANGE.TWELVE_MONTHS,
     );
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});
+
+describe('SM FILTER ERROR', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    FolderLoadPage.loadFolders();
+    PatientMessageCustomFolderPage.loadMessages();
+  });
+
+  it('focuses on relevant error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT).should('be.focused');
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears keyword error on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.get(Locators.CLEAR_FILTERS).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.not.exist;
+      });
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-drafts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-drafts.cypress.spec.js
@@ -1,7 +1,7 @@
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import PatientInboxPage from '../pages/PatientInboxPage';
 import mockDraftMessages from '../fixtures/draftsResponse/drafts-messages-response.json';
-import { AXE_CONTEXT, Data } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Data, Alerts } from '../utils/constants';
 import FolderLoadPage from '../pages/FolderLoadPage';
 import PatientFilterPage from '../pages/PatientFilterPage';
 
@@ -105,6 +105,44 @@ describe('SM DRAFTS ADD FILTER FIXED DATE RANGE', () => {
       Data.DATE_RANGE.TWELVE_MONTHS,
     );
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});
+
+describe('SM FILTER ERROR', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    FolderLoadPage.loadFolders();
+    FolderLoadPage.loadDraftMessages();
+  });
+
+  it('focuses on relevant error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT).should('be.focused');
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears keyword error on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.get(Locators.CLEAR_FILTERS).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.not.exist;
+      });
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-inbox.cypress.spec.js
@@ -1,7 +1,7 @@
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import PatientInboxPage from '../pages/PatientInboxPage';
 import mockMessages from '../fixtures/threads-response.json';
-import { AXE_CONTEXT, Data } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Data, Alerts } from '../utils/constants';
 import PatientFilterPage from '../pages/PatientFilterPage';
 
 describe('SM INBOX ADD FILTER CATEGORY', () => {
@@ -90,6 +90,42 @@ describe('SM INBOX ADD FILTER FIXED DATE RANGE', () => {
       Data.DATE_RANGE.TWELVE_MONTHS,
     );
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});
+
+describe('SM FILTER ERROR', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+  });
+
+  it('focuses on relevant error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT).should('be.focused');
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears keyword error on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.get(Locators.CLEAR_FILTERS).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.not.exist;
+      });
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-sent.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-sent.cypress.spec.js
@@ -1,9 +1,9 @@
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import PatientInboxPage from '../pages/PatientInboxPage';
 import mockSentMessages from '../fixtures/sentResponse/sent-messages-response.json';
-import { AXE_CONTEXT, Data } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Data, Alerts } from '../utils/constants';
 import FolderLoadPage from '../pages/FolderLoadPage';
-import PatentMessageSentPage from '../pages/PatientMessageSentPage';
+import PatientMessageSentPage from '../pages/PatientMessageSentPage';
 import PatientFilterPage from '../pages/PatientFilterPage';
 
 describe('SM SENT ADD FILTER CATEGORY', () => {
@@ -16,7 +16,7 @@ describe('SM SENT ADD FILTER CATEGORY', () => {
     SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
-    PatentMessageSentPage.loadMessages();
+    PatientMessageSentPage.loadMessages();
     PatientFilterPage.openAdditionalFilter();
     PatientFilterPage.selectAdvancedSearchCategory('Appointment');
     PatientFilterPage.clickApplyFilterButton(filterResultResponse);
@@ -47,7 +47,7 @@ describe('SM SENT ADD FILTER FIXED DATE RANGE', () => {
     SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
-    PatentMessageSentPage.loadMessages();
+    PatientMessageSentPage.loadMessages();
     PatientFilterPage.openAdditionalFilter();
   });
 
@@ -110,6 +110,44 @@ describe('SM SENT ADD FILTER FIXED DATE RANGE', () => {
       Data.DATE_RANGE.TWELVE_MONTHS,
     );
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});
+
+describe('SM FILTER ERROR', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    FolderLoadPage.loadFolders();
+    PatientMessageSentPage.loadMessages();
+  });
+
+  it('focuses on relevant error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT).should('be.focused');
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears keyword error on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.get(Locators.CLEAR_FILTERS).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.not.exist;
+      });
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-trash.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-trash.cypress.spec.js
@@ -1,7 +1,7 @@
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import PatientInboxPage from '../pages/PatientInboxPage';
 import mockTrashMessages from '../fixtures/trashResponse/trash-messages-response.json';
-import { AXE_CONTEXT, Data } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Data, Alerts } from '../utils/constants';
 import FolderLoadPage from '../pages/FolderLoadPage';
 import PatientFilterPage from '../pages/PatientFilterPage';
 
@@ -107,6 +107,44 @@ describe('SM TRASH ADVANCED FIXED DATE RANGE SEARCH', () => {
       Data.DATE_RANGE.TWELVE_MONTHS,
     );
 
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});
+
+describe('SM FILTER ERROR', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    FolderLoadPage.loadFolders();
+    FolderLoadPage.loadDeletedMessages();
+  });
+
+  it('focuses on relevant error', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT).should('be.focused');
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('clears keyword error on filter clear', () => {
+    cy.get(Locators.BUTTONS.FILTER).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.equal(Alerts.SEARCH_TERM_REQUIRED);
+      });
+    cy.get(Locators.CLEAR_FILTERS).click();
+    cy.get(Locators.BLOCKS.FILTER_KEYWORD_INPUT)
+      .invoke('attr', 'error')
+      .then(errorAttr => {
+        expect(errorAttr).to.not.exist;
+      });
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filters-elements.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filters-elements.cypress.spec.js
@@ -3,7 +3,7 @@ import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import mockMessages from '../fixtures/threads-response.json';
 import { AXE_CONTEXT, Arrays } from '../utils/constants';
 import FolderLoadPage from '../pages/FolderLoadPage';
-import PatentMessageSentPage from '../pages/PatientMessageSentPage';
+import PatientMessageSentPage from '../pages/PatientMessageSentPage';
 import PatientFilterPage from '../pages/PatientFilterPage';
 import PatientMessageCustomFolderPage from '../pages/PatientMessageCustomFolderPage';
 
@@ -30,7 +30,7 @@ describe('SM ADDITIONAL FILTER ELEMENTS', () => {
 
   it('verify Sent folder buttons and dropdowns', () => {
     FolderLoadPage.loadFolders();
-    PatentMessageSentPage.loadMessages();
+    PatientMessageSentPage.loadMessages();
 
     cy.get(`#content`).should('have.attr', 'hidden');
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -272,6 +272,7 @@ export const Locators = {
   BLOCKS: {
     ATTACHMENTS: '.attachments-list',
     FILTER_START_DATE: `[data-testid="date-start"]`,
+    FILTER_KEYWORD_INPUT: `[data-testid="keyword-search-input"]`,
     FILTER_END_DATE: `[data-testid="date-end"]`,
   },
   CHECKBOX: {
@@ -364,6 +365,7 @@ export const Alerts = {
   VIRUS_MULTI_ATTCH: `Our file scanner found a problem with your attachments. To send your message, remove the attachments.`,
   SAVE_DRAFT: `Do you want to save your draft message?`,
   SAVE_CHANGES: `Do you want to save your changes to this draft?`,
+  SEARCH_TERM_REQUIRED: 'Please enter a search term.',
 };
 
 export const Data = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Improvements have been made to the way the message filter handles invalid inputs. Specifically, if the filter has invalid inputs the application focuses the first invalid input, expanding the custom accordion if necessary. Clearing the filter also clears out all invalid input alerts.
 
## Related issue(s)
[121972](https://github.com/department-of-veterans-affairs/va.gov-team/issues/121972)

## Testing done
specs added

## Screenshots

https://github.com/user-attachments/assets/dda7a898-ea1a-455a-ae62-1b459b9c715b



## What areas of the site does it impact?
SM application

## Acceptance criteria
**Case 1**
Given there is an error in the additional filters area

- And the additional filters are collapsed
- When the user invokes “Apply filters”
- Then the additional filters area will expand
- And the additional filter area with the error will report an error on the UI
- And focus will be brought to the highest error report on the UI


**Case 2** 
 Given there is an error above the additional filters area

-And the additional filters are collapsed
-When the user invokes “Apply filters”
-The filter area with the error will report an error on the UI
-And focus will be brought to the error report on the UI
### Quality Assurance & Testing
AC is met and filter functionality is preserved