### PR TITLE
MHV [SM web] - RX Renewal Flow - redirect on draft "delete"

### DIFF
--- a/src/applications/mhv-medications/components/shared/RxRenewalDeleteDraftSuccessAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/RxRenewalDeleteDraftSuccessAlert.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const RxRenewalDeleteDraftSuccessAlert = () => {
+  const [visible, setIsVisible] = useState(true);
+  return (
+    <VaAlert
+      slim
+      closeable
+      role="status"
+      status="success"
+      visible={visible}
+      className="vads-u-margin-bottom--3"
+      data-testid="rx-renewal-delete-draft-success-alert"
+      onCloseEvent={() => {
+        setIsVisible(false);
+      }}
+    >
+      <p className="vads-u-margin-y--0">You successfully deleted your draft.</p>
+    </VaAlert>
+  );
+};
+
+export default RxRenewalDeleteDraftSuccessAlert;

--- a/src/applications/mhv-medications/components/shared/RxRenewalMessageSuccessAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/RxRenewalMessageSuccessAlert.jsx
@@ -8,6 +8,7 @@ const RxRenewalMessageSuccessAlert = () => {
       status="success"
       visible
       className="vads-u-margin-bottom--3"
+      data-testid="rx-renewal-message-success-alert"
     >
       <h2 slot="headline">Message Sent</h2>
       <p>

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -83,6 +83,7 @@ import {
 import { buildPdfData } from '../util/buildPdfData';
 import { generateMedicationsPdfFile } from '../util/generateMedicationsPdfFile';
 import FilterAriaRegion from '../components/MedicationsList/FilterAriaRegion';
+import RxRenewalDeleteDraftSuccessAlert from '../components/shared/RxRenewalDeleteDraftSuccessAlert';
 
 const Prescriptions = () => {
   const { search } = useLocation();
@@ -94,6 +95,7 @@ const Prescriptions = () => {
   const hasMedsByMailFacility = useSelector(selectHasMedsByMailFacility);
   const [searchParams] = useSearchParams();
   const rxRenewalMessageSuccess = searchParams.get('rxRenewalMessageSuccess');
+  const deleteDraftSuccess = searchParams.get('draftDeleteSuccess');
 
   // Get sort/filter selections from store.
   const selectedSortOption = useSelector(selectSortOption);
@@ -629,9 +631,10 @@ const Prescriptions = () => {
   };
 
   const renderRxRenewalMessageSuccess = () => {
-    if (!rxRenewalMessageSuccess) return null;
+    if (deleteDraftSuccess) return <RxRenewalDeleteDraftSuccessAlert />;
 
-    return <RxRenewalMessageSuccessAlert />;
+    if (rxRenewalMessageSuccess) return <RxRenewalMessageSuccessAlert />;
+    return null;
   };
 
   const renderHeader = () => {

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -42,10 +42,11 @@ describe('Medications Prescriptions container', () => {
     },
   };
 
-  const setup = (state = initialState) => {
+  const setup = (state = initialState, url = '/') => {
     return renderWithStoreAndRouterV6(<Prescriptions />, {
       initialState: state,
       reducers: reducer,
+      initialEntries: [url],
       additionalMiddlewares: [
         allergiesApiModule.allergiesApi.middleware,
         prescriptionsApiModule.prescriptionsApi.middleware,
@@ -279,5 +280,25 @@ describe('Medications Prescriptions container', () => {
     expect(screen.queryByTestId('meds-by-mail-header')).not.to.exist;
     expect(screen.queryByTestId('meds-by-mail-top-level-text')).not.to.exist;
     expect(screen.queryByTestId('meds-by-mail-additional-info')).not.to.exist;
+  });
+
+  describe('renderRxRenewalMessageSuccess', () => {
+    it('should render component with deleteDraftSuccess query param', async () => {
+      const screen = setup(initialState, '?page=1&draftDeleteSuccess=true');
+      await waitFor(() => {
+        expect(screen.getByTestId('rx-renewal-delete-draft-success-alert')).to
+          .exist;
+      });
+    });
+
+    it('should render component with rxRenewalMessageSuccess query param', async () => {
+      const screen = setup(
+        initialState,
+        '?page=1&rxRenewalMessageSuccess=true',
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('rx-renewal-message-success-alert')).to.exist;
+      });
+    });
   });
 });

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -1167,6 +1167,7 @@ const ComposeForm = props => {
             setNavigationError={setNavigationError}
             setUnsavedNavigationError={setUnsavedNavigationError}
             savedComposeDraft={!!draft}
+            redirectPath={redirectPath}
           />
         </div>
       </form>

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeFormActionButtons.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeFormActionButtons.jsx
@@ -21,6 +21,7 @@ const ComposeFormActionButtons = props => {
     setHideDraft,
     setIsEditing,
     savedComposeDraft,
+    redirectPath,
   } = props;
 
   return (
@@ -85,6 +86,7 @@ const ComposeFormActionButtons = props => {
         setHideDraft={setHideDraft}
         setIsEditing={setIsEditing}
         savedComposeDraft={savedComposeDraft}
+        redirectPath={redirectPath}
       />
     </div>
   );
@@ -100,6 +102,7 @@ ComposeFormActionButtons.propTypes = {
   isModalVisible: PropTypes.bool,
   messageBody: PropTypes.string,
   navigationError: PropTypes.object,
+  redirectPath: PropTypes.string,
   refreshThreadCallback: PropTypes.func,
   savedComposeDraft: PropTypes.bool,
   savedForm: PropTypes.bool,

--- a/src/applications/mhv-secure-messaging/components/Draft/DeleteDraft.jsx
+++ b/src/applications/mhv-secure-messaging/components/Draft/DeleteDraft.jsx
@@ -19,6 +19,28 @@ import { addAlert } from '../../actions/alerts';
 import { deleteDraft } from '../../actions/draftDetails';
 import * as Constants from '../../util/constants';
 
+const _computeDraftDeleteRedirect = redirectPath => {
+  // Parse the URL
+  const [basePath, queryString] = redirectPath.split('?');
+  if (!queryString) {
+    // No query string, just add the param
+    return `${redirectPath}?draftDeleteSuccess=true`;
+  }
+
+  // Split query params
+  const params = queryString
+    .split('&')
+    .filter(param => !param.startsWith('rxRenewalMessageSuccess'));
+
+  // Add the new param
+  params.push('draftDeleteSuccess=true');
+
+  // Reconstruct the URL
+  return `${basePath}?${params.join('&')}`;
+};
+
+export { _computeDraftDeleteRedirect };
+
 const DeleteDraft = props => {
   const history = useHistory();
   const location = useLocation();
@@ -104,14 +126,8 @@ const DeleteDraft = props => {
           : DefaultFolders.DRAFTS.id;
 
         if (redirectPath) {
-          // Remove rxRenewalMessageSuccess query param if present
-          const cleanRedirectPath = redirectPath
-            .replace(
-              /[?&]rxRenewalMessageSuccess=?(true|false)?(&|$)/g,
-              (match, p1, p2) => (p2 === '&' ? '&' : ''),
-            )
-            .replace(/[?&]$/, '');
-          window.location.replace(cleanRedirectPath);
+          const finalPath = _computeDraftDeleteRedirect(redirectPath);
+          window.location.replace(finalPath);
         } else if (pathname.includes('/new-message')) {
           navigateToFolderByFolderId(
             activeFolder ? activeFolder.folderId : DefaultFolders.DRAFTS.id,

--- a/src/applications/mhv-secure-messaging/components/Draft/DeleteDraft.jsx
+++ b/src/applications/mhv-secure-messaging/components/Draft/DeleteDraft.jsx
@@ -40,6 +40,7 @@ const DeleteDraft = props => {
     setHideDraft,
     setIsEditing,
     savedComposeDraft,
+    redirectPath,
   } = props;
 
   const showIcon = useState(!!cannotReply);
@@ -102,14 +103,21 @@ const DeleteDraft = props => {
           ? activeFolder.folderId
           : DefaultFolders.DRAFTS.id;
 
-        if (pathname.includes('/new-message')) {
+        if (redirectPath) {
+          // Remove rxRenewalMessageSuccess query param if present
+          const cleanRedirectPath = redirectPath
+            .replace(
+              /[?&]rxRenewalMessageSuccess=?(true|false)?(&|$)/g,
+              (match, p1, p2) => (p2 === '&' ? '&' : ''),
+            )
+            .replace(/[?&]$/, '');
+          window.location.replace(cleanRedirectPath);
+        } else if (pathname.includes('/new-message')) {
           navigateToFolderByFolderId(
             activeFolder ? activeFolder.folderId : DefaultFolders.DRAFTS.id,
             history,
           );
-        }
-
-        if (pathname.includes(Paths.REPLY)) {
+        } else if (pathname.includes(Paths.REPLY)) {
           history.goBack();
         } else if (pathname.includes(Paths.MESSAGE_THREAD + draftId)) {
           navigateToFolderByFolderId(defaultFolderId, history);
@@ -200,6 +208,7 @@ DeleteDraft.propTypes = {
   isModalVisible: PropType.bool,
   messageBody: PropType.string,
   navigationError: PropType.object,
+  redirectPath: PropType.string,
   refreshThreadCallback: PropType.func,
   savedComposeDraft: PropType.bool,
   setHideDraft: PropType.func,

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
@@ -2246,4 +2246,82 @@ describe('Compose form component', () => {
       });
     });
   });
+
+  describe('redirectPath prop', () => {
+    it('should pass redirectPath to ComposeFormActionButtons when prescription.redirectPath exists', () => {
+      const redirectPath = '/my-health/medications';
+
+      // Create a spy on React.createElement to intercept ComposeFormActionButtons props
+      const ComposeFormActionButtons = require('../../../components/ComposeForm/ComposeFormActionButtons')
+        .default;
+      const createElementSpy = sandbox.spy(React, 'createElement');
+
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          prescription: {
+            renewalPrescription: undefined,
+            redirectPath,
+            error: undefined,
+            isLoading: false,
+          },
+        },
+      };
+
+      setup(customState, Paths.COMPOSE, {
+        recipients: customState.sm.recipients,
+        signature: {},
+        pageTitle: 'Start your message',
+      });
+
+      // Find the call to createElement with ComposeFormActionButtons
+      const actionButtonsCall = createElementSpy
+        .getCalls()
+        .find(call => call.args[0] === ComposeFormActionButtons);
+
+      expect(actionButtonsCall).to.exist;
+      expect(actionButtonsCall.args[1]).to.have.property(
+        'redirectPath',
+        redirectPath,
+      );
+    });
+
+    it('should pass undefined redirectPath to ComposeFormActionButtons when prescription.redirectPath does not exist', () => {
+      // Create a spy on React.createElement to intercept ComposeFormActionButtons props
+      const ComposeFormActionButtons = require('../../../components/ComposeForm/ComposeFormActionButtons')
+        .default;
+      const createElementSpy = sandbox.spy(React, 'createElement');
+
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          prescription: {
+            renewalPrescription: undefined,
+            redirectPath: undefined,
+            error: undefined,
+            isLoading: false,
+          },
+        },
+      };
+
+      setup(customState, Paths.COMPOSE, {
+        recipients: customState.sm.recipients,
+        signature: {},
+        pageTitle: 'Start your message',
+      });
+
+      // Find the call to createElement with ComposeFormActionButtons
+      const actionButtonsCall = createElementSpy
+        .getCalls()
+        .find(call => call.args[0] === ComposeFormActionButtons);
+
+      expect(actionButtonsCall).to.exist;
+      expect(actionButtonsCall.args[1]).to.have.property(
+        'redirectPath',
+        undefined,
+      );
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/ComposeFormActionButtons.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/ComposeFormActionButtons.unit.spec.jsx
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import ComposeFormActionButtons from '../../components/ComposeForm/ComposeFormActionButtons';
+
+describe('ComposeFormActionButtons', () => {
+  const defaultProps = {
+    onSend: () => {},
+    onSaveDraft: () => {},
+    formPopulated: false,
+    setDeleteButtonClicked: () => {},
+    cannotReply: false,
+    draftBody: '',
+    draftId: null,
+    draftsCount: 0,
+    navigationError: null,
+    refreshThreadCallback: () => {},
+    setNavigationError: () => {},
+    setUnsavedNavigationError: () => {},
+    messageBody: '',
+    draftSequence: null,
+    setHideDraft: () => {},
+    setIsEditing: () => {},
+    savedComposeDraft: false,
+  };
+
+  it('should pass redirectPath prop to DeleteDraft component', () => {
+    const redirectPath = '/my-health/medications';
+
+    const props = {
+      ...defaultProps,
+      redirectPath,
+    };
+
+    // Render the component and examine its children
+    const element = ComposeFormActionButtons(props);
+
+    // Find the DeleteDraft component in the children
+    const deleteDraftElement = element.props.children[2];
+
+    // Verify DeleteDraft receives the redirectPath prop
+    expect(deleteDraftElement.props).to.have.property(
+      'redirectPath',
+      redirectPath,
+    );
+  });
+
+  it('should not pass redirectPath prop to DeleteDraft when not provided', () => {
+    // Render the component and examine its children
+    const element = ComposeFormActionButtons(defaultProps);
+
+    // Find the DeleteDraft component in the children
+    const deleteDraftElement = element.props.children[2];
+
+    // Verify DeleteDraft receives undefined when not provided
+    expect(deleteDraftElement.props).to.have.property(
+      'redirectPath',
+      undefined,
+    );
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
@@ -3,7 +3,9 @@ import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-li
 import { expect } from 'chai';
 import { fireEvent, waitFor, cleanup } from '@testing-library/react';
 import sinon from 'sinon';
-import DeleteDraft from '../../components/Draft/DeleteDraft';
+import DeleteDraft, {
+  _computeDraftDeleteRedirect,
+} from '../../components/Draft/DeleteDraft';
 import { drafts, inbox, sent } from '../fixtures/folder-inbox-response.json';
 import thread from '../fixtures/reducers/thread-with-multiple-drafts-reducer.json';
 import reducer from '../../reducers';
@@ -429,6 +431,77 @@ describe('Delete Draft component', () => {
       );
 
       expect(getByTestId('delete-draft-button')).to.exist;
+    });
+  });
+
+  describe('_computeDraftDeleteRedirect', () => {
+    it('should add draftDeleteSuccess=true to path without query params', () => {
+      const result = _computeDraftDeleteRedirect('/my-health/medications');
+      expect(result).to.equal('/my-health/medications?draftDeleteSuccess=true');
+    });
+
+    it('should add draftDeleteSuccess=true to path with existing query params', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?tab=renewals',
+      );
+      expect(result).to.equal(
+        '/my-health/medications?tab=renewals&draftDeleteSuccess=true',
+      );
+    });
+
+    it('should remove rxRenewalMessageSuccess=true and add draftDeleteSuccess=true', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?rxRenewalMessageSuccess=true',
+      );
+      expect(result).to.equal('/my-health/medications?draftDeleteSuccess=true');
+    });
+
+    it('should remove rxRenewalMessageSuccess=false and add draftDeleteSuccess=true', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?rxRenewalMessageSuccess=false',
+      );
+      expect(result).to.equal('/my-health/medications?draftDeleteSuccess=true');
+    });
+
+    it('should remove rxRenewalMessageSuccess without value and add draftDeleteSuccess=true', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?rxRenewalMessageSuccess',
+      );
+      expect(result).to.equal('/my-health/medications?draftDeleteSuccess=true');
+    });
+
+    it('should handle rxRenewalMessageSuccess in middle of query string', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?tab=renewals&rxRenewalMessageSuccess=true&other=param',
+      );
+      expect(result).to.equal(
+        '/my-health/medications?tab=renewals&other=param&draftDeleteSuccess=true',
+      );
+    });
+
+    it('should handle rxRenewalMessageSuccess at end of query string', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?tab=renewals&rxRenewalMessageSuccess=true',
+      );
+      expect(result).to.equal(
+        '/my-health/medications?tab=renewals&draftDeleteSuccess=true',
+      );
+    });
+
+    it('should handle rxRenewalMessageSuccess at start of query string', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?rxRenewalMessageSuccess=true&other=param',
+      );
+      expect(result).to.equal(
+        '/my-health/medications?other=param&draftDeleteSuccess=true',
+      );
+    });
+
+    it('should handle multiple rxRenewalMessageSuccess params (edge case)', () => {
+      const result = _computeDraftDeleteRedirect(
+        '/my-health/medications?rxRenewalMessageSuccess=true&rxRenewalMessageSuccess=false',
+      );
+      expect(result).to.equal('/my-health/medications?draftDeleteSuccess=true');
     });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
@@ -406,4 +406,29 @@ describe('Delete Draft component', () => {
       expect(setNavigationErrorSpy.calledWith(null)).to.be.true;
     });
   });
+
+  describe('redirectPath prop', () => {
+    it('renders with redirectPath prop', async () => {
+      const initialState = {
+        sm: {
+          folders: {
+            folder: inbox,
+          },
+        },
+      };
+
+      const redirectPath = '/my-health/medications';
+      const { getByTestId } = renderWithStoreAndRouter(
+        <DeleteDraft
+          draftId={123456}
+          draftsCount={1}
+          redirectPath={redirectPath}
+          savedComposeDraft
+        />,
+        { initialState, reducers: reducer, path: Paths.COMPOSE },
+      );
+
+      expect(getByTestId('delete-draft-button')).to.exist;
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
@@ -299,6 +299,60 @@ describe('SM Medications Renewal Request', () => {
       cy.findByText('Message Sent.').should('be.visible');
       cy.url().should('include', '/my-health/secure-messages/inbox/');
     });
+
+    it('verify user is redirected to redirectPath after deleting a draft', () => {
+      cy.intercept(
+        'GET',
+        `${Paths.INTERCEPT.PRESCRIPTIONS}/24654491`,
+        medicationResponse,
+      ).as('medicationById');
+      const prescriptionId = '24654491';
+      const redirectPath = encodeURIComponent('/my-health/medications');
+
+      cy.visit(
+        `${
+          Paths.UI_MAIN
+        }/new-message?prescriptionId=${prescriptionId}&redirectPath=${redirectPath}`,
+      );
+      cy.wait('@medicationById');
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        decodeURIComponent(redirectPath),
+      );
+      PatientComposePage.selectComboBoxRecipient(
+        mockRecipients.data[0].attributes.name,
+      );
+      cy.findByTestId(`continue-button`).click();
+
+      SharedComponents.backBreadcrumb().should(
+        'have.attr',
+        'href',
+        '/my-health/secure-messages/new-message/select-care-team/',
+      );
+      PatientComposePage.validateAddYourMedicationWarningBanner(false);
+      PatientComposePage.validateRecipientTitle(
+        `VA Madison health care - ${mockRecipients.data[0].attributes.name}`,
+      );
+
+      PatientComposePage.validateCategorySelection('MEDICATIONS');
+      PatientComposePage.validateMessageSubjectField('Renewal Needed');
+
+      const expectedMessageBodyText = [
+        `Medication name, strength, and form: ABACAVIR SO4 600MG/LAMIVUDINE 300MG TAB`,
+        `Prescription number: 2721195`,
+        `Provider who prescribed it: Bob Taylor`,
+        `Number of refills left: `,
+        `Prescription expiration date: November 8, 2025`,
+        `Reason for use: `,
+        `Quantity: 4`,
+      ].join('\n');
+
+      PatientComposePage.validateMessageBodyField(expectedMessageBodyText);
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+      PatientComposePage.deleteUnsavedDraft();
+      cy.url().should('include', decodeURIComponent(redirectPath));
+    });
   });
   describe('not in curated list flow', () => {
     const customFeatureToggles = GeneralFunctionsPage.updateFeatureToggles([

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
@@ -307,7 +307,9 @@ describe('SM Medications Renewal Request', () => {
         medicationResponse,
       ).as('medicationById');
       const prescriptionId = '24654491';
-      const redirectPath = encodeURIComponent('/my-health/medications');
+      const redirectPath = encodeURIComponent(
+        '/my-health/medications?page=1&rxRenewalMessageSuccess=true',
+      );
 
       cy.visit(
         `${
@@ -351,7 +353,10 @@ describe('SM Medications Renewal Request', () => {
       PatientComposePage.validateMessageBodyField(expectedMessageBodyText);
       cy.injectAxeThenAxeCheck(AXE_CONTEXT);
       PatientComposePage.deleteUnsavedDraft();
-      cy.url().should('include', decodeURIComponent(redirectPath));
+      cy.url().should(
+        'include',
+        'http://localhost:3001/my-health/medications/?page=1&draftDeleteSuccess=true',
+      );
     });
   });
   describe('not in curated list flow', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request introduces improvements to the medication renewal and secure messaging flows, mainly by adding support for a new redirect mechanism after deleting a draft. It ensures users are redirected to the correct location with a success alert, and cleans up query parameters to avoid conflicting messages. The changes also include new and updated tests to verify the new behavior.

**Medication renewal and success alert improvements:**

* Added a new `RxRenewalDeleteDraftSuccessAlert` component to display a success message when a draft is deleted, and updated the logic in `Prescriptions.jsx` to show this alert based on the new `draftDeleteSuccess` query parameter. [[1]](diffhunk://#diff-777965325a23616cbafa4887a2b713b0db1e984c4bb6cb0f6415dc391880c55aR1-R24) [[2]](diffhunk://#diff-e4c26bbc12972783856a48f3a72b40dc932b9968ed6d0ac898c3f07606aabfe8R98) [[3]](diffhunk://#diff-e4c26bbc12972783856a48f3a72b40dc932b9968ed6d0ac898c3f07606aabfe8L632-R637)
* Updated the success alert for renewal messages to use a test ID for easier testing.

**Secure messaging draft deletion and redirect logic:**

* Implemented a new `_computeDraftDeleteRedirect` utility in `DeleteDraft.jsx` to handle redirects after draft deletion. This function removes any existing `rxRenewalMessageSuccess` parameter and adds `draftDeleteSuccess=true` to the URL. The redirect logic in `DeleteDraft.jsx` now uses this utility and supports a `redirectPath` prop. [[1]](diffhunk://#diff-2c39fd0f10931a1df497b21e1c5628b0e10626c0a439a554066542e5880ef818R22-R43) [[2]](diffhunk://#diff-2c39fd0f10931a1df497b21e1c5628b0e10626c0a439a554066542e5880ef818L105-R136)
* Propagated the `redirectPath` prop through compose form components, ensuring it is passed to all relevant places and included in prop types. [[1]](diffhunk://#diff-412343cc8f3763140ceab70d02f229df4ac646c818750a101678c5507d4b7901R1170) [[2]](diffhunk://#diff-8501b7390426a83f64838b2f4222b3253ec8102636e595670ca86d84732dc5b7R24) [[3]](diffhunk://#diff-8501b7390426a83f64838b2f4222b3253ec8102636e595670ca86d84732dc5b7R89) [[4]](diffhunk://#diff-8501b7390426a83f64838b2f4222b3253ec8102636e595670ca86d84732dc5b7R105) [[5]](diffhunk://#diff-2c39fd0f10931a1df497b21e1c5628b0e10626c0a439a554066542e5880ef818R65) [[6]](diffhunk://#diff-2c39fd0f10931a1df497b21e1c5628b0e10626c0a439a554066542e5880ef818R227)

**Testing and validation:**

* Added and updated unit tests for the new redirect logic and alert rendering, including tests for `_computeDraftDeleteRedirect`, passing `redirectPath` through components, and verifying the correct alert is shown. [[1]](diffhunk://#diff-f8da70be69e6f9d45d1556121706ee344d4afa519e78f3ede17d429bf50f3bacR284-R303) [[2]](diffhunk://#diff-dcdabffad9e135efd1764261446ececa431bae041f2b1bbedb8292695c92a289R2249-R2326) [[3]](diffhunk://#diff-a3db009359598154dc39fdf0942252df206090c48a7c3daa1bc1120c1172213dR1-R59) [[4]](diffhunk://#diff-d35b34e75870501940c6b5b0282a00f41c3cab4de9fa1b792824eda132288078R411-R506)
* Added an end-to-end Cypress test to verify users are redirected with the correct query parameters after deleting a draft.

These changes improve user experience by providing clearer feedback and navigation after deleting medication renewal drafts, and ensure the code is robustly tested.

## Related issue(s)

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/124770
- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/125351

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
![2025-11-14 15 29 58](https://github.com/user-attachments/assets/2b6535b7-9976-468c-b1bf-29726a7b170a)

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |<img width="200" height="643" alt="image" src="https://github.com/user-attachments/assets/f4ce234a-cf2f-4d50-b8ce-f4572b2f9127" />|
| Desktop |        |<img width="200" height="706" alt="image" src="https://github.com/user-attachments/assets/7c3cab6f-3823-443a-97c3-edd069a4647d" />|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
