### PR TITLE
[#124909] Travel Pay, skip claim details redirect for client routing

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
@@ -39,7 +39,7 @@ const ChooseExpenseType = () => {
   };
 
   const handleBack = () => {
-    navigate(`/file-new-claim/${apptId}`);
+    navigate(`/file-new-claim/${apptId}`, { state: { skipRedirect: true } });
   };
 
   return (

--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 
 import { BTSSS_PORTAL_URL } from '../../../constants';
 import { createComplexClaim } from '../../../redux/actions';
@@ -17,11 +17,15 @@ import { ComplexClaimsHelpSection } from '../../HelpText';
 const IntroductionPage = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const location = useLocation();
 
   const { data: appointment } = useSelector(selectAppointment);
   const complexClaim = useSelector(selectComplexClaim);
 
   const apptId = appointment?.id;
+
+  // Only render redirect component if this is NOT from client-side navigation
+  const shouldShowRedirect = !location.state?.skipRedirect;
 
   const createClaim = async () => {
     if (!appointment) {
@@ -59,7 +63,7 @@ const IntroductionPage = () => {
 
   return (
     <>
-      <ComplexClaimRedirect />
+      {shouldShowRedirect && <ComplexClaimRedirect />}
       <div data-testid="introduction-page">
         <h1>File a travel reimbursement claim</h1>
         <div className="vads-u-margin-left--2">


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

The evaluation of the redirect component added in #40164 was preventing the "back" button on `/choose-expense` to work. Adding a skip option so client navigation can happen naturally while within the complex claims flow.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/124909

## Testing done

Tested cases entering complex claims from an external (to the complex claims flow) entry point (appointments, claim details) vs. cases client routing to the intro page from within complex claims (back button from /choose-expense) to ensure the latter does not evaluate the redirect logic whereas the former does.

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user