### PR TITLE
#112816: Refactor useEffect calls in Prescriptions container

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
@@ -44,7 +44,7 @@ const MedicationsList = props => {
     navigate(`/?page=${page}`, {
       replace: true,
     });
-    updateLoadingStatus(null, 'Loading your medications...');
+    updateLoadingStatus('Loading your medications...');
     waitForRenderThenFocus(displaynumberOfPrescriptionsSelector, document, 500);
   };
 

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -5,12 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  Link,
-  useNavigate,
-  useLocation,
-  useSearchParams,
-} from 'react-router-dom-v5-compat';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom-v5-compat';
 import { useSelector, useDispatch } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
@@ -78,15 +73,14 @@ import { selectPrescriptionId } from '../selectors/selectPrescription';
 import {
   selectSortOption,
   selectFilterOption,
-  selectPageNumber,
 } from '../selectors/selectPreferences';
 import { buildPdfData } from '../util/buildPdfData';
 import { generateMedicationsPdfFile } from '../util/generateMedicationsPdfFile';
 import FilterAriaRegion from '../components/MedicationsList/FilterAriaRegion';
-import RxRenewalDeleteDraftSuccessAlert from '../components/shared/RxRenewalDeleteDraftSuccessAlert';
+import { useURLPagination } from '../hooks/useURLPagination';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 const Prescriptions = () => {
-  const { search } = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const ssoe = useSelector(isAuthenticatedWithSSOe);
@@ -95,15 +89,12 @@ const Prescriptions = () => {
   const hasMedsByMailFacility = useSelector(selectHasMedsByMailFacility);
   const [searchParams] = useSearchParams();
   const rxRenewalMessageSuccess = searchParams.get('rxRenewalMessageSuccess');
-  const deleteDraftSuccess = searchParams.get('draftDeleteSuccess');
 
   // Get sort/filter selections from store.
   const selectedSortOption = useSelector(selectSortOption);
   const selectedFilterOption = useSelector(selectFilterOption);
-  const currentPage = useSelector(selectPageNumber);
 
-  // Track if we've initialized from session storage
-  const initializedFromSession = useRef(false);
+  const { currentPage, handlePageChange } = useURLPagination();
 
   // Consolidate query parameters into a single state object to avoid multiple re-renders
   const [queryParams, setQueryParams] = useState({
@@ -115,6 +106,16 @@ const Prescriptions = () => {
     filterOption: filterOptions[selectedFilterOption]?.url || '',
   });
 
+  useEffect(
+    () => {
+      setQueryParams(prev => ({
+        ...prev,
+        page: currentPage,
+      }));
+    },
+    [currentPage],
+  );
+
   // Use the consolidated query parameters for RTK Query
   const {
     data: prescriptionsData,
@@ -123,21 +124,7 @@ const Prescriptions = () => {
     isFetching: isPrescriptionsFetching,
   } = useGetPrescriptionsListQuery(queryParams);
 
-  // Extract page from URL query params
-  const page = useMemo(
-    () => {
-      const query = new URLSearchParams(search);
-      return Number(query.get('page'));
-    },
-    [search],
-  );
-
-  // Mark as initialized after the first render
-  useEffect(() => {
-    if (!initializedFromSession.current) {
-      initializedFromSession.current = true;
-    }
-  }, []);
+  const isLoading = isPrescriptionsLoading || isPrescriptionsFetching;
 
   const { pagination, meta } = prescriptionsData || {};
   const paginatedPrescriptionsList = useMemo(
@@ -151,7 +138,6 @@ const Prescriptions = () => {
   );
   const { prescriptions: filteredList } = prescriptionsData || [];
   const { filterCount } = meta || {};
-
   const prescriptionId = useSelector(selectPrescriptionId);
   const [prescriptionsExportList, setPrescriptionsExportList] = useState([]);
   const [shouldPrint, setShouldPrint] = useState(false);
@@ -160,7 +146,6 @@ const Prescriptions = () => {
     false,
   );
   const isAlertVisible = useMemo(() => false, []);
-  const [isLoading, setLoading] = useState();
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   const [loadingMessage, setLoadingMessage] = useState('');
   const [pdfTxtGenerateStatus, setPdfTxtGenerateStatus] = useState({
@@ -172,19 +157,13 @@ const Prescriptions = () => {
 
   const refillAlertList = prescriptionsData?.refillAlertList || [];
 
-  const updateLoadingStatus = (newIsLoading, newLoadingMessage) => {
-    if (newIsLoading !== null) setLoading(newIsLoading);
-    if (newLoadingMessage) setLoadingMessage(newLoadingMessage);
-  };
-
   // Update filter and sort in a single function
   const updateFilterAndSort = (newFilterOption, newSortOption) => {
     // Prepare updates for a single state change
     const updates = {};
 
     const isFiltering = newFilterOption !== null;
-    updateLoadingStatus(
-      null,
+    setLoadingMessage(
       `${isFiltering ? 'Filtering' : 'Sorting'} your medications...`,
     );
 
@@ -224,16 +203,6 @@ const Prescriptions = () => {
     navigate('/?page=1', { replace: true });
   };
 
-  // Handle pagination changes
-  const handlePageChange = newPage => {
-    dispatch(setPageNumber(newPage));
-    setQueryParams(prev => ({
-      ...prev,
-      page: newPage,
-    }));
-    navigate(`/?page=${newPage}`, { replace: true });
-  };
-
   const printRxList = useCallback(() => {
     window.print();
   }, []);
@@ -241,19 +210,6 @@ const Prescriptions = () => {
   const goToPrevious = () => {
     scrollLocation?.current?.scrollIntoView();
   };
-
-  // Load from URL params if needed
-  useEffect(
-    () => {
-      if (page && page !== queryParams.page) {
-        setQueryParams(prev => ({
-          ...prev,
-          page,
-        }));
-      }
-    },
-    [page, queryParams.page],
-  );
 
   useEffect(() => {
     if (!isLoading) {
@@ -301,55 +257,15 @@ const Prescriptions = () => {
     [
       isLoading,
       filteredList,
-      // isFirstLoad TODO: This breaks the code. Need to refactor to add this.
+      // TODO: This breaks the code because it causes the "Showing X - Y of Z medications" to be focused on initial page load.
+      // Need to refactor these hooks to better handle the initial loading state to add this.
+      // isFirstLoad
     ],
   );
 
-  // Update page title
-  useEffect(
-    () => {
-      updatePageTitle('Medications | Veterans Affairs');
-    },
-    [currentPage],
-  );
-
-  // Update loading state based on RTK Query states
-  useEffect(
-    () => {
-      updateLoadingStatus(isPrescriptionsLoading || isPrescriptionsFetching);
-
-      // Reset the loading message after finishing loading.
-      if (!isPrescriptionsFetching && !isPrescriptionsLoading) {
-        setLoadingMessage('');
-      }
-    },
-    [isPrescriptionsLoading, isPrescriptionsFetching],
-  );
-
-  // Handle URL validation
-  useEffect(
-    () => {
-      if (Number.isNaN(page) || page < 1) {
-        navigate(`/?page=${currentPage || 1}`, { replace: true });
-      } else if (page !== currentPage) {
-        // If the URL page parameter differs from our Redux state, update Redux
-        dispatch(setPageNumber(page));
-      }
-    },
-    [page, navigate, currentPage, dispatch],
-  );
-
-  const baseTitle = 'Medications | Veterans Affairs';
-  usePrintTitle(baseTitle, userName, dob, updatePageTitle);
-
-  useEffect(
-    () => {
-      if (!selectedFilterOption) {
-        dispatch(setFilterOption(ALL_MEDICATIONS_FILTER_KEY));
-      }
-    },
-    [dispatch, selectedFilterOption],
-  );
+  const basePageTitle = 'Medications | Veterans Affairs';
+  usePageTitle(basePageTitle);
+  usePrintTitle(basePageTitle, userName, dob, updatePageTitle);
 
   const txtData = useCallback(
     (rxList, allergiesList) => {
@@ -449,7 +365,6 @@ const Prescriptions = () => {
         });
         // Set the print trigger instead of using setTimeout
         setShouldPrint(true);
-        updateLoadingStatus(false, '');
       }
     },
     [
@@ -470,13 +385,6 @@ const Prescriptions = () => {
       }
     },
     [shouldPrint, printRxList],
-  );
-
-  useEffect(
-    () => {
-      setPrescriptionsExportList([]);
-    },
-    [selectedFilterOption, selectedSortOption],
   );
 
   const handleExportListDownload = async format => {
@@ -624,17 +532,16 @@ const Prescriptions = () => {
         rxList={filteredList}
         scrollLocation={scrollLocation}
         selectedSortOption={selectedSortOption}
-        updateLoadingStatus={updateLoadingStatus}
+        updateLoadingStatus={setLoadingMessage}
         onPageChange={handlePageChange}
       />
     );
   };
 
   const renderRxRenewalMessageSuccess = () => {
-    if (deleteDraftSuccess) return <RxRenewalDeleteDraftSuccessAlert />;
+    if (!rxRenewalMessageSuccess) return null;
 
-    if (rxRenewalMessageSuccess) return <RxRenewalMessageSuccessAlert />;
-    return null;
+    return <RxRenewalMessageSuccessAlert />;
   };
 
   const renderHeader = () => {

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -77,6 +77,7 @@ import {
 import { buildPdfData } from '../util/buildPdfData';
 import { generateMedicationsPdfFile } from '../util/generateMedicationsPdfFile';
 import FilterAriaRegion from '../components/MedicationsList/FilterAriaRegion';
+import RxRenewalDeleteDraftSuccessAlert from '../components/shared/RxRenewalDeleteDraftSuccessAlert';
 import { useURLPagination } from '../hooks/useURLPagination';
 import { usePageTitle } from '../hooks/usePageTitle';
 
@@ -89,6 +90,7 @@ const Prescriptions = () => {
   const hasMedsByMailFacility = useSelector(selectHasMedsByMailFacility);
   const [searchParams] = useSearchParams();
   const rxRenewalMessageSuccess = searchParams.get('rxRenewalMessageSuccess');
+  const deleteDraftSuccess = searchParams.get('draftDeleteSuccess');
 
   // Get sort/filter selections from store.
   const selectedSortOption = useSelector(selectSortOption);
@@ -539,9 +541,10 @@ const Prescriptions = () => {
   };
 
   const renderRxRenewalMessageSuccess = () => {
-    if (!rxRenewalMessageSuccess) return null;
+    if (deleteDraftSuccess) return <RxRenewalDeleteDraftSuccessAlert />;
 
-    return <RxRenewalMessageSuccessAlert />;
+    if (rxRenewalMessageSuccess) return <RxRenewalMessageSuccessAlert />;
+    return null;
   };
 
   const renderHeader = () => {

--- a/src/applications/mhv-medications/hooks/usePageTitle.js
+++ b/src/applications/mhv-medications/hooks/usePageTitle.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import * as mhvExports from '@department-of-veterans-affairs/mhv/exports';
+
+/**
+ * Custom hook to set the page title using MHV's updatePageTitle function
+ * @param {string} title - The page title
+ * @param {object} [options] - Optional parameters for testing
+ * @param {function} [options.updatePageTitle] - Custom updatePageTitle function for testing
+ * @returns {void}
+ */
+export const usePageTitle = (
+  title,
+  { updatePageTitle: customUpdatePageTitle } = {},
+) => {
+  useEffect(
+    () => {
+      const updatePageTitleDefault = mhvExports.updatePageTitle;
+      const updatePageTitle = customUpdatePageTitle || updatePageTitleDefault;
+      updatePageTitle(title);
+    },
+    [title, customUpdatePageTitle],
+  );
+};

--- a/src/applications/mhv-medications/hooks/useURLPagination.js
+++ b/src/applications/mhv-medications/hooks/useURLPagination.js
@@ -1,0 +1,58 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { selectPageNumber } from '../selectors/selectPreferences';
+import { setPageNumber } from '../redux/preferencesSlice';
+
+/**
+ * Custom hook to manage pagination state via URL query parameters
+ * @param {object} [options] - Optional parameters for testing
+ * @param {function} [options.navigate] - Custom navigate function for testing
+ * @returns {{ currentPage: number, handlePageChange: function }}
+ */
+export const useURLPagination = ({ navigate: customNavigate } = {}) => {
+  const dispatch = useDispatch();
+  const navigateDefault = useNavigate();
+  const navigate = customNavigate || navigateDefault;
+  const { search } = useLocation();
+  const currentPage = useSelector(selectPageNumber) || 1;
+
+  const page = useMemo(
+    () => {
+      const query = new URLSearchParams(search);
+      return Number(query.get('page'));
+    },
+    [search],
+  );
+
+  useEffect(
+    () => {
+      if (Number.isNaN(page) || page < 1) {
+        navigate(`/?page=${currentPage || 1}`, { replace: true });
+        return;
+      }
+
+      if (page !== currentPage) {
+        dispatch(setPageNumber(page));
+      }
+    },
+    [page, navigate, currentPage, dispatch],
+  );
+
+  /**
+   * Callback to handle page changes
+   * @param {number} newPage The new page value
+   */
+  const handlePageChange = newPage => {
+    if (Number.isNaN(newPage) || newPage < 1) {
+      return;
+    }
+    dispatch(setPageNumber(newPage));
+    navigate(`/?page=${newPage}`, { replace: true });
+  };
+
+  return {
+    currentPage,
+    handlePageChange,
+  };
+};

--- a/src/applications/mhv-medications/tests/hooks/usePageTitle.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/usePageTitle.unit.spec.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { expect } from 'chai';
+import { waitFor, render } from '@testing-library/react';
+import sinon from 'sinon';
+import { updatePageTitle } from '@department-of-veterans-affairs/mhv/exports';
+import { usePageTitle } from '../../hooks/usePageTitle';
+
+function renderHook(renderCallback, { initialProps } = {}) {
+  const result = React.createRef();
+
+  function TestComponent({ renderCallbackProps }) {
+    result.current = renderCallback(renderCallbackProps);
+    return null;
+  }
+
+  const { rerender, unmount } = render(
+    <TestComponent renderCallbackProps={initialProps} />,
+  );
+
+  return {
+    result,
+    rerender: newProps =>
+      rerender(<TestComponent renderCallbackProps={newProps} />),
+    unmount,
+  };
+}
+
+describe('usePageTitle', () => {
+  let sandbox;
+  let updatePageTitleSpy;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    updatePageTitleSpy = sandbox.spy(updatePageTitle);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('calls updatePageTitle on mount', async () => {
+    renderHook(() =>
+      usePageTitle('Medications Page', { updatePageTitle: updatePageTitleSpy }),
+    );
+
+    await waitFor(() => {
+      expect(updatePageTitleSpy.calledWith('Medications Page')).to.be.true;
+    });
+  });
+
+  it('calls updatePageTitle again when title changes', async () => {
+    const { rerender } = renderHook(
+      title => usePageTitle(title, { updatePageTitle: updatePageTitleSpy }),
+      { initialProps: 'Title 1' },
+    );
+
+    await waitFor(() => {
+      expect(updatePageTitleSpy.calledWith('Title 1')).to.be.true;
+    });
+
+    rerender('Title 2');
+
+    await waitFor(() => {
+      expect(updatePageTitleSpy.callCount).to.equal(2);
+      expect(updatePageTitleSpy.secondCall.calledWith('Title 2')).to.be.true;
+    });
+  });
+
+  it('does not call updatePageTitle again if title is the same', async () => {
+    const { rerender } = renderHook(
+      title => usePageTitle(title, { updatePageTitle: updatePageTitleSpy }),
+      { initialProps: 'Title 1' },
+    );
+
+    await waitFor(() => {
+      expect(updatePageTitleSpy.calledWith('Title 1')).to.be.true;
+    });
+
+    rerender('Title 1');
+
+    // Wait a tick to ensure the effect runs
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(updatePageTitleSpy.callCount).to.equal(1);
+  });
+});

--- a/src/applications/mhv-medications/tests/hooks/useURLPagination.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useURLPagination.unit.spec.jsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import * as sinon from 'sinon';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
+import * as redux from 'react-redux';
+import { useURLPagination } from '../../hooks/useURLPagination';
+
+function renderHook(renderCallback, options = {}) {
+  const { initialProps, ...renderOptions } = options;
+  const result = React.createRef();
+  result.current = null;
+
+  function TestComponent({ renderCallbackProps }) {
+    const hookResult = renderCallback(renderCallbackProps);
+    result.current = hookResult;
+
+    React.useEffect(() => {
+      result.current = hookResult;
+    });
+
+    return null;
+  }
+
+  const { rerender: baseRerender, unmount } = render(
+    <TestComponent renderCallbackProps={initialProps} />,
+    renderOptions,
+  );
+
+  function rerender(rerenderCallbackProps) {
+    return baseRerender(
+      <TestComponent renderCallbackProps={rerenderCallbackProps} />,
+    );
+  }
+
+  return { result, rerender, unmount };
+}
+
+/**
+ * Creates a test wrapper with Redux Provider and MemoryRouter
+ * @param {Object} mockStore the mock Redux store
+ * @param {number} page The page number to include as the initialEntries 'page' query parameter
+ * @returns {React.Component} A React component wrapping children with Provider and MemoryRouter
+ */
+function createTestWrapper(mockStore, page = 1) {
+  const Wrapper = ({ children }) => (
+    <Provider store={mockStore}>
+      <MemoryRouter initialEntries={[page !== null ? `/?page=${page}` : '']}>
+        {children}
+      </MemoryRouter>
+    </Provider>
+  );
+
+  Wrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  return Wrapper;
+}
+
+describe('useURLPagination', () => {
+  let sandbox;
+  let mockStore;
+  let wrapper;
+  let dispatchSpy;
+  let navigateStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    mockStore = configureStore([])({ rx: { preferences: { pageNumber: 1 } } });
+    dispatchSpy = sandbox.spy();
+    navigateStub = sandbox.stub();
+
+    sandbox.stub(redux, 'useDispatch').returns(dispatchSpy);
+
+    wrapper = createTestWrapper(mockStore);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns currentPage and handlePageChange', async () => {
+    wrapper = createTestWrapper(mockStore);
+
+    const { result } = renderHook(() => useURLPagination(), {
+      wrapper,
+    });
+    expect(result.current.currentPage).to.equal(1);
+    expect(result.current.handlePageChange).to.be.a('function');
+  });
+
+  it('No action is dispatched for invalid page number (negative)', async () => {
+    wrapper = createTestWrapper(mockStore, -4);
+
+    renderHook(
+      () =>
+        useURLPagination({
+          navigate: navigateStub,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(dispatchSpy.called).to.be.false;
+      expect(navigateStub.calledWith('/?page=1', { replace: true })).to.be.true;
+    });
+  });
+
+  it("Redirects to page 1 and doesn't dispatch an action when the page query param is missing", async () => {
+    wrapper = createTestWrapper(mockStore, null);
+
+    renderHook(
+      () =>
+        useURLPagination({
+          navigate: navigateStub,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(dispatchSpy.called).to.be.false;
+      expect(navigateStub.calledWith('/?page=1', { replace: true })).to.be.true;
+    });
+  });
+
+  it('Dispatches action when the page query param is different from the current page number in state', async () => {
+    mockStore = configureStore([])({ rx: { preferences: { pageNumber: 5 } } });
+    wrapper = createTestWrapper(mockStore, 12);
+
+    renderHook(() => useURLPagination({ navigate: navigateStub }), { wrapper });
+
+    await waitFor(() => {
+      expect(
+        dispatchSpy.calledWith({
+          type: 'preferences/setPageNumber',
+          payload: 12,
+        }),
+      ).to.be.true;
+      expect(navigateStub.called).to.be.false;
+    });
+  });
+
+  it('No action is dispatched for invalid page number (NaN)', async () => {
+    wrapper = createTestWrapper(mockStore, 'invalid');
+
+    renderHook(() => useURLPagination({ navigate: navigateStub }), { wrapper });
+
+    await waitFor(() => {
+      expect(dispatchSpy.called).to.be.false;
+      expect(navigateStub.calledWith('/?page=1', { replace: true })).to.be.true;
+    });
+  });
+
+  it('dispatches correct action if pageNumber !== page number in state', async () => {
+    mockStore = configureStore([])({ rx: { preferences: { pageNumber: 5 } } });
+    wrapper = createTestWrapper(mockStore);
+    renderHook(() => useURLPagination({ navigate: navigateStub }), { wrapper });
+    await waitFor(() => {
+      expect(dispatchSpy.called).to.be.true;
+      expect(navigateStub.called).to.be.false;
+    });
+  });
+
+  it('handlePageChange dispatches correct action', async () => {
+    const { result } = renderHook(
+      () => useURLPagination({ navigate: navigateStub }),
+      { wrapper },
+    );
+    result.current.handlePageChange(2);
+
+    await waitFor(() => {
+      expect(
+        dispatchSpy.calledWith({
+          type: 'preferences/setPageNumber',
+          payload: 2,
+        }),
+      ).to.be.true;
+      expect(navigateStub.calledWith('/?page=2', { replace: true })).to.be.true;
+    });
+  });
+
+  it('handlePageChange does not dispatch an action or redirect for invalid page number (negative)', async () => {
+    const { result } = renderHook(
+      () => useURLPagination({ navigate: navigateStub }),
+      { wrapper },
+    );
+    result.current.handlePageChange(0);
+
+    await waitFor(() => {
+      expect(dispatchSpy.called).to.be.false;
+      expect(navigateStub.called).to.be.false;
+    });
+  });
+
+  it('handlePageChange does not dispatch an action or redirect for invalid page number (NaN)', async () => {
+    const { result } = renderHook(
+      () => useURLPagination({ navigate: navigateStub }),
+      { wrapper },
+    );
+    result.current.handlePageChange(Number.NaN);
+
+    await waitFor(() => {
+      expect(dispatchSpy.called).to.be.false;
+      expect(navigateStub.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This is a refactor for the `Prescriptions` container. It was identified in [#122816](https://github.com/department-of-veterans-affairs/va.gov-team/issues/122816) that this container had 12 unique `useEffects`, so this PR simplifies this a bit. This trims it down to 6 calls, and abstracts some pieces out into new hooks.

Here's what happened to each of these calls:

[#1](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L134-L138) - Dead code, removed. This `initializedFromSession` ref wasn't being used.

[#2](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L243-L254) - Kept. This is related to the logic in `useURLPagination`, but I think the component managing its own query param state makes sense.

[#3](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L256-L264) - Kept

[#4](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L266-L278) - Kept

[#5](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L280-L304) - Kept

^ These 3 are all related to focusing different elements in response to various states. I tried to combine them, but it got confusing quickly, so I think keeping them as simple effects makes sense.

[#6](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L307-L312) - Moved into new hook, usePageTitle. This is a common action and we can reuse this on other pages that set titles.

Note: slight logic change - previously the page title was being updated whenever `currentPage` changed (e.g. when you go from page 1 to page 2, the title would be updated). However, it always set the title to the same value, so there isn't any visual change.

This code now only sets the title when the title is changed.

[#7](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L315-L325) - Removed – now using RTK state

[#8](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L328-L338) - Moved into new hook useURLPagination

[#9](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L343-L350) - Removed – handled by redux defaults

[#10](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L423-L461) - Kept – suggested refactor ([#125263](https://github.com/department-of-veterans-affairs/va.gov-team/issues/125263))

[#11](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L463-L471) - Kept. I considered using a `setTimeout(...)` [here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L449) instead, but I think the `useEffect` is cleaner.

[#12](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-medications/containers/Prescriptions.jsx#L473-L478) - Kept – related to file export

I also created:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125267
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125263

For further cleanup work on this component

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122816

## Testing done

Regression tested filtering, sorting, and the pagination handling on the `my-health/medications` page where this component is rendered.

## Screenshots

**Before**

https://github.com/user-attachments/assets/8f272897-5bdd-4698-b5fc-51c85e4ed5e2

**After**

https://github.com/user-attachments/assets/679add50-11d1-4153-ac6d-585ce411dcf0


## What areas of the site does it impact?

This only impacts the `/my-health/medications` page.

This effects:
  - Initial loading state
  - Loading after filtering
  - Loading after sorting
  - Handling of pagination parameters in URL (`page`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user