### PR TITLE
[FL autosuggest prototype] Icons misaligned when browser font size is changed

### DIFF
--- a/src/applications/facility-locator/components/search-form/autosuggest/sass/autosuggest.scss
+++ b/src/applications/facility-locator/components/search-form/autosuggest/sass/autosuggest.scss
@@ -15,6 +15,7 @@ div[id$="-autosuggest-container"] {
 
     @media (min-width: $small-desktop-screen) {
       flex-direction: row;
+
       &.fl-sm-desktop {
         flex-direction: column;
         align-items: flex-start;
@@ -111,6 +112,8 @@ div[id$="-autosuggest-container"] {
           background-color: transparent;
           padding: 0;
           margin: 0;
+          position: relative;
+
 
           &:hover {
             background-color: unset;
@@ -120,6 +123,10 @@ div[id$="-autosuggest-container"] {
           va-icon {
             color: var(--vads-color-base-dark) !important;
             margin: 0 !important;
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
           }
         }
       }
@@ -130,6 +137,7 @@ div[id$="-autosuggest-container"] {
         background-color: transparent;
         padding: 0;
         margin: 0;
+        position: relative;
 
         &:hover {
           background-color: unset;
@@ -139,6 +147,10 @@ div[id$="-autosuggest-container"] {
         va-icon {
           color: var(--vads-color-base-dark) !important;
           margin: 0 !important;
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          transform: translate(-50%, -50%);
         }
       }
     }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Styling was added to the va-icon elements nested inside the X/clear and caret buttons in the facility locator form, to ensure that they remained centered in Chrome, even when the font size was set to 'extra large'
- To reproduce, steps copied from [this ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22513)
  1. Using Chrome, go to the Settings, search for “font,” and increase the font size to “Very Large.”
  2. Go to [autosuggest prototype](https://staging.va.gov/find-locations/)
  3. Type into the fields (location and services type).
   4. See that the 'X' icons are misaligned.
  5. Also see that in the services type field the caret is misaligned.

## Related issue(s)

- [FL autosuggest prototype: Icons misaligned when browser font size is changed #22513](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22513)

## Testing done

- When font was changed to 'extra large' in Chrome, the icons inside of the buttons inside of the inputs would be misaligned
- When the form is interacted with in Chrome (in mobile and in desktop) and the font size is changed to 'extra large' (on desktop) and maximally zoomed in (in mobile) the icons are centered 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="1170" height="2532" alt="IMG_5035" src="https://github.com/user-attachments/assets/0eeb54da-5c40-4282-84d8-22a83c949f0c" />|<img width="1170" height="2532" alt="IMG_5034" src="https://github.com/user-attachments/assets/9ccc9404-7cca-4c54-8792-5bab3172c0ba" />|
| Desktop |<img width="413" height="766" alt="Screenshot 2025-11-17 at 4 13 26 PM" src="https://github.com/user-attachments/assets/f4a0c8ee-862e-4d8e-be66-4583a38b5493" />|<img width="373" height="766" alt="Screenshot 2025-11-17 at 4 16 30 PM" src="https://github.com/user-attachments/assets/b39e426f-3d99-4dc5-913c-a38afd078c58" />|

## What areas of the site does it impact?
- Facility locator page/form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA