### PR TITLE
0969 | Post MVP - Update waived income pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
@@ -29,7 +29,7 @@ import {
   otherRecipientRelationshipTypeUI,
   updatedRecipientNameRequired,
   requireExpandedArrayField,
-  resolveRecipientFullName,
+  updatedResolveRecipientFullName,
   sharedRecipientRelationshipBase,
   showUpdatedContent,
   sharedYesNoOptionsBase,
@@ -74,7 +74,7 @@ export const options = {
       if (!isDefined(item?.recipientRelationship) || !isDefined(item?.payer)) {
         return undefined;
       }
-      const fullName = resolveRecipientFullName(item, formData);
+      const fullName = updatedResolveRecipientFullName(item, formData);
       const possessiveName = formatPossessiveString(fullName);
       return `${possessiveName} income from ${item.payer}`;
     },

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
@@ -79,34 +79,37 @@ describe('income receipt waiver list and loop pages', () => {
       veteranFullName: { first: 'John', last: 'Doe' },
       otherVeteranFullName: { first: 'Alex', last: 'Smith' },
     };
-    it('should return "John Doe’s income receipt waiver" if recipient is Veteran', () => {
+    it('should return "John Doe’s waived income from `payer`" if recipient is Veteran', () => {
       const item = {
         recipientRelationship: 'VETERAN',
         recipientName: { first: 'Jane', last: 'Smith' },
+        payer: 'social security',
       };
       expect(options.text.getItemName(item, 0, mockFormData)).to.equal(
-        'John Doe’s waived income',
+        'John Doe’s waived income from social security',
       );
     });
-    it('should return "Alex Smith’s income receipt waiver" if recipient is Veteran and not logged in', () => {
+    it('should return "Alex Smith’s waived income from `payer`" if recipient is Veteran and not logged in', () => {
       const item = {
         recipientRelationship: 'VETERAN',
         recipientName: { first: 'Jane', last: 'Smith' },
+        payer: 'social security',
       };
       expect(
         options.text.getItemName(item, 0, {
           ...mockFormData,
           isLoggedIn: false,
         }),
-      ).to.equal('Alex Smith’s waived income');
+      ).to.equal('Alex Smith’s waived income from social security');
     });
-    it('should return "Jane Smith’s income receipt waiver" if recipient is not Veteran', () => {
+    it('should return "Jane Smith’s waived income from `payer`" if recipient is not Veteran', () => {
       const item = {
         recipientRelationship: 'SPOUSE',
         recipientName: { first: 'Jane', last: 'Smith' },
+        payer: 'social security',
       };
       expect(options.text.getItemName(item, 0, mockFormData)).to.equal(
-        'Jane Smith’s waived income',
+        'Jane Smith’s waived income from social security',
       );
     });
   });
@@ -118,6 +121,7 @@ describe('income receipt waiver list and loop pages', () => {
       'view:paymentsWillResume': _,
       recipientRelationship,
       recipientName,
+      payer,
       paymentResumeDate,
       ...baseItem
     } = testData.data.incomeReceiptWaivers[0];
@@ -132,6 +136,7 @@ describe('income receipt waiver list and loop pages', () => {
       'view:paymentsWillResume': _,
       recipientRelationship,
       recipientName,
+      payer,
       paymentResumeDate,
       ...baseItem
     } = testDataZeroes.data.incomeReceiptWaivers[0];
@@ -499,7 +504,7 @@ describe('income receipt waiver list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-text-input[label="Income payer name"]'],
+      ['va-text-input[label="Who pays this waived income?"]'],
       'payer',
     );
     testSubmitsWithoutErrors(
@@ -556,7 +561,7 @@ describe('income receipt waiver list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-radio[label="Do you expect the payments to resume?"]'],
+      ['va-radio[label="Will payments from this waived income start again?"]'],
       'payments',
     );
     testSubmitsWithoutErrors(
@@ -588,7 +593,7 @@ describe('income receipt waiver list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      ['va-memorable-date[label="When will the payments resume?"]'],
+      ['va-memorable-date[label="When will the payments start again?"]'],
       'date',
     );
     testSubmitsWithoutErrors(


### PR DESCRIPTION
### Summary of Changes
This update applies **Post-MVP Design QA feedback** to the **Waived Income** chapter of the 0969 form.  
The changes include refined text and alignment with the design spec. These updates ensure consistency across the Post-MVP income-related chapters.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111740
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111742

### How to Set Up in Local Environment
1. Start the local environment
2. Navigate to the 0969 form:  
   http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/

### How to Test
1. Go to the **Waived Income** chapter.  
2. Use a `claimantType` such as **Veteran** or **Parent** to verify the updated pages.  
3. Review the **name** and **information pages** conditional logic based on 'cliamantType'.  
4. Confirm there are no regressions in navigation, schema validation, or accessibility.

### Feature Flag Note
- These updates are included under the Post-MVP feature flag for the 0969 form:
  - `income_and_assets_content_updates`

### Acceptance Criteria
- [x] Updated text and layout per Design QA feedback.  
- [x] Name and information pages match the design spec.  
- [x] No accessibility or validation regressions.  
- [x] Verified behind the Post-MVP feature flag.

### Definition of Done
- [ ] Code reviewed and approved.  
- [ ] Verified locally and on staging.  
- [x] Automated tests passing.  
- [x] Aligned with design system typography and spacing standards.