### PR TITLE
Update how clinic count events are emitted in VAOS

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
@@ -70,10 +70,6 @@ export default function ClinicChoicePage() {
   useEffect(
     () => {
       document.title = `${pageTitle} | Veterans Affairs`;
-      recordEvent({
-        event: `${GA_PREFIX}-clinic-choice-count`,
-        'clinic-count': schema.properties.clinicId.enum.length - 1,
-      });
       dispatch(startDirectScheduleFlow({ isRecordEvent: false }));
     },
     [dispatch],
@@ -81,6 +77,12 @@ export default function ClinicChoicePage() {
 
   useEffect(
     () => {
+      if (Number.isInteger(schema.properties.clinicId.enum.length)) {
+        recordEvent({
+          event: `${GA_PREFIX}-clinic-choice-count`,
+          'clinic-count': schema.properties.clinicId.enum.length - 1,
+        });
+      }
       if (schema.properties.clinicId.enum.length > 2) {
         focusFormHeader();
       } else {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update vaos clinic count events to eliminate/reduce the empty events
- We were emitting the event on page load but the schema may not have been loaded at the time leading to a lot of not set values in the event payload.
- This PR updates so the event is emitted whenever we have non-null clinic counts
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121414

## Testing done

- Tested locally

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

