### PR TITLE
fix(4192): Hide correct optional pages for currently employed

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.js
@@ -146,7 +146,8 @@ const formConfig = {
           uiSchema: employmentTerminationUiSchema,
           schema: employmentTerminationSchema,
           depends: formData =>
-            formData?.employmentDates?.currentlyEmployed !== true,
+            !!formData?.employmentDates?.endingDate &&
+            !formData?.employmentDates?.currentlyEmployed,
         },
         employmentLastPayment: {
           path: 'employment-last-payment',
@@ -154,7 +155,8 @@ const formConfig = {
           uiSchema: employmentLastPaymentUiSchema,
           schema: employmentLastPaymentSchema,
           depends: formData =>
-            formData?.employmentDates?.currentlyEmployed !== true,
+            !!formData?.employmentDates?.endingDate &&
+            !formData?.employmentDates?.currentlyEmployed,
         },
       },
     },

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.js
@@ -145,12 +145,16 @@ const formConfig = {
           title: 'Employment Termination',
           uiSchema: employmentTerminationUiSchema,
           schema: employmentTerminationSchema,
+          depends: formData =>
+            formData?.employmentDates?.currentlyEmployed !== true,
         },
         employmentLastPayment: {
           path: 'employment-last-payment',
           title: 'Employment Last Payment',
           uiSchema: employmentLastPaymentUiSchema,
           schema: employmentLastPaymentSchema,
+          depends: formData =>
+            formData?.employmentDates?.currentlyEmployed !== true,
         },
       },
     },

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.unit.spec.jsx
@@ -177,34 +177,47 @@ describe('Form Configuration', () => {
         expect(page.depends).to.be.a('function');
       });
 
-      it('should show page when veteran is NOT currently employed', () => {
+      it('should show page when employment ended (has ending date, not currently employed)', () => {
         const formData = {
           employmentDates: {
+            endingDate: '2024-01-15',
             currentlyEmployed: false,
           },
         };
         expect(page.depends(formData)).to.be.true;
       });
 
-      it('should hide page when veteran IS currently employed', () => {
+      it('should show page when has ending date and currentlyEmployed is undefined', () => {
         const formData = {
           employmentDates: {
+            endingDate: '2024-01-15',
+          },
+        };
+        expect(page.depends(formData)).to.be.true;
+      });
+
+      it('should hide page when currently employed (even with ending date)', () => {
+        const formData = {
+          employmentDates: {
+            endingDate: '2024-01-15',
             currentlyEmployed: true,
           },
         };
         expect(page.depends(formData)).to.be.false;
       });
 
-      it('should show page when currentlyEmployed is undefined', () => {
+      it('should hide page when no ending date provided', () => {
         const formData = {
-          employmentDates: {},
+          employmentDates: {
+            currentlyEmployed: false,
+          },
         };
-        expect(page.depends(formData)).to.be.true;
+        expect(page.depends(formData)).to.be.false;
       });
 
-      it('should show page when employmentDates section is missing', () => {
+      it('should hide page when employmentDates section is missing', () => {
         const formData = {};
-        expect(page.depends(formData)).to.be.true;
+        expect(page.depends(formData)).to.be.false;
       });
     });
 
@@ -215,34 +228,47 @@ describe('Form Configuration', () => {
         expect(page.depends).to.be.a('function');
       });
 
-      it('should show page when veteran is NOT currently employed', () => {
+      it('should show page when employment ended (has ending date, not currently employed)', () => {
         const formData = {
           employmentDates: {
+            endingDate: '2024-01-15',
             currentlyEmployed: false,
           },
         };
         expect(page.depends(formData)).to.be.true;
       });
 
-      it('should hide page when veteran IS currently employed', () => {
+      it('should show page when has ending date and currentlyEmployed is undefined', () => {
         const formData = {
           employmentDates: {
+            endingDate: '2024-01-15',
+          },
+        };
+        expect(page.depends(formData)).to.be.true;
+      });
+
+      it('should hide page when currently employed (even with ending date)', () => {
+        const formData = {
+          employmentDates: {
+            endingDate: '2024-01-15',
             currentlyEmployed: true,
           },
         };
         expect(page.depends(formData)).to.be.false;
       });
 
-      it('should show page when currentlyEmployed is undefined', () => {
+      it('should hide page when no ending date provided', () => {
         const formData = {
-          employmentDates: {},
+          employmentDates: {
+            currentlyEmployed: false,
+          },
         };
-        expect(page.depends(formData)).to.be.true;
+        expect(page.depends(formData)).to.be.false;
       });
 
-      it('should show page when employmentDates section is missing', () => {
+      it('should hide page when employmentDates section is missing', () => {
         const formData = {};
-        expect(page.depends(formData)).to.be.true;
+        expect(page.depends(formData)).to.be.false;
       });
     });
   });
@@ -542,6 +568,9 @@ describe('Form Configuration', () => {
       expect(() =>
         employmentTerminationPage.depends({ employmentDates: null }),
       ).to.not.throw();
+      expect(employmentTerminationPage.depends(null)).to.be.false;
+      expect(employmentTerminationPage.depends(undefined)).to.be.false;
+      expect(employmentTerminationPage.depends({})).to.be.false;
     });
 
     it('should handle missing form data in employment last payment conditional', () => {
@@ -554,6 +583,9 @@ describe('Form Configuration', () => {
       expect(() =>
         employmentLastPaymentPage.depends({ employmentDates: null }),
       ).to.not.throw();
+      expect(employmentLastPaymentPage.depends(null)).to.be.false;
+      expect(employmentLastPaymentPage.depends(undefined)).to.be.false;
+      expect(employmentLastPaymentPage.depends({})).to.be.false;
     });
   });
 

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/form/form.unit.spec.jsx
@@ -169,6 +169,82 @@ describe('Form Configuration', () => {
     it('should have exactly 5 pages in employment information chapter', () => {
       expect(Object.keys(chapter.pages)).to.have.lengthOf(5);
     });
+
+    describe('employmentTermination conditional logic', () => {
+      const page = chapter.pages.employmentTermination;
+
+      it('should have conditional depends function', () => {
+        expect(page.depends).to.be.a('function');
+      });
+
+      it('should show page when veteran is NOT currently employed', () => {
+        const formData = {
+          employmentDates: {
+            currentlyEmployed: false,
+          },
+        };
+        expect(page.depends(formData)).to.be.true;
+      });
+
+      it('should hide page when veteran IS currently employed', () => {
+        const formData = {
+          employmentDates: {
+            currentlyEmployed: true,
+          },
+        };
+        expect(page.depends(formData)).to.be.false;
+      });
+
+      it('should show page when currentlyEmployed is undefined', () => {
+        const formData = {
+          employmentDates: {},
+        };
+        expect(page.depends(formData)).to.be.true;
+      });
+
+      it('should show page when employmentDates section is missing', () => {
+        const formData = {};
+        expect(page.depends(formData)).to.be.true;
+      });
+    });
+
+    describe('employmentLastPayment conditional logic', () => {
+      const page = chapter.pages.employmentLastPayment;
+
+      it('should have conditional depends function', () => {
+        expect(page.depends).to.be.a('function');
+      });
+
+      it('should show page when veteran is NOT currently employed', () => {
+        const formData = {
+          employmentDates: {
+            currentlyEmployed: false,
+          },
+        };
+        expect(page.depends(formData)).to.be.true;
+      });
+
+      it('should hide page when veteran IS currently employed', () => {
+        const formData = {
+          employmentDates: {
+            currentlyEmployed: true,
+          },
+        };
+        expect(page.depends(formData)).to.be.false;
+      });
+
+      it('should show page when currentlyEmployed is undefined', () => {
+        const formData = {
+          employmentDates: {},
+        };
+        expect(page.depends(formData)).to.be.true;
+      });
+
+      it('should show page when employmentDates section is missing', () => {
+        const formData = {};
+        expect(page.depends(formData)).to.be.true;
+      });
+    });
   });
 
   describe('Duty Status Chapter Pages', () => {
@@ -453,6 +529,30 @@ describe('Form Configuration', () => {
       expect(() => benefitsDetailsPage.depends({})).to.not.throw();
       expect(() =>
         benefitsDetailsPage.depends({ benefitsInformation: null }),
+      ).to.not.throw();
+    });
+
+    it('should handle missing form data in employment termination conditional', () => {
+      const employmentTerminationPage =
+        formConfig.chapters.employmentInformationChapter.pages
+          .employmentTermination;
+      expect(() => employmentTerminationPage.depends(null)).to.not.throw();
+      expect(() => employmentTerminationPage.depends(undefined)).to.not.throw();
+      expect(() => employmentTerminationPage.depends({})).to.not.throw();
+      expect(() =>
+        employmentTerminationPage.depends({ employmentDates: null }),
+      ).to.not.throw();
+    });
+
+    it('should handle missing form data in employment last payment conditional', () => {
+      const employmentLastPaymentPage =
+        formConfig.chapters.employmentInformationChapter.pages
+          .employmentLastPayment;
+      expect(() => employmentLastPaymentPage.depends(null)).to.not.throw();
+      expect(() => employmentLastPaymentPage.depends(undefined)).to.not.throw();
+      expect(() => employmentLastPaymentPage.depends({})).to.not.throw();
+      expect(() =>
+        employmentLastPaymentPage.depends({ employmentDates: null }),
       ).to.not.throw();
     });
   });

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/tests/fixtures/data/currently-employed.json
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/tests/fixtures/data/currently-employed.json
@@ -37,14 +37,6 @@
     "employmentConcessions": {
       "concessions": "Flexible deployment schedule to accommodate special missions. Employer provides advanced equipment and permits remote field operations with autonomous decision-making authority."
     },
-    "employmentTermination": {
-      "dateLastWorked": "2025-10-31"
-    },
-    "employmentLastPayment": {
-      "dateOfLastPayment": "2025-10-31",
-      "grossAmountLastPayment": 5500,
-      "lumpSumPayment": "no"
-    },
     "dutyStatus": {
       "reserveOrGuardStatus": false
     },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders

## Summary

This PR fixes a bug in VA Form 21-4192 (Request for Employment Information) where users who
indicated the veteran is currently employed were incorrectly being shown employment termination
questions.

**Bug Description:**
When users checked "currently employed" on the Employment Dates page, they were still shown the
"Employment Termination" and "Employment Last Payment" pages asking for information about when
employment ended, creating a confusing and contradictory user experience.

**Root Cause:**
The `employmentTermination` and `employmentLastPayment` pages in the form configuration lacked
conditional `depends` functions to check employment status. These pages were always displayed
regardless of whether the veteran was currently employed.

**Solution:**
Added `depends` functions to both pages that conditionally show/hide based on the
`currentlyEmployed` field:

- Pages now only appear when `currentlyEmployed !== true`
- When a user indicates current employment, these pages are skipped
- Includes proper null/undefined handling for edge cases

**Team:**
Benefits Intake Optimization (Aquia) - This team owns and maintains the 21-4192 form application.

**Flipper:**
This bug fix does not require a feature flipper. The form is already behind the `form4192Enabled`
feature toggle.

## Related issue(s)

- Staging Review finding: department-of-veterans-affairs/va.gov-team#125271

## Testing done

**Old Behavior:**

1. User navigates to Employment Dates page
1. User checks "Veteran is currently employed at [employer]"
1. User proceeds through form
1. User is incorrectly shown "Termination of employment" page with message "On a previous page,
you indicated that [veteran] stopped working. Why did they stop working?"
1. User is also shown "Last payment" page asking for final payment details

**New Behavior:**

1. User navigates to Employment Dates page
1. User checks "Veteran is currently employed at [employer]"
1. User proceeds through form
1. Employment Termination and Last Payment pages are **skipped**
1. User goes directly to Duty Status chapter

**Steps to Verify:**

**Scenario 1: Currently Employed (pages should be hidden)**

1. Start form at `/employment-dates`
1. Enter a beginning date
1. Check "Veteran is currently employed" checkbox
1. Click Continue
1. Verify you skip directly to Employment Earnings and Hours
1. Continue through form
1. Verify Employment Termination page is not shown
1. Verify Employment Last Payment page is not shown

**Scenario 2: Employment Ended (pages should be shown)**

1. Start form at `/employment-dates`
1. Enter a beginning date
1. Do NOT check "currently employed"
1. Enter an ending date
1. Click Continue
1. Continue through Employment Earnings, Hours, and Concessions
1. Verify Employment Termination page IS shown
1. Verify Employment Last Payment page IS shown

**Tests Completed:**

- Unit tests added for conditional logic (10 new test cases)
- All existing unit tests pass
- Linting passes
- Test fixture data updated to match new logic
- Manual testing with `currently-employed.json` fixture
- Manual testing with `minimal.json` fixture (employment ended)

## Screenshots

Selected currently employed
<img width="810" height="1075" alt="Screenshot 2025-11-14 at 3 51 27 PM" src="https://github.com/user-attachments/assets/6bb950b4-ded5-418f-92a0-cfbc076b0cdb" />

As expected with the fixed form skips, reasons for termination and goes to details about employment

<img width="776" height="1264" alt="Screenshot 2025-11-14 at 3 51 34 PM" src="https://github.com/user-attachments/assets/f03e78d4-58ed-4ec0-b520-12d6d668fb17" />


## What areas of the site does it impact?

**Scope:** Only impacts VA Form 21-4192 (Request for Employment Information in Connection with
Claim for Disability Benefits)

**Specific pages affected:**

- `/employment-termination` - Now conditionally shown based on employment status
- `/employment-last-payment` - Now conditionally shown based on employment status

**No impact to:**

- Other VA forms or applications
- Shared platform components
- Other areas of the 21-4192 form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (JSDoc comments in place)
- [ ] Screenshot of the developed feature is added (N/A - logic change only)
- [ ] Accessibility testing has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (no new events needed)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (not applicable for this fix)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a
test user (testing in progress)

## Requested Feedback

**Files Changed:**

1. `config/form/form.js` - Added `depends` functions to 2 pages (lines 148-149, 156-157)
1. `config/form/form.unit.spec.jsx` - Added 10 test cases covering conditional logic
1. `tests/fixtures/data/currently-employed.json` - Removed inconsistent termination/payment data

**Testing Notes:**

- The fix uses defensive programming with optional chaining to handle edge cases
- Test coverage includes null, undefined, and missing form data scenarios
- Fixture data now correctly represents the currently employed scenario
