### PR TITLE
123820 BIO - Change surviving relatives screener to a Yes/No question - form 21P-601

### DIFF
--- a/src/applications/simple-forms/21P-601/config/form.js
+++ b/src/applications/simple-forms/21P-601/config/form.js
@@ -219,27 +219,15 @@ const formConfig = {
         },
         relativesSummary: {
           ...relativesPages.relativesSummary,
-          depends: formData =>
-            formData?.survivors?.hasNone !== true &&
-            (!!formData?.survivors?.hasSpouse ||
-              !!formData?.survivors?.hasChildren ||
-              !!formData?.survivors?.hasParents),
+          depends: formData => formData?.survivors === true,
         },
         relativeNamePage: {
           ...relativesPages.relativeNamePage,
-          depends: formData =>
-            formData?.survivors?.hasNone !== true &&
-            (!!formData?.survivors?.hasSpouse ||
-              !!formData?.survivors?.hasChildren ||
-              !!formData?.survivors?.hasParents),
+          depends: formData => formData?.survivors === true,
         },
         relativeAddressPage: {
           ...relativesPages.relativeAddressPage,
-          depends: formData =>
-            formData?.survivors?.hasNone !== true &&
-            (!!formData?.survivors?.hasSpouse ||
-              !!formData?.survivors?.hasChildren ||
-              !!formData?.survivors?.hasParents),
+          depends: formData => formData?.survivors === true,
         },
       },
     },

--- a/src/applications/simple-forms/21P-601/config/submit-transformer.js
+++ b/src/applications/simple-forms/21P-601/config/submit-transformer.js
@@ -1,5 +1,9 @@
 import { transformForSubmit as defaultTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 
+function hasRelativeType(relatives, type) {
+  return relatives?.some(r => r.relationship === type) || false;
+}
+
 function transformForSubmit(formConfig, form) {
   const transformedData = JSON.parse(
     defaultTransformForSubmit(formConfig, form),
@@ -145,10 +149,10 @@ function transformForSubmit(formConfig, form) {
     inReplyReferTo,
     // Section 2: Surviving Relatives (Questions 13-14)
     survivingRelatives: {
-      hasSpouse: transformedData.survivors.hasSpouse || false,
-      hasChildren: transformedData.survivors.hasChildren || false,
-      hasParents: transformedData.survivors.hasParents || false,
-      hasNone: transformedData.survivors.hasNone || false,
+      hasSpouse: hasRelativeType(transformedData.survivingRelatives, 'spouse'),
+      hasChildren: hasRelativeType(transformedData.survivingRelatives, 'child'),
+      hasParents: hasRelativeType(transformedData.survivingRelatives, 'parent'),
+      hasNone: !transformedData.survivors,
       wantsToWaiveSubstitution:
         transformedData.wantsToWaiveSubstitution || false,
       relatives: (transformedData.survivingRelatives || []).map(relative => ({

--- a/src/applications/simple-forms/21P-601/pages/relativesOverview.js
+++ b/src/applications/simple-forms/21P-601/pages/relativesOverview.js
@@ -1,39 +1,25 @@
 import {
   titleUI,
-  checkboxGroupUI,
-  checkboxGroupSchema,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 export default {
   uiSchema: {
-    ...titleUI('Who survived the deceased beneficiary?'),
-    survivors: checkboxGroupUI({
-      title: 'Check all that apply',
-      required: () => true,
-      labels: {
-        hasSpouse: 'Spouse',
-        hasChildren: 'Child or children',
-        hasParents: 'Parent(s)',
-        hasNone: 'None (no surviving relatives)',
-      },
-    }),
+    ...titleUI('Survivors of the beneficiary'),
+    survivors: yesNoUI('Are there any survivors of the beneficiary?'),
     'view:noSurvivorsMessage': {
       'ui:description':
         'Since there are no surviving relatives, you may be eligible for reimbursement of last illness and burial expenses if you paid them.',
       'ui:options': {
-        hideIf: formData => formData?.survivors?.hasNone !== true,
+        hideIf: formData => [true, undefined].includes(formData?.survivors),
       },
     },
   },
   schema: {
     type: 'object',
     properties: {
-      survivors: checkboxGroupSchema([
-        'hasSpouse',
-        'hasChildren',
-        'hasParents',
-        'hasNone',
-      ]),
+      survivors: yesNoSchema,
       'view:noSurvivorsMessage': {
         type: 'object',
         properties: {},

--- a/src/applications/simple-forms/21P-601/pages/relativesOverview.js
+++ b/src/applications/simple-forms/21P-601/pages/relativesOverview.js
@@ -7,7 +7,10 @@ import {
 export default {
   uiSchema: {
     ...titleUI('Survivors of the beneficiary'),
-    survivors: yesNoUI('Are there any survivors of the beneficiary?'),
+    survivors: yesNoUI({
+      title: 'Are there any survivors of the beneficiary?',
+      required: () => true,
+    }),
     'view:noSurvivorsMessage': {
       'ui:description':
         'Since there are no surviving relatives, you may be eligible for reimbursement of last illness and burial expenses if you paid them.',

--- a/src/applications/simple-forms/21P-601/tests/21P-601.cypress.spec.js
+++ b/src/applications/simple-forms/21P-601/tests/21P-601.cypress.spec.js
@@ -11,7 +11,6 @@ import {
   fillDateWebComponentPattern,
   fillTextAreaWebComponent,
   selectRadioWebComponent,
-  selectCheckboxGroupWebComponent,
   reviewAndSubmitPageFlow,
 } from '../../shared/tests/e2e/helpers';
 
@@ -235,28 +234,6 @@ const testConfig = createTestConfig(
                 data.wantsToWaiveSubstitution,
               );
             }
-            cy.axeCheck();
-            cy.findByText(/continue/i, { selector: 'button' }).click();
-          });
-        });
-      },
-
-      'surviving-relatives': ({ afterHook }) => {
-        cy.injectAxeThenAxeCheck();
-        afterHook(() => {
-          cy.get('@testData').then(data => {
-            const relativesData = {
-              hasSpouse: data.survivors.hasSpouse || false,
-              hasChildren: data.survivors.hasChildren || false,
-              hasParents: data.survivors.hasParents || false,
-              hasNone: data.survivors.hasNone || false,
-            };
-            cy.selectVaCheckbox(
-              `consent-checkbox`,
-              data.consentToMailMissingRequiredFiles,
-            );
-            selectCheckboxGroupWebComponent(relativesData);
-
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/minimal-test.json
@@ -31,11 +31,6 @@
   "claimantEmail": "jennifer.wilson@email.com",
   "relationshipToDeceased": "executor",
   "wantsToWaiveSubstitution": false,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": false,
-    "hasParents": false,
-    "hasNone": true
-  },
+  "survivors": false,
   "claimingReimbursement": false
 }

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-beneficiary-not-veteran.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-beneficiary-not-veteran.json
@@ -31,12 +31,7 @@
   "claimantEmail": "manderson@email.com",
   "relationshipToDeceased": "executor",
   "wantsToWaiveSubstitution": false,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": true,
-    "hasParents": false,
-    "hasNone": false
-  },
+  "survivors": true,
   "claimingReimbursement": false,
   "survivingRelatives": [
     {

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-child.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-child.json
@@ -32,12 +32,7 @@
   "claimantEmail": "chris.anderson@university.edu",
   "relationshipToDeceased": "executor",
   "wantsToWaiveSubstitution": false,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": true,
-    "hasParents": false,
-    "hasNone": false
-  },
+  "survivors": true,
   "survivingRelatives": [
     {
       "fullName": {

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-creditor.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-creditor.json
@@ -26,12 +26,7 @@
   "claimantEmail": "billing@funeralhome.com",
   "relationshipToDeceased": "creditor",
   "wantsToWaiveSubstitution": true,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": false,
-    "hasParents": false,
-    "hasNone": true
-  },
+  "survivors": false,
   "claimingReimbursement": true,
   "expenses": [
     {

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-executor.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-executor.json
@@ -26,12 +26,7 @@
   "claimantEmail": "patricia.davis@lawfirm.com",
   "relationshipToDeceased": "executor",
   "wantsToWaiveSubstitution": true,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": false,
-    "hasParents": false,
-    "hasNone": true
-  },
+  "survivors": false,
   "claimingReimbursement": true,
   "lastIllnessExpenses": 23500,
   "expenses": [

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-parent.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-parent.json
@@ -26,12 +26,7 @@
   "claimantEmail": "mwilson@email.com",
   "relationshipToDeceased": "executor",
   "wantsToWaiveSubstitution": false,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": false,
-    "hasParents": true,
-    "hasNone": false
-  },
+  "survivors": true,
   "survivingRelatives": [
     {
       "fullName": {

--- a/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-spouse.json
+++ b/src/applications/simple-forms/21P-601/tests/e2e/fixtures/data/test-data-spouse.json
@@ -31,12 +31,7 @@
   "claimantEmail": "robert.johnson@email.com",
   "relationshipToDeceased": "executor",
   "wantsToWaiveSubstitution": false,
-  "survivors": {
-    "hasSpouse": false,
-    "hasChildren": true,
-    "hasParents": false,
-    "hasNone": false
-  },
+  "survivors": true,
   "survivingRelatives": [
     {
       "fullName": {

--- a/src/applications/simple-forms/21P-601/tests/unit/config-branch-dependencies.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-601/tests/unit/config-branch-dependencies.unit.spec.jsx
@@ -42,69 +42,13 @@ describe('21P-601 form configuration branch dependencies', () => {
     describe('relativesSummary page dependencies', () => {
       const { relativesSummary } = survivingRelativesChapter.pages;
 
-      it('should show page when hasSpouse is true and hasNone is not true', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-            hasNone: false,
-          },
-        };
+      it('should show page when survivors is true', () => {
+        const formData = { survivors: true };
         expect(relativesSummary.depends(formData)).to.be.true;
       });
 
-      it('should show page when hasChildren is true and hasNone is not true', () => {
-        const formData = {
-          survivors: {
-            hasChildren: true,
-            hasNone: false,
-          },
-        };
-        expect(relativesSummary.depends(formData)).to.be.true;
-      });
-
-      it('should show page when hasParents is true and hasNone is not true', () => {
-        const formData = {
-          survivors: {
-            hasParents: true,
-            hasNone: false,
-          },
-        };
-        expect(relativesSummary.depends(formData)).to.be.true;
-      });
-
-      it('should show page when multiple survivor types are selected', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-            hasChildren: true,
-            hasParents: true,
-            hasNone: false,
-          },
-        };
-        expect(relativesSummary.depends(formData)).to.be.true;
-      });
-
-      it('should hide page when hasNone is true', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-            hasChildren: true,
-            hasParents: true,
-            hasNone: true,
-          },
-        };
-        expect(relativesSummary.depends(formData)).to.be.false;
-      });
-
-      it('should hide page when no survivor types are selected', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: false,
-            hasChildren: false,
-            hasParents: false,
-            hasNone: false,
-          },
-        };
+      it('should hide page when survivors is false', () => {
+        const formData = { survivors: false };
         expect(relativesSummary.depends(formData)).to.be.false;
       });
 
@@ -114,21 +58,7 @@ describe('21P-601 form configuration branch dependencies', () => {
       });
 
       it('should hide page when survivors is undefined', () => {
-        const formData = {
-          survivors: undefined,
-        };
-        expect(relativesSummary.depends(formData)).to.be.false;
-      });
-
-      it('should handle null values in survivors', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: null,
-            hasChildren: null,
-            hasParents: null,
-            hasNone: null,
-          },
-        };
+        const formData = { survivors: undefined };
         expect(relativesSummary.depends(formData)).to.be.false;
       });
     });
@@ -136,49 +66,18 @@ describe('21P-601 form configuration branch dependencies', () => {
     describe('relativeNamePage dependencies', () => {
       const { relativeNamePage } = survivingRelativesChapter.pages;
 
-      it('should show page when hasSpouse is true and hasNone is not true', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-            hasNone: false,
-          },
-        };
+      it('should show page when survivors is true', () => {
+        const formData = { survivors: true };
         expect(relativeNamePage.depends(formData)).to.be.true;
       });
 
-      it('should show page when hasChildren is true', () => {
-        const formData = {
-          survivors: {
-            hasChildren: true,
-          },
-        };
-        expect(relativeNamePage.depends(formData)).to.be.true;
-      });
-
-      it('should show page when hasParents is true', () => {
-        const formData = {
-          survivors: {
-            hasParents: true,
-          },
-        };
-        expect(relativeNamePage.depends(formData)).to.be.true;
-      });
-
-      it('should hide page when hasNone is true even if others are selected', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-            hasChildren: true,
-            hasNone: true,
-          },
-        };
+      it('should hide page when survivors is false', () => {
+        const formData = { survivors: false };
         expect(relativeNamePage.depends(formData)).to.be.false;
       });
 
-      it('should hide page when no survivors are selected', () => {
-        const formData = {
-          survivors: {},
-        };
+      it('should hide page when survivors is undefined', () => {
+        const formData = { survivors: undefined };
         expect(relativeNamePage.depends(formData)).to.be.false;
       });
     });
@@ -186,50 +85,19 @@ describe('21P-601 form configuration branch dependencies', () => {
     describe('relativeAddressPage dependencies', () => {
       const { relativeAddressPage } = survivingRelativesChapter.pages;
 
-      it('should show page when hasSpouse is true and hasNone is not true', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-            hasNone: false,
-          },
-        };
+      it('should show page when survivors is true', () => {
+        const formData = { survivors: true };
         expect(relativeAddressPage.depends(formData)).to.be.true;
       });
 
-      it('should show page when hasChildren is true', () => {
-        const formData = {
-          survivors: {
-            hasChildren: true,
-          },
-        };
-        expect(relativeAddressPage.depends(formData)).to.be.true;
-      });
-
-      it('should show page when hasParents is true', () => {
-        const formData = {
-          survivors: {
-            hasParents: true,
-          },
-        };
-        expect(relativeAddressPage.depends(formData)).to.be.true;
-      });
-
-      it('should hide page when hasNone is true', () => {
-        const formData = {
-          survivors: {
-            hasNone: true,
-          },
-        };
+      it('should hide page when survivors is false', () => {
+        const formData = { survivors: false };
         expect(relativeAddressPage.depends(formData)).to.be.false;
       });
 
-      it('should handle undefined hasNone with valid selections', () => {
-        const formData = {
-          survivors: {
-            hasSpouse: true,
-          },
-        };
-        expect(relativeAddressPage.depends(formData)).to.be.true;
+      it('should hide page when survivors is undefined', () => {
+        const formData = { survivors: undefined };
+        expect(relativeAddressPage.depends(formData)).to.be.false;
       });
     });
   });
@@ -481,29 +349,6 @@ describe('21P-601 form configuration branch dependencies', () => {
       const chapterDependsFn = survivingRelativesChapter.depends;
       // Chapter level depends should handle null
       expect(() => chapterDependsFn(formData)).to.not.throw();
-    });
-
-    it('should handle partial survivors data', () => {
-      const formData = {
-        survivors: {
-          hasSpouse: true,
-          // hasChildren and hasParents are undefined
-        },
-      };
-      expect(survivingRelativesChapter.pages.relativesSummary.depends(formData))
-        .to.be.true;
-    });
-
-    it('should handle string values for boolean fields', () => {
-      const formData = {
-        survivors: {
-          hasSpouse: 'true', // string instead of boolean
-          hasNone: 'false',
-        },
-      };
-      // JavaScript truthy/falsy evaluation should handle this
-      expect(survivingRelativesChapter.pages.relativesSummary.depends(formData))
-        .to.be.true;
     });
   });
 });

--- a/src/applications/simple-forms/21P-601/tests/unit/form-config.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-601/tests/unit/form-config.unit.spec.jsx
@@ -206,47 +206,17 @@ describe('21P-601 form config', () => {
     });
 
     it('should show summary when has survivors is true', () => {
-      const formData = { survivors: { hasNone: false, hasSpouse: true } };
-      expect(summaryDependsFn(formData)).to.be.true;
-    });
-
-    it('should show summary when has survivors is true and hasChildren is true', () => {
-      const formData = { survivors: { hasNone: false, hasChildren: true } };
-      expect(summaryDependsFn(formData)).to.be.true;
-    });
-
-    it('should show summary when has survivors is true and hasParents is true', () => {
-      const formData = { survivors: { hasNone: false, hasParents: true } };
+      const formData = { survivors: true };
       expect(summaryDependsFn(formData)).to.be.true;
     });
 
     it('should show relative name page when has survivors is true', () => {
-      const formData = { survivors: { hasNone: false, hasSpouse: true } };
-      expect(relNameDependsFn(formData)).to.be.true;
-    });
-
-    it('should show relative name page when has survivors is true and hasChildren is true', () => {
-      const formData = { survivors: { hasNone: false, hasChildren: true } };
-      expect(relNameDependsFn(formData)).to.be.true;
-    });
-
-    it('should show relative name page when has survivors is true and hasParents is true', () => {
-      const formData = { survivors: { hasNone: false, hasParents: true } };
+      const formData = { survivors: true };
       expect(relNameDependsFn(formData)).to.be.true;
     });
 
     it('should show relative address page when has survivors is true', () => {
-      const formData = { survivors: { hasNone: false, hasSpouse: true } };
-      expect(relAddressDependsFn(formData)).to.be.true;
-    });
-
-    it('should show relative address page when has survivors is true and hasChildren is true', () => {
-      const formData = { survivors: { hasNone: false, hasChildren: true } };
-      expect(relAddressDependsFn(formData)).to.be.true;
-    });
-
-    it('should show relative address page when has survivors is true and hasParents is true', () => {
-      const formData = { survivors: { hasNone: false, hasParents: true } };
+      const formData = { survivors: true };
       expect(relAddressDependsFn(formData)).to.be.true;
     });
   });

--- a/src/applications/simple-forms/21P-601/tests/unit/pages-relatives.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-601/tests/unit/pages-relatives.unit.spec.jsx
@@ -46,24 +46,12 @@ describe('21P-601 relatives page configurations', () => {
       expect(relativesOverview.schema.properties).to.have.property('survivors');
     });
 
-    it('has checkbox group schema for survivors', () => {
+    it('has yesNo schema for survivors', () => {
       expect(relativesOverview.schema.properties.survivors).to.exist;
       expect(relativesOverview.schema.properties.survivors).to.have.property(
         'type',
-        'object',
+        'boolean',
       );
-      expect(
-        relativesOverview.schema.properties.survivors.properties,
-      ).to.have.property('hasSpouse');
-      expect(
-        relativesOverview.schema.properties.survivors.properties,
-      ).to.have.property('hasChildren');
-      expect(
-        relativesOverview.schema.properties.survivors.properties,
-      ).to.have.property('hasParents');
-      expect(
-        relativesOverview.schema.properties.survivors.properties,
-      ).to.have.property('hasNone');
     });
 
     it('has correct schema structure', () => {
@@ -84,23 +72,13 @@ describe('21P-601 relatives page configurations', () => {
       expect(titleConfig).to.not.be.a('string');
     });
 
-    it('has survivors checkbox group UI configuration', () => {
+    it('has survivors yesNoUI configuration', () => {
       const survivorsUI = relativesOverview.uiSchema.survivors;
       expect(survivorsUI).to.exist;
-      expect(survivorsUI['ui:title']).to.equal('Check all that apply');
-      expect(survivorsUI['ui:required']).to.be.a('function');
-      expect(survivorsUI['ui:required']()).to.be.true;
-      // checkboxGroupUI uses ui:webComponentField, not ui:widget
+      expect(survivorsUI['ui:title']).to.equal(
+        'Are there any survivors of the beneficiary?',
+      );
       expect(survivorsUI['ui:webComponentField']).to.exist;
-    });
-
-    it('has correct checkbox labels', () => {
-      const survivorsUI = relativesOverview.uiSchema.survivors;
-      // The labels are spread directly into the survivorsUI object, not nested in ui:options
-      expect(survivorsUI.hasSpouse).to.exist;
-      expect(survivorsUI.hasChildren).to.exist;
-      expect(survivorsUI.hasParents).to.exist;
-      expect(survivorsUI.hasNone).to.exist;
     });
 
     it('has conditional message', () => {
@@ -108,58 +86,16 @@ describe('21P-601 relatives page configurations', () => {
         'ui:options'
       ];
       expect(hideIf).to.be.a('function');
-      expect(hideIf({ survivors: { hasNone: true } })).to.be.false;
-      expect(hideIf({ survivors: { hasNone: false } })).to.be.true;
-    });
-
-    it('shows message when hasNone is selected', () => {
-      const messageUI = relativesOverview.uiSchema['view:noSurvivorsMessage'];
-      expect(messageUI['ui:description']).to.include('no surviving relatives');
-      expect(messageUI['ui:description']).to.include(
-        'eligible for reimbursement',
-      );
-      expect(messageUI['ui:description']).to.include(
-        'last illness and burial expenses',
-      );
+      expect(hideIf({ survivors: false })).to.be.false;
+      expect(hideIf({ survivors: true })).to.be.true;
     });
 
     it('hides message when other options are selected', () => {
       const { hideIf } = relativesOverview.uiSchema['view:noSurvivorsMessage'][
         'ui:options'
       ];
-      expect(hideIf({ survivors: { hasSpouse: true } })).to.be.true;
-      expect(hideIf({ survivors: { hasChildren: true } })).to.be.true;
-      expect(hideIf({ survivors: { hasParents: true } })).to.be.true;
-      expect(hideIf({ survivors: {} })).to.be.true;
-    });
-
-    it('validates required field function', () => {
-      const requiredFn = relativesOverview.uiSchema.survivors['ui:required'];
-      expect(requiredFn).to.be.a('function');
-      // Test with different contexts
-      expect(requiredFn({})).to.be.true;
-      expect(requiredFn({ formData: {} })).to.be.true;
-      expect(requiredFn({ formData: { survivors: {} } })).to.be.true;
-    });
-
-    it('has proper survivors schema properties', () => {
-      const survivorsSchema = relativesOverview.schema.properties.survivors;
-      expect(survivorsSchema.properties.hasSpouse).to.have.property(
-        'type',
-        'boolean',
-      );
-      expect(survivorsSchema.properties.hasChildren).to.have.property(
-        'type',
-        'boolean',
-      );
-      expect(survivorsSchema.properties.hasParents).to.have.property(
-        'type',
-        'boolean',
-      );
-      expect(survivorsSchema.properties.hasNone).to.have.property(
-        'type',
-        'boolean',
-      );
+      expect(hideIf({ survivors: true })).to.be.true;
+      expect(hideIf({ survivors: undefined })).to.be.true;
     });
 
     it('has view:noSurvivorsMessage with empty properties', () => {
@@ -168,23 +104,6 @@ describe('21P-601 relatives page configurations', () => {
       expect(messageSchema).to.have.property('properties');
       expect(messageSchema.properties).to.be.an('object');
       expect(Object.keys(messageSchema.properties)).to.have.lengthOf(0);
-    });
-
-    it('handles multiple hasNone scenarios correctly', () => {
-      const { hideIf } = relativesOverview.uiSchema['view:noSurvivorsMessage'][
-        'ui:options'
-      ];
-      // When hasNone is true and others are false
-      expect(hideIf({ survivors: { hasNone: true, hasSpouse: false } })).to.be
-        .false;
-      // When hasNone is false explicitly
-      expect(hideIf({ survivors: { hasNone: false } })).to.be.true;
-      // When hasNone is undefined
-      expect(hideIf({ survivors: { hasSpouse: true } })).to.be.true;
-      // When survivors object is empty
-      expect(hideIf({ survivors: {} })).to.be.true;
-      // When survivors is undefined
-      expect(hideIf({})).to.be.true;
     });
   });
 

--- a/src/applications/simple-forms/21P-601/tests/unit/pages-relatives.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-601/tests/unit/pages-relatives.unit.spec.jsx
@@ -75,6 +75,8 @@ describe('21P-601 relatives page configurations', () => {
     it('has survivors yesNoUI configuration', () => {
       const survivorsUI = relativesOverview.uiSchema.survivors;
       expect(survivorsUI).to.exist;
+      expect(survivorsUI['ui:required']).to.be.a('function');
+      expect(survivorsUI['ui:required']()).to.be.true;
       expect(survivorsUI['ui:title']).to.equal(
         'Are there any survivors of the beneficiary?',
       );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the surviving relatives screener question to eliminate a bug that allowed users to bypass the relatives entry flow.

### Before
Originally, this page was a checkbox group that asked for the types of surviving relatives (e.g., parent, child). However, it also had a "None" checkbox option. 

If "None" and a relative type like "parent" were selected simultaneously, form `depends` logic would only consider the "None" and would then skip the following section where the user _should_ have been required to enter the relative's information.

### After
Now, the question is a simple yes/no asking whether or not there are surviving relatives. If the user answers yes, they are then sent to the relative entry loop, where they were already specifying the type of each relative to begin with.

This eliminates the bug where they could skip relative entry, and simplifies the ask on the user.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123820

## Testing done

- Manual
- Cypress
- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Question |<img width="627" height="591" alt="before" src="https://github.com/user-attachments/assets/536f17f8-e4f9-4c17-a3e9-a15a4d86152e" />|<img width="608" height="480" alt="after" src="https://github.com/user-attachments/assets/168b108b-f7fb-45f9-a685-f3c0b3ddf163" />|

| |None|Has survivors|
|-|-|-|
|PDF|<img width="906" height="197" alt="Screenshot 2025-11-17 at 10 50 05" src="https://github.com/user-attachments/assets/5bfdd117-cbe5-43a3-aad9-f49c958792d2" />|<img width="908" height="254" alt="Screenshot 2025-11-17 at 10 48 28" src="https://github.com/user-attachments/assets/ff092371-b01b-4226-aa3f-7965d831f78c" />|

## What areas of the site does it impact?

Simple form 21P-601

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA