### PR TITLE
[120335] Form Upload: Update content for rest of Form Upload

### DIFF
--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -73,10 +73,10 @@ const CustomReviewTopContent = () => {
   return (
     <>
       <div className="vads-u-display--flex vads-l-row vads-u-justify-content--space-between vads-u-align-items--baseline vads-u-border-bottom--1px vads-u-margin-top--1 vads-u-margin-bottom--4">
-        <h3>Personal information</h3>
+        <h3>Veteran’s information</h3>
         <EditLink
           href={`/${formNumber}/name-and-zip-code`}
-          label="Edit Personal information"
+          label="Edit Veteran’s information"
         />
       </div>
       {renderPersonalInfo()}

--- a/src/applications/simple-forms/form-upload/tests/unit/components/CustomReviewTopContent.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/components/CustomReviewTopContent.unit.spec.jsx
@@ -125,7 +125,7 @@ describe('CustomReviewTopContent', () => {
   it('renders the correct headers', () => {
     const { getByText } = subject();
 
-    expect(getByText('Personal information')).to.exist;
+    expect(getByText('Veteran’s information')).to.exist;
     expect(getByText('Uploaded file')).to.exist;
   });
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Very small update to the review page of Form Upload flow, to make the header of the Veteran's Information details match the chapter title.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/120340#issuecomment-3553848468

## Testing done

Local and unit test.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="877" height="827" alt="image" src="https://github.com/user-attachments/assets/fef62cf5-d0a0-443b-bd01-6c94db1cdbe4" /> | <img width="877" height="827" alt="image" src="https://github.com/user-attachments/assets/c121a8b0-c926-4861-98a6-1a14174cad22" /> |

## What areas of the site does it impact?

Form Upload

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
