### PR TITLE
10-10dx | Add scaffolding for expanding Cypress test suite

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/10-10d-extended.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/10-10d-extended.cypress.spec.js
@@ -4,16 +4,11 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 import {
-  createSummaryHandler,
-  fillAddressAndGoToNext,
+  fillStatementOfTruthAndSubmit,
   setupBasicTest,
-  startAsGuestUser,
+  startAsNewUser,
 } from './utils';
 
-// define handlers for ArrayBuilder sections
-const handleApplicantSummary = createSummaryHandler('root_view:hasApplicants');
-
-// define test config
 const testConfig = createTestConfig(
   {
     dataPrefix: 'data',
@@ -21,51 +16,10 @@ const testConfig = createTestConfig(
     dataSets: ['minimal-test'],
     pageHooks: {
       introduction: ({ afterHook }) => {
-        afterHook(() => startAsGuestUser());
-      },
-      'your-mailing-address': ({ afterHook }) => {
-        afterHook(() => {
-          cy.get('@testData').then(data => {
-            fillAddressAndGoToNext('certifierAddress', data.certifierAddress);
-          });
-        });
-      },
-      'veteran-mailing-address': ({ afterHook }) => {
-        afterHook(() => {
-          cy.get('@testData').then(data => {
-            fillAddressAndGoToNext('sponsorAddress', data.sponsorAddress);
-          });
-        });
-      },
-      'review-your-applicants': ({ afterHook }) => {
-        afterHook(() => handleApplicantSummary());
-      },
-      'applicant-mailing-address/:index': ({ afterHook, index }) => {
-        afterHook(() => {
-          cy.get('@testData').then(data => {
-            fillAddressAndGoToNext(
-              'applicantAddress',
-              data.applicants[index].applicantAddress,
-            );
-          });
-        });
+        afterHook(() => startAsNewUser());
       },
       'review-and-submit': ({ afterHook }) => {
-        afterHook(() => {
-          cy.get('@testData').then(data => {
-            cy.get('va-statement-of-truth')
-              .shadow()
-              .within(() => {
-                cy.get('va-text-input').then($el =>
-                  cy.fillVaTextInput($el, data.statementOfTruthSignature),
-                );
-                cy.get('va-checkbox').then($el =>
-                  cy.selectVaCheckbox($el, true),
-                );
-              });
-            cy.get('va-button[text*="submit" i]').click();
-          });
-        });
+        afterHook(() => fillStatementOfTruthAndSubmit());
       },
     },
     setupPerTest: () => setupBasicTest(),

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/mocks/prefill.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/mocks/prefill.json
@@ -1,0 +1,6 @@
+{
+  "statusCode": 200,
+  "body": {
+    "metadata": {}
+  }
+}

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/mocks/save-in-progress.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/mocks/save-in-progress.json
@@ -1,0 +1,30 @@
+{
+  "statusCode": 200,
+  "body": {
+    "data": {
+      "id": "",
+      "type": "in_progress_forms",
+      "attributes": {
+        "formId": "10-10D-EXTENDED",
+        "createdAt": "2025-01-01T00:00:00.000Z",
+        "updatedAt": "2025-01-01T00:00:00.000Z",
+        "metadata": {
+          "version": 0,
+          "returnUrl": "/who-is-applying",
+          "savedAt": 1739200257608,
+          "submission": {
+            "status": false,
+            "errorMessage": false,
+            "id": false,
+            "timestamp": false,
+            "hasAttemptedSubmit": false
+          },
+          "createdAt": 1739200226,
+          "expiresAt": 32472162000,
+          "lastUpdated": 1739200257,
+          "inProgressFormId": 12345
+        }
+      }
+    }
+  }
+}

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/fillers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/fillers.js
@@ -1,7 +1,11 @@
-import { goToNextPage } from './helpers';
-
-export const fillAddressAndGoToNext = (fieldName, fieldData) => {
-  cy.fillAddressWebComponentPattern(fieldName, fieldData);
-  cy.injectAxeThenAxeCheck();
-  goToNextPage();
+export const fillStatementOfTruthAndSubmit = () => {
+  cy.get('@testData').then(data => {
+    cy.get('va-statement-of-truth').then($el => {
+      cy.fillVaStatementOfTruth($el, {
+        fullName: data.statementOfTruthSignature,
+        checked: true,
+      });
+    });
+    cy.get('va-button[text*="submit" i]').click();
+  });
 };

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
@@ -3,36 +3,17 @@ export const goToNextPage = pagePath => {
   if (pagePath) cy.location('pathname').should('include', pagePath);
 };
 
-export const startAsGuestUser = () => {
-  cy.get('va-alert-sign-in').within(() => {
+export const startAsNewUser = ({ auth = false } = {}) => {
+  if (auth) {
+    cy.get('[href="#start"]').click();
+    cy.wait('@mockPrefill');
+  } else {
     cy.get('a.schemaform-start-button').click();
-  });
+  }
   cy.location('pathname').should('include', '/who-is-applying');
 };
 
-// helpers for creating state machines to handle ArrayBuilder actions
-export const countArrayItems = (selectors = ['va-card']) => {
-  return cy.get('body').then($body => {
-    for (const sel of selectors) {
-      const n = $body.find(sel).length;
-      if (n > 0) return n;
-    }
-    return 0;
-  });
-};
-
-export const createSummaryHandler = fieldName => {
-  return () => {
-    countArrayItems().then(count => {
-      const shouldAdd = count === 0;
-      cy.log(
-        `Summary detected ${count} existing item(s); selecting ${
-          shouldAdd ? 'Yes (Add)' : 'No (Finish)'
-        }`,
-      );
-      cy.selectYesNoVaRadioOption(fieldName, shouldAdd);
-      cy.injectAxeThenAxeCheck();
-      goToNextPage();
-    });
-  };
+export const startAsInProgressUser = () => {
+  cy.get('[data-testid="continue-your-application"]').click();
+  cy.wait('@mockPrefill');
 };

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/setup.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/setup.js
@@ -1,7 +1,10 @@
 import manifest from '../../../manifest.json';
 import mockFeatures from '../fixtures/mocks/feature-toggles.json';
 import mockMaintenanceWindows from '../fixtures/mocks/maintenance-windows.json';
+import mockPrefill from '../fixtures/mocks/prefill.json';
+import mockSaveInProgress from '../fixtures/mocks/save-in-progress.json';
 import mockSubmission from '../fixtures/mocks/submission.json';
+import mockUser from '../fixtures/mocks/user.json';
 import mockVamc from '../fixtures/mocks/vamc-ehr.json';
 
 const APIs = {
@@ -12,14 +15,30 @@ const APIs = {
 };
 
 export const setupBasicTest = (props = {}) => {
-  Cypress.config({ scrollBehavior: 'nearest' });
+  Cypress.config({ includeShadowDom: true, scrollBehavior: 'nearest' });
 
   const { features = mockFeatures } = props;
 
   cy.intercept('GET', APIs.features, features).as('mockFeatures');
   cy.intercept('GET', APIs.maintenance, mockMaintenanceWindows);
   cy.intercept('GET', APIs.vamc, mockVamc);
-  cy.intercept('POST', APIs.submit, mockSubmission).as('mockSubmit');
+  cy.intercept('POST', APIs.submit, mockSubmission);
+};
+
+export const setupForAuth = (props = {}) => {
+  const {
+    features = mockFeatures,
+    prefill = mockPrefill,
+    user = mockUser,
+  } = props;
+
+  setupBasicTest({ features });
+  cy.intercept('GET', APIs.saveInProgress, prefill).as('mockPrefill');
+  cy.intercept('PUT', APIs.saveInProgress, mockSaveInProgress);
+
+  cy.login(user);
+  cy.visit(manifest.rootUrl);
+  cy.wait(['@mockUser', '@mockFeatures']);
 };
 
 export const setupForGuest = (props = {}) => {

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/setup.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/setup.js
@@ -10,6 +10,7 @@ import mockVamc from '../fixtures/mocks/vamc-ehr.json';
 const APIs = {
   features: '/v0/feature_toggles*',
   maintenance: '/v0/maintenance_windows',
+  saveInProgress: '/v0/in_progress_forms/10-10D-EXTENDED',
   submit: '/ivc_champva/v1/forms/10-10d-ext',
   vamc: '/data/cms/vamc-ehr.json',
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds fixtures and additional helpers to scaffold for an effort to expand the Cypress test suite. The fixtures and helpers allow for authenticated flows with prefill and save-in-progress. The PR also removes unnecessary manual overrides, as the Platform Form Tester now includes support for web component address and ArrayBuilder patterns.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#123994

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Cypress tests can be ran in both guest and auth mode
- Tests are free from unnecessary manual overrides

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user