### PR TITLE
Create OH FF for the frontend and toggle to v2 endpoints

### DIFF
--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -252,7 +252,7 @@ export const prescriptionsApi = createApi({
               data: {
                 ...result,
                 successfulIds: result.data.attributes.prescriptionList || [],
-                failedIds: result.data.attributes.failedPrescriptionIds || [],
+                failedIds: result.data.attributes.failedPrescriptionList || [],
               },
             };
           } catch ({ errors }) {

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -17,7 +17,7 @@ import { selectCernerPilotFlag } from '../util/selectors';
 
 const documentationApiBasePath = `${environment.API_URL}/my_health/v1`;
 
-const getApiBasePath = state => {
+export const getApiBasePath = state => {
   // Handle loading state - default to v1
   if (!state?.featureToggles || state.featureToggles.loading) {
     return `${environment.API_URL}/my_health/v1`;
@@ -27,7 +27,7 @@ const getApiBasePath = state => {
   return `${environment.API_URL}/my_health/${isCernerPilot ? 'v2' : 'v1'}`;
 };
 
-const getRefillMethod = state => {
+export const getRefillMethod = state => {
   // Handle loading state - default to PATCH
   if (!state?.featureToggles || state.featureToggles.loading) {
     return 'PATCH';

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -16,8 +16,8 @@ import {
 import { selectCernerPilotFlag } from '../util/selectors';
 
 const apiBasePath = selectCernerPilotFlag
-  ? `${environment.API_URL}/my_health/v1`
-  : `${environment.API_URL}/my_health/v2`;
+  ? `${environment.API_URL}/my_health/v2`
+  : `${environment.API_URL}/my_health/v1`;
 
 const documentationApiBasePath = `${environment.API_URL}/my_health/v1`;
 

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -167,18 +167,20 @@ export const prescriptionsApi = createApi({
     }),
     refillPrescription: builder.mutation({
       query: id => {
+        const isCernerPilotEnabled = selectCernerPilotFlag();
         return {
           path: `${apiBasePath}/prescriptions/${id}/refill`,
-          options: { method: 'PATCH' },
+          options: { method: isCernerPilotEnabled ? 'POST' : 'PATCH' },
         };
       },
     }),
     bulkRefillPrescriptions: builder.mutation({
       query: ids => {
+        const isCernerPilotEnabled = selectCernerPilotFlag();
         const idParams = ids.map(id => `ids[]=${id}`).join('&');
         return {
           path: `${apiBasePath}/prescriptions/refill_prescriptions?${idParams}`,
-          options: { method: 'PATCH' },
+          options: { method: isCernerPilotEnabled ? 'POST' : 'PATCH' },
         };
       },
       invalidatesTags: ['Prescription'],

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -24,6 +24,11 @@ const getApiBasePath = state => {
     : `${environment.API_URL}/my_health/v1`;
 };
 
+const getRefillMethod = state => {
+  const isCernerPilot = selectCernerPilotFlag(state);
+  return isCernerPilot ? 'POST' : 'PATCH';
+};
+
 // Create the prescriptions API slice
 export const prescriptionsApi = createApi({
   reducerPath: 'prescriptionsApi',
@@ -248,14 +253,14 @@ export const prescriptionsApi = createApi({
     refillPrescription: builder.mutation({
       queryFn: async (id, { getState }) => {
         const apiBasePath = getApiBasePath(getState());
-        const isCernerPilotEnabled = selectCernerPilotFlag(getState());
+        const method = getRefillMethod(getState());
         const path = `${apiBasePath}/prescriptions/${id}/refill`;
 
         const defaultOptions = {
           headers: {
             'Content-Type': 'application/json',
           },
-          method: isCernerPilotEnabled ? 'POST' : 'PATCH',
+          method,
         };
 
         try {
@@ -274,7 +279,7 @@ export const prescriptionsApi = createApi({
     bulkRefillPrescriptions: builder.mutation({
       queryFn: async (ids, { getState }) => {
         const apiBasePath = getApiBasePath(getState());
-        const isCernerPilotEnabled = selectCernerPilotFlag(getState());
+        const method = getRefillMethod(getState());
         const idParams = ids.map(id => `ids[]=${id}`).join('&');
         const path = `${apiBasePath}/prescriptions/refill_prescriptions?${idParams}`;
 
@@ -282,7 +287,7 @@ export const prescriptionsApi = createApi({
           headers: {
             'Content-Type': 'application/json',
           },
-          method: isCernerPilotEnabled ? 'POST' : 'PATCH',
+          method,
         };
 
         try {

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -13,8 +13,13 @@ import {
   INCLUDE_IMAGE_ENDPOINT,
   rxListSortingOptions,
 } from '../util/constants';
+import { selectCernerPilotFlag } from '../util/selectors';
 
-const apiBasePath = `${environment.API_URL}/my_health/v1`;
+const apiBasePath = selectCernerPilotFlag
+  ? `${environment.API_URL}/my_health/v1`
+  : `${environment.API_URL}/my_health/v2`;
+
+const documentationApiBasePath = `${environment.API_URL}/my_health/v1`;
 
 // Create the prescriptions API slice
 export const prescriptionsApi = createApi({
@@ -152,7 +157,7 @@ export const prescriptionsApi = createApi({
     }),
     getPrescriptionDocumentation: builder.query({
       query: id => ({
-        path: `${apiBasePath}/prescriptions/${id}/documentation`,
+        path: `${documentationApiBasePath}/prescriptions/${id}/documentation`,
       }),
       transformResponse: response => {
         return response?.data?.attributes?.html

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -251,8 +251,8 @@ export const prescriptionsApi = createApi({
             return {
               data: {
                 ...result,
-                successfulIds: result.prescriptionList || [],
-                failedIds: result.failedPrescriptionIds || [],
+                successfulIds: result.data.attributes.prescriptionList || [],
+                failedIds: result.data.attributes.failedPrescriptionIds || [],
               },
             };
           } catch ({ errors }) {

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -194,7 +194,6 @@ export const prescriptionsApi = createApi({
     }),
     refillPrescription: builder.mutation({
       query: id => {
-        // If you later use getRefillMethod(state), you can wire it here via api.getState()
         return {
           path: `/prescriptions/${id}/refill`,
           options: state => ({

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -214,15 +214,18 @@ const Prescriptions = () => {
     scrollLocation?.current?.scrollIntoView();
   };
 
-  useEffect(() => {
-    if (!isLoading) {
-      if (prescriptionId) {
-        goToPrevious();
-      } else {
-        focusElement(document.querySelector('h1'));
+  useEffect(
+    () => {
+      if (!isLoading) {
+        if (prescriptionId) {
+          goToPrevious();
+        } else {
+          focusElement(document.querySelector('h1'));
+        }
       }
-    }
-  }, []);
+    },
+    [isLoading, prescriptionId],
+  );
 
   useEffect(
     () => {

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 import {
@@ -34,6 +34,8 @@ import ProcessList from '../components/shared/ProcessList';
 import { refillProcessStepGuide } from '../util/processListData';
 import { useGetAllergiesQuery } from '../api/allergiesApi';
 import { selectUserDob, selectUserFullName } from '../selectors/selectUser';
+import { selectCernerPilotFlag } from '../util/selectors';
+
 import { selectSortOption } from '../selectors/selectPreferences';
 
 const RefillPrescriptions = () => {
@@ -43,6 +45,8 @@ const RefillPrescriptions = () => {
     error: refillableError,
   } = useGetRefillablePrescriptionsQuery();
 
+  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
+
   const [
     bulkRefillPrescriptions,
     result,
@@ -51,14 +55,24 @@ const RefillPrescriptions = () => {
 
   const refillAlertList = refillableData?.refillAlertList || [];
 
-  const getMedicationsByIds = (ids, prescriptions) => {
-    if (!ids || !prescriptions) return [];
-    return ids.map(id =>
-      prescriptions.find(
-        prescription => prescription.prescriptionId === Number(id),
-      ),
-    );
-  };
+  const getMedicationsByIds = useCallback(
+    (ids, prescriptions) => {
+      if (!ids || !prescriptions) return [];
+
+      return ids.map(id =>
+        prescriptions.find(prescription => {
+          if (isOracleHealthPilot) {
+            return (
+              prescription.prescriptionId === Number(id.id) &&
+              prescription.stationNumber === id.stationNumber
+            );
+          }
+          return prescription.prescriptionId === Number(id);
+        }),
+      );
+    },
+    [isOracleHealthPilot],
+  );
 
   const successfulMeds = useMemo(
     () =>
@@ -66,7 +80,11 @@ const RefillPrescriptions = () => {
         result?.data?.successfulIds,
         refillableData?.prescriptions,
       ),
-    [result?.data?.successfulIds, refillableData?.prescriptions],
+    [
+      getMedicationsByIds,
+      result?.data?.successfulIds,
+      refillableData?.prescriptions,
+    ],
   );
 
   const failedMeds = useMemo(
@@ -75,7 +93,11 @@ const RefillPrescriptions = () => {
         result?.data?.failedIds,
         refillableData?.prescriptions,
       ),
-    [result?.data?.failedIds, refillableData?.prescriptions],
+    [
+      getMedicationsByIds,
+      result?.data?.failedIds,
+      refillableData?.prescriptions,
+    ],
   );
 
   const [hasNoOptionSelectedError, setHasNoOptionSelectedError] = useState(
@@ -95,7 +117,6 @@ const RefillPrescriptions = () => {
   const { data: allergies, error: allergiesError } = useGetAllergiesQuery();
   const userName = useSelector(selectUserFullName);
   const dob = useSelector(selectUserDob);
-
   // Memoized Values
   const selectedRefillListLength = useMemo(() => selectedRefillList.length, [
     selectedRefillList,
@@ -108,7 +129,12 @@ const RefillPrescriptions = () => {
       window.scrollTo(0, 0);
 
       // Get just the prescription IDs for the bulk refill
-      const prescriptionIds = selectedRefillList.map(rx => rx.prescriptionId);
+      const prescriptionIds = selectedRefillList.map(rx => {
+        if (isOracleHealthPilot) {
+          return { id: rx.prescriptionId, stationNumber: rx.stationNumber };
+        }
+        return rx.prescriptionId;
+      });
 
       try {
         await bulkRefillPrescriptions(prescriptionIds).unwrap();

--- a/src/applications/mhv-medications/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-medications/mocks/api/feature-toggles/index.js
@@ -7,6 +7,7 @@ const generateFeatureToggles = (toggles = {}) => {
     mhvMedicationsDontIncrementIpeCount = true,
     mhvMedicationsDisplayNewCernerFacilityAlert = true,
     mhvSecureMessagingMedicationsRenewalRequest = false,
+    mhvMedicationsCernerPilot = true,
   } = toggles;
 
   return {
@@ -40,6 +41,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_secure_messaging_medications_renewal_request',
           value: mhvSecureMessagingMedicationsRenewalRequest,
+        },
+        {
+          name: 'mhv_medications_cerner_pilot',
+          value: mhvMedicationsCernerPilot,
         },
       ],
     },

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -64,6 +64,17 @@ const responses = {
       failedIds,
     });
   },
+  'POST /my_health/v2/prescriptions/refill_prescriptions': (req, res) => {
+    // Get requested IDs from query params.
+    const { ids } = req.query;
+    // Emulate a successful refill for the first ID and failed refill for subsequent IDs
+    const successfulIds = ids[0] ? [ids[0]] : [];
+    const failedIds = ids[1] ? ids.slice(1) : [];
+    return res.status(200).json({
+      successfulIds,
+      failedIds,
+    });
+  },
   /**
   'GET /my_health/v1/medical_records/allergies': (req, res) => {
     // Emulate a 500 error

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -80,13 +80,13 @@ const responses = {
   // Includes both v1 and v2 endpoints for refill prescriptions
   'POST /my_health/v2/prescriptions/refill_prescriptions': (req, res) => {
     // Get requested IDs from query params.
-    const { ids } = req.query;
+    const ids = req.body;
     // Emulate a successful refill for the first ID and failed refill for subsequent IDs
     const successfulIds = ids[0] ? [ids[0]] : [];
     const failedIds = ids[1] ? ids.slice(1) : [];
     return res.status(200).json({
-      successfulIds,
-      failedIds,
+      prescriptionList: successfulIds,
+      failedPrescriptionIds: failedIds,
     });
   },
   /**

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -85,8 +85,10 @@ const responses = {
     const successfulIds = ids[0] ? [ids[0]] : [];
     const failedIds = ids[1] ? ids.slice(1) : [];
     return res.status(200).json({
-      prescriptionList: successfulIds,
-      failedPrescriptionIds: failedIds,
+      data: {
+        prescriptionList: successfulIds,
+        failedPrescriptionIds: failedIds,
+      },
     });
   },
   /**

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -40,20 +40,20 @@ const responses = {
   'GET /my_health/v1/messaging/folders': folders.allFoldersWithUnreadMessages,
   // MHV Medications endpoints below
   'GET /my_health/v1/medical_records/allergies': allergies.all,
-  'GET /my_health/v1/prescriptions': (_req, res) => {
+  'GET /my_health/v2/prescriptions': (_req, res) => {
     delaySingleResponse(
       () => res.json(prescriptions.generateMockPrescriptions(_req)),
       2250,
     );
   },
   // 'GET /my_health/v1/prescriptions': prescriptionsFixture,
-  'GET /my_health/v1/prescriptions/list_refillable_prescriptions': (
+  'GET /my_health/v2/prescriptions/list_refillable_prescriptions': (
     _req,
     res,
   ) => {
     delaySingleResponse(() => res.json(refillablePrescriptionsFixture), 2250);
   },
-  'PATCH /my_health/v1/prescriptions/refill_prescriptions': (req, res) => {
+  'PATCH /my_health/v2/prescriptions/refill_prescriptions': (req, res) => {
     // Get requested IDs from query params.
     const { ids } = req.query;
     // Emulate a successful refill for the first ID and failed refill for subsequent IDs
@@ -107,7 +107,7 @@ const responses = {
   //     ],
   //   });
   // },
-  'GET /my_health/v1/prescriptions/:id': (req, res) => {
+  'GET /my_health/v2/prescriptions/:id': (req, res) => {
     const { id } = req.params;
     const data = {
       data: prescriptions.mockPrescription(id, {

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -87,7 +87,7 @@ const responses = {
     return res.status(200).json({
       data: {
         prescriptionList: successfulIds,
-        failedPrescriptionIds: failedIds,
+        failedPrescriptionList: failedIds,
       },
     });
   },

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -40,6 +40,12 @@ const responses = {
   'GET /my_health/v1/messaging/folders': folders.allFoldersWithUnreadMessages,
   // MHV Medications endpoints below
   'GET /my_health/v1/medical_records/allergies': allergies.all,
+  'GET /my_health/v1/prescriptions': (_req, res) => {
+    delaySingleResponse(
+      () => res.json(prescriptions.generateMockPrescriptions(_req)),
+      2250,
+    );
+  },
   'GET /my_health/v2/prescriptions': (_req, res) => {
     delaySingleResponse(
       () => res.json(prescriptions.generateMockPrescriptions(_req)),
@@ -47,13 +53,20 @@ const responses = {
     );
   },
   // 'GET /my_health/v1/prescriptions': prescriptionsFixture,
+  'GET /my_health/v1/prescriptions/list_refillable_prescriptions': (
+    _req,
+    res,
+  ) => {
+    delaySingleResponse(() => res.json(refillablePrescriptionsFixture), 2250);
+  },
+  // Includes both v1 and v2 endpoints for refillable prescriptions
   'GET /my_health/v2/prescriptions/list_refillable_prescriptions': (
     _req,
     res,
   ) => {
     delaySingleResponse(() => res.json(refillablePrescriptionsFixture), 2250);
   },
-  'PATCH /my_health/v2/prescriptions/refill_prescriptions': (req, res) => {
+  'PATCH /my_health/v1/prescriptions/refill_prescriptions': (req, res) => {
     // Get requested IDs from query params.
     const { ids } = req.query;
     // Emulate a successful refill for the first ID and failed refill for subsequent IDs
@@ -64,6 +77,7 @@ const responses = {
       failedIds,
     });
   },
+  // Includes both v1 and v2 endpoints for refill prescriptions
   'POST /my_health/v2/prescriptions/refill_prescriptions': (req, res) => {
     // Get requested IDs from query params.
     const { ids } = req.query;
@@ -118,6 +132,31 @@ const responses = {
   //     ],
   //   });
   // },
+  'GET /my_health/v1/prescriptions/:id': (req, res) => {
+    const { id } = req.params;
+    const data = {
+      data: prescriptions.mockPrescription(id, {
+        cmopNdcNumber: '00093721410',
+      }),
+      meta: {
+        sort: {
+          dispStatus: 'DESC',
+          dispensedDate: 'DESC',
+          prescriptionName: 'DESC',
+        },
+        pagination: {
+          currentPage: 1,
+          perPage: 10,
+          totalPages: 1,
+          totalEntries: 1,
+        },
+        updatedAt: 'Wed, 28 Feb 2024 09:58:42 EST',
+        failedStationList: 'string',
+      },
+    };
+    delaySingleResponse(() => res.json(data), 2250);
+  },
+  // Includes both v1 and v2 endpoints for prescriptions
   'GET /my_health/v2/prescriptions/:id': (req, res) => {
     const { id } = req.params;
     const data = {

--- a/src/applications/mhv-medications/routes.jsx
+++ b/src/applications/mhv-medications/routes.jsx
@@ -9,7 +9,8 @@ import AppProviders from './containers/AppProviders';
 import App from './containers/App';
 import RxBreadcrumbs from './containers/RxBreadcrumbs';
 import { allergiesLoader } from './loaders/allergiesLoader';
-import { prescriptionsLoader } from './loaders/prescriptionsLoader';
+// Disabling loaders temporarily while rolling out Oracle Health Pilot
+// import { prescriptionsLoader } from './loaders/prescriptionsLoader';
 
 const Prescriptions = lazy(() => import('./containers/Prescriptions'));
 const RefillPrescriptions = lazy(() =>
@@ -64,17 +65,17 @@ const routes = [
   {
     path: 'refill',
     element: <RouteWrapper Component={RefillPrescriptions} />,
-    loader: prescriptionsLoader,
+    // loader: prescriptionsLoader,
   },
   {
     path: '/',
     element: <RouteWrapper Component={Prescriptions} />,
-    loader: prescriptionsLoader,
+    // loader: prescriptionsLoader,
   },
   {
     path: 'prescription/:prescriptionId/documentation',
     element: <RouteWrapper Component={PrescriptionDetailsDocumentation} />,
-    loader: prescriptionsLoader,
+    // loader: prescriptionsLoader,
   },
   {
     path: 'prescription/:prescriptionId',

--- a/src/applications/mhv-medications/routes.jsx
+++ b/src/applications/mhv-medications/routes.jsx
@@ -10,6 +10,7 @@ import App from './containers/App';
 import RxBreadcrumbs from './containers/RxBreadcrumbs';
 import { allergiesLoader } from './loaders/allergiesLoader';
 // Disabling loaders temporarily while rolling out Oracle Health Pilot
+// TODO: When the pilot is complete, re-enable loaders
 // import { prescriptionsLoader } from './loaders/prescriptionsLoader';
 
 const Prescriptions = lazy(() => import('./containers/Prescriptions'));

--- a/src/applications/mhv-medications/tests/api/prescriptionsApi.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/api/prescriptionsApi.unit.spec.jsx
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { environment } from '@department-of-veterans-affairs/platform-utilities/exports';
+
+// TODO: Add complete unit test suite for prescriptionsApi
+describe('API base path', () => {
+  it('should use v2 path when Cerner pilot flag is enabled', () => {
+    const mockState = {
+      featureToggles: {
+        mhvMedicationsCernerPilot: true,
+      },
+    };
+    const apiBasePath = mockState.featureToggles.mhvMedicationsCernerPilot
+      ? `${environment.API_URL}/my_health/v2`
+      : `${environment.API_URL}/my_health/v1`;
+    expect(apiBasePath).to.equal(`${environment.API_URL}/my_health/v2`);
+  });
+
+  it('should use v1 path when Cerner pilot flag is disabled', () => {
+    const mockState = {
+      featureToggles: {
+        mhvMedicationsCernerPilot: false,
+      },
+    };
+    const apiBasePath = mockState.featureToggles.mhvMedicationsCernerPilot
+      ? `${environment.API_URL}/my_health/v2`
+      : `${environment.API_URL}/my_health/v1`;
+    expect(apiBasePath).to.equal(`${environment.API_URL}/my_health/v1`);
+  });
+});

--- a/src/applications/mhv-medications/tests/api/prescriptionsApi.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/api/prescriptionsApi.unit.spec.jsx
@@ -1,29 +1,124 @@
 import { expect } from 'chai';
 import { environment } from '@department-of-veterans-affairs/platform-utilities/exports';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { getApiBasePath, getRefillMethod } from '../../api/prescriptionsApi';
 
-// TODO: Add complete unit test suite for prescriptionsApi
-describe('API base path', () => {
-  it('should use v2 path when Cerner pilot flag is enabled', () => {
-    const mockState = {
-      featureToggles: {
-        mhvMedicationsCernerPilot: true,
-      },
-    };
-    const apiBasePath = mockState.featureToggles.mhvMedicationsCernerPilot
-      ? `${environment.API_URL}/my_health/v2`
-      : `${environment.API_URL}/my_health/v1`;
-    expect(apiBasePath).to.equal(`${environment.API_URL}/my_health/v2`);
+describe('prescriptionsApi', () => {
+  describe('getApiBasePath', () => {
+    it('should return v2 path when Cerner pilot flag is enabled', () => {
+      const mockState = {
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
+          loading: false,
+        },
+      };
+
+      const result = getApiBasePath(mockState);
+
+      expect(result).to.equal(`${environment.API_URL}/my_health/v2`);
+    });
+
+    it('should return v1 path when Cerner pilot flag is disabled', () => {
+      const mockState = {
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: false,
+          loading: false,
+        },
+      };
+
+      const result = getApiBasePath(mockState);
+
+      expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
+    });
+
+    it('should default to v1 path when feature toggles are loading', () => {
+      const mockState = {
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
+          loading: true,
+        },
+      };
+
+      const result = getApiBasePath(mockState);
+
+      expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
+    });
+
+    it('should default to v1 path when featureToggles object is missing', () => {
+      const mockState = {};
+
+      const result = getApiBasePath(mockState);
+
+      expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
+    });
+
+    it('should default to v1 path when featureToggles is null', () => {
+      const mockState = {
+        featureToggles: null,
+      };
+
+      const result = getApiBasePath(mockState);
+
+      expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
+    });
   });
 
-  it('should use v1 path when Cerner pilot flag is disabled', () => {
-    const mockState = {
-      featureToggles: {
-        mhvMedicationsCernerPilot: false,
-      },
-    };
-    const apiBasePath = mockState.featureToggles.mhvMedicationsCernerPilot
-      ? `${environment.API_URL}/my_health/v2`
-      : `${environment.API_URL}/my_health/v1`;
-    expect(apiBasePath).to.equal(`${environment.API_URL}/my_health/v1`);
+  describe('getRefillMethod', () => {
+    it('should return POST when Cerner pilot flag is enabled', () => {
+      const mockState = {
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
+          loading: false,
+        },
+      };
+
+      const result = getRefillMethod(mockState);
+
+      expect(result).to.equal('POST');
+    });
+
+    it('should return PATCH when Cerner pilot flag is disabled', () => {
+      const mockState = {
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: false,
+          loading: false,
+        },
+      };
+
+      const result = getRefillMethod(mockState);
+
+      expect(result).to.equal('PATCH');
+    });
+
+    it('should default to PATCH when feature toggles are loading', () => {
+      const mockState = {
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
+          loading: true,
+        },
+      };
+
+      const result = getRefillMethod(mockState);
+
+      expect(result).to.equal('PATCH');
+    });
+
+    it('should default to PATCH when featureToggles is missing', () => {
+      const mockState = {};
+
+      const result = getRefillMethod(mockState);
+
+      expect(result).to.equal('PATCH');
+    });
+
+    it('should default to PATCH when featureToggles is null', () => {
+      const mockState = {
+        featureToggles: null,
+      };
+
+      const result = getRefillMethod(mockState);
+
+      expect(result).to.equal('PATCH');
+    });
   });
 });

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -285,4 +285,203 @@ describe('Refill Prescriptions Component', () => {
     expect(title).to.have.text('Refill prescriptions');
     expect(screen.getByTestId('no-refills-message')).to.exist;
   });
+
+  describe('Oracle Health Pilot Flag Tests', () => {
+    it('calls bulkRefillPrescriptions with simple IDs when pilot flag is disabled', async () => {
+      sandbox.restore();
+      const bulkRefillStub = sinon.stub().resolves({
+        data: { successfulIds: [22377956], failedIds: [] },
+      });
+      sandbox
+        .stub(prescriptionsApiModule, 'useGetRefillablePrescriptionsQuery')
+        .returns({
+          data: {
+            prescriptions: [refillablePrescriptions[0]],
+            meta: {},
+          },
+          error: false,
+          isLoading: false,
+          isFetching: false,
+        });
+      sandbox
+        .stub(prescriptionsApiModule, 'useBulkRefillPrescriptionsMutation')
+        .returns([bulkRefillStub, { isLoading: false, error: null }]);
+      stubAllergiesApi({ sandbox });
+
+      const stateWithPilotDisabled = {
+        ...initialState,
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          mhv_medications_cerner_pilot: false,
+        },
+      };
+
+      const screen = setup(stateWithPilotDisabled);
+      const checkbox = await screen.findByTestId(
+        'refill-prescription-checkbox-0',
+      );
+      checkbox.__events.vaChange({ detail: { checked: true } });
+
+      const button = await screen.findByTestId('request-refill-button');
+      button.click();
+
+      await waitFor(() => {
+        expect(bulkRefillStub.calledOnce).to.be.true;
+        // Should pass array of simple IDs when pilot flag is disabled
+        expect(bulkRefillStub.firstCall.args[0]).to.deep.equal([22377956]);
+      });
+    });
+
+    it('calls bulkRefillPrescriptions with ID objects when pilot flag is enabled', async () => {
+      sandbox.restore();
+      const bulkRefillStub = sinon.stub().resolves({
+        data: {
+          successfulIds: [{ id: 22377956, stationNumber: '989' }],
+          failedIds: [],
+        },
+      });
+      const prescriptionWithStation = {
+        ...refillablePrescriptions[0],
+        stationNumber: '989',
+      };
+      sandbox
+        .stub(prescriptionsApiModule, 'useGetRefillablePrescriptionsQuery')
+        .returns({
+          data: {
+            prescriptions: [prescriptionWithStation],
+            meta: {},
+          },
+          error: false,
+          isLoading: false,
+          isFetching: false,
+        });
+      sandbox
+        .stub(prescriptionsApiModule, 'useBulkRefillPrescriptionsMutation')
+        .returns([bulkRefillStub, { isLoading: false, error: null }]);
+      stubAllergiesApi({ sandbox });
+
+      const stateWithPilotEnabled = {
+        ...initialState,
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          mhv_medications_cerner_pilot: true,
+        },
+      };
+
+      const screen = setup(stateWithPilotEnabled);
+      const checkbox = await screen.findByTestId(
+        'refill-prescription-checkbox-0',
+      );
+      checkbox.__events.vaChange({ detail: { checked: true } });
+
+      const button = await screen.findByTestId('request-refill-button');
+      button.click();
+
+      await waitFor(() => {
+        expect(bulkRefillStub.calledOnce).to.be.true;
+        // Should pass array of ID objects with stationNumber when pilot flag is enabled
+        expect(bulkRefillStub.firstCall.args[0]).to.deep.equal([
+          { id: 22377956, stationNumber: '989' },
+        ]);
+      });
+    });
+
+    it('matches medications by ID and stationNumber when pilot flag is enabled', async () => {
+      sandbox.restore();
+      const bulkRefillStub = sinon.stub().resolves({
+        data: {
+          successfulIds: [{ id: 22377956, stationNumber: '989' }],
+          failedIds: [],
+        },
+      });
+      const prescriptionWithStation = {
+        ...refillablePrescriptions[0],
+        stationNumber: '989',
+      };
+      sandbox
+        .stub(prescriptionsApiModule, 'useGetRefillablePrescriptionsQuery')
+        .returns({
+          data: {
+            prescriptions: [prescriptionWithStation],
+            meta: {},
+          },
+          error: false,
+          isLoading: false,
+          isFetching: false,
+        });
+      sandbox
+        .stub(prescriptionsApiModule, 'useBulkRefillPrescriptionsMutation')
+        .returns([bulkRefillStub, { isLoading: false, error: null }]);
+      stubAllergiesApi({ sandbox });
+
+      const stateWithPilotEnabled = {
+        ...initialState,
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          mhv_medications_cerner_pilot: true,
+        },
+      };
+
+      const screen = setup(stateWithPilotEnabled);
+      const checkbox = await screen.findByTestId(
+        'refill-prescription-checkbox-0',
+      );
+      checkbox.__events.vaChange({ detail: { checked: true } });
+
+      const button = await screen.findByTestId('request-refill-button');
+      button.click();
+
+      // Wait for success notification which uses getMedicationsByIds internally
+      await waitFor(() => {
+        expect(bulkRefillStub.calledOnce).to.be.true;
+      });
+    });
+
+    it('matches medications by ID only when pilot flag is disabled', async () => {
+      sandbox.restore();
+      const bulkRefillStub = sinon.stub().resolves({
+        data: {
+          successfulIds: [22377956],
+          failedIds: [],
+        },
+      });
+      sandbox
+        .stub(prescriptionsApiModule, 'useGetRefillablePrescriptionsQuery')
+        .returns({
+          data: {
+            prescriptions: [refillablePrescriptions[0]],
+            meta: {},
+          },
+          error: false,
+          isLoading: false,
+          isFetching: false,
+        });
+      sandbox
+        .stub(prescriptionsApiModule, 'useBulkRefillPrescriptionsMutation')
+        .returns([bulkRefillStub, { isLoading: false, error: null }]);
+      stubAllergiesApi({ sandbox });
+
+      const stateWithPilotDisabled = {
+        ...initialState,
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          mhv_medications_cerner_pilot: false,
+        },
+      };
+
+      const screen = setup(stateWithPilotDisabled);
+      const checkbox = await screen.findByTestId(
+        'refill-prescription-checkbox-0',
+      );
+      checkbox.__events.vaChange({ detail: { checked: true } });
+
+      const button = await screen.findByTestId('request-refill-button');
+      button.click();
+
+      // Wait for success notification which uses getMedicationsByIds internally
+      await waitFor(() => {
+        expect(bulkRefillStub.calledOnce).to.be.true;
+      });
+    });
+  });
 });

--- a/src/applications/mhv-medications/tests/e2e/fixtures/refill-success.v2.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/refill-success.v2.json
@@ -3,10 +3,6 @@
         "id": "f179abbc-19c5-4a66-bfea-3285e972f1bd",
         "type": "PrescriptionRefills",
         "attributes": {
-            "failedStationList": [
-                "979"
-            ],
-            "successfulStationList": [],
             "lastUpdatedTime": "2025-11-20T19:59:03Z",
             "prescriptionList": [
                 {
@@ -14,7 +10,7 @@
                     "stationNumber": "989"
                 }
             ],
-            "failedPrescriptionIds": [],
+            "failedPrescriptionList": [],
             "errors": [
                 {
                     "developerMessage": "Service unavailable",

--- a/src/applications/mhv-medications/tests/e2e/fixtures/refill-success.v2.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/refill-success.v2.json
@@ -1,0 +1,28 @@
+{
+    "data": {
+        "id": "f179abbc-19c5-4a66-bfea-3285e972f1bd",
+        "type": "PrescriptionRefills",
+        "attributes": {
+            "failedStationList": [
+                "979"
+            ],
+            "successfulStationList": [],
+            "lastUpdatedTime": "2025-11-20T19:59:03Z",
+            "prescriptionList": [
+                {
+                    "id": 22545165,
+                    "stationNumber": "989"
+                }
+            ],
+            "failedPrescriptionIds": [],
+            "errors": [
+                {
+                    "developerMessage": "Service unavailable",
+                    "prescriptionId": "25115094",
+                    "stationNumber": "979"
+                }
+            ],
+            "infoMessages": []
+        }
+    }
+}

--- a/src/applications/mhv-medications/tests/e2e/fixtures/toggles-response.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/toggles-response.json
@@ -21,6 +21,10 @@
             {
                 "name": "mhv_secure_messaging_medications_renewal_request",
                 "value": true
+            },
+            {
+                "name": "mhv_medications_cerner_pilot",
+                "value": true
             }
         ]
     }

--- a/src/applications/mhv-medications/tests/e2e/fixtures/toggles-response.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/toggles-response.json
@@ -24,7 +24,7 @@
             },
             {
                 "name": "mhv_medications_cerner_pilot",
-                "value": true
+                "value": false
             }
         ]
     }

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-request-success-alert-link-to-list-page-v2.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-request-success-alert-link-to-list-page-v2.cypress.spec.js
@@ -1,8 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsRefillPage from './pages/MedicationsRefillPage';
-import prescription from './fixtures/active-prescriptions-with-refills.json';
 import prescriptions from './fixtures/listOfPrescriptions.json';
-import successRequest from './fixtures/refill-success.json';
+import successRequest from './fixtures/refill-success.v2.json';
 import mockToggles from './fixtures/toggles-response.json';
 
 describe('Medications Refill Success Alert Message Link (v2)', () => {
@@ -27,7 +26,7 @@ describe('Medications Refill Success Alert Message Link (v2)', () => {
       throw new Error(
         'v1 endpoint should not be called when Cerner pilot flag is enabled',
       );
-    }).as('refillList');
+    });
     site.login();
     cy.intercept('GET', '/v0/feature_toggles?*', mockTogglesV2).as(
       'featureToggles',
@@ -37,17 +36,13 @@ describe('Medications Refill Success Alert Message Link (v2)', () => {
   it('visits Medications List Link on Success Alert with v2 endpoint', () => {
     const refillPage = new MedicationsRefillPage();
     refillPage.loadRefillPage(prescriptions, 'my_health/v2');
-    cy.injectAxe();
-    cy.axeCheck('main');
+    cy.injectAxeThenAxeCheck();
     refillPage.verifyRefillPageTitle();
-    refillPage.clickPrescriptionRefillCheckboxForSuccessfulRequest(
-      prescription,
-    );
-    refillPage.clickRequestRefillButtonforSuccessfulRequests(
-      prescription.data.attributes.prescriptionId,
-      successRequest,
-    );
+
+    refillPage.clickPrescriptionRefillCheckboxForSuccessfulRequestV2();
+
+    refillPage.clickRequestRefillButtonForSuccessfulRequestsV2(successRequest);
+
     refillPage.verifyRefillRequestSuccessConfirmationMessage();
-    refillPage.clickMedicationsListPageLinkOnRefillSuccessAlertOnRefillsPage();
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-request-success-alert-link-to-list-page-v2.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-request-success-alert-link-to-list-page-v2.cypress.spec.js
@@ -3,15 +3,22 @@ import MedicationsRefillPage from './pages/MedicationsRefillPage';
 import prescription from './fixtures/active-prescriptions-with-refills.json';
 import prescriptions from './fixtures/listOfPrescriptions.json';
 import successRequest from './fixtures/refill-success.json';
+import mockToggles from './fixtures/toggles-response.json';
 
 describe('Medications Refill Success Alert Message Link (v2)', () => {
   beforeEach(() => {
     const site = new MedicationsSite();
     // Mock feature flag for v2 endpoint
+    const baseFeatures = mockToggles.data.features.filter(
+      f => f.name !== 'mhv_medications_cerner_pilot',
+    );
     const mockTogglesV2 = {
       data: {
         type: 'feature_toggles',
-        features: [{ name: 'mhv_medications_cerner_pilot', value: true }],
+        features: [
+          ...baseFeatures,
+          { name: 'mhv_medications_cerner_pilot', value: true },
+        ],
       },
     };
 

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -2,6 +2,9 @@ import medicationsList from '../fixtures/listOfPrescriptions.json';
 import allergies from '../fixtures/allergies.json';
 import { medicationsUrls } from '../../../util/constants';
 import { Paths } from '../utils/constants';
+import { selectCernerPilotFlag } from '../../../util/selectors';
+
+const basePath = selectCernerPilotFlag ? 'my_health/v2' : 'my_health/v1';
 
 class MedicationsRefillPage {
   loadRefillPage = prescriptions => {
@@ -10,7 +13,7 @@ class MedicationsRefillPage {
     );
     cy.intercept(
       'GET',
-      'my_health/v1/prescriptions/list_refillable_prescriptions',
+      `${basePath}/prescriptions/list_refillable_prescriptions`,
       prescriptions,
     ).as('refillList');
     cy.intercept('GET', '/my_health/v1/medical_records/allergies', allergies);
@@ -77,12 +80,12 @@ class MedicationsRefillPage {
   clickGoToMedicationsListPage = () => {
     cy.intercept(
       'GET',
-      'my_health/v1/prescriptions?page=1&per_page=20All%20medications',
+      `${basePath}/prescriptions?page=1&per_page=20All%20medications`,
       medicationsList,
     ).as('medicationsList');
     cy.intercept(
       'GET',
-      '/my_health/v1/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true',
+      `${basePath}/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true`,
       medicationsList,
     );
     cy.intercept('GET', '/my_health/v1/medical_records/allergies', allergies);
@@ -272,7 +275,7 @@ class MedicationsRefillPage {
   clickPrescriptionRefillCheckbox = prescription => {
     cy.intercept(
       'PATCH',
-      '/my_health/v1/prescriptions/refill_prescriptions?ids[]=22377949',
+      `${basePath}/prescriptions/refill_prescriptions?ids[]=22377949`,
       prescription,
     );
     cy.get('[data-testid="refill-prescription-checkbox-2"]').click({
@@ -286,7 +289,7 @@ class MedicationsRefillPage {
   ) => {
     cy.intercept(
       'PATCH',
-      `/my_health/v1/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
+      `${basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       failedRequest,
     ).as('failedRefillRequest');
     cy.get('[data-testid="request-refill-button"]').should('exist');
@@ -305,7 +308,7 @@ class MedicationsRefillPage {
   clickPrescriptionRefillCheckboxForSuccessfulRequest = prescription => {
     cy.intercept(
       'PATCH',
-      '/my_health/v1/prescriptions/refill_prescriptions?ids[]=22545165',
+      `${basePath}/prescriptions/refill_prescriptions?ids[]=22545165`,
       prescription,
     );
     cy.get('[data-testid="refill-prescription-checkbox-0"]').click({
@@ -316,7 +319,7 @@ class MedicationsRefillPage {
   clickRequestRefillButtonforSuccessfulRequests = (prescriptionId, success) => {
     cy.intercept(
       'PATCH',
-      `/my_health/v1/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
+      `${basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       success,
     ).as('refillSuccess');
     cy.get('[data-testid="request-refill-button"]').should('exist');
@@ -332,7 +335,7 @@ class MedicationsRefillPage {
   ) => {
     cy.intercept(
       'PATCH',
-      `/my_health/v2/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,
+      `${basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,
       partialsuccess,
     );
     cy.get('[data-testid="request-refill-button"]').should('exist');
@@ -441,7 +444,7 @@ class MedicationsRefillPage {
     cy.intercept('GET', Paths.MED_LIST, medicationsList).as('medicationsList');
     cy.intercept(
       'GET',
-      '/my_health/v1/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true',
+      '/my_health/v2/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true',
       medicationsList,
     );
     cy.intercept('GET', '/my_health/v1/medical_records/allergies', allergies);

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -12,7 +12,7 @@ class MedicationsRefillPage {
     return this.basePath.includes('v2') ? 'POST' : 'PATCH';
   };
 
-  loadRefillPage = (prescriptions, basePath = 'my_health/v1') => {
+  loadRefillPage = (prescriptions, basePath = this.basePath) => {
     this.basePath = basePath;
     cy.intercept('GET', `${Paths.DELAY_ALERT}`, prescriptions).as(
       'delayAlertRxList',

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -282,7 +282,7 @@ class MedicationsRefillPage {
 
   clickPrescriptionRefillCheckbox = prescription => {
     cy.intercept(
-      'PATCH',
+      this.getRefillMethod(),
       `${this.basePath}/prescriptions/refill_prescriptions?ids[]=22377949`,
       prescription,
     );
@@ -346,7 +346,7 @@ class MedicationsRefillPage {
     partialsuccess,
   ) => {
     cy.intercept(
-      'PATCH',
+      this.getRefillMethod(),
       `${
         this.basePath
       }/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -332,7 +332,7 @@ class MedicationsRefillPage {
   ) => {
     cy.intercept(
       'PATCH',
-      `/my_health/v1/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,
+      `/my_health/v2/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,
       partialsuccess,
     );
     cy.get('[data-testid="request-refill-button"]').should('exist');

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -288,7 +288,7 @@ class MedicationsRefillPage {
     failedRequest,
   ) => {
     cy.intercept(
-      'PATCH',
+      selectCernerPilotFlag ? 'POST' : 'PATCH',
       `${basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       failedRequest,
     ).as('failedRefillRequest');
@@ -307,7 +307,7 @@ class MedicationsRefillPage {
 
   clickPrescriptionRefillCheckboxForSuccessfulRequest = prescription => {
     cy.intercept(
-      'PATCH',
+      selectCernerPilotFlag ? 'POST' : 'PATCH',
       `${basePath}/prescriptions/refill_prescriptions?ids[]=22545165`,
       prescription,
     );
@@ -318,7 +318,7 @@ class MedicationsRefillPage {
 
   clickRequestRefillButtonforSuccessfulRequests = (prescriptionId, success) => {
     cy.intercept(
-      'PATCH',
+      selectCernerPilotFlag ? 'POST' : 'PATCH',
       `${basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       success,
     ).as('refillSuccess');

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -6,7 +6,7 @@ import { Paths } from '../utils/constants';
 class MedicationsRefillPage {
   // basePath can be set per test based on feature flag state
   basePath = 'my_health/v1';
-  
+
   // Helper to determine HTTP method based on basePath
   getRefillMethod = () => {
     return this.basePath.includes('v2') ? 'POST' : 'PATCH';
@@ -91,7 +91,9 @@ class MedicationsRefillPage {
     ).as('medicationsList');
     cy.intercept(
       'GET',
-      `${this.basePath}/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true`,
+      `${
+        this.basePath
+      }/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true`,
       medicationsList,
     );
     cy.intercept('GET', '/my_health/v1/medical_records/allergies', allergies);
@@ -295,7 +297,9 @@ class MedicationsRefillPage {
   ) => {
     cy.intercept(
       this.getRefillMethod(),
-      `${this.basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
+      `${
+        this.basePath
+      }/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       failedRequest,
     ).as('failedRefillRequest');
     cy.get('[data-testid="request-refill-button"]').should('exist');
@@ -325,7 +329,9 @@ class MedicationsRefillPage {
   clickRequestRefillButtonforSuccessfulRequests = (prescriptionId, success) => {
     cy.intercept(
       this.getRefillMethod(),
-      `${this.basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
+      `${
+        this.basePath
+      }/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       success,
     ).as('refillSuccess');
     cy.get('[data-testid="request-refill-button"]').should('exist');
@@ -341,7 +347,9 @@ class MedicationsRefillPage {
   ) => {
     cy.intercept(
       'PATCH',
-      `${this.basePath}/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,
+      `${
+        this.basePath
+      }/prescriptions/refill_prescriptions?ids[]=${prescriptionId1}&ids[]=${prescriptionId2}`,
       partialsuccess,
     );
     cy.get('[data-testid="request-refill-button"]').should('exist');
@@ -450,7 +458,9 @@ class MedicationsRefillPage {
     cy.intercept('GET', Paths.MED_LIST, medicationsList).as('medicationsList');
     cy.intercept(
       'GET',
-      `${this.basePath}/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true`,
+      `${
+        this.basePath
+      }/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true`,
       medicationsList,
     );
     cy.intercept('GET', '/my_health/v1/medical_records/allergies', allergies);

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -8,8 +8,12 @@ class MedicationsRefillPage {
   basePath = 'my_health/v1';
 
   // Helper to determine HTTP method based on basePath
+  isV2 = () => {
+    return this.basePath.includes('v2');
+  };
+
   getRefillMethod = () => {
-    return this.basePath.includes('v2') ? 'POST' : 'PATCH';
+    return this.isV2() ? 'POST' : 'PATCH';
   };
 
   loadRefillPage = (prescriptions, basePath = this.basePath) => {
@@ -309,6 +313,35 @@ class MedicationsRefillPage {
   };
 
   clickRefillRequestButton = () => {
+    cy.get('[data-testid="request-refill-button"]').should('exist');
+    cy.get('[data-testid="request-refill-button"]').click({
+      waitForAnimations: true,
+    });
+  };
+
+  clickPrescriptionRefillCheckboxForSuccessfulRequestV2 = ({
+    index = 0,
+  } = {}) => {
+    cy.get(`[data-testid="refill-prescription-checkbox-${index}"]`).click({
+      waitForAnimations: true,
+    });
+  };
+
+  clickRequestRefillButtonForSuccessfulRequestsV2 = success => {
+    cy.intercept(
+      this.getRefillMethod(),
+      `${this.basePath}/prescriptions/refill_prescriptions`,
+      req => {
+        // assert that the req.body is an array of objects with the id and stationNumber keys
+        expect(req.body).to.deep.equal([
+          {
+            id: 22545165,
+            stationNumber: '989',
+          },
+        ]);
+        req.reply(success);
+      },
+    ).as('refillSuccess');
     cy.get('[data-testid="request-refill-button"]').should('exist');
     cy.get('[data-testid="request-refill-button"]').click({
       waitForAnimations: true,

--- a/src/applications/mhv-medications/util/selectors.js
+++ b/src/applications/mhv-medications/util/selectors.js
@@ -24,3 +24,6 @@ export const selectSecureMessagingMedicationsRenewalRequestFlag = state =>
   state.featureToggles[
     FEATURE_FLAG_NAMES.mhvSecureMessagingMedicationsRenewalRequest
   ];
+
+export const selectCernerPilotFlag = state =>
+  state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -173,6 +173,7 @@
   "mhvMedicalRecordsSupportBackendPaginationLabTest": "mhv_medical_records_support_backend_pagination_lab_test",
   "mhvMedicalRecordsSupportBackendPaginationVaccine": "mhv_medical_records_support_backend_pagination_vaccine",
   "mhvMedicalRecordsSupportBackendPaginationVital": "mhv_medical_records_support_backend_pagination_vital",
+  "mhvMedicationsCernerPilot": "mhv_medications_cerner_pilot",
   "mhvMedicationsDisplayAllergies": "mhv_medications_display_allergies",
   "mhvMedicationsDisplayDocumentationContent": "mhv_medications_display_documentation_content",
   "mhvMedicationsDisplayGrouping": "mhv_medications_display_grouping",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary


This pull request implements support for the Oracle Health (Cerner) pilot in the MHV Medications application. The changes introduce dynamic switching between v1 and v2 API endpoints and HTTP methods based on a feature flag, update the bulk refill logic and data structures to support the new API, and expand test and mock coverage for the new behaviors. It also temporarily disables certain route loaders during the pilot rollout.

Key changes include:

**API version and method selection based on feature flag:**
- Added `getApiBasePath` and `getRefillMethod` utilities to dynamically select the API base path (`v1` or `v2`) and HTTP method (`PATCH` or `POST`) for refill-related requests, depending on the `mhvMedicationsCernerPilot` feature flag.
- Updated all API endpoint calls in `prescriptionsApi.js` to use the dynamic base path and method, ensuring that requests are routed appropriately for pilot and non-pilot users. [[1]](diffhunk://#diff-1cbec2d0e66af2431e2571f8f1c1ec9394f100bf31ea27c9388750ee7d9ea2a6L50-R78) [[2]](diffhunk://#diff-1cbec2d0e66af2431e2571f8f1c1ec9394f100bf31ea27c9388750ee7d9ea2a6L84-R112) [[3]](diffhunk://#diff-1cbec2d0e66af2431e2571f8f1c1ec9394f100bf31ea27c9388750ee7d9ea2a6L112-R140) [[4]](diffhunk://#diff-1cbec2d0e66af2431e2571f8f1c1ec9394f100bf31ea27c9388750ee7d9ea2a6L128-R156) [[5]](diffhunk://#diff-1cbec2d0e66af2431e2571f8f1c1ec9394f100bf31ea27c9388750ee7d9ea2a6L154-R288)

**Bulk refill and prescription matching logic:**
- Modified the bulk refill mutation to send different payload shapes and handle different response structures for v2 (pilot) vs. v1 (non-pilot), including using `{ id, stationNumber }` objects for pilot users. [[1]](diffhunk://#diff-1cbec2d0e66af2431e2571f8f1c1ec9394f100bf31ea27c9388750ee7d9ea2a6L154-R288) [[2]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199L111-R137)
- Updated the logic for matching successful and failed refills to prescriptions, with special handling for the new identifier structure in pilot mode. [[1]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199L54-R87) [[2]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199L78-R100)

**Mocks and test coverage:**
- Enhanced API mocks to support v2 endpoints, POST refill requests, and the new identifier formats for pilot users. [[1]](diffhunk://#diff-0d022e7685787c280d1402c486b49c2599e87b96bbd7808ac46b5a56a291a2feR49-R68) [[2]](diffhunk://#diff-0d022e7685787c280d1402c486b49c2599e87b96bbd7808ac46b5a56a291a2feR80-R93) [[3]](diffhunk://#diff-0d022e7685787c280d1402c486b49c2599e87b96bbd7808ac46b5a56a291a2feR161-R185)
- Added unit tests for `getApiBasePath` and `getRefillMethod` to verify correct behavior under various feature flag states.
- Updated feature toggle mocks to include the new `mhvMedicationsCernerPilot` flag. [[1]](diffhunk://#diff-91de824d7f4032407c78eb2410a4b04f92c413f772b706d0a68641616cf0a52bR10) [[2]](diffhunk://#diff-91de824d7f4032407c78eb2410a4b04f92c413f772b706d0a68641616cf0a52bR45-R48)

**UI and routing adjustments:**
- Updated the `RefillPrescriptions` container to use the new identifier structure and logic for pilot users, and to select the pilot flag from Redux state. [[1]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199R37-R38) [[2]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199R48-R49) [[3]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199L54-R87) [[4]](diffhunk://#diff-c8a0848d0a5008e22a2005d2ef16ad35b9706e694fdfb6e5413e90a7b431e199L111-R137)
- Temporarily disabled route loaders in `routes.jsx` to ease pilot rollout, with a TODO to re-enable them after the pilot. [[1]](diffhunk://#diff-c420f8cc4b79d1f6243a95f4011675d41c63b3535915b171a9bad923fe044bc1L12-R14) [[2]](diffhunk://#diff-c420f8cc4b79d1f6243a95f4011675d41c63b3535915b171a9bad923fe044bc1L67-R79)

These changes ensure that the application can seamlessly support both legacy and pilot users, while maintaining testability and flexibility for future feature flag rollouts.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125749
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125750

## Testing done

- Wrote a small unit test
- Updated e2e tests
- Tested locally

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
