### PR TITLE
123441: Added (temporary) hardcoded src-only span to Alert H2 so that…

### DIFF
--- a/src/platform/mhv/components/MhvAlertConfirmEmail/AlertAddContactEmail.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/AlertAddContactEmail.jsx
@@ -24,7 +24,10 @@ const AlertAddContactEmail = ({ recordEvent, onSkipClick }) => {
       dataTestid="mhv-alert--add-contact-email"
       className="vads-u-margin-y--2"
     >
-      <h2 slot="headline">{headline}</h2>
+      <h2 slot="headline">
+        <span className="usa-sr-only">warning</span>
+        {headline}
+      </h2>
       <React.Fragment key=".1">
         <p>{CONTENT}</p>
         <p>

--- a/src/platform/mhv/components/MhvAlertConfirmEmail/AlertConfirmContactEmail.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/AlertConfirmContactEmail.jsx
@@ -28,7 +28,10 @@ const AlertConfirmContactEmail = ({
       dataTestid="mhv-alert--confirm-contact-email"
       className="vads-u-margin-y--2"
     >
-      <h2 slot="headline">{headline}</h2>
+      <h2 slot="headline">
+        <span className="usa-sr-only">warning</span>
+        {headline}
+      </h2>
       <React.Fragment key=".1">
         <p>{CONTENT}</p>
         <p

--- a/src/platform/mhv/components/MhvAlertConfirmEmail/AlertSystemResponse.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/AlertSystemResponse.jsx
@@ -42,7 +42,10 @@ const AlertSystemResponse = ({
       className="vads-u-margin-y--2"
       tabIndex={-1}
     >
-      <h2 slot="headline">{headline}</h2>
+      <h2 slot="headline">
+        <span className="usa-sr-only">{status}</span>
+        {headline}
+      </h2>
       <p className="vads-u-margin-y--0">{content}</p>
     </VaAlert>
   );

--- a/src/platform/mhv/components/MhvAlertConfirmEmail/ProfileAlertConfirmEmail.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/ProfileAlertConfirmEmail.jsx
@@ -38,7 +38,10 @@ const AlertConfirmContactEmail = ({
       role="status"
       dataTestid="profile-alert--confirm-contact-email"
     >
-      <h2 slot="headline">{headline}</h2>
+      <h2 slot="headline">
+        <span className="usa-sr-only">warning</span>
+        {headline}
+      </h2>
       <React.Fragment key=".1">
         <p>
           We’ll send notifications about your VA health care and benefits to

--- a/src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx
+++ b/src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx
@@ -326,7 +326,7 @@ describe('<MhvAlertConfirmEmail />', () => {
       );
       await waitFor(() => {
         getByTestId('mhv-alert--add-contact-email');
-        getByRole('heading', { name: /^Add a contact email$/ });
+        getByRole('heading', { name: /Add a contact email$/ });
 
         // getByRole('link', { name: /^Go to profile/ });
         const linkSelector = 'va-link-action[text~="Go to profile"]';

--- a/src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx
+++ b/src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx
@@ -109,7 +109,7 @@ describe('<MhvAlertConfirmEmail />', () => {
       );
       await waitFor(() => {
         getByTestId('mhv-alert--confirm-contact-email');
-        getByRole('heading', { name: /^Confirm your contact email$/ });
+        getByRole('heading', { name: /Confirm your contact email$/ });
 
         // getByRole('button', { name: /^Confirm$/ });
         const button = container.querySelector('va-button[text="Confirm"]');

--- a/src/platform/mhv/tests/components/ProfileAlertConfirmEmail.unit.spec.jsx
+++ b/src/platform/mhv/tests/components/ProfileAlertConfirmEmail.unit.spec.jsx
@@ -142,7 +142,7 @@ describe('<ProfileAlertConfirmEmail />', () => {
       );
       await waitFor(() => {
         getByTestId('profile-alert--confirm-contact-email');
-        getByRole('heading', { name: /^Confirm your contact email$/ });
+        getByRole('heading', { name: /Confirm your contact email$/ });
 
         const buttonPair = container.querySelector('va-button-pair');
         expect(buttonPair).to.exist;
@@ -336,7 +336,7 @@ describe('<ProfileAlertConfirmEmail />', () => {
       );
       await waitFor(() => {
         getByTestId('profile-alert--add-contact-email');
-        getByRole('heading', { name: /^Add a contact email$/ });
+        getByRole('heading', { name: /Add a contact email$/ });
 
         const buttonPair = container.querySelector('va-button-pair');
         expect(buttonPair).to.exist;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds screenreader-only span to H2 in the email alerts to announce the alert status that is displayed by the CSS-only icon.
- Updated tests to account for additional text in H2. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123441
- https://github.com/department-of-veterans-affairs/va.gov-team/milestone/1601

## Testing done

- unit test passed
- manually a11y tested in (VO) screenreader and with keyboard-only navigation
- Steps for local testing MyHealtheVet && Profile:

(mind your portnumber)

- http://localhost:3001/my-health/
- http://localhost:3001/profile/contact-information

**Force email alert**
- **selectors.js** ~ line 25:
/src/platform/mhv/components/MhvAlertConfirmEmail/selectors.js
  - add/uncomment out the `export const showAlert = state => true;` line
  - comment the original `export const showAlert = state => ...` block

```js
// export const showAlert = state => true;
export const showAlert = state =>
  !dismissedAlertViaCookie() &&
  !state.featureToggles.loading &&
  state.featureToggles.mhvEmailConfirmation &&
  !state.user.profile.loading &&
  state.user.profile.vaPatient &&
  (!selectContactEmailAddress(state) ||
    !selectContactEmailConfirmationDate(state) ||
    isBefore(
      new Date(selectContactEmailConfirmationDate(state)),
      new Date(DATE_THRESHOLD),
    ) ||
    !selectContactEmailUpdatedAt(state) ||
    isBefore(
      new Date(selectContactEmailUpdatedAt(state)),
      new Date(DATE_THRESHOLD),
    ));
```

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- [ ] for the alerts that are related to the confirm or update email address for notifications, on myVA, MHV, Profile...
  - the css-based icons that represent **Info | Error | Success | Warning** alert status will be correctly conveyed to the users of Assistive Tech (AT)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
