### PR TITLE
Autosuggest/22458-The location input errors on blur instead of on submit

### DIFF
--- a/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
@@ -99,9 +99,12 @@ function AddressAutosuggest({
 
   const onBlur = () => {
     const value = inputValue?.trimStart() || '';
-    onChange({ searchString: ' ' });
-    onChange({ searchString: value });
+
     // not expected to search when user leaves the field
+    if (value !== '') {
+      onChange({ searchString: ' ' });
+      onChange({ searchString: value });
+    }
   };
 
   const handleInputChange = e => {

--- a/src/applications/facility-locator/tests/e2e/errorMessages.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/errorMessages.cypress.spec.js
@@ -44,10 +44,10 @@ for (const featureSet of featureSets) {
       h.focusElement(h.CITY_STATE_ZIP_INPUT);
       h.findSelectInVaSelect(h.FACILITY_TYPE_DROPDOWN).focus();
 
-      h.errorMessageContains(addrErrorMessage);
+      h.submitSearchForm();
 
-      h.typeInCityStateInput('A', true);
-      h.verifyElementDoesNotExist(h.SEARCH_FORM_ERROR_MESSAGE);
+      h.errorMessageContains(addrErrorMessage);
+      // h.verifyElementDoesNotExist(h.SEARCH_FORM_ERROR_MESSAGE);
     });
 
     it('shows error message when leaving facility type field empty', () => {

--- a/src/applications/facility-locator/tests/e2e/errorMessages.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/errorMessages.cypress.spec.js
@@ -45,9 +45,7 @@ for (const featureSet of featureSets) {
       h.findSelectInVaSelect(h.FACILITY_TYPE_DROPDOWN).focus();
 
       h.submitSearchForm();
-
       h.errorMessageContains(addrErrorMessage);
-      // h.verifyElementDoesNotExist(h.SEARCH_FORM_ERROR_MESSAGE);
     });
 
     it('shows error message when leaving facility type field empty', () => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- _(Summarize the changes that have been made to the platform)_
- The “Zip code or city, state” field’s error triggers when the user tabs out of the field, not when they press “Search."
- To reproduce:
  - Go to [autosuggest prototype](https://staging.va.gov/find-locations/)
  - TAB into, then out of, the location field, without typing anything
  - See the error "Enter a zip code or a city and state in the search box" immediately after leaving the field
- Solution: The query is updated onBlur, and will error if the value in the input is empty. A conditional statement was placed in order to prevent the input from triggering an error onBlur with an empty statement. 
- Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22473

## Testing done

- Previously, the “Zip code or city, state” field’s error triggers when the user tabs out of the field, not when they press “Search." 
- 
- Tested Safari and Chrome in development, in both mobile and desktop
- On each browser/device combination, no error was produced on blur when the input was empty

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="1170" height="2532" alt="IMG_5017" src="https://github.com/user-attachments/assets/5899305f-3291-45e8-8600-3c65118d0032" /> | <img width="1170" height="2532" alt="IMG_5015" src="https://github.com/user-attachments/assets/4382666e-eb5a-44ab-b113-cb83c3e145af" /> |
| Desktop | <img width="365" height="453" alt="Screenshot 2025-11-14 at 11 25 13 AM" src="https://github.com/user-attachments/assets/a948e5d7-51b3-4def-9842-7b0fd6c46f04" />| <img width="379" height="384" alt="Screenshot 2025-11-14 at 11 22 09 AM" src="https://github.com/user-attachments/assets/fe716f95-4f8c-4d81-b0cb-234bf7008777" /> |

## What areas of the site does it impact?

- Facility Locator page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


## Requested Feedback

As addressed in a comment in[ the relevant ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22458), this ticket broaches the question if there should be an error on blur, if the location input information is not formatted correctly. Just flagging this for documentation purposes! 
