### PR TITLE
updated refill prescriptions component - shows the correct "last filled on" date for refill if dispensedDate is null

### DIFF
--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -167,9 +167,11 @@ describe('Refill Prescriptions Component', () => {
     expect(lastFilledEl)
       .to.have.property('checkbox-description')
       .that.includes(
-        `Last filled on ${dateFormat(
-          refillablePrescriptions[0].dispensedDate,
-        )}`,
+        refillablePrescriptions[0].dispensedDate
+          ? `Last filled on ${dateFormat(
+              refillablePrescriptions[0].dispensedDate,
+            )}`
+          : 'Not filled yet',
       );
   });
 


### PR DESCRIPTION
Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
refill prescriptions component - shows the correct "last filled on" date unit test in `RefillPrescriptions.unit.spec.jsx` file was failing but was returning 'Last filled on None noted' if the `dispensedDate` was `null` but displays "Not filled yet" in `RefillPrescriptions.jsx` on the interface. 

## Related issue(s)
department-of-veterans-affairs/va.gov-team#125275

## Testing done
update the refillablePrescriptionsList.json with this [payload](https://github.com/department-of-veterans-affairs/vets-website/pull/39993/files#diff-c75a262871b647e2cff7259f7c08b1d70c6bd1da4f93f9904826a67b0716be29)

## Screenshots
<img width="812" height="240" alt="Screenshot 2025-11-17 at 6 19 50 PM" src="https://github.com/user-attachments/assets/027cff26-ad98-4245-962f-20ba7465ff50" />


_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
