### PR TITLE
Arc/background info only accept pdf and docx

### DIFF
--- a/src/applications/accreditation/21a/pages/helpers/backgroundInformationDetailsPageSchema.js
+++ b/src/applications/accreditation/21a/pages/helpers/backgroundInformationDetailsPageSchema.js
@@ -40,9 +40,9 @@ const backgroundInformationDetails = ({
           title: 'Provide any relevant documents',
           required: false,
           maxFileSize: 26214400, // 25MB in bytes
-          accept: '.pdf',
+          accept: '.pdf,.docx',
           hint:
-            'You may add .pdf documents under 25MB. Please name documents with clear, descriptive names.',
+            'You may add .pdf or .docx documents under 25MB. Please name documents with clear, descriptive names.',
           name: `${path}-file-input`,
           fileUploadUrl: url,
           skipUpload: false,

--- a/src/applications/accreditation/21a/pages/helpers/backgroundInformationDetailsPageSchema.js
+++ b/src/applications/accreditation/21a/pages/helpers/backgroundInformationDetailsPageSchema.js
@@ -40,9 +40,9 @@ const backgroundInformationDetails = ({
           title: 'Provide any relevant documents',
           required: false,
           maxFileSize: 26214400, // 25MB in bytes
-          accept: '.pdf,.doc,.jpg,.jpeg,.txt',
+          accept: '.pdf',
           hint:
-            'You may add .pdf, .doc, .jpg, or .txt documents under 25MB. Please name documents with clear, descriptive names.',
+            'You may add .pdf documents under 25MB. Please name documents with clear, descriptive names.',
           name: `${path}-file-input`,
           fileUploadUrl: url,
           skipUpload: false,

--- a/src/applications/accreditation/21a/tests/unit/pages/06-background-information-chapter/backgroundInformationDetailsPageSchema.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/06-background-information-chapter/backgroundInformationDetailsPageSchema.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('backgroundInformationDetailsPageSchema (multi-file upload)', () => {
 
     expect(opts).to.be.an('object');
     expect(opts.maxFileSize).to.equal(26214400);
-    expect(opts.accept).to.equal('.pdf,.doc,.jpg,.jpeg,.txt');
+    expect(opts.accept).to.equal('.pdf');
     expect(opts.name).to.equal(`${path}-file-input`);
 
     const expectedPrefix = `${

--- a/src/applications/accreditation/21a/tests/unit/pages/06-background-information-chapter/backgroundInformationDetailsPageSchema.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/06-background-information-chapter/backgroundInformationDetailsPageSchema.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('backgroundInformationDetailsPageSchema (multi-file upload)', () => {
 
     expect(opts).to.be.an('object');
     expect(opts.maxFileSize).to.equal(26214400);
-    expect(opts.accept).to.equal('.pdf');
+    expect(opts.accept).to.equal('.pdf,.docx');
     expect(opts.name).to.equal(`${path}-file-input`);
 
     const expectedPrefix = `${


### PR DESCRIPTION
## Summary

- Currently only have upload accept PDF or DOCX. Will add and support other document types going forward

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123400#issuecomment-3533860607

## Testing done

- tested locally. Tested e2e test locally. Adding screenshots

## Screenshots
<img width="573" height="630" alt="Screenshot 2025-11-16 at 10 22 52 PM" src="https://github.com/user-attachments/assets/8ed17f3c-7646-4414-a6e0-6e808450fd0d" />
<img width="607" height="657" alt="Screenshot 2025-11-16 at 10 22 22 PM" src="https://github.com/user-attachments/assets/46e65efa-ed7f-4e80-b5db-85dbb94a14c7" />


## What areas of the site does it impact?

representative/accreditation/attorney-claims-agent-form-21a/
## Acceptance criteria

### Quality Assurance & Testing

- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Screenshot of the developed feature is added

### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user