### PR TITLE
removed quantity field from med list txt file and refresh export list on filter or sort updates

### DIFF
--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -200,6 +200,7 @@ const Prescriptions = () => {
         ...prev,
         ...updates,
       }));
+      setPrescriptionsExportList([]);
     }
 
     navigate('/?page=1', { replace: true });

--- a/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
@@ -80,7 +80,6 @@ describe('VA prescription Config', () => {
   it('should create "Most recent prescription" section', () => {
     const txt = buildVAPrescriptionTXT(prescriptionDetails.data.attributes);
     expect(txt).to.include('Most recent prescription');
-    expect(txt).to.include('Quantity: 30');
     expect(txt).to.include(
       prescriptionDetails.data.attributes.prescriptionName,
     );

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -64,7 +64,6 @@ const getAttributes = rx =>
     fieldLine('Pharmacy phone number', rx.phoneNumber),
     fieldLine('Instructions', rx.sig),
     fieldLine('Reason for use', rx.indicationForUse),
-    fieldLine('Quantity', rx.quantity),
     `Prescribed on: ${dateFormat(
       rx.orderedDate,
       DATETIME_FORMATS.longMonthDate,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Addressed [QA comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/118663#issuecomment-3554093135) to remove quantity field from med list txt file and refresh export list on filter/sort updates

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118663

## Testing done

- Confirmed txt file no longer had Quantity attribute
- Confirmed selecting a new filter or sort get applied after 1st download/print button is clicked

## What areas of the site does it impact?

- Only medication list page

## Acceptance criteria

- address QA review comments

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user