### PR TITLE
Cypress | Update start form & statement of truth commands

### DIFF
--- a/src/applications/caregivers/tests/e2e/utils/setup.js
+++ b/src/applications/caregivers/tests/e2e/utils/setup.js
@@ -74,9 +74,9 @@ export const pageHooks = {
         const signatures =
           statementOfTruthActions[testKey] || statementOfTruthActions.default;
         signatures.forEach(role =>
-          cy.fillVaStatementOfTruth(LABELS[role], {
+          cy.fillVaStatementOfTruth({
+            field: LABELS[role],
             fullName: role === 'representative' ? parties[role] : undefined,
-            checked: true,
           }),
         );
       });

--- a/src/applications/caregivers/tests/e2e/utils/setup.js
+++ b/src/applications/caregivers/tests/e2e/utils/setup.js
@@ -77,6 +77,7 @@ export const pageHooks = {
           cy.fillVaStatementOfTruth({
             field: LABELS[role],
             fullName: role === 'representative' ? parties[role] : undefined,
+            checked: true,
           }),
         );
       });

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/fillers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/fillers.js
@@ -2,6 +2,7 @@ export const fillStatementOfTruthAndSubmit = () => {
   cy.get('@testData').then(data => {
     cy.fillVaStatementOfTruth({
       fullName: data.statementOfTruthSignature,
+      checked: true,
     });
     cy.get('va-button[text*="submit" i]').click();
   });

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/fillers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/fillers.js
@@ -1,10 +1,7 @@
 export const fillStatementOfTruthAndSubmit = () => {
   cy.get('@testData').then(data => {
-    cy.get('va-statement-of-truth').then($el => {
-      cy.fillVaStatementOfTruth($el, {
-        fullName: data.statementOfTruthSignature,
-        checked: true,
-      });
+    cy.fillVaStatementOfTruth({
+      fullName: data.statementOfTruthSignature,
     });
     cy.get('va-button[text*="submit" i]').click();
   });

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
@@ -4,12 +4,8 @@ export const goToNextPage = pagePath => {
 };
 
 export const startAsNewUser = ({ auth = false } = {}) => {
-  if (auth) {
-    cy.get('[href="#start"]').click();
-    cy.wait('@mockPrefill');
-  } else {
-    cy.get('a.schemaform-start-button').click();
-  }
+  cy.clickStartForm();
+  if (auth) cy.wait('@mockPrefill');
   cy.location('pathname').should('include', '/who-is-applying');
 };
 

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -175,8 +175,8 @@ Cypress.Commands.add('clickFormBack', () => {
 
 Cypress.Commands.add('clickStartForm', () => {
   cy.get(
-    'a.vads-c-action-link--green[href="#start"], va-link-action[href="#start"]',
+    'a.schemaform-start-button, a.vads-c-action-link--green[href="#start"], va-link-action[href="#start"]',
   )
     .first()
-    .click();
+    .click(FORCE_OPTION);
 });

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -578,7 +578,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'fillVaStatementOfTruth',
-  ({ field = '', fullName = '', checked = true } = {}) => {
+  ({ field = '', fullName = '', checked } = {}) => {
     let element;
 
     if (!field) {

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -578,19 +578,22 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'fillVaStatementOfTruth',
-  (field, { fullName, checked } = {}) => {
-    if (!fullName && typeof checked !== 'boolean') return;
+  ({ field = '', fullName = '', checked = true } = {}) => {
+    let element;
 
-    const element =
-      typeof field === 'string'
-        ? cy.get(`va-statement-of-truth[name="${field}"]`)
-        : cy.wrap(field);
+    if (!field) {
+      element = cy.get('va-statement-of-truth');
+    } else if (typeof field === 'string') {
+      element = cy.get(`va-statement-of-truth[name="${field}"]`);
+    } else {
+      element = cy.wrap(field);
+    }
 
     element.shadow().within(() => {
       if (fullName) {
         cy.get('va-text-input').then($el => cy.fillVaTextInput($el, fullName));
       }
-      if (checked) {
+      if (typeof checked === 'boolean') {
         cy.get('va-checkbox').then($el => cy.selectVaCheckbox($el, checked));
       }
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates two Cypress commands for increased flexibility. The start command now targets both the logged in and guest user start buttons and the statement of truth command now allows for a target that does not need a name prop.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#123994

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Commands are robust and flexible

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
