### PR TITLE
add label to supporting docs edit for screen readers

### DIFF
--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -103,7 +103,10 @@ const CustomReviewTopContent = () => {
         <>
           <div className="vads-u-display--flex vads-l-row vads-u-justify-content--space-between vads-u-align-items--baseline vads-u-border-bottom--1px vads-u-margin-top--1 vads-u-margin-bottom--4">
             <h3>Uploaded supporting documents</h3>
-            <EditLink href={`/${formNumber}/upload-supporting-documents`} />
+            <EditLink
+              href={`/${formNumber}/upload-supporting-documents`}
+              label="Edit Uploaded supporting documents"
+            />
           </div>
           {filesForSupportingDocuments && (
             <VaFileInputMultiple


### PR DESCRIPTION
Add accessibility label to link for screen readers.


## Summary

-  added a descriptive label for screen readers


## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5188

## Testing done

- tested locally with screen reader

## Screenshots

<img width="1081" height="615" alt="Screenshot 2025-11-14 at 3 37 39 PM" src="https://github.com/user-attachments/assets/f395aa37-c828-408d-88c8-267fa35faa01" />


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact? -> upload forms

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x ] Browser console contains no warnings or errors.
- [x ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x ] Did you login to a local build and verify all authenticated routes work as expected with a test user

