### PR TITLE
124751: Implement save PDF on confirmation page

### DIFF
--- a/src/applications/dispute-debt/config/submitForm.js
+++ b/src/applications/dispute-debt/config/submitForm.js
@@ -21,6 +21,9 @@ const submitForm = (form, formConfig) => {
   return handlePdfGeneration(body)
     .then(response => {
       // response should be a FormData object with the generated PDFs
+      const pdfFile = response.get('files[]');
+      const pdfUrl = URL.createObjectURL(pdfFile);
+
       return apiRequest(submitUrl, {
         method: 'POST',
         body: response,
@@ -34,7 +37,10 @@ const submitForm = (form, formConfig) => {
           event: `${trackingPrefix}-submission-success`,
           ...eventData,
         });
-        return apiResponse;
+        return {
+          apiResponse,
+          ...(pdfUrl && { pdfUrl }),
+        };
       });
     })
     .catch(error => {

--- a/src/applications/dispute-debt/config/submitForm.js
+++ b/src/applications/dispute-debt/config/submitForm.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
-import { handlePdfGeneration } from '../utils/pdfHelpers';
+import { handlePdfGeneration, generateVeteranPdf } from '../utils/pdfHelpers';
 
 // only capturing counts here, no PII
 const buildEventData = ({ education = {}, compAndPen = {} }) => {
@@ -18,15 +18,25 @@ const submitForm = (form, formConfig) => {
   const body = formConfig.transformForSubmit(formConfig, form);
   const eventData = buildEventData(body);
 
-  return handlePdfGeneration(body)
-    .then(response => {
+  return Promise.all([
+    handlePdfGeneration(body), // existing vendor/API PDFs (FormData)
+    generateVeteranPdf(body), // new veteran-facing PDF (Blob)
+  ])
+    .then(([vendorFormData, veteranFormData]) => {
       // response should be a FormData object with the generated PDFs
-      const pdfFile = response.get('files[]');
-      const pdfUrl = URL.createObjectURL(pdfFile);
+      if (!vendorFormData) {
+        // If our vendor PDF generation failed, bail before hitting the API
+        throw new Error('PDF generation failed');
+      }
+
+      // Veteran-facing PDF URL (for confirmation page)
+      const veteranPdfFile = veteranFormData && veteranFormData.get('files[]');
+      const veteranPdfUrl =
+        veteranPdfFile && URL.createObjectURL(veteranPdfFile);
 
       return apiRequest(submitUrl, {
         method: 'POST',
-        body: response,
+        body: vendorFormData,
       }).then(apiResponse => {
         if (apiResponse.errors) {
           throw new Error('API submission failed', apiResponse.errors);
@@ -39,7 +49,7 @@ const submitForm = (form, formConfig) => {
         });
         return {
           apiResponse,
-          ...(pdfUrl && { pdfUrl }),
+          ...(veteranPdfUrl && { pdfUrl: veteranPdfUrl }),
         };
       });
     })

--- a/src/applications/dispute-debt/containers/ConfirmationPage.jsx
+++ b/src/applications/dispute-debt/containers/ConfirmationPage.jsx
@@ -44,13 +44,15 @@ export const ConfirmationPage = ({ route }) => {
       confirmationNumber={confirmationNumber}
       formConfig={formConfig}
       submitDate={timestamp || ''}
+      pdfUrl={submission.response?.pdfUrl}
+      filename="VA-Dispute-Debt-Submission.pdf"
     >
       <ConfirmationView.SubmissionAlert
         title="Your dispute submission is in progress"
         content="You will receive a letter in the email confirming receipt within 60 days."
         actions={null}
       />
-      {/* <ConfirmationView.SavePdfDownload /> */}
+      <ConfirmationView.SavePdfDownload />
       <ChapterSectionCollection
         formConfig={trimmedConfig}
         header="Information you submitted on this dispute"

--- a/src/applications/dispute-debt/containers/ConfirmationPage.jsx
+++ b/src/applications/dispute-debt/containers/ConfirmationPage.jsx
@@ -23,8 +23,8 @@ export const ConfirmationPage = ({ route }) => {
   const { submission } = form;
   const { response, timestamp } = submission || {};
 
-  // no confirmation number is returned from the API currently
-  const { confirmationNumber = '' } = response || {};
+  // Keeping it here, but not currently using it from DMC pdfs, due to order of PDF creation and API response
+  const confirmationNumber = response?.apiResponse?.submissionId || '';
 
   // Dropping reason chapter to better match designs and avoid extra repeating noise
   const trimmedConfig = {

--- a/src/applications/dispute-debt/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
+import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
+import formConfig from '../../config/form';
+
 import { ConfirmationPage } from '../../containers/ConfirmationPage';
 
 const createMockStore = (state = {}) => ({
@@ -13,19 +16,13 @@ const createMockStore = (state = {}) => ({
 describe('ConfirmationPage', () => {
   const defaultProps = {
     route: {
-      formConfig: {
-        formId: 'DISPUTE-DEBT',
-        trackingPrefix: 'dispute-debt',
-        chapters: {
-          personalInformationChapter: {},
-          debtSelectionChapter: {},
-        },
-      },
+      formConfig,
     },
   };
 
   const defaultState = {
     form: {
+      ...createInitialState(formConfig),
       submission: {
         response: {
           pdfUrl: 'test-pdf-url.pdf',
@@ -52,28 +49,17 @@ describe('ConfirmationPage', () => {
       </Provider>,
     );
 
-    // Find the va-link element
     const vaLink = container.querySelector('va-link');
     expect(vaLink).to.exist;
 
-    // Check attributes
     expect(vaLink.getAttribute('download')).to.equal('true');
     expect(vaLink.getAttribute('filetype')).to.equal('PDF');
     expect(vaLink.getAttribute('filename')).to.equal(
       'VA-Dispute-Debt-Submission.pdf',
     );
+
     expect(vaLink.getAttribute('text')).to.equal(
-      'Download a copy of your VA Form 5655',
+      'Download a copy of your VA Form DISPUTE-DEBT',
     );
-
-    // Check the link text content
-    const linkText = vaLink.shadowRoot?.textContent.trim();
-    expect(linkText).to.include('Download a copy of your VA Form DISPUTE-DEBT');
-    expect(linkText).to.include('(PDF)');
-
-    // Check the icon is present
-    const icon = vaLink.shadowRoot?.querySelector('va-icon');
-    expect(icon).to.exist;
-    expect(icon.getAttribute('class')).to.include('link-icon--left');
   });
 });

--- a/src/applications/dispute-debt/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import { ConfirmationPage } from '../../containers/ConfirmationPage';
+
+const createMockStore = (state = {}) => ({
+  getState: () => state,
+  subscribe: () => {},
+  dispatch: () => {},
+});
+
+describe('ConfirmationPage', () => {
+  const defaultProps = {
+    route: {
+      formConfig: {
+        formId: 'DISPUTE-DEBT',
+        trackingPrefix: 'dispute-debt',
+        chapters: {
+          personalInformationChapter: {},
+          debtSelectionChapter: {},
+        },
+      },
+    },
+  };
+
+  const defaultState = {
+    form: {
+      submission: {
+        response: {
+          pdfUrl: 'test-pdf-url.pdf',
+          confirmationNumber: '12345',
+        },
+        timestamp: '2023-11-13T12:00:00Z',
+      },
+    },
+  };
+
+  it('renders without errors', () => {
+    const { container } = render(
+      <Provider store={createMockStore(defaultState)}>
+        <ConfirmationPage {...defaultProps} />
+      </Provider>,
+    );
+    expect(container).to.exist;
+  });
+
+  it('renders the PDF download link with correct attributes', () => {
+    const { container } = render(
+      <Provider store={createMockStore(defaultState)}>
+        <ConfirmationPage {...defaultProps} />
+      </Provider>,
+    );
+
+    // Find the va-link element
+    const vaLink = container.querySelector('va-link');
+    expect(vaLink).to.exist;
+
+    // Check attributes
+    expect(vaLink.getAttribute('download')).to.equal('true');
+    expect(vaLink.getAttribute('filetype')).to.equal('PDF');
+    expect(vaLink.getAttribute('filename')).to.equal(
+      'VA-Dispute-Debt-Submission.pdf',
+    );
+    expect(vaLink.getAttribute('text')).to.equal(
+      'Download a copy of your VA Form 5655',
+    );
+
+    // Check the link text content
+    const linkText = vaLink.shadowRoot?.textContent.trim();
+    expect(linkText).to.include('Download a copy of your VA Form DISPUTE-DEBT');
+    expect(linkText).to.include('(PDF)');
+
+    // Check the icon is present
+    const icon = vaLink.shadowRoot?.querySelector('va-icon');
+    expect(icon).to.exist;
+    expect(icon.getAttribute('class')).to.include('link-icon--left');
+  });
+});

--- a/src/platform/forms-system/src/js/components/ConfirmationView/ConfirmationView.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ConfirmationView.jsx
@@ -66,6 +66,7 @@ import { useDevOnlyButtons } from './useDevOnlyButtons';
  * @param {boolean} [props.devOnly.showButtons]
  * @param {Object} [props.devOnly.mockData]
  * @param {string} [props.pdfUrl]
+ * @param {string} [props.filename]
  * @param {string} [props.confirmationNumber]
  * @param {Date} [props.submitDate]
  */
@@ -73,6 +74,7 @@ export const ConfirmationView = props => {
   const { formConfig, devOnly, children } = props;
   const { form } = useSelector(state => state);
   const [pdfUrl, setPdfUrl] = useState(props.pdfUrl);
+  const [filename, setFilename] = useState(props.filename);
   const [confirmationNumber, setConfirmationNumber] = useState(
     props.confirmationNumber,
   );
@@ -83,8 +85,9 @@ export const ConfirmationView = props => {
       setPdfUrl(props.pdfUrl);
       setConfirmationNumber(props.confirmationNumber);
       setSubmitDate(props.submitDate || null);
+      setFilename(props.filename);
     },
-    [props.pdfUrl, props.confirmationNumber, props.submitDate],
+    [props.pdfUrl, props.confirmationNumber, props.submitDate, props.filename],
   );
 
   const DevOnlyButtons = useDevOnlyButtons({
@@ -93,6 +96,7 @@ export const ConfirmationView = props => {
     setPdfUrl,
     setConfirmationNumber,
     setSubmitDate,
+    setFilename,
   });
 
   const contextValue = {
@@ -100,6 +104,7 @@ export const ConfirmationView = props => {
     confirmationNumber,
     formConfig,
     pdfUrl,
+    filename,
     devOnly,
     chapterSectionCollection: props.chapterSectionCollection,
   };
@@ -144,6 +149,7 @@ export const ConfirmationView = props => {
         pdfUrl={pdfUrl}
         trackingPrefix={formConfig.trackingPrefix}
         formId={formConfig.formId}
+        filename={filename}
       />
       <ChapterSectionCollection
         formConfig={formConfig}
@@ -176,6 +182,7 @@ ConfirmationView.propTypes = {
   }),
   pdfUrl: PropTypes.string,
   submitDate: PropTypes.any,
+  filename: PropTypes.string,
 };
 
 ConfirmationView.SubmissionAlert = SubmissionAlertWithContext;

--- a/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
@@ -245,6 +245,7 @@ export const SavePdfDownload = ({
   formId,
   title,
   content,
+  filename,
 }) => {
   const onClick = () => {
     recordEvent({
@@ -268,6 +269,7 @@ export const SavePdfDownload = ({
       <va-link
         download
         filetype="PDF"
+        filename={filename}
         href={pdfUrl}
         onClick={onClick}
         text={`Download a copy of your VA Form ${formId}`}
@@ -283,10 +285,11 @@ SavePdfDownload.propTypes = {
   trackingPrefix: PropTypes.string,
   title: PropTypes.string,
   content: PropTypes.string,
+  filename: PropTypes.string,
 };
 
 export const SavePdfDownloadWithContext = ({ className, title, content }) => {
-  const { pdfUrl, formConfig } = useConfirmation();
+  const { pdfUrl, formConfig, filename } = useConfirmation();
 
   return (
     <SavePdfDownload
@@ -296,6 +299,7 @@ export const SavePdfDownloadWithContext = ({ className, title, content }) => {
       formId={formConfig.formId}
       title={title}
       content={content}
+      filename={filename}
     />
   );
 };

--- a/src/platform/pdf/templates/dispute_debt_veteran_facing.js
+++ b/src/platform/pdf/templates/dispute_debt_veteran_facing.js
@@ -1,0 +1,618 @@
+import { format } from 'date-fns';
+import { formatDateLong } from 'platform/utilities/date';
+import { MissingFieldsException } from '../utils/exceptions/MissingFieldsException';
+import {
+  createAccessibleDoc,
+  createHeading,
+  registerVaGovFonts,
+  generateFooterContent,
+  generateInitialHeaderContent,
+} from './utils';
+
+const defaultConfig = {
+  margins: { top: 40, bottom: 40, left: 30, right: 30 },
+  text: {
+    boldFont: 'SourceSansPro-Bold',
+    font: 'SourceSansPro-Regular',
+    monospaceFont: 'RobotoMono-Regular',
+    size: 12,
+  },
+  headings: {
+    H1: {
+      font: 'Bitter-Bold',
+      size: 30,
+    },
+    H2: {
+      font: 'Bitter-Bold',
+      size: 24,
+    },
+    H3: {
+      font: 'Bitter-Bold',
+      size: 16,
+    },
+    H4: {
+      font: 'Bitter-Bold',
+      size: 14,
+    },
+    H5: {
+      font: 'Bitter-Bold',
+      size: 12,
+    },
+  },
+};
+
+const validate = data => {
+  const missingFields = [];
+
+  // Validate top-level data fields
+  const requiredFieldsData = ['selectedDebts', 'submissionDetails', 'veteran'];
+  const missingDataFields = requiredFieldsData.filter(field => !data[field]);
+  missingFields.push(...missingDataFields.map(field => `data.${field}`));
+
+  // Early return if critical fields are missing
+  if (missingDataFields.length > 0) {
+    throw new MissingFieldsException(missingFields);
+  }
+
+  const { selectedDebts, submissionDetails, veteran } = data;
+
+  // Validate submissionDetails
+  const requiredFieldsSubmissionDetails = ['submissionDateTime'];
+  const missingSubmissionFields = requiredFieldsSubmissionDetails.filter(
+    field => !submissionDetails[field],
+  );
+  missingFields.push(
+    ...missingSubmissionFields.map(field => `submissionDetails.${field}`),
+  );
+
+  // Validate veteran fields
+  const requiredFieldsVeteran = [
+    'dob',
+    'veteranFullName',
+    'ssnLastFour',
+    'mailingAddress',
+    'email',
+    'mobilePhone',
+  ];
+  const missingVeteranFields = requiredFieldsVeteran.filter(
+    field => !veteran[field],
+  );
+  missingFields.push(...missingVeteranFields.map(field => `veteran.${field}`));
+
+  // Only validate nested objects if parent objects exist
+  if (veteran.mailingAddress) {
+    const requiredFieldsMailingAddress = [
+      'addressLine1',
+      'city',
+      'countryName',
+      'zipCode',
+      'stateCode',
+    ];
+    const missingAddressFields = requiredFieldsMailingAddress.filter(
+      field => !veteran.mailingAddress[field],
+    );
+    missingFields.push(
+      ...missingAddressFields.map(field => `veteran.mailingAddress.${field}`),
+    );
+  }
+
+  if (veteran.mobilePhone) {
+    const requiredFieldsMobilePhone = [
+      'phoneNumber',
+      'countryCode',
+      'areaCode',
+    ];
+    const missingPhoneFields = requiredFieldsMobilePhone.filter(
+      field => !veteran.mobilePhone[field],
+    );
+    missingFields.push(
+      ...missingPhoneFields.map(field => `veteran.mobilePhone.${field}`),
+    );
+  }
+
+  if (veteran.veteranFullName) {
+    const requiredFieldsVeteranFullName = ['first', 'last'];
+    const missingNameFields = requiredFieldsVeteranFullName.filter(
+      field => !veteran.veteranFullName[field],
+    );
+    missingFields.push(
+      ...missingNameFields.map(field => `veteran.veteranFullName.${field}`),
+    );
+  }
+
+  // Validate selectedDebts
+  if (!Array.isArray(selectedDebts) || selectedDebts.length === 0) {
+    missingFields.push('selectedDebts (must be a non-empty array)');
+  } else {
+    selectedDebts.forEach((debt, index) => {
+      const requiredFieldsDebt = ['label', 'disputeReason', 'supportStatement'];
+      const missingDebtFields = requiredFieldsDebt.filter(
+        field => !debt[field],
+      );
+      missingFields.push(
+        ...missingDebtFields.map(field => `selectedDebts[${index}].${field}`),
+      );
+    });
+  }
+
+  if (missingFields.length > 0) {
+    throw new MissingFieldsException(missingFields);
+  }
+};
+
+// TODO:
+// handle page breaks, so H3 sections don't break across pages
+
+// Generation notes:
+// Header spacing - paragraphGap to set spacing after the header
+// Content spacing - lineGap to set spacing after the text before each label item in bold
+// bullets - indent is the prop used to move the bullet point over, bulletIndent is just for nested lists
+
+const generate = async (data = {}, config = defaultConfig) => {
+  validate(data);
+  const doc = createAccessibleDoc(
+    {
+      author: 'U.S. Department of Veterans Affairs',
+      subject: 'Debt dispute from VA.gov',
+      title: 'Debt Dispute',
+      lang: 'en-US',
+    },
+    config,
+  );
+  await registerVaGovFonts(doc);
+  doc.addPage({ margins: config.margins });
+
+  const wrapper = doc.struct('Document');
+  doc.addStructure(wrapper);
+
+  const { selectedDebts, submissionDetails, veteran } = data;
+
+  const headerData = {
+    headerLeft: '',
+    headerRight: '',
+    footerLeft: 'VA.gov',
+    footerRight: 'Page %PAGE_NUMBER% of %TOTAL_PAGES%',
+    ...data,
+  };
+
+  await generateInitialHeaderContent(doc, wrapper, headerData, config);
+
+  // =====================================
+  // * Title Section *
+  // =====================================
+  const titleSection = doc.struct('Sect', {
+    title: 'Title',
+  });
+  titleSection.add(
+    createHeading(doc, 'H1', config, 'Debt dispute from VA.gov', {
+      x: config.margins.left,
+      y: doc.y,
+    }),
+  );
+
+  doc.moveDown(3);
+
+  const useCompAndPenTitle = selectedDebts?.some(
+    debt => debt.deductionCode === '30',
+  );
+
+  const dmcRoutingTitle = useCompAndPenTitle
+    ? 'DMC Routing: C&P Dispute'
+    : 'DMC Routing: Education Dispute';
+  titleSection.add(
+    createHeading(doc, 'H2', config, dmcRoutingTitle, {
+      x: config.margins.left,
+      y: doc.y,
+      paragraphGap: 12,
+    }),
+  );
+
+  doc.moveDown(3);
+
+  titleSection.end();
+  wrapper.add(titleSection);
+
+  // =====================================
+  // * Submission Type Section *
+  // =====================================
+  const submissionTypeSection = doc.struct('Sect', {
+    title: 'Submission Type',
+  });
+  const submissionTypeTitle = 'Submission type:';
+  submissionTypeSection.add(
+    createHeading(doc, 'H3', config, submissionTypeTitle, {
+      x: config.margins.left,
+      y: doc.y,
+      paragraphGap: 6,
+    }),
+  );
+
+  doc.moveDown(2);
+
+  // bulletIndent prop is just for nested lists
+  // regular indent for text will shit the bullet points over
+  const listOptions = {
+    baseline: 'hanging',
+    listType: 'bullet',
+    bulletRadius: 2,
+    indent: 10,
+    textIndent: 15,
+  };
+
+  submissionTypeSection.add(
+    doc.struct('List', { title: 'Submission type' }, () => {
+      doc
+        .fontSize(config.text.size)
+        .font(config.text.font)
+        .list(
+          selectedDebts?.map(
+            debt => `${debt?.deductionCode || ''} - ${debt?.label || ''}`,
+          ),
+          listOptions,
+        );
+    }),
+  );
+
+  submissionTypeSection.end();
+  wrapper.add(submissionTypeSection);
+  doc.moveDown();
+
+  // =====================================
+  // * VA Logo Fetch logo as base64 *
+  // =====================================
+  const { logoUrl } = submissionDetails;
+  if (logoUrl) {
+    const response = await fetch(logoUrl);
+    const arrayBuffer = await response.arrayBuffer();
+    const base64Image = `data:image/png;base64,${Buffer.from(
+      arrayBuffer,
+    ).toString('base64')}`;
+
+    // right align logo
+    const logoWidth = 150;
+    const logoX = config.margins.left;
+    wrapper.add(
+      doc.struct(
+        'Figure',
+        { alt: 'VA U.S Department of Veteran Affairs' },
+        () => {
+          doc.image(base64Image, logoX, doc.y, { width: logoWidth });
+        },
+      ),
+    );
+    doc.moveDown();
+  }
+
+  // =====================================
+  // * Submission details *
+  // =====================================
+  const { submissionDateTime } = submissionDetails;
+  const submissionDate = format(submissionDateTime, 'MMMM d, yyyy');
+  const submissionTimeET = format(submissionDateTime, "h:mm a 'ET'");
+
+  const submissionDetailsSection = doc.struct('Sect', {
+    title: 'Submission Type',
+  });
+  submissionDetailsSection.add(
+    createHeading(doc, 'H3', config, 'Submission Details', {
+      x: config.margins.left,
+      y: doc.y,
+      // paragraphGap: 12,
+    }),
+  );
+
+  submissionDetailsSection.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.font)
+        .fontSize(config.text.size)
+        .text('Date: ', { continued: true });
+      doc.text(submissionDate || '');
+    }),
+  );
+
+  submissionDetailsSection.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.font)
+        .fontSize(config.text.size)
+        .text('Time: ', { continued: true });
+      doc.text(submissionTimeET || '');
+    }),
+  );
+
+  submissionDetailsSection.end();
+  wrapper.add(submissionDetailsSection);
+  doc.moveDown();
+
+  // =====================================
+  // * Informational header *
+  // =====================================
+  wrapper.add(
+    createHeading(doc, 'H2', config, 'Information submitted on this dispute', {
+      x: config.margins.left,
+      paragraphGap: 12,
+    }),
+  );
+
+  // =====================================
+  // * Veteran Personal Information *
+  // =====================================
+  const { dob, veteranFullName } = veteran;
+
+  const veteranPersonalInformation = doc.struct('Sect', {
+    title: "Veteran's personal information",
+  });
+  veteranPersonalInformation.add(
+    createHeading(doc, 'H3', config, "Veteran's personal information", {
+      x: config.margins.left,
+      paragraphGap: 12,
+    }),
+  );
+
+  // loop through all portions of the veteran name
+  Object.keys(veteranFullName).forEach(key => {
+    const nameLabel =
+      key === 'suffix'
+        ? 'Suffix'
+        : `${key.charAt(0).toUpperCase() + key.slice(1)} name`;
+
+    veteranPersonalInformation.add(
+      doc.struct('P', () => {
+        doc
+          .font(config.text.boldFont)
+          .fontSize(config.text.size)
+          .text(nameLabel);
+        doc.font(config.text.font).text(veteranFullName[key] || '', {
+          lineGap: 8,
+        });
+      }),
+    );
+    doc.moveDown();
+  });
+
+  // veteran dob
+  const formattedDob = dob ? formatDateLong(dob) : 'Not provided';
+
+  veteranPersonalInformation.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Date of birth');
+      doc.font(config.text.font).text(formattedDob, {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranPersonalInformation.end();
+  wrapper.add(veteranPersonalInformation);
+  doc.moveDown();
+
+  // =====================================
+  // * Veteran identification information *
+  // =====================================
+  const { ssnLastFour } = veteran;
+
+  const veteranIdentificationInformation = doc.struct('Sect', {
+    title: "Veteran's identification information",
+  });
+  veteranIdentificationInformation.add(
+    createHeading(doc, 'H3', config, "Veteran's identification information", {
+      x: config.margins.left,
+      paragraphGap: 12,
+    }),
+  );
+
+  veteranIdentificationInformation.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Social Security number');
+      doc.font(config.text.font).text(ssnLastFour || '');
+    }),
+  );
+
+  veteranIdentificationInformation.end();
+  wrapper.add(veteranIdentificationInformation);
+  doc.moveDown();
+
+  // =====================================
+  // * Veteran mailing address *
+  // =====================================
+  const {
+    mailingAddress: {
+      addressLine1,
+      addressLine2,
+      addressLine3,
+      city,
+      countryName,
+      zipCode,
+      stateCode,
+    },
+  } = veteran;
+  const veteranMailingAddress = doc.struct('Sect', {
+    title: "Veteran's mailing address",
+  });
+  veteranMailingAddress.add(
+    createHeading(doc, 'H3', config, "Veteran's mailing address", {
+      paragraphGap: 12,
+    }),
+  );
+
+  veteranMailingAddress.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Country', config.margins.left, doc.y);
+      doc.font(config.text.font).text(countryName || '', {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranMailingAddress.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Street address', config.margins.left, doc.y);
+      doc.font(config.text.font).text(addressLine1 || '', {
+        lineGap: 8,
+      });
+      if (addressLine2)
+        doc.text(addressLine2 || '', {
+          lineGap: 8,
+        });
+      if (addressLine3)
+        doc.text(addressLine3 || '', {
+          lineGap: 8,
+        });
+    }),
+  );
+
+  veteranMailingAddress.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('City');
+      doc.font(config.text.font).text(city, {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranMailingAddress.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('State', config.margins.left, doc.y);
+      doc.font(config.text.font).text(stateCode || '', {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranMailingAddress.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Postal code');
+      doc.font(config.text.font).text(zipCode || '', {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranMailingAddress.end();
+  wrapper.add(veteranMailingAddress);
+  doc.moveDown();
+
+  // =====================================
+  // * Veteran contact information *
+  // =====================================
+  const {
+    email,
+    mobilePhone: { phoneNumber, countryCode, areaCode, extension },
+  } = veteran;
+  const formattedPhoneNumber = `${countryCode || ''} ${areaCode ||
+    ''} ${phoneNumber || ''}${extension ? ` ext. ${extension}` : ''}`;
+
+  const veteranContactInformation = doc.struct('Sect', {
+    title: "Veteran's contact information",
+  });
+  veteranContactInformation.add(
+    createHeading(doc, 'H3', config, "Veteran's contact information", {
+      paragraphGap: 12,
+    }),
+  );
+
+  veteranContactInformation.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Phone number');
+      doc.font(config.text.font).text(formattedPhoneNumber, {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranContactInformation.add(
+    doc.struct('P', () => {
+      doc
+        .font(config.text.boldFont)
+        .fontSize(config.text.size)
+        .text('Email');
+      doc.font(config.text.font).text(email || '', {
+        lineGap: 8,
+      });
+    }),
+  );
+
+  veteranContactInformation.end();
+  wrapper.add(veteranContactInformation);
+  doc.moveDown();
+
+  // =====================================
+  // * Selected debts *
+  // =====================================
+  selectedDebts.forEach(debt => {
+    const { disputeReason, supportStatement } = debt;
+    const selectedDebtsSection = doc.struct('Sect', {
+      title: debt?.label || '',
+    });
+    selectedDebtsSection.add(
+      createHeading(doc, 'H3', config, debt.label, {
+        paragraphGap: 12,
+      }),
+    );
+
+    selectedDebtsSection.add(
+      doc.struct('P', () => {
+        doc
+          .font(config.text.boldFont)
+          .fontSize(config.text.size)
+          .text('Dispute reason');
+        doc.font(config.text.font).text(disputeReason || '', {
+          lineGap: 8,
+        });
+      }),
+    );
+
+    doc.moveDown();
+
+    selectedDebtsSection.add(
+      doc.struct('P', () => {
+        doc
+          .font(config.text.boldFont)
+          .fontSize(config.text.size)
+          .text('Dispute statement');
+        doc.font(config.text.font).text(supportStatement || '', {
+          lineGap: 8,
+        });
+      }),
+    );
+
+    selectedDebtsSection.end();
+    wrapper.add(selectedDebtsSection);
+    doc.moveDown();
+  });
+
+  // =====================================
+  // * Wrap it up *
+  // =====================================
+  await generateFooterContent(doc, wrapper, headerData, config);
+  wrapper.end();
+  doc.flushPages();
+  return doc;
+};
+
+export { generate, validate };

--- a/src/platform/pdf/templates/index.js
+++ b/src/platform/pdf/templates/index.js
@@ -36,4 +36,8 @@ templates.disputeDebt = () => {
   return require('./dispute_debt');
 };
 
+templates.disputeDebtVeteranFacing = () => {
+  return require('./dispute_debt_veteran_facing');
+};
+
 export { templates };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Platform has a new component that lets a veteran download a PDF of the form they filed. We needed to implement it.
- Uncommented <ConfirmationView.SavePdfDownload /> component on Confirmation page to show Platform PDF download component. 
- Made changes to Platform components to ensure `filename` attr is passed through in order to successfully trigger a download to the user's file system. This was determined via this [Slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1763041924991439). Currently, it doesn't trigger a file download. It just opens the file in the same browser tab the link is in, taking the user away from their current page context.
- Created separate PDF template and generation path to accommodate the visual differences in Veteran facing PDF and the PDF that gets sent to the DMC.
- _Member of CDP Team_

## Related issue(s)

- _Link to ticket created in vets-website_:
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/124751)

## Testing done

- Feature was previously commented out. Created unit test for new addition to test
- Testing to make sure the component shows by verifying the content and link, and the the A tag inside the va-link component has the correct `download={"filename.xyz"}` attr on it.
- Verified that the pdf does download to the user's file system with the correct file name.
- 

## Screenshots
<img width="728" height="734" alt="Screenshot 2025-11-17 at 3 24 24 PM" src="https://github.com/user-attachments/assets/1b738271-a4d1-4416-9311-2107ab10dccf" />

## What areas of the site does it impact?

CDP usage, and it fixes an issue with the filename attr not being sent properly to the ConfirmationView.SavePdfDownload component. Read this thread for more background [Slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1763041924991439)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
