### PR TITLE
fix(ci): apply NODE_OPTIONS to Cypress test execution to resolve cy.v…

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -864,7 +864,7 @@ jobs:
 
       - name: Start server
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 --host=127.0.0.1 &
 
       - name: Wait for server
         run: |
@@ -967,7 +967,7 @@ jobs:
             node_modules
 
       - name: Start server
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 --host=127.0.0.1 &
 
       - name: Wait for server
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-16-cores-latest
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
       continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
@@ -130,6 +133,9 @@ jobs:
   fetch-allow-lists:
     name: Fetch Test Stability Allow Lists
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -680,6 +686,9 @@ jobs:
   testing-reports-prep:
     name: Testing Reports Prep
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     continue-on-error: true
     outputs:
       app_list: ${{ env.APPLICATION_LIST }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -130,6 +130,9 @@ jobs:
   fetch-allow-lists:
     name: Fetch Test Stability Allow Lists
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -680,6 +683,9 @@ jobs:
   testing-reports-prep:
     name: Testing Reports Prep
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     continue-on-error: true
     outputs:
       app_list: ${{ env.APPLICATION_LIST }}
@@ -1024,7 +1030,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
-          ref: node-22-bug-bash-testing
+          ref: node-22-merge-conflicts
 
       - name: Get Node version
         id: get-node-version

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,9 +15,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-16-cores-latest
-    permissions:
-      id-token: write
-      contents: read
     outputs:
       entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
       continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
@@ -133,9 +130,6 @@ jobs:
   fetch-allow-lists:
     name: Fetch Test Stability Allow Lists
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -686,9 +680,6 @@ jobs:
   testing-reports-prep:
     name: Testing Reports Prep
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-      contents: read
     continue-on-error: true
     outputs:
       app_list: ${{ env.APPLICATION_LIST }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -891,6 +891,7 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           APP_URLS: ${{ needs.tests-prep.outputs.app_urls }}
           NUM_CONTAINERS: ${{ needs.tests-prep.outputs.num_containers }}
+          NODE_OPTIONS: '--dns-result-order=ipv4first'
 
       - name: Archive test videos
         if: ${{ needs.tests-prep.outputs.cypress-tests != '[]' && failure() }}
@@ -971,6 +972,22 @@ jobs:
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
 
+      - name: Wait for server
+        run: |
+          echo "Waiting for server to be ready..."
+          for i in {1..30}; do
+            if curl -f http://localhost:3001 > /dev/null 2>&1; then
+              echo "Server is ready!"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying..."
+            sleep 2
+          done
+          echo "Server failed to start"
+          exit 1
+        env:
+          NODE_OPTIONS: '--dns-result-order=ipv4first'
+
       - name: Download Tests to verify
         uses: ./.github/workflows/download-artifact
         with:
@@ -986,6 +1003,7 @@ jobs:
           APP_URLS: ${{ needs.tests-prep.outputs.app_urls }}
           NUM_CONTAINERS: 1
           IS_STRESS_TEST: true
+          NODE_OPTIONS: '--dns-result-order=ipv4first'
 
       - name: Archive test videos
         if: ${{ failure() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -869,7 +869,7 @@ jobs:
       - name: Wait for server
         run: |
           echo "Waiting for server to be ready..."
-          for i in {1..30}; do
+          for i in $(seq 1 30); do
             if curl -f http://127.0.0.1:3001 > /dev/null 2>&1; then
               echo "Server is ready!"
               exit 0
@@ -972,7 +972,7 @@ jobs:
       - name: Wait for server
         run: |
           echo "Waiting for server to be ready..."
-          for i in {1..30}; do
+          for i in $(seq 1 30); do
             if curl -f http://127.0.0.1:3001 > /dev/null 2>&1; then
               echo "Server is ready!"
               exit 0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -864,13 +864,13 @@ jobs:
 
       - name: Start server
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 --host=0.0.0.0 &
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
 
       - name: Wait for server
         run: |
           echo "Waiting for server to be ready..."
           for i in {1..30}; do
-            if curl -f http://localhost:3001 > /dev/null 2>&1; then
+            if curl -f http://127.0.0.1:3001 > /dev/null 2>&1; then
               echo "Server is ready!"
               exit 0
             fi
@@ -879,8 +879,6 @@ jobs:
           done
           echo "Server failed to start"
           exit 1
-        env:
-            NODE_OPTIONS: '--dns-result-order=ipv4first'
 
       - name: Run Cypress tests
         if: needs.tests-prep.outputs.cypress-tests != '[]'
@@ -891,7 +889,6 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           APP_URLS: ${{ needs.tests-prep.outputs.app_urls }}
           NUM_CONTAINERS: ${{ needs.tests-prep.outputs.num_containers }}
-          NODE_OPTIONS: '--dns-result-order=ipv4first'
 
       - name: Archive test videos
         if: ${{ needs.tests-prep.outputs.cypress-tests != '[]' && failure() }}
@@ -970,13 +967,13 @@ jobs:
             node_modules
 
       - name: Start server
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 --host=0.0.0.0 &
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
 
       - name: Wait for server
         run: |
           echo "Waiting for server to be ready..."
           for i in {1..30}; do
-            if curl -f http://localhost:3001 > /dev/null 2>&1; then
+            if curl -f http://127.0.0.1:3001 > /dev/null 2>&1; then
               echo "Server is ready!"
               exit 0
             fi
@@ -985,8 +982,6 @@ jobs:
           done
           echo "Server failed to start"
           exit 1
-        env:
-          NODE_OPTIONS: '--dns-result-order=ipv4first'
 
       - name: Download Tests to verify
         uses: ./.github/workflows/download-artifact
@@ -1003,7 +998,6 @@ jobs:
           APP_URLS: ${{ needs.tests-prep.outputs.app_urls }}
           NUM_CONTAINERS: 1
           IS_STRESS_TEST: true
-          NODE_OPTIONS: '--dns-result-order=ipv4first'
 
       - name: Archive test videos
         if: ${{ failure() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -864,7 +864,7 @@ jobs:
 
       - name: Start server
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 --host=0.0.0.0 &
 
       - name: Wait for server
         run: |
@@ -970,7 +970,7 @@ jobs:
             node_modules
 
       - name: Start server
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 --host=0.0.0.0 &
 
       - name: Wait for server
         run: |

--- a/config/cypress.config.js
+++ b/config/cypress.config.js
@@ -190,7 +190,7 @@ const cypressConfig = {
         config,
       );
     },
-    baseUrl: 'http://localhost:3001',
+    baseUrl: 'http://127.0.0.1:3001',
     specPattern: 'src/**/tests/**/*.cypress.spec.js?(x)',
     supportFile: 'src/platform/testing/e2e/cypress/support/index.js',
     includeShadowDom: true,

--- a/src/applications/ask-va/tests/e2e/run-yaml-tests.cypress.spec.js
+++ b/src/applications/ask-va/tests/e2e/run-yaml-tests.cypress.spec.js
@@ -130,6 +130,8 @@ const executeSteps = (steps, folder) => {
 describe('YAML tests', () => {
   describe(`Preload flows`, () => {
     describe('Run tests', () => {
+      const baseUrl = Cypress.config('baseUrl');
+      const inquiriesEndpoint = '**/ask_va_api/v0/inquiries';
       // eslint-disable-next-line func-names
       const testRunner = function(folder, path, file) {
         let flowYML = EMPTY_FLOW_YML;
@@ -144,10 +146,10 @@ describe('YAML tests', () => {
           if (flow.runOnCI === true) {
             if (['13m.yml'].includes(file)) {
               cy.visit(
-                'http://localhost:3001/contact-us/ask-va/user/dashboard/A-20250409-2205184',
+                `${baseUrl}/contact-us/ask-va/user/dashboard/A-20250409-2205184`,
               );
             } else {
-              cy.visit('http://localhost:3001/contact-us/ask-va/');
+              cy.visit(`${baseUrl}/contact-us/ask-va/`);
             }
             cy.injectAxeThenAxeCheck();
             executeSteps(flow.steps, folder);
@@ -185,23 +187,11 @@ describe('YAML tests', () => {
             }
           } else {
             if (['4k.yml'].includes(file)) {
-              cy.intercept(
-                'GET',
-                'http://localhost:3000/ask_va_api/v0/inquiries',
-                mockMultipleInquiries,
-              );
+              cy.intercept('GET', inquiriesEndpoint, mockMultipleInquiries);
             } else if (['14g.yml', '18g.yml'].includes(file)) {
-              cy.intercept(
-                'GET',
-                'http://localhost:3000/ask_va_api/v0/inquiries',
-                mockOneInquiry,
-              );
+              cy.intercept('GET', inquiriesEndpoint, mockOneInquiry);
             } else {
-              cy.intercept(
-                'GET',
-                `http://localhost:3000/ask_va_api/v0/inquiries`,
-                mockNoInquiries,
-              );
+              cy.intercept('GET', inquiriesEndpoint, mockNoInquiries);
             }
             cy.login(mockUserDefault);
           }

--- a/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
+++ b/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
@@ -1,6 +1,7 @@
 import manifest from '../manifest.json';
 
 describe(manifest.appName, () => {
+  const baseUrl = Cypress.config('baseUrl');
   beforeEach(() => {
     const featureToggles = {
       data: {
@@ -21,10 +22,7 @@ describe(manifest.appName, () => {
   it('is accessible', () => {
     cy.axeCheck();
 
-    cy.url().should(
-      'eq',
-      'http://localhost:3001/health-care/connected-devices/',
-    );
+    cy.url().should('eq', `${baseUrl}/health-care/connected-devices/`);
   });
 
   it("displays login modal after clicking 'Sign in or create an account' for veteran NOT logged in", () => {

--- a/src/applications/discover-your-benefits/tests/e2e/confirmation-page.cypress.spec.js
+++ b/src/applications/discover-your-benefits/tests/e2e/confirmation-page.cypress.spec.js
@@ -1,6 +1,6 @@
 describe('Confirmation Page', () => {
-  const confirmationUrl =
-    'http://localhost:3001/discover-your-benefits/confirmation?benefits=GIB%2CFHV%2CSVC%2CVRE%2CVSC%2CDHS%2CVAP%2CMHC%2CFMP%2CVAL%2CDIS%2CCOE%2CVAH%2CBUR%2CBRG%2CSVB';
+  const baseUrl = Cypress.config('baseUrl');
+  const confirmationUrl = `${baseUrl}/discover-your-benefits/confirmation?benefits=GIB%2CFHV%2CSVC%2CVRE%2CVSC%2CDHS%2CVAP%2CMHC%2CFMP%2CVAL%2CDIS%2CCOE%2CVAH%2CBUR%2CBRG%2CSVB`;
 
   beforeEach(() => {
     cy.visit(confirmationUrl);

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility-navigate-away.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility-navigate-away.cypress.spec.js
@@ -9,6 +9,7 @@ import mockFacilities from '../fixtures/facilityResponse/cerner-facility-mock-da
 import mockMixRecipients from '../fixtures/multi-facilities-recipients-response.json';
 
 describe('SM SINGLE FACILITY CONTACT LIST', () => {
+  const baseUrl = Cypress.config('baseUrl');
   beforeEach(() => {
     SecureMessagingSite.login(
       mockToggles,
@@ -35,7 +36,7 @@ describe('SM SINGLE FACILITY CONTACT LIST', () => {
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
         expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/medications/about`,
+          `${baseUrl}${Paths.UI_MAIN}/medications/about`,
         );
       });
     });
@@ -54,7 +55,7 @@ describe('SM SINGLE FACILITY CONTACT LIST', () => {
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
         expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/find-locations`,
+          `${baseUrl}${Paths.UI_MAIN}/find-locations`,
         );
       });
     });
@@ -72,9 +73,7 @@ describe('SM SINGLE FACILITY CONTACT LIST', () => {
 
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
-        expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/inbox/`,
-        );
+        expect(win.location.href).to.eq(`${baseUrl}${Paths.UI_MAIN}/inbox/`);
       });
     });
   });
@@ -92,7 +91,7 @@ describe('SM SINGLE FACILITY CONTACT LIST', () => {
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
         expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/contact-list`,
+          `${baseUrl}${Paths.UI_MAIN}/contact-list`,
         );
       });
     });

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility-navigate-away.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility-navigate-away.cypress.spec.js
@@ -4,6 +4,7 @@ import ContactListPage from '../pages/ContactListPage';
 import { AXE_CONTEXT, Paths } from '../utils/constants';
 
 describe('SM SINGLE FACILITY CONTACT LIST NAVIGATE AWAY', () => {
+  const baseUrl = Cypress.config('baseUrl');
   beforeEach(() => {
     SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
@@ -24,7 +25,7 @@ describe('SM SINGLE FACILITY CONTACT LIST NAVIGATE AWAY', () => {
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
         expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/medications/about`,
+          `${baseUrl}${Paths.UI_MAIN}/medications/about`,
         );
       });
     });
@@ -43,7 +44,7 @@ describe('SM SINGLE FACILITY CONTACT LIST NAVIGATE AWAY', () => {
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
         expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/find-locations`,
+          `${baseUrl}${Paths.UI_MAIN}/find-locations`,
         );
       });
     });
@@ -61,9 +62,7 @@ describe('SM SINGLE FACILITY CONTACT LIST NAVIGATE AWAY', () => {
 
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
-        expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/inbox/`,
-        );
+        expect(win.location.href).to.eq(`${baseUrl}${Paths.UI_MAIN}/inbox/`);
       });
     });
   });
@@ -81,7 +80,7 @@ describe('SM SINGLE FACILITY CONTACT LIST NAVIGATE AWAY', () => {
       cy.then(() => {
         expect(beforeUnloadStub).to.have.been.called;
         expect(win.location.href).to.eq(
-          `http://localhost:3001${Paths.UI_MAIN}/contact-list`,
+          `${baseUrl}${Paths.UI_MAIN}/contact-list`,
         );
       });
     });

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -1,5 +1,9 @@
 import { pageNotFoundHeading } from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 
+const baseUrl =
+  (globalThis.Cypress && globalThis.Cypress.config('baseUrl')) ||
+  'http://127.0.0.1:3001';
+
 export const AXE_CONTEXT = '.secure-messaging-container';
 
 export const Paths = {
@@ -464,7 +468,7 @@ export const Data = {
   },
   CL_LINK_TEXT: 'Show more teams in your contact list',
   URL: {
-    LANDING_PAGE: `http://localhost:3001/my-health/secure-messages/`,
+    LANDING_PAGE: `${baseUrl}/my-health/secure-messages/`,
   },
   FAQ_LINK: {
     URL: {

--- a/src/applications/proxy-rewrite/tests/utilities/links.unit.spec.jsx
+++ b/src/applications/proxy-rewrite/tests/utilities/links.unit.spec.jsx
@@ -26,6 +26,12 @@ describe('updateLinkDomain utility', () => {
     );
   });
 
+  it('should correctly format a 127.0.0.1 link', () => {
+    expect(updateLinkDomain('http://127.0.0.1:3001/health-care')).to.equal(
+      'https://www.va.gov/health-care',
+    );
+  });
+
   it('should correctly format a staging link without www', () => {
     expect(updateLinkDomain('http://localhost:3002/health-care')).to.equal(
       'https://www.va.gov/health-care',

--- a/src/applications/proxy-rewrite/utilities/links.js
+++ b/src/applications/proxy-rewrite/utilities/links.js
@@ -3,6 +3,7 @@ export const updateLinkDomain = href => {
 
   const domainsNeedingUpdate = [
     'http://localhost:3001',
+    'http://127.0.0.1:3001',
     'http://localhost:3002',
     'https://staging.va.gov',
     'https://www.staging.va.gov',

--- a/src/applications/representative-appoint/api/fetchRepStatus.js
+++ b/src/applications/representative-appoint/api/fetchRepStatus.js
@@ -1,13 +1,14 @@
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import environment, {
+  isLocalhostBaseUrl,
+} from '@department-of-veterans-affairs/platform-utilities/environment';
 import { REPRESENTATIVE_STATUS_API } from '../constants/api';
 
 export const fetchRepStatus = async () => {
-  const requestUrl = `${
-    environment.BASE_URL === 'http://localhost:3001'
-      ? `https://staging-api.va.gov`
-      : `${environment.API_URL}`
-  }${REPRESENTATIVE_STATUS_API}`;
+  const baseUrl = isLocalhostBaseUrl(environment.BASE_URL)
+    ? `https://staging-api.va.gov`
+    : `${environment.API_URL}`;
+  const requestUrl = `${baseUrl}${REPRESENTATIVE_STATUS_API}`;
   const apiSettings = {
     'Content-Type': 'application/json',
     mode: 'cors',

--- a/src/applications/representative-appoint/api/fetchRepresentatives.js
+++ b/src/applications/representative-appoint/api/fetchRepresentatives.js
@@ -1,4 +1,6 @@
-import environment from 'platform/utilities/environment';
+import environment, {
+  isLocalhostBaseUrl,
+} from 'platform/utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
 import { REPRESENTATIVES_API } from '../constants/api';
 import manifest from '../manifest.json';
@@ -17,10 +19,9 @@ export const fetchRepresentatives = async ({ query }) => {
 
   const startTime = new Date().getTime();
 
-  const apiUrl =
-    environment.BASE_URL === 'http://localhost:3001'
-      ? `https://staging-api.va.gov`
-      : `${environment.API_URL}`;
+  const apiUrl = isLocalhostBaseUrl(environment.BASE_URL)
+    ? `https://staging-api.va.gov`
+    : `${environment.API_URL}`;
 
   return new Promise((resolve, reject) => {
     fetch(`${apiUrl}${REPRESENTATIVES_API}?query=${query}`, apiSettings)

--- a/src/applications/representative-appoint/api/sendNextStepsEmail.js
+++ b/src/applications/representative-appoint/api/sendNextStepsEmail.js
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/browser';
 
-import environment from 'platform/utilities/environment';
+import environment, {
+  isLocalhostBaseUrl,
+} from 'platform/utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
 import { NEXT_STEPS_EMAIL_API } from '../constants/api';
 import manifest from '../manifest.json';
@@ -20,10 +22,9 @@ export default async function sendNextStepsEmail(body) {
     body: JSON.stringify(body),
   };
 
-  const apiUrl =
-    environment.BASE_URL === 'http://localhost:3001'
-      ? `https://staging-api.va.gov`
-      : `${environment.API_URL}`;
+  const apiUrl = isLocalhostBaseUrl(environment.BASE_URL)
+    ? `https://staging-api.va.gov`
+    : `${environment.API_URL}`;
 
   try {
     const response = await fetch(

--- a/src/applications/representative-search/config.js
+++ b/src/applications/representative-search/config.js
@@ -1,4 +1,6 @@
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import environment, {
+  isLocalhostBaseUrl,
+} from '@department-of-veterans-affairs/platform-utilities/environment';
 import compact from 'lodash/compact';
 import { RepresentativeType } from './constants';
 import manifest from './manifest.json';
@@ -35,7 +37,7 @@ export const endpointOptions = {
 export const useStagingDataLocally = true;
 
 const baseUrl =
-  useStagingDataLocally && environment.BASE_URL === 'http://localhost:3001'
+  useStagingDataLocally && isLocalhostBaseUrl(environment.BASE_URL)
     ? `https://staging-api.va.gov`
     : `${environment.API_URL}`;
 

--- a/src/applications/time-of-need/utils/helpers.js
+++ b/src/applications/time-of-need/utils/helpers.js
@@ -77,7 +77,10 @@ export function getCemeteries(query = '') {
     .catch(error => {
       // Prototype: do not call Sentry.captureException(error)
       // Light dev-only console notice so the variable is used
-      if (window?.location?.hostname === 'localhost') {
+      if (
+        window?.location?.hostname === 'localhost' ||
+        window?.location?.hostname === '127.0.0.1'
+      ) {
         // eslint-disable-next-line no-console
         console.warn('getCemeteries request failed', error);
       }

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -89,7 +89,7 @@ dl.review {
     column-gap: 0.9375rem;
     > dd {
       font-weight: bold;
-      @media (min-width: variables.$xsmall-screen) {
+      @media (min-width: #{variables.$xsmall-screen}) {
         text-align: right;
       }
     }
@@ -97,7 +97,7 @@ dl.review {
       margin-top: 0;
       margin-bottom: 0;
     }
-    @media (min-width: variables.$xsmall-screen) {
+    @media (min-width: #{variables.$xsmall-screen}) {
       flex-direction: row;
     }
   }
@@ -121,7 +121,7 @@ dl.review-auto-margin {
       margin-top: 0;
       margin-bottom: 0;
     }
-    @media (min-width: variables.$small-screen) {
+    @media (min-width: #{variables.$small-screen}) {
       flex-direction: row;
       > dd {
         padding-left: 5px;
@@ -232,7 +232,7 @@ label {
 }
 
 .schemaform-array-row-title:focus {
-  @include mixins.focus-gold-light-outline;
+  @include mixins.focus-gold-light-outline();
   display: inline-block;
 }
 
@@ -742,7 +742,7 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
   .rjsf-web-component-field.#{$element}::part(header) {
     font-size: $desktop-font-size;
 
-    @media (max-width: variables.$small-screen) {
+  @media (max-width: #{variables.$small-screen}) {
       font-size: $mobile-font-size;
     }
   }

--- a/src/platform/site-wide/drupal-static-data/connect/fetch.js
+++ b/src/platform/site-wide/drupal-static-data/connect/fetch.js
@@ -17,7 +17,9 @@ export const fetchDrupalStaticDataFile = async ({
 }) => {
   // Use API_URL for localhost, BASE_URL otherwise
   const isLocal = useLocalOverride
-    ? environment.isLocalhost?.() || window.location.hostname === 'localhost'
+    ? environment.isLocalhost?.() ||
+      window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1'
     : false;
 
   // Set the base URL based on the environment or custom server

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -5,11 +5,12 @@
 
 import ENVIRONMENTS from 'site/constants/environments';
 import ENVIRONMENT_CONFIGURATIONS from 'site/constants/environments-configs';
+import VSP_ENVIRONMENTS from 'site/constants/vsp-environments';
+import isLocalhostBaseUrl from './isLocalhostBaseUrl';
 
 /* Separate constants as workaround for Sentry environments rollout until completion of
  * https://github.com/department-of-veterans-affairs/va.gov-team/issues/13425
  */
-import VSP_ENVIRONMENTS from 'site/constants/vsp-environments';
 
 // __BUILDTYPE__ is defined as a global variable in our Webpack config, ultimately used
 // to indicate the name of our current environment as passed from our build script. This should
@@ -113,3 +114,5 @@ export default Object.freeze({
     return !!(window?.Mocha || process?.env?.NODE_ENV === 'test');
   },
 });
+
+export { isLocalhostBaseUrl };

--- a/src/platform/utilities/environment/isLocalhostBaseUrl.js
+++ b/src/platform/utilities/environment/isLocalhostBaseUrl.js
@@ -1,0 +1,18 @@
+const LOOPBACK_HOSTS = ['localhost', '127.0.0.1'];
+const LOCAL_PROTOCOLS = ['http', 'https'];
+
+const LOCAL_BASE_URLS = new Set(
+  LOOPBACK_HOSTS.flatMap(host =>
+    LOCAL_PROTOCOLS.map(protocol => `${protocol}://${host}:3001`),
+  ),
+);
+
+/**
+ * Determines if a base URL points to the local webpack dev server.
+ *
+ * @param {string} baseUrl - URL to evaluate.
+ * @returns {boolean} - True when url is a loopback host on port 3001.
+ */
+const isLocalhostBaseUrl = baseUrl => LOCAL_BASE_URLS.has(baseUrl);
+
+export default isLocalhostBaseUrl;


### PR DESCRIPTION
## Summary

- **Fixed cy.visit localhost connection failures in CI by using explicit IPv4 address (127.0.0.1) in Cypress baseUrl**
  - Node 22 changed DNS resolution behavior to prefer IPv6 (::1) over IPv4 (127.0.0.1) when resolving localhost
  - Changed Cypress baseUrl from `http://localhost:3001` to `http://127.0.0.1:3001` to force IPv4 connections
  - Updated application code to recognize both 'localhost' and '127.0.0.1' as local environments:
    - `src/platform/site-wide/drupal-static-data/connect/fetch.js` - Updated isLocal check
    - `src/applications/time-of-need/utils/helpers.js` - Updated dev console warning check
  - Updated CI "Wait for server" health checks to use `http://127.0.0.1:3001`
  - This approach preserves compatibility with local development while fixing CI issues

## Related issue(s)
- https://github.com/orgs/department-of-veterans-affairs/projects/1335/views/12?pane=issue&itemId=137466738&issue=department-of-veterans-affairs%7Cva.gov-team%7C124417

## Testing done

- CI is self-testing on commit. We will know if this is passing before it's merged automatically.

### Previous unsuccessful approaches:
- Changing Cypress baseUrl to 127.0.0.1 (initially reverted due to missing application code updates)
- Applying NODE_OPTIONS='--dns-result-order=ipv4first' to test execution (doesn't affect browser DNS resolution)
- Binding test server to 0.0.0.0 to listen on all interfaces (didn't resolve IPv6 connection issues in CI)