### PR TITLE
[#2716] Add differentiation between singular and plural character(s) for chatbot character limit

### DIFF
--- a/src/applications/virtual-agent/hooks/useCharacterLimit.js
+++ b/src/applications/virtual-agent/hooks/useCharacterLimit.js
@@ -40,7 +40,8 @@ export function getSrElement() {
 export function getCounterText(currentLength, characterLimit) {
   const charactersLeft = characterLimit - currentLength;
   const textSuffix = currentLength === 0 ? 'allowed' : 'left';
-  return `${charactersLeft} characters ${textSuffix}`;
+  const character = charactersLeft === 1 ? 'character' : 'characters';
+  return `${charactersLeft} ${character} ${textSuffix}`;
 }
 
 /**

--- a/src/applications/virtual-agent/tests/hooks/useCharacterLimit.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useCharacterLimit.unit.spec.jsx
@@ -195,6 +195,18 @@ describe('useCharacterLimit', () => {
       expect(result).to.equal('0 characters left');
     });
 
+    it('should use singular "character" when exactly 1 character is left', () => {
+      const result = getCounterText(CHARACTER_LIMIT - 1, CHARACTER_LIMIT);
+
+      expect(result).to.equal('1 character left');
+    });
+
+    it('should use plural "characters" when more than 1 character is left', () => {
+      const result = getCounterText(CHARACTER_LIMIT - 2, CHARACTER_LIMIT);
+
+      expect(result).to.equal('2 characters left');
+    });
+
     it('should work with different character limits', () => {
       const customLimit = 200;
       const result = getCounterText(50, customLimit);
@@ -268,6 +280,21 @@ describe('useCharacterLimit', () => {
       expect(mockSrElement.textContent).to.equal('11 characters left');
       expect(mockCounterElement.classList.remove.calledWith('warning')).to.be
         .true;
+    });
+
+    it('should use singular "character" when exactly 1 character is left', () => {
+      mockInputElement.value = 'a'.repeat(CHARACTER_LIMIT - 1);
+
+      updateCounter(
+        mockCounterElement,
+        mockSrElement,
+        mockInputElement,
+        CHARACTER_LIMIT,
+        RED_THRESHOLD,
+      );
+
+      expect(mockCounterElement.textContent).to.equal('1 character left');
+      expect(mockSrElement.textContent).to.equal('1 character left');
     });
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- When the character limit is 0 characters left or more than 1 characters left, the text will use plural "characters"
- When the character limit is 1 character left, the text will use singular "character"

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/2716

## Testing done

- Prior behavior was always using plural "characters"
- Ran chatbot locally and verified the changes
- Added unit tests for these cases

## Screenshots
<img width="411" height="641" alt="Image" src="https://github.com/user-attachments/assets/6850b129-051a-48fe-b559-1f0bedccf226" />

<img width="412" height="644" alt="Image" src="https://github.com/user-attachments/assets/d48c08c8-1a3b-42f9-b25e-c3e30c8b30f1" />

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed