### PR TITLE
fix <va-back-to-top> jitter by removing flex/grid wrapper in Ask VA Footer

### DIFF
--- a/src/applications/ask-va/components/Footer.jsx
+++ b/src/applications/ask-va/components/Footer.jsx
@@ -44,9 +44,7 @@ const Footer = ({ currentLocation, categoryID, topicID }) => {
           </div>
         </div>
         <div className="row">
-          <div className="usa-width-two-thirds vads-u-display--flex vads-u-justify-content--flex-end">
-            <va-back-to-top />
-          </div>
+          <va-back-to-top />
         </div>
       </div>
     </>


### PR DESCRIPTION
This pull request makes a small change to the `Footer` component by removing an unnecessary `div` wrapper around the `<va-back-to-top />` element, simplifying the component structure.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No

## Summary

- This PR removes a flex-aligned USWDS wrapper (usa-width-two-thirds vads-u-display--flex vads-u-justify-content--flex-end) around the <va-back-to-top> component in the Ask VA Footer.jsx.
- Bug reproduction: On the Ask VA “Contact Us” page (`/contact-us/ask-va`), scroll toward the bottom of the page. The back-to-top link visibly jitters/jumps horizontally and vertically as you approach the footer.
- The jittering was caused by our implementation wrapping the component inside a flex-aligned USWDS column. Removing the flex wrapper and letting the component sit in a normal block layout resolves both changing layout and stacking text issues and matches VADS guidance. All Ask VA tests are passing. Reference:
[Platform Design System Storybook](https://design.va.gov/storybook/?path=/docs/components-va-back-to-top--docs) shows the component rendered without any flex or alignment wrappers:

## Related issue(s)

- Closes department-of-veterans-affairs/ask-va/issues/1834

## Testing done

- Old behavior: `<va-back-to-top>` visually jumps/jitters at the bottom of the Ask VA pages due to layout reflows caused by the flex/grid wrapper.
- Steps to verify new behavior:
  - Visit `/contact-us/ask-va/` locally.
  - Scroll up and down until `<va-back-to-top>` link element appears/disappears.
  - Confirm the link remains visually stable with no horizontal or vertical jumps.
- All Ask VA Mocha tests pass: `yarn test:unit:summary --apps=ask-va`
- No snapshots or selectors required updating, confirming the component now aligns with expected VADS structure.

## Screenshots
### Mobile Before Video
https://github.com/user-attachments/assets/fe8c83fc-edd1-479a-8351-ea5ec0474e84

### Desktop Before Video
https://github.com/user-attachments/assets/9e1f4f0c-f4df-4c54-8013-1cdde71636cd

### Mobile After Video
https://github.com/user-attachments/assets/ee4e0401-bc71-431b-aac5-d939bd823cbc

### After Desktop Video
https://github.com/user-attachments/assets/7bbd3f9f-7d34-41b9-81c4-be53cb9cadcf



## What areas of the site does it impact?
* This change only affects the Ask VA application Footer component.
* No shared components, site-wide footer logic, or platform-level utilities were modified.

## Acceptance criteria

### Quality Assurance & Testing
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
