### PR TITLE
Follow up - Update title tag of CareTeamHelp component to match docs

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx
@@ -97,6 +97,16 @@ describe('CareTeamHelp', () => {
     expect(screen.getByRole('heading', { level: 1 })).to.exist;
   });
 
+  it('sets the document title', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(document.title).to.equal(
+        'Care Team Help - Start Message | Veterans Affairs',
+      );
+    });
+  });
+
   it('shows VistA-only content when user has only VistA systems', () => {
     const screen = setup(vistaOnlyState);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js
@@ -79,6 +79,9 @@ describe('SM CURATED LIST BREADCRUMBS', () => {
 
       // Removed the "Can't" in verifyPageHeader for testing purposes
       GeneralFunctionsPage.verifyPageHeader('find your care team?');
+      GeneralFunctionsPage.verifyPageTitle(
+        'Care Team Help - Start Message | Veterans Affairs',
+      );
       cy.location('pathname').should('equal', Data.LINKS.CARE_TEAM_HELP);
       cy.injectAxeThenAxeCheck(AXE_CONTEXT);
 

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -475,8 +475,7 @@ export const PageTitles = {
   CONVERSATION_TITLE_TAG: 'Conversation | Veterans Affairs',
   EDIT_DRAFT_PAGE_TITLE_TAG:
     'Edit draft - MHV Secure Messaging | Veterans Affairs',
-  CARE_TEAM_HELP_TITLE_TAG:
-    'Can’t find your care team? - Messages | Veterans Affairs',
+  CARE_TEAM_HELP_TITLE_TAG: 'Care Team Help - Start Message | Veterans Affairs',
 };
 
 export const PageHeaders = {


### PR DESCRIPTION

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR is a follow up based on a finding from [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39456), which corrects the title tag for the Care Team Help page. 

## Related issue(s)

- [Ticket Link](https://github.com/department-of-veterans-affairs/vets-website/issues/40029)
- https://github.com/department-of-veterans-affairs/vets-website/pull/39456

## Testing done

- e2e test: `mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js`
- unit test: `src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx`

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
