### PR TITLE
[#124336] Travel Pay, claim details re-entry to complex claims

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -144,6 +144,8 @@ export default function ClaimDetailsContent({
           claimStatus === STATUSES.Saved.name) && (
           <va-link-action
             text="Complete and file your claim"
+            // Specifically NOT a client-side route to ensure
+            // redirect logic is evaluated upon entry into complex claims
             href={`/my-health/travel-pay/file-new-claim/${claimId}`}
           />
         )}

--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -9,6 +9,7 @@ import { STATUSES, FORM_100998_LINK } from '../constants';
 import { toPascalCase, currency } from '../util/string-helpers';
 import DocumentDownload from './DocumentDownload';
 import DecisionReason from './DecisionReason';
+import OutOfBoundsAppointmentAlert from './alerts/OutOfBoundsAppointmentAlert';
 
 const title = 'Your travel reimbursement claim';
 
@@ -24,6 +25,7 @@ export default function ClaimDetailsContent({
   reimbursementAmount,
   documents,
   decisionLetterReason,
+  isOutOfBounds,
 }) {
   useSetPageTitle('Travel Reimbursement Claim Details');
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
@@ -32,6 +34,9 @@ export default function ClaimDetailsContent({
   );
   const claimsMgmtDecisionReasonToggle = useToggleValue(
     TOGGLE_NAMES.travelPayClaimsManagementDecisionReason,
+  );
+  const complexClaimsToggle = useToggleValue(
+    TOGGLE_NAMES.travelPayEnableComplexClaims,
   );
 
   const [appointmentDate, appointmentTime] = formatDateTime(
@@ -89,6 +94,12 @@ export default function ClaimDetailsContent({
       <h1>
         {title} for {appointmentDate}
       </h1>
+      {complexClaimsToggle &&
+        isOutOfBounds && (
+          <div className="vads-u-margin-y--4">
+            <OutOfBoundsAppointmentAlert />
+          </div>
+        )}
       <span
         className="vads-u-font-size--h2 vads-u-font-weight--bold"
         data-testid="claim-details-claim-number"
@@ -104,7 +115,10 @@ export default function ClaimDetailsContent({
               className="vads-u-margin-top--2"
               data-testid="status-definition-text"
             >
-              {STATUSES[toPascalCase(claimStatus)].definition}
+              {complexClaimsToggle
+                ? STATUSES[toPascalCase(claimStatus)].alternativeDefinition ||
+                  STATUSES[toPascalCase(claimStatus)].definition
+                : STATUSES[toPascalCase(claimStatus)].definition}
             </p>
           ) : (
             <p className="vads-u-margin-top--2">
@@ -125,6 +139,14 @@ export default function ClaimDetailsContent({
             getDocLinkList(documentCategories.clerk)}
         </>
       )}
+      {complexClaimsToggle &&
+        (claimStatus === STATUSES.Incomplete.name ||
+          claimStatus === STATUSES.Saved.name) && (
+          <va-link-action
+            text="Complete and file your claim"
+            href={`/my-health/travel-pay/file-new-claim/${claimId}`}
+          />
+        )}
       <h2 className="vads-u-font-size--h3">Claim information</h2>
       {claimsMgmtToggle && (
         <>
@@ -173,7 +195,8 @@ export default function ClaimDetailsContent({
         Claim submission timeline
       </p>
       <p className="vads-u-margin-y--0">
-        Submitted on {createDate} at {createTime}
+        {complexClaimsToggle ? 'Created' : 'Submitted'} on {createDate} at{' '}
+        {createTime}
       </p>
       <p className="vads-u-margin-y--0">
         Updated on {updateDate} at {updateTime}
@@ -262,6 +285,7 @@ ClaimDetailsContent.propTypes = {
   modifiedOn: PropTypes.string.isRequired,
   decisionLetterReason: PropTypes.string,
   documents: PropTypes.array,
+  isOutOfBounds: PropTypes.bool,
   reimbursementAmount: PropTypes.number,
   totalCostRequested: PropTypes.number,
 };

--- a/src/applications/travel-pay/constants.js
+++ b/src/applications/travel-pay/constants.js
@@ -23,6 +23,8 @@ export const STATUSES = {
       'You saved changes to your claim, but you did not submit it to BTSSS for review. Submit the claim so BTSSS can begin processing your claim.',
     definition:
       'We saved your claim. Make sure to submit it within 30 days of your appointment.',
+    alternativeDefinition:
+      'We saved the expenses you’ve added so far. But you haven’t filed your travel reimbursement claim yet. Make sure to complete and file your claim within 30 days of your appointment.',
     reasons: null,
   },
   InProcess: {

--- a/src/applications/travel-pay/tests/e2e/claim-details-content.cypress.spec.js
+++ b/src/applications/travel-pay/tests/e2e/claim-details-content.cypress.spec.js
@@ -7,7 +7,7 @@ describe(`${appName} -- Claim Details Content`, () => {
   beforeEach(() => {
     cy.clock(new Date(2024, 5, 25), ['Date']);
     cy.intercept('/data/cms/vamc-ehr.json', {});
-    ApiInitializer.initializeFeatureToggle.withAllFeatures();
+    ApiInitializer.initializeFeatureToggle.withSmocOnly();
     ApiInitializer.initializeClaims.happyPath();
   });
 

--- a/src/applications/travel-pay/tests/e2e/claim-details-edge-cases.cypress.spec.js
+++ b/src/applications/travel-pay/tests/e2e/claim-details-edge-cases.cypress.spec.js
@@ -7,7 +7,7 @@ describe(`${appName} -- Claim Details Edge Cases`, () => {
   beforeEach(() => {
     cy.clock(new Date(2024, 5, 25), ['Date']);
     cy.intercept('/data/cms/vamc-ehr.json', {});
-    ApiInitializer.initializeFeatureToggle.withAllFeatures();
+    ApiInitializer.initializeFeatureToggle.withSmocOnly();
     ApiInitializer.initializeClaims.happyPath();
   });
 

--- a/src/applications/travel-pay/tests/e2e/complex-claims-claim-details.cypress.spec.js
+++ b/src/applications/travel-pay/tests/e2e/complex-claims-claim-details.cypress.spec.js
@@ -1,0 +1,279 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+import { appName, rootUrl } from '../../manifest.json';
+import user from '../fixtures/user.json';
+import ApiInitializer from './utilities/ApiInitializer';
+
+describe(`${appName} -- Complex Claims Claim Details`, () => {
+  beforeEach(() => {
+    cy.clock(new Date(2024, 5, 25), ['Date']);
+    cy.intercept('/data/cms/vamc-ehr.json', {});
+    ApiInitializer.initializeFeatureToggle.withAllFeatures();
+    ApiInitializer.initializeClaims.happyPath();
+  });
+
+  afterEach(() => {
+    cy.clock().invoke('restore');
+  });
+
+  describe('Complex claims specific features', () => {
+    beforeEach(() => {
+      ApiInitializer.initializeClaimDetails.happyPath();
+      cy.login(user);
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('displays "Created on" instead of "Submitted on" with complex claims enabled', () => {
+      cy.contains('h2', 'Claim information').should('be.visible');
+
+      // Should show "Created on" when complex claims toggle is enabled
+      cy.contains('Created on').should('be.visible');
+      cy.contains('March 12, 2025').should('be.visible');
+      cy.contains('Updated on').should('be.visible');
+
+      // Should not show "Submitted on"
+      cy.contains('Submitted on').should('not.exist');
+    });
+
+    it('displays out of bounds appointment alert for out of bounds claims', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Incomplete',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 0,
+        reimbursementAmount: 0,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [],
+        isOutOfBounds: true,
+      });
+
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Should display the out of bounds alert
+      cy.get('va-alert[status="warning"]').should('be.visible');
+      cy.contains('Your appointment happened more than 30 days ago').should(
+        'be.visible',
+      );
+    });
+
+    it('does not display out of bounds alert when isOutOfBounds is false', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Incomplete',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 0,
+        reimbursementAmount: 0,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [],
+        isOutOfBounds: false,
+      });
+
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Should not display the out of bounds alert
+      cy.get('va-alert[status="warning"]').should('not.exist');
+      cy.contains('Your appointment happened more than 30 days ago').should(
+        'not.exist',
+      );
+    });
+
+    it('displays "Complete and file your claim" link for Incomplete status', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Incomplete',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 0,
+        reimbursementAmount: 0,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [],
+      });
+
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Should show the complete and file link
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'be.visible',
+      );
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'have.attr',
+        'href',
+        '/my-health/travel-pay/file-new-claim/73611905-71bf-46ed-b1ec-e790593b8565',
+      );
+    });
+
+    it('displays "Complete and file your claim" link for Saved status', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Saved',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 20.0,
+        reimbursementAmount: 0,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [],
+      });
+
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Should show the complete and file link
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'be.visible',
+      );
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'have.attr',
+        'href',
+        '/my-health/travel-pay/file-new-claim/73611905-71bf-46ed-b1ec-e790593b8565',
+      );
+    });
+
+    it('does not display "Complete and file your claim" link for other statuses', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Approved for payment',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 20.0,
+        reimbursementAmount: 14.52,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [],
+      });
+
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Should not show the complete and file link for approved claims
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'not.exist',
+      );
+    });
+
+    it('displays alternative status definitions when available', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Incomplete',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 0,
+        reimbursementAmount: 0,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [],
+      });
+
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Should display alternative definition for Incomplete status when complex claims is enabled
+      cy.get('[data-testid="status-definition-text"]').should('be.visible');
+      // The alternative definition should be shown (if it exists in constants)
+    });
+  });
+
+  describe('Date formatting with complex claims', () => {
+    it('formats dates correctly with "Created on" label', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: 'date-test-complex',
+        claimNumber: 'TC0000000000020',
+        claimStatus: 'Saved',
+        appointmentDate: '2024-06-15T14:30:00.000Z',
+        facilityName: 'Test VA Medical Center',
+        totalCostRequested: 30.0,
+        reimbursementAmount: 0,
+        createdOn: '2024-06-16T10:00:00.000Z',
+        modifiedOn: '2024-06-17T15:45:00.000Z',
+        documents: [],
+      });
+
+      cy.login(user);
+      cy.visit(`${rootUrl}/claims/date-test-complex`);
+
+      // Should show "Created on" with formatted date
+      cy.contains('Created on').should('be.visible');
+      cy.contains('Updated on').should('be.visible');
+
+      // Should not show "Submitted on"
+      cy.contains('Submitted on').should('not.exist');
+    });
+  });
+
+  describe('Combined complex claims scenarios', () => {
+    it('displays all complex claims features together for Incomplete claim', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: 'complex-full-test',
+        claimNumber: 'TC0000000000021',
+        claimStatus: 'Incomplete',
+        appointmentDate: '2024-03-01T09:00:00.000Z',
+        facilityName: 'Complex Claims VA Medical Center',
+        totalCostRequested: 0,
+        reimbursementAmount: 0,
+        createdOn: '2024-03-02T09:00:00.000Z',
+        modifiedOn: '2024-03-02T09:00:00.000Z',
+        documents: [],
+        isOutOfBounds: true,
+      });
+
+      cy.login(user);
+      cy.visit(`${rootUrl}/claims/complex-full-test`);
+      cy.injectAxeThenAxeCheck();
+
+      // Should show out of bounds alert
+      cy.get('va-alert[status="warning"]').should('be.visible');
+
+      // Should show "Created on"
+      cy.contains('Created on').should('be.visible');
+
+      // Should show complete and file link
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'be.visible',
+      );
+
+      // Should show status definition
+      cy.get('[data-testid="status-definition-text"]').should('be.visible');
+    });
+
+    it('displays complex claims features for Saved claim without out of bounds alert', () => {
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: 'complex-saved-test',
+        claimNumber: 'TC0000000000022',
+        claimStatus: 'Saved',
+        appointmentDate: '2024-05-01T13:00:00.000Z',
+        facilityName: 'Test VA Medical Center',
+        totalCostRequested: 25.0,
+        reimbursementAmount: 0,
+        createdOn: '2024-05-01T14:00:00.000Z',
+        modifiedOn: '2024-05-01T14:00:00.000Z',
+        documents: [],
+        isOutOfBounds: false,
+      });
+
+      cy.login(user);
+      cy.visit(`${rootUrl}/claims/complex-saved-test`);
+
+      // Should not show out of bounds alert
+      cy.get('va-alert[status="warning"]').should('not.exist');
+
+      // Should show "Created on"
+      cy.contains('Created on').should('be.visible');
+
+      // Should show complete and file link
+      cy.get('va-link-action[text="Complete and file your claim"]').should(
+        'be.visible',
+      );
+
+      // Should show submitted amount
+      cy.contains('Submitted amount of $25').should('be.visible');
+    });
+  });
+});

--- a/src/applications/travel-pay/tests/util/appointment-helpers.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/util/appointment-helpers.unit.spec.jsx
@@ -6,6 +6,7 @@ import {
   transformVAOSAppointment,
   isPastAppt,
   getDaysLeft,
+  calculateIsOutOfBounds,
 } from '../../util/appointment-helpers';
 
 const appointment = require('../fixtures/appointment.json');
@@ -98,6 +99,72 @@ describe('getDaysLeft', () => {
     MockDate.set('2024-06-25T14:00:00Z');
     const actual = getDaysLeft('2024-05-05T14:00:00Z');
     expect(actual).to.eq(0);
+  });
+});
+
+describe('calculateIsOutOfBounds', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  it('returns false for an appointment within 30 days', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('2024-06-05T14:00:00Z');
+    expect(result).to.be.false;
+  });
+
+  it('returns false for an appointment exactly 30 days ago', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('2024-05-26T15:00:00Z');
+    expect(result).to.be.false;
+  });
+
+  it('returns true for an appointment 31 days ago', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('2024-05-25T14:00:00Z');
+    expect(result).to.be.true;
+  });
+
+  it('returns true for an appointment more than 30 days ago', () => {
+    MockDate.set('2024-06-25T14:00:00Z');
+    const result = calculateIsOutOfBounds('2024-05-05T14:00:00Z');
+    expect(result).to.be.true;
+  });
+
+  it('returns false for a future appointment', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('2024-07-05T14:00:00Z');
+    expect(result).to.be.false;
+  });
+
+  it("returns false for today's appointment", () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('2024-06-25T14:00:00Z');
+    expect(result).to.be.false;
+  });
+
+  it('returns false when dateString is null', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds(null);
+    expect(result).to.be.false;
+  });
+
+  it('returns false when dateString is undefined', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds(undefined);
+    expect(result).to.be.false;
+  });
+
+  it('returns false when dateString is empty string', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('');
+    expect(result).to.be.false;
+  });
+
+  it('returns false for invalid date string', () => {
+    MockDate.set('2024-06-25T15:00:00Z');
+    const result = calculateIsOutOfBounds('invalid-date');
+    expect(result).to.be.false;
   });
 });
 

--- a/src/applications/travel-pay/util/appointment-helpers.js
+++ b/src/applications/travel-pay/util/appointment-helpers.js
@@ -45,6 +45,27 @@ export function getDaysLeft(datetimeString) {
   return daysSinceAppt > 30 ? 0 : 30 - daysSinceAppt;
 }
 
+/**
+ * Calculate if an appointment/claim is out of bounds (more than 30 days old)
+ * @param {string} dateString - ISO date string for the appointment date
+ * @returns {boolean} - true if more than 30 days old, false otherwise
+ */
+export function calculateIsOutOfBounds(dateString) {
+  if (!dateString) {
+    return false;
+  }
+
+  try {
+    const daysSinceAppt = differenceInCalendarDays(
+      new Date(),
+      new Date(dateString),
+    );
+    return daysSinceAppt > 30;
+  } catch (error) {
+    return false;
+  }
+}
+
 export function isPastAppt(appointment) {
   const isVideo = appointment.kind && appointment.kind === 'telehealth';
   const threshold = isVideo ? 240 : 60;
@@ -77,7 +98,9 @@ export function transformVAOSAppointment(appt) {
   const daysSinceAppt = isPast
     ? differenceInCalendarDays(new Date(), new Date(appt.localStartTime))
     : null;
-  const isOutOfBounds = daysSinceAppt ? daysSinceAppt > 30 : false;
+  const isOutOfBounds = isPast
+    ? calculateIsOutOfBounds(appt.localStartTime)
+    : false;
 
   // This property will be helpful for complex claims
   // Adding now because we might need to specifically exclude them until then?


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding the option to resume a complex claim from the claim details page. Additionally adding some alerts on claim details for >30 days appointments.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/124336

## Testing done

Used the API mocks to test resuming Saved and Incomplete claim status types. Made sure the redirects still worked for anything that wasn't a valid "resume" type.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="750" height="2645" alt="before_mobile" src="https://github.com/user-attachments/assets/46089fbf-fb6d-483d-be43-2da38d50442a" /> | <img width="750" height="3441" alt="after_mobile" src="https://github.com/user-attachments/assets/8ebb1b0f-7230-4cda-ad7b-bb616acddf5a" /> |
| Desktop | <img width="2454" height="2383" alt="before_desktop" src="https://github.com/user-attachments/assets/41e1163f-adfb-452b-8831-7b4713c27d9b" /> | <img width="2454" height="2898" alt="after_desktop" src="https://github.com/user-attachments/assets/a7123816-49cc-4bda-b8f9-343f44ead000" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user