### PR TITLE
AskVA - 1931 - 508 audit, removed non visual lists

### DIFF
--- a/src/applications/ask-va/containers/DashboardCards.jsx
+++ b/src/applications/ask-va/containers/DashboardCards.jsx
@@ -198,7 +198,7 @@ const DashboardCards = () => {
 
     return (
       <>
-        <ul
+        <div
           className={
             hasBusinessLevelAuth
               ? 'dashboard-cards-grid-with-business'
@@ -206,7 +206,7 @@ const DashboardCards = () => {
           }
         >
           {currentInquiries.map(card => (
-            <li key={card.id} className="dashboard-card-list">
+            <div key={card.id} className="dashboard-card-list">
               <va-card class="vacard">
                 <h3 className="vads-u-margin-top--0 vads-u-margin-bottom--0">
                   <span className="vads-u-margin-bottom--1p5 vads-u-display--block">
@@ -221,32 +221,30 @@ const DashboardCards = () => {
                     {`Submitted on ${formatDate(card.attributes.createdOn)}`}
                   </span>
                 </h3>
-                <dl>
-                  <div className="vads-u-margin--0 vads-u-padding-bottom--1">
-                    <dt className="vads-u-font-weight--bold vads-u-display--inline">
-                      Last updated:
-                    </dt>{' '}
-                    <dd className="vads-u-display--inline">
-                      {formatDate(card.attributes.lastUpdate)}
-                    </dd>
-                  </div>
-                  <div className="vads-u-margin--0 vads-u-padding-bottom--1">
-                    <dt className="vads-u-font-weight--bold vads-u-display--inline">
-                      Reference number:
-                    </dt>{' '}
-                    <dd className="vads-u-display--inline">
-                      {card.attributes.inquiryNumber}
-                    </dd>
-                  </div>
-                  <div className="vads-u-margin-bottom--0 vacardCategory multiline-ellipsis-1">
-                    <dt className="vads-u-font-weight--bold vads-u-display--inline">
-                      Category:
-                    </dt>{' '}
-                    <dd className="vads-u-display--inline">
-                      {card.attributes.categoryName}
-                    </dd>
-                  </div>
-                </dl>
+                <div className="vads-u-margin--0 vads-u-padding-bottom--1">
+                  <span className="vads-u-font-weight--bold vads-u-display--inline">
+                    Last updated:
+                  </span>{' '}
+                  <span className="vads-u-display--inline">
+                    {formatDate(card.attributes.lastUpdate)}
+                  </span>
+                </div>
+                <div className="vads-u-margin--0 vads-u-padding-bottom--1">
+                  <span className="vads-u-font-weight--bold vads-u-display--inline">
+                    Reference number:
+                  </span>{' '}
+                  <span className="vads-u-display--inline">
+                    {card.attributes.inquiryNumber}
+                  </span>
+                </div>
+                <div className="vads-u-margin-bottom--0 vacardCategory multiline-ellipsis-1">
+                  <span className="vads-u-font-weight--bold vads-u-display--inline">
+                    Category:
+                  </span>{' '}
+                  <span className="vads-u-display--inline">
+                    {card.attributes.categoryName}
+                  </span>
+                </div>
                 <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-margin-bottom--1 vads-u-margin-top--1p5" />
                 <p className="vacardSubmitterQuestion">
                   {card.attributes.submitterQuestion}
@@ -265,9 +263,9 @@ const DashboardCards = () => {
                   />
                 </Link>
               </va-card>
-            </li>
+            </div>
           ))}
-        </ul>
+        </div>
 
         {totalPages > 1 && (
           <VaPagination

--- a/src/applications/ask-va/tests/containers/DashboardCards.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/DashboardCards.unit.spec.jsx
@@ -463,7 +463,9 @@ describe('<DashboardCards>', () => {
       const filterSummary = await view.findByText(/showing/i);
       expect(filterSummary.textContent).to.include('categories in Personal');
 
-      const resultsBefore = await view.findAllByRole('listitem');
+      const resultsBefore = await view.container.querySelectorAll(
+        '.dashboard-card-list',
+      );
       expect(resultsBefore.length).to.equal(2);
       expect(resultsBefore[0].textContent).to.include('Reference number: A-2');
 
@@ -480,7 +482,9 @@ describe('<DashboardCards>', () => {
       filterButtons.__events.primaryClick();
 
       // Confirrm the list is now just one desired result
-      const resultsAfter = await view.findAllByRole('listitem');
+      const resultsAfter = await view.container.querySelectorAll(
+        '.dashboard-card-list',
+      );
       expect(resultsAfter.length).to.equal(1);
       expect(resultsAfter[0].textContent).to.include('Reference number: A-3');
     });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- On the Ask VA page, list structures are being used for layout purposes instead of semantic grouping. This causes screen readers (e.g., JAWS) to announce misleading list and definition list information, even though no visual lists are presented. 
- Replication Steps
  - Navigate to the Ask VA page
  - Use JAWS or another screen reader to browse the page with arrow keys.
  - After the text “Showing 1-4 of 5 results for ‘All’ statuses and ‘All’ categories in Business”, note that JAWS announces “list of 4 items” and “definition list of 3 items nesting level 1”.
- Replace the ```<ul><li>``` and ```<dl><dt><dd>``` with ```<div>``` and  ```<span>``` respectively
- AskVA

## Related issue(s)

- [508 Critical: Use Correct Semantic Elements or ARIA Markup for Lists and Definitions 1931](https://github.com/department-of-veterans-affairs/ask-va/issues/1931#top)


## Testing done

Using Mac VoiceOver on the local environment
*Prior to the change*
- After announcing the number of cards, the number of cards was listed again
- On each card, the definition list would announce that there were three items, then list each term twice
*After the change*
- Announced the number of cards a single time
- Each card announces the term once


## Screenshots

This was a semantic element change.  Screenshots of before and after are documented in the issue to confirm there was no visual change

## What areas of the site does it impact?

Solely AskVA and associated test

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

