### PR TITLE
123435 mhv portal incorrect link to profile

### DIFF
--- a/src/applications/mhv-landing-page/tests/e2e/confirm-email-address-no-email.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/confirm-email-address-no-email.cypress.spec.js
@@ -18,7 +18,7 @@ describe('MHV Email Confirmation Alert - Add Email', () => {
     LandingPage.clickAddEmail();
 
     cy.url().should('include', '/profile/contact-information');
-    cy.hash().should('equal', '#contact-email-address');
+    cy.hash().should('equal', '#email-address');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/mhv-landing-page/tests/e2e/confirm-email-address.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/confirm-email-address.cypress.spec.js
@@ -87,7 +87,7 @@ describe('MHV Email Confirmation Alert - Confirm Email', () => {
     // Click the edit link and verify redirection to contact info page.
     LandingPage.clickErrorEditEmailLink();
     cy.url().should('include', '/profile/contact-information');
-    cy.hash().should('equal', '#contact-email-address');
+    cy.hash().should('equal', '#email-address');
 
     cy.injectAxeThenAxeCheck();
   });
@@ -115,7 +115,7 @@ describe('MHV Email Confirmation Alert - Confirm Email', () => {
     LandingPage.clickEditEmailLink();
 
     cy.url().should('include', '/profile/contact-information');
-    cy.hash().should('equal', '#contact-email-address');
+    cy.hash().should('equal', '#email-address');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/mhv-landing-page/tests/e2e/pages/LandingPage.js
+++ b/src/applications/mhv-landing-page/tests/e2e/pages/LandingPage.js
@@ -98,9 +98,7 @@ class LandingPage {
 
   clickErrorEditEmailLink = () => {
     cy.findByTestId('mhv-alert--confirm-error')
-      .find(
-        'va-link[href="/profile/contact-information#contact-email-address"]',
-      )
+      .find('va-link[href="/profile/contact-information#email-address"]')
       .shadow()
       .find('a')
       .click();
@@ -108,9 +106,7 @@ class LandingPage {
 
   clickEditEmailLink = () => {
     cy.findByTestId('mhv-alert--confirm-contact-email')
-      .find(
-        'va-link[href="/profile/contact-information#contact-email-address"]',
-      )
+      .find('va-link[href="/profile/contact-information#email-address"]')
       .shadow()
       .find('a')
       .click();

--- a/src/applications/personalization/dashboard/tests/e2e/confirm-email-address.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/confirm-email-address.cypress.spec.js
@@ -103,7 +103,7 @@ describe('MHV Email Confirmation Alert - Confirm Email', () => {
     // Click the edit link and verify redirection to contact info page.
     DashboardPage.clickErrorEditEmailLink();
     cy.url().should('include', '/profile/contact-information');
-    cy.hash().should('equal', '#contact-email-address');
+    cy.hash().should('equal', '#email-address');
 
     cy.injectAxeThenAxeCheck();
   });
@@ -131,7 +131,7 @@ describe('MHV Email Confirmation Alert - Confirm Email', () => {
     DashboardPage.clickEditEmailLink();
 
     cy.url().should('include', '/profile/contact-information');
-    cy.hash().should('equal', '#contact-email-address');
+    cy.hash().should('equal', '#email-address');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/dashboard/tests/e2e/pages/Dashboard.js
+++ b/src/applications/personalization/dashboard/tests/e2e/pages/Dashboard.js
@@ -17,9 +17,7 @@ class DashboardPage {
 
   clickErrorEditEmailLink = () => {
     cy.findByTestId('mhv-alert--confirm-error')
-      .find(
-        'va-link[href="/profile/contact-information#contact-email-address"]',
-      )
+      .find('va-link[href="/profile/contact-information#email-address"]')
       .shadow()
       .find('a')
       .click();
@@ -27,9 +25,7 @@ class DashboardPage {
 
   clickEditEmailLink = () => {
     cy.findByTestId('mhv-alert--confirm-contact-email')
-      .find(
-        'va-link[href="/profile/contact-information#contact-email-address"]',
-      )
+      .find('va-link[href="/profile/contact-information#email-address"]')
       .shadow()
       .find('a')
       .click();

--- a/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
@@ -100,18 +100,18 @@ const ContactInformation = () => {
         if (retryTimeoutId) clearTimeout(retryTimeoutId);
       };
 
+      const selector = hash;
+      const scrollTarget =
+        getScrollTarget(hash) || document.querySelector(selector);
+
       // early return if for profile referrer
-      if (cameFromProfileRoot) return cleanup();
+      if (cameFromProfileRoot) return cleanup;
 
       // early return if no hash > focus on default focus target
       if (!hash) {
         focusElement('[data-focus-target]');
-        return cleanup();
+        return cleanup;
       }
-
-      const selector = hash;
-      const scrollTarget =
-        getScrollTarget(hash) || document.querySelector(selector);
 
       // both focus and scroll to element
       const focusAndScroll = el => {
@@ -146,7 +146,7 @@ const ContactInformation = () => {
       const existing = document.querySelector(selector);
       if (existing) {
         focusAndScroll(scrollTarget || existing);
-        return cleanup();
+        return cleanup;
       }
 
       // retry loop with timeout to wait for element to appear

--- a/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
@@ -134,7 +134,12 @@ const ContactInformation = () => {
                 waitForRenderThenFocus(selector, document, 50, 'button');
               } else {
                 focusTimeoutId = setTimeout(() => {
-                  if (!cancelled) focusElement(el);
+                  if (!cancelled) {
+                    if (!el.hasAttribute('tabindex')) {
+                      el.setAttribute('tabindex', '-1');
+                    }
+                    focusElement(el);
+                  }
                 }, 350);
               }
             }, 200);

--- a/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
@@ -17,41 +17,7 @@ import Headline from '../ProfileSectionHeadline';
 import ContactInformationContent from './ContactInformationContent';
 
 import { PROFILE_PATHS } from '../../constants';
-
-// drops the leading `edit` from the hash and looks for that element
-const getScrollTarget = hash => {
-  const hashWithoutLeadingEdit = hash.replace(/^#edit-/, '#');
-  return document.querySelector(hashWithoutLeadingEdit);
-};
-
-// Normalize a string to a slug: lowercase, alphanumerics separated by single hyphen
-const toSlug = str =>
-  str
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/--+/g, '-');
-
-// Attempt to derive a matching va-button for any #edit-* hash by comparing normalized labels
-// This avoids brittle hard-coded label maps and automatically supports new edit buttons.
-const getEditButtonFromHash = hash => {
-  if (!/^#edit-/.test(hash)) return null;
-  const slug = hash.replace(/^#edit-/, '');
-
-  // 1. Direct element with id equal to hash (future-proof if markup adds ids)
-  const direct = document.querySelector(hash);
-  if (direct) return direct;
-
-  // 2. Look for va-button whose label when normalized (minus leading 'edit ') matches slug
-  const buttons = Array.from(document.querySelectorAll('va-button[label]'));
-  for (const btn of buttons) {
-    const rawLabel = btn.getAttribute('label') || '';
-    const labelWithoutEditPrefix = rawLabel.replace(/^edit\s+/i, '');
-    const normalized = toSlug(labelWithoutEditPrefix);
-    if (normalized === slug) return btn;
-  }
-  return null;
-};
+import { getEditButtonFromHash, getScrollTarget } from '../../util/hashUtils';
 
 const ContactInformation = () => {
   const lastLocation = useLastLocation();

--- a/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
@@ -61,7 +61,6 @@ const ContactInformation = () => {
 
   useEffect(
     () => {
-      // Origininal:
       // Set the focus on the page's focus target _unless_ one of the following is true:
       // - there is a hash in the URL and there is a named-anchor that matches
       //   the hash
@@ -69,13 +68,6 @@ const ContactInformation = () => {
       //   user got to the Profile via a link to /profile or /profile/ we want
       //   to focus on the "Profile" sub-nav H1, not the H2 on this page, for
       //   a11y reasonse
-      // New: refactored to improve reliability of focus and scroll behavior for hash-based navigation
-      // and dynamic content loading.
-
-      // Skip complex focus logic in test environments to avoid noisy warnings
-      // if (process.env.NODE_ENV === 'test') {
-      //   return undefined;
-      // }
 
       const cameFromProfileRoot = Boolean(
         lastLocation?.pathname?.match(

--- a/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.hash.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.hash.unit.spec.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ContactInformation from '@@profile/components/contact-information/ContactInformation';
+import {
+  createBasicInitialState,
+  createFeatureTogglesState,
+  renderWithProfileReducers,
+} from '../../unit-test-helpers';
+
+const makeState = () => ({
+  ...createBasicInitialState(),
+  ...createFeatureTogglesState(),
+});
+
+/**
+ * Deep-link hash behavior unit tests
+ *
+ * Note: These tests verify that the correct elements are made focusable (tabindex="-1")
+ * but do not test actual focus behavior. jsdom does not fully support focus management,
+ * especially for web components with shadow DOM.
+ *
+ * Actual focus behavior is tested in E2E tests:
+ * @see src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
+ */
+describe('ContactInformation deep-link hash behavior', () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers({
+      shouldAdvanceTime: false,
+      toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'],
+    });
+  });
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore();
+    }
+    document.body.innerHTML = '';
+  });
+
+  const renderWithHash = hash => {
+    window.history.pushState({}, '', `/profile/contact-information${hash}`);
+    const initialState = makeState();
+    return renderWithProfileReducers(
+      <MemoryRouter initialEntries={[`/profile/contact-information${hash}`]}>
+        <ContactInformation />
+      </MemoryRouter>,
+      { initialState },
+    );
+  };
+
+  it('renders with default focus target when no hash present', () => {
+    const { container } = renderWithHash('');
+    clock.tick(500);
+
+    const defaultTarget = container.querySelector('[data-focus-target="true"]');
+    expect(defaultTarget).to.exist;
+    expect(defaultTarget.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('renders with matching element for valid legacy hash', () => {
+    const anchor = document.createElement('div');
+    anchor.id = 'home-phone';
+    document.body.appendChild(anchor);
+
+    renderWithHash('#home-phone');
+    clock.tick(500);
+
+    expect(anchor.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('renders with matching edit button for valid #edit-* hash', () => {
+    const btn = document.createElement('va-button');
+    btn.setAttribute('label', 'Edit Home Phone');
+    document.body.appendChild(btn);
+
+    renderWithHash('#edit-home-phone');
+    clock.tick(500);
+
+    expect(btn.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('falls back to default target for invalid hash', () => {
+    const { container } = renderWithHash('#edit-nonexistent');
+    clock.tick(2000); // Allow retries to exhaust
+
+    const defaultTarget = container.querySelector('[data-focus-target="true"]');
+    expect(defaultTarget).to.exist;
+    expect(defaultTarget.getAttribute('tabindex')).to.equal('-1');
+  });
+});

--- a/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.unit.spec.jsx
@@ -62,6 +62,8 @@ const testContactInfo = () => {
   // expect(view.getByText('804-205-5544, ext. 17747')).to.exist;
   // expect(view.getByText('214-718-2112', { exact: false })).to.exist;
 
+  // check for multiple alongusername in email address when alert is rendered and
+  // contact email is also rendered (confirm + edit)
   expect(view.getAllByText(/alongusername/)).to.have.length.above(0);
 };
 

--- a/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.unit.spec.jsx
@@ -62,7 +62,7 @@ const testContactInfo = () => {
   // expect(view.getByText('804-205-5544, ext. 17747')).to.exist;
   // expect(view.getByText('214-718-2112', { exact: false })).to.exist;
 
-  expect(view.getByText(/alongusername/)).to.exist;
+  expect(view.getAllByText(/alongusername/)).to.have.length.above(0);
 };
 
 describe('ContactInformation', () => {

--- a/src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
@@ -1,7 +1,5 @@
 import { PROFILE_PATHS } from '@@profile/constants';
-
 import { mockNotificationSettingsAPIs } from '../helpers';
-
 import mockUser from '../../fixtures/users/user-36.json';
 
 const deepLinks = [

--- a/src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
@@ -72,8 +72,6 @@ function checkAllDeepLinks(mobile = false) {
     cy.visit(url);
     // Wait for the element to exist and be visible
     // focus should be managed correctly
-    cy.log('profile path: ', PROFILE_PATHS.CONTACT_INFORMATION);
-    // console.log('expectedTarget: ', expectedTarget);
     getTargetElement(expectedTarget)
       .should('exist')
       .and('be.visible')

--- a/src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/deep-links.cypress.spec.js
@@ -70,9 +70,14 @@ function checkAllDeepLinks(mobile = false) {
 
   deepLinks.forEach(({ url, expectedTarget }) => {
     cy.visit(url);
+    // Wait for the element to exist and be visible
     // focus should be managed correctly
-    // console.log('expectedTarget', expectedTarget);
-    getTargetElement(expectedTarget).should('have.focus');
+    cy.log('profile path: ', PROFILE_PATHS.CONTACT_INFORMATION);
+    // console.log('expectedTarget: ', expectedTarget);
+    getTargetElement(expectedTarget)
+      .should('exist')
+      .and('be.visible')
+      .and('have.focus');
   });
 }
 

--- a/src/applications/personalization/profile/tests/util/hashUtils.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/hashUtils.unit.spec.jsx
@@ -68,8 +68,9 @@ describe('contact-information hashUtils', () => {
     it('does not strip internal "edit" words (only leading)', () => {
       const btn = addButton('Primary Editor Contact');
       // slug becomes 'primary-editor-contact'; hash must match that
-      // eslint-disable-next-line prettier/prettier
-      expect(getEditButtonFromHash('#edit-primary-editor-contact', root)).to.equal(btn);
+      expect(
+        getEditButtonFromHash('#edit-primary-editor-contact', root),
+      ).to.equal(btn);
     });
 
     it('returns null when no matching button', () => {

--- a/src/applications/personalization/profile/tests/util/hashUtils.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/hashUtils.unit.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { expect } from 'chai';
 import {
   toSlug,
@@ -10,7 +9,9 @@ describe('contact-information hashUtils', () => {
   describe('toSlug', () => {
     it('normalizes punctuation and case', () => {
       expect(toSlug('Home Phone #')).to.equal('home-phone');
-      expect(toSlug('Edit   Mailing   Address!')).to.equal('edit-mailing-address');
+      expect(toSlug('Edit   Mailing   Address!')).to.equal(
+        'edit-mailing-address',
+      );
     });
     it('collapses multiple separators', () => {
       expect(toSlug('A--B__C***D')).to.equal('a-b-c-d');
@@ -47,7 +48,9 @@ describe('contact-information hashUtils', () => {
       const direct = document.createElement('div');
       direct.id = 'edit-email-address';
       root.appendChild(direct);
-      expect(getEditButtonFromHash('#edit-email-address', root)).to.equal(direct);
+      expect(getEditButtonFromHash('#edit-email-address', root)).to.equal(
+        direct,
+      );
     });
 
     it('matches by normalized label (leading Edit stripped)', () => {
@@ -57,7 +60,9 @@ describe('contact-information hashUtils', () => {
 
     it('normalizes complex label spacing/punctuation', () => {
       const btn = addButton('Edit   Mailing Address (Primary)');
-      expect(getEditButtonFromHash('#edit-mailing-address-primary', root)).to.equal(btn);
+      expect(
+        getEditButtonFromHash('#edit-mailing-address-primary', root),
+      ).to.equal(btn);
     });
 
     it('does not strip internal "edit" words (only leading)', () => {
@@ -69,7 +74,9 @@ describe('contact-information hashUtils', () => {
 
     it('returns null when no matching button', () => {
       addButton('Edit Home Phone');
-      expect(getEditButtonFromHash('#edit-something-else', root)).to.equal(null);
+      expect(getEditButtonFromHash('#edit-something-else', root)).to.equal(
+        null,
+      );
     });
   });
 

--- a/src/applications/personalization/profile/tests/util/hashUtils.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/hashUtils.unit.spec.jsx
@@ -1,0 +1,104 @@
+/* eslint-disable prettier/prettier */
+import { expect } from 'chai';
+import {
+  toSlug,
+  getEditButtonFromHash,
+  getScrollTarget,
+} from '../../util/hashUtils';
+
+describe('contact-information hashUtils', () => {
+  describe('toSlug', () => {
+    it('normalizes punctuation and case', () => {
+      expect(toSlug('Home Phone #')).to.equal('home-phone');
+      expect(toSlug('Edit   Mailing   Address!')).to.equal('edit-mailing-address');
+    });
+    it('collapses multiple separators', () => {
+      expect(toSlug('A--B__C***D')).to.equal('a-b-c-d');
+    });
+    it('handles empty/undefined safely', () => {
+      expect(toSlug('')).to.equal('');
+      expect(toSlug(undefined)).to.equal('');
+      expect(toSlug(null)).to.equal('');
+    });
+  });
+
+  describe('getEditButtonFromHash', () => {
+    let root;
+    beforeEach(() => {
+      root = document.createElement('div');
+      document.body.appendChild(root);
+    });
+    afterEach(() => {
+      document.body.removeChild(root);
+    });
+
+    const addButton = label => {
+      const btn = document.createElement('va-button');
+      btn.setAttribute('label', label);
+      root.appendChild(btn);
+      return btn;
+    };
+
+    it('returns null for non edit hash', () => {
+      expect(getEditButtonFromHash('#home-phone', root)).to.equal(null);
+    });
+
+    it('matches direct id when present', () => {
+      const direct = document.createElement('div');
+      direct.id = 'edit-email-address';
+      root.appendChild(direct);
+      expect(getEditButtonFromHash('#edit-email-address', root)).to.equal(direct);
+    });
+
+    it('matches by normalized label (leading Edit stripped)', () => {
+      const btn = addButton('Edit Home Phone');
+      expect(getEditButtonFromHash('#edit-home-phone', root)).to.equal(btn);
+    });
+
+    it('normalizes complex label spacing/punctuation', () => {
+      const btn = addButton('Edit   Mailing Address (Primary)');
+      expect(getEditButtonFromHash('#edit-mailing-address-primary', root)).to.equal(btn);
+    });
+
+    it('does not strip internal "edit" words (only leading)', () => {
+      const btn = addButton('Primary Editor Contact');
+      // slug becomes 'primary-editor-contact'; hash must match that
+      // eslint-disable-next-line prettier/prettier
+      expect(getEditButtonFromHash('#edit-primary-editor-contact', root)).to.equal(btn);
+    });
+
+    it('returns null when no matching button', () => {
+      addButton('Edit Home Phone');
+      expect(getEditButtonFromHash('#edit-something-else', root)).to.equal(null);
+    });
+  });
+
+  describe('getScrollTarget', () => {
+    let root;
+    beforeEach(() => {
+      root = document.createElement('div');
+      document.body.appendChild(root);
+    });
+    afterEach(() => {
+      document.body.removeChild(root);
+    });
+
+    it('transforms edit hash to legacy anchor', () => {
+      const legacy = document.createElement('section');
+      legacy.id = 'home-phone';
+      root.appendChild(legacy);
+      expect(getScrollTarget('#edit-home-phone', root)).to.equal(legacy);
+    });
+
+    it('returns element for non edit hash unchanged', () => {
+      const el = document.createElement('div');
+      el.id = 'mailing-address';
+      root.appendChild(el);
+      expect(getScrollTarget('#mailing-address', root)).to.equal(el);
+    });
+
+    it('returns null when element missing', () => {
+      expect(getScrollTarget('#edit-non-existent', root)).to.equal(null);
+    });
+  });
+});

--- a/src/applications/personalization/profile/util/hashUtils.js
+++ b/src/applications/personalization/profile/util/hashUtils.js
@@ -1,0 +1,82 @@
+/**
+ * Utilities for hash-based deep linking to Contact Information edit controls.
+ *
+ * Why this exists:
+ *  - Legacy anchors like #home-phone (#<field>) still exist; new design introduces
+ *    deep links of the form #edit-home-phone to jump directly to an "Edit ..." button.
+ *  - We cannot rely on hard-coded IDs for every edit button (web components may not expose
+ *    predictable internal markup). We instead derive targets from the visible button labels.
+ *  - Labels can change punctuation/casing; normalization makes matching resilient.
+ *
+ * Usage pattern:
+ *  - When loading the page, read window.location.hash.
+ *  - If hash starts with #edit-, attempt to focus the associated va-button via label match.
+ *  - Else fall back to legacy anchor (drop leading "edit-").
+ *  - If element not yet in DOM (async render), retry until found or timeout, then focus default.
+ */
+
+/**
+ * Normalize a string into a slug:
+ *  - lowercase
+ *  - runs of non-alphanumerics replaced with single hyphen
+ *  - trim leading/trailing hyphens
+ *  - collapse duplicate hyphens
+ */
+export const toSlug = str =>
+  (str || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/--+/g, '-');
+
+/**
+ * Given a hash like "#edit-home-phone" attempt to locate the corresponding va-button.
+ * Strategy:
+ *  1. If hash does not start with "#edit-" return null.
+ *  2. Try direct id match (future-proof if we add id="#edit-home-phone" later).
+ *  3. Iterate va-button elements with a label attribute; remove a leading "edit ",
+ *     normalize remainder, compare to slug portion of hash.
+ * Returns the first matching element or null.
+ *
+ * @param {string} hash - Location hash including leading '#'
+ * @param {Document|ParentNode} root - Optional root for querying (testability)
+ */
+export const getEditButtonFromHash = (hash, root = document) => {
+  if (typeof hash !== 'string' || !/^#edit-/.test(hash)) return null;
+  const slug = hash.replace(/^#edit-/, '');
+
+  // Direct element id match
+  try {
+    const direct = root.querySelector(hash);
+    if (direct) return direct;
+  } catch {
+    // ignore malformed selectors
+  }
+
+  const buttons = Array.from(root.querySelectorAll('va-button[label]'));
+  for (const btn of buttons) {
+    const rawLabel = btn.getAttribute('label') || '';
+    // Remove only a leading "edit " (case-insensitive)
+    const labelWithoutEditPrefix = rawLabel.replace(/^edit\s+/i, '');
+    const normalized = toSlug(labelWithoutEditPrefix);
+    if (normalized === slug) return btn;
+  }
+  return null;
+};
+
+/**
+ * For legacy hashes (#home-phone) and new edit hashes (#edit-home-phone),
+ * transform "#edit-home-phone" -> "#home-phone" to attempt a scroll target.
+ *
+ * @param {string} hash
+ * @param {Document|ParentNode} root
+ */
+export const getScrollTarget = (hash, root = document) => {
+  if (typeof hash !== 'string') return null;
+  const transformed = hash.replace(/^#edit-/, '#');
+  try {
+    return root.querySelector(transformed);
+  } catch {
+    return null;
+  }
+};

--- a/src/platform/mhv/components/MhvAlertConfirmEmail/AlertAddContactEmail.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/AlertAddContactEmail.jsx
@@ -8,8 +8,7 @@ import {
 
 const CONTENT = `We’ll send notifications about your VA health care and
   benefits to this email.`;
-const VA_PROFILE_EMAIL_HREF =
-  '/profile/contact-information#contact-email-address';
+const VA_PROFILE_EMAIL_HREF = '/profile/contact-information#email-address';
 
 // implements https://www.figma.com/design/CAChU51fWYMZsgDR5RXeSc/MHV-Landing-Page?node-id=7184-45009&t=CogySEDQUAcvZwHQ-4
 const AlertAddContactEmail = ({ recordEvent, onSkipClick }) => {

--- a/src/platform/mhv/components/MhvAlertConfirmEmail/AlertConfirmContactEmailContent.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/AlertConfirmContactEmailContent.jsx
@@ -25,7 +25,7 @@ export const AlertConfirmContactEmailContent = ({
 
     <p>
       <VaLink
-        href="/profile/contact-information#contact-email-address"
+        href="/profile/contact-information#email-address"
         text="Go to profile to update your contact email"
       />
     </p>

--- a/src/platform/mhv/tests/components/AlertConfirmAddContactEmailError.spec.jsx
+++ b/src/platform/mhv/tests/components/AlertConfirmAddContactEmailError.spec.jsx
@@ -33,7 +33,7 @@ describe('AlertConfirmAddContactEmailError />', () => {
     );
     expect(link).to.exist;
     expect(link.getAttribute('href')).to.equal(
-      '/profile/contact-information#contact-email-address',
+      '/profile/contact-information#email-address',
     );
 
     expect(recordEvent.calledOnce).to.be.true;

--- a/src/platform/mhv/tests/components/AlertConfirmContactEmailContent.spec.jsx
+++ b/src/platform/mhv/tests/components/AlertConfirmContactEmailContent.spec.jsx
@@ -29,7 +29,7 @@ describe('<AlertConfirmContactEmailContent />', async () => {
     );
     expect(link).to.exist;
     expect(link.getAttribute('href')).to.equal(
-      '/profile/contact-information#contact-email-address',
+      '/profile/contact-information#email-address',
     );
   });
 

--- a/src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx
+++ b/src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx
@@ -117,7 +117,7 @@ describe('<MhvAlertConfirmEmail />', () => {
 
         // getByRole('link', { name: /^Go to profile/ });
         const link = container.querySelector('va-link[text~="Go to profile"]');
-        const href = '/profile/contact-information#contact-email-address';
+        const href = '/profile/contact-information#email-address';
         expect(link.href).to.equal(href);
       });
     });
@@ -334,7 +334,7 @@ describe('<MhvAlertConfirmEmail />', () => {
         // getByRole('link', { name: /^Go to profile/ });
         const linkSelector = 'va-link-action[text~="Go to profile"]';
         const link = container.querySelector(linkSelector);
-        const href = '/profile/contact-information#contact-email-address';
+        const href = '/profile/contact-information#email-address';
         expect(link.href).to.equal(href);
 
         // getByRole('button', { name: /^Skip adding email$/ });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Email Confirmation Flow > user selects to add/edit on profile page
- Fixing the incorrect links with hash in the email alerts to target the email section heading (H2) of the profile/contact-info page
- refactored existing useEffect for focus and scrolling to page element to account for dynamic/async content load order.


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123435
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122590

## Testing done

- unit test passed
- manually a11y tested in (VO) screenreader and with keyboard-only navigation
- Steps for local testing MyHealtheVet && Profile:

(mind your portnumber)

- http://localhost:3001/my-health/
- http://localhost:3001/profile/contact-information

**Force email alert**
- **selectors.js** ~ line 25:
/src/platform/mhv/components/MhvAlertConfirmEmail/selectors.js
  - add/uncomment out the `export const showAlert = state => true;` line
  - comment the original `export const showAlert = state => ...` block

```js
// export const showAlert = state => true;
export const showAlert = state =>
  !dismissedAlertViaCookie() &&
  !state.featureToggles.loading &&
  state.featureToggles.mhvEmailConfirmation &&
  !state.user.profile.loading &&
  state.user.profile.vaPatient &&
  (!selectContactEmailAddress(state) ||
    !selectContactEmailConfirmationDate(state) ||
    isBefore(
      new Date(selectContactEmailConfirmationDate(state)),
      new Date(DATE_THRESHOLD),
    ) ||
    !selectContactEmailUpdatedAt(state) ||
    isBefore(
      new Date(selectContactEmailUpdatedAt(state)),
      new Date(DATE_THRESHOLD),
    ));
```


## Screenshots

- screenshots in linked related tickets
- video of scroll function
https://github.com/user-attachments/assets/7cdc3ac8-9d76-4312-9ac9-909dbfb0207a
- video with VO screenreader on
https://github.com/user-attachments/assets/1e363cf1-6223-41ec-b41d-2849456dbfc0



## What areas of the site does it impact?

- https://staging.va.gov/my-va/
- https://staging.va.gov/my-health/
- https://staging.va.gov/profile/contact-information

## Acceptance criteria
- [ ] The links to profile/contact-information in the email add/confirmation alerts components properly target the correct page and  `#email-address` page id (H2 element) 
- [ ] Once the page/components load, the page scrolls to the defined page id `#email-address` and focus is set on this element.
  - Once scroll and focus occur, the screen reader (VO) will properly announce the current focus item H2 Email Address and allow the user to navigate to the next content or button on the page (*an additional alert in this case)
  - **Note** the profile page suppresses the yellow focus indicator on headings

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added (via related issue links)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
