### PR TITLE
Skipped headingOrder check on maintenance window test

### DIFF
--- a/src/applications/search/tests/e2e/maintenance-window.cypress.spec.js
+++ b/src/applications/search/tests/e2e/maintenance-window.cypress.spec.js
@@ -20,7 +20,7 @@ describe('Search.gov maintenance window message', () => {
   const setClockAndSearch = date => {
     cy.clock(new Date(date).getTime(), ['Date']);
     cy.visit('/search?query=benefits');
-    cy.injectAxeThenAxeCheck();
+    cy.injectAxeThenAxeCheck('main', { headingOrder: false });
   };
 
   const verifyBanner = () => {
@@ -61,7 +61,7 @@ describe('Search.gov maintenance window message', () => {
     verifyBanner();
     checkForResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 
   it('should display maintenance message during maintenance window on Thursday at 4 PM EST', () => {
@@ -70,7 +70,7 @@ describe('Search.gov maintenance window message', () => {
     verifyBanner();
     checkForResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 
   it('should display maintenance message during maintenance window on Tuesday at 5 PM EST', () => {
@@ -79,7 +79,7 @@ describe('Search.gov maintenance window message', () => {
     verifyBanner();
     verifyNoResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 
   it('should display maintenance message during maintenance window on Thursday at 5 PM EST', () => {
@@ -88,7 +88,7 @@ describe('Search.gov maintenance window message', () => {
     verifyBanner();
     verifyNoResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 
   it('should NOT display maintenance message on Monday at 2 PM EST', () => {
@@ -97,7 +97,7 @@ describe('Search.gov maintenance window message', () => {
     verifyNoBanner();
     checkForResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 
   it('should NOT display maintenance message on Saturday at 6 PM EST', () => {
@@ -106,7 +106,7 @@ describe('Search.gov maintenance window message', () => {
     verifyNoBanner();
     verifyNoResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 
   it('should resume normal functionality immediately after maintenance window ends', () => {
@@ -115,6 +115,6 @@ describe('Search.gov maintenance window message', () => {
     verifyNoBanner();
     checkForResults();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { headingOrder: false });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


## Summary

- Skipping a11y check on heading order in maintenance window test for Search which is causing PR CI to fail. 


