### PR TITLE
Fix subheading level on review page and remove redundant one

### DIFF
--- a/src/applications/ask-va/components/reviewPage/ReviewSectionContent.jsx
+++ b/src/applications/ask-va/components/reviewPage/ReviewSectionContent.jsx
@@ -55,5 +55,5 @@ ReviewSectionContent.propTypes = {
   editSection: PropTypes.func.isRequired,
   items: PropTypes.array.isRequired,
   keys: PropTypes.array.isRequired,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 };

--- a/src/applications/ask-va/components/reviewPage/ReviewSectionContent.jsx
+++ b/src/applications/ask-va/components/reviewPage/ReviewSectionContent.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
 
 const ReviewSectionContent = ({
   title,
@@ -47,3 +48,10 @@ const ReviewSectionContent = ({
 };
 
 export default ReviewSectionContent;
+
+ReviewSectionContent.propTypes = {
+  editSection: PropTypes.func.isRequired,
+  items: PropTypes.array.isRequired,
+  keys: PropTypes.array.isRequired,
+  title: PropTypes.string.isRequired,
+};

--- a/src/applications/ask-va/components/reviewPage/ReviewSectionContent.jsx
+++ b/src/applications/ask-va/components/reviewPage/ReviewSectionContent.jsx
@@ -20,10 +20,12 @@ const ReviewSectionContent = ({
     >
       <div className="form-review-panel-page vads-u-margin-bottom--0">
         <form className="rjsf">
-          <div className="form-review-panel-page-header-row">
-            <h4 className="form-review-panel-page-header vads-u-font-size--h5 vads-u-margin-bottom--2">
-              {title}
-            </h4>
+          <div className="form-review-panel-page-header-row vads-u-margin-bottom--2">
+            {!!title && (
+              <h5 className="form-review-panel-page-header vads-u-font-size--h5">
+                {title}
+              </h5>
+            )}
             <div className="vads-u-justify-content--flex-end">
               <VaButton
                 text="Edit"

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -34,6 +34,7 @@ import FileUpload from '../components/FileUpload';
 import ReviewCollapsibleChapter from '../components/ReviewCollapsibleChapter';
 import ReviewSectionContent from '../components/reviewPage/ReviewSectionContent';
 import SaveCancelButtons from '../components/reviewPage/SaveCancelButtons';
+// eslint-disable-next-line import/no-cycle
 import formConfig from '../config/form';
 import { DownloadLink } from '../config/helpers';
 import {
@@ -316,7 +317,9 @@ const ReviewPage = props => {
                   expandedPages={chapter.expandedPages}
                   chapterFormConfig={chapter.formConfig}
                   chapterKey={chapter.name}
+                  // eslint-disable-next-line react/prop-types
                   form={props.form}
+                  // eslint-disable-next-line react/prop-types
                   formContext={props.formContext}
                   onEdit={handleEdit}
                   open={chapter.open}
@@ -350,7 +353,9 @@ const ReviewPage = props => {
                   expandedPages={chapter.expandedPages}
                   chapterFormConfig={chapter.formConfig}
                   chapterKey={chapter.name}
+                  // eslint-disable-next-line react/prop-types
                   form={props.form}
+                  // eslint-disable-next-line react/prop-types
                   formContext={props.formContext}
                   onEdit={handleEdit}
                   showButtons
@@ -459,7 +464,9 @@ const ReviewPage = props => {
                           expandedPages={chapter.expandedPages}
                           chapterFormConfig={chapter.formConfig}
                           chapterKey={chapter.name}
+                          // eslint-disable-next-line react/prop-types
                           form={props.form}
+                          // eslint-disable-next-line react/prop-types
                           formContext={props.formContext}
                           onEdit={handleEdit}
                           showButtons={false}
@@ -498,7 +505,9 @@ const ReviewPage = props => {
                     expandedPages={chapter.expandedPages}
                     chapterFormConfig={chapter.formConfig}
                     chapterKey={chapter.name}
+                    // eslint-disable-next-line react/prop-types
                     form={props.form}
+                    // eslint-disable-next-line react/prop-types
                     formContext={props.formContext}
                     onEdit={handleEdit}
                     showButtons
@@ -590,7 +599,9 @@ const ReviewPage = props => {
                           expandedPages={chapter.expandedPages}
                           chapterFormConfig={chapter.formConfig}
                           chapterKey={chapter.name}
+                          // eslint-disable-next-line react/prop-types
                           form={props.form}
+                          // eslint-disable-next-line react/prop-types
                           formContext={props.formContext}
                           onEdit={handleEdit}
                           showButtons={false}
@@ -629,7 +640,9 @@ const ReviewPage = props => {
                     expandedPages={chapter.expandedPages}
                     chapterFormConfig={chapter.formConfig}
                     chapterKey={chapter.name}
+                    // eslint-disable-next-line react/prop-types
                     form={props.form}
+                    // eslint-disable-next-line react/prop-types
                     formContext={props.formContext}
                     onEdit={handleEdit}
                     showButtons
@@ -728,7 +741,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -782,7 +797,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -837,7 +854,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -892,7 +911,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -955,7 +976,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -1035,7 +1058,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -1128,7 +1153,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -1229,7 +1256,9 @@ const ReviewPage = props => {
                         expandedPages={chapter.expandedPages}
                         chapterFormConfig={chapter.formConfig}
                         chapterKey={chapter.name}
+                        // eslint-disable-next-line react/prop-types
                         form={props.form}
+                        // eslint-disable-next-line react/prop-types
                         formContext={props.formContext}
                         onEdit={handleEdit}
                         showButtons={false}
@@ -1296,7 +1325,9 @@ const ReviewPage = props => {
                     expandedPages={chapter.expandedPages}
                     chapterFormConfig={chapter.formConfig}
                     chapterKey={chapter.name}
+                    // eslint-disable-next-line react/prop-types
                     form={props.form}
+                    // eslint-disable-next-line react/prop-types
                     formContext={props.formContext}
                     onEdit={handleEdit}
                     showButtons

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -235,9 +235,10 @@ const ReviewPage = props => {
     );
   };
 
-  useEffect(async () => {
-    await getUploadedFiles();
-    focusElement('h2');
+  useEffect(() => {
+    getUploadedFiles().then(() => {
+      focusElement('h2');
+    });
   }, []);
 
   return (
@@ -380,12 +381,11 @@ const ReviewPage = props => {
               .filter(chapter => chapter.name === 'veteransPersonalInformation')
               .map(chapter => {
                 return (
-                  <>
+                  <React.Fragment key={chapter.name}>
                     <div
                       name={`chapter${
                         chapterTitles.veteransPersonalInformation
                       }ScrollElement`}
-                      key={chapter.name}
                     />
                     {!editSection.includes(
                       chapterTitles.veteransPersonalInformation,
@@ -485,7 +485,7 @@ const ReviewPage = props => {
                         />
                       </>
                     )}
-                  </>
+                  </React.Fragment>
                 );
               })}
 
@@ -532,12 +532,11 @@ const ReviewPage = props => {
               )
               .map(chapter => {
                 return (
-                  <>
+                  <React.Fragment key={chapter.name}>
                     <div
                       name={`chapter${
                         chapterTitles.familyMembersPersonalInformation
                       }ScrollElement`}
-                      key={chapter.name}
                     />
                     {!editSection.includes(
                       chapterTitles.familyMembersPersonalInformation,
@@ -617,7 +616,7 @@ const ReviewPage = props => {
                         />
                       </>
                     )}
-                  </>
+                  </React.Fragment>
                 );
               })}
 
@@ -661,12 +660,11 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'yourInformation')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.yourInformation
                     }ScrollElement`}
-                    key={chapter.name}
                   />
                   {!editSection.includes(chapterTitles.yourInformation) ? (
                     <ReviewSectionContent
@@ -752,7 +750,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -760,7 +758,7 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'yourPostalCode')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${chapterTitles.yourPostalCode}ScrollElement`}
                     key={chapter.name}
@@ -806,7 +804,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -814,12 +812,11 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'yourVAHealthFacility')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.yourVAHealthFacility
                     }ScrollElement`}
-                    key={chapter.name}
                   />
                   {!editSection.includes(chapterTitles.yourVAHealthFacility) ? (
                     <ReviewSectionContent
@@ -862,7 +859,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -870,12 +867,11 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'stateOfProperty')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.stateOfProperty
                     }ScrollElement`}
-                    key={chapter.name}
                   />
                   {!editSection.includes(chapterTitles.stateOfProperty) ? (
                     <ReviewSectionContent
@@ -918,7 +914,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -926,12 +922,11 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'yourVREInformation')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.yourVREInformation
                     }ScrollElement`}
-                    key={chapter.name}
                   />
                   {!editSection.includes(chapterTitles.yourVREInformation) ? (
                     <ReviewSectionContent
@@ -982,7 +977,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -990,18 +985,16 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'schoolInformation')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.schoolInformation
                     }ScrollElement`}
-                    key={chapter.name}
                   />
                   {!editSection.includes(chapterTitles.schoolInformation) ? (
                     <ReviewSectionContent
                       title={chapterTitles.schoolInformation}
-                      editSection={editAll}
-                      // use pagesToMoveConfig if combining pages
+                      editSection={editAll} // use pagesToMoveConfig if combining pages
                       keys={pagesToMoveConfig.schoolInformation}
                       items={[
                         {
@@ -1064,7 +1057,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -1072,7 +1065,7 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'yourContactInformation')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.yourContactInformation
@@ -1157,7 +1150,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
 
@@ -1165,7 +1158,7 @@ const ReviewPage = props => {
             .filter(chapter => chapter.name === 'yourMailingAddress')
             .map(chapter => {
               return (
-                <>
+                <React.Fragment key={chapter.name}>
                   <div
                     name={`chapter${
                       chapterTitles.yourMailingAddress
@@ -1258,7 +1251,7 @@ const ReviewPage = props => {
                       />
                     </>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
         </VaAccordionItem>
@@ -1467,11 +1460,19 @@ ReviewPage.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
-  formData: PropTypes.object,
+  askVA: PropTypes.object,
+  chapters: PropTypes.array, // Of what?
+  formData: PropTypes.object, // Shape?
   goBack: PropTypes.func,
   goForward: PropTypes.func,
-  loggedIn: PropTypes.bool,
   isUserLOA3: PropTypes.bool,
+  loggedIn: PropTypes.bool,
+  setData: PropTypes.func,
+  setEditMode: PropTypes.func,
+  setValid: PropTypes.func,
+  setViewedPages: PropTypes.func,
+  uploadFile: PropTypes.func,
+  onSetData: PropTypes.func,
 };
 
 const mapDispatchToProps = {

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -1283,7 +1283,6 @@ const ReviewPage = props => {
                 </>
                 {!editSection.includes(chapterTitles.yourQuestion) ? (
                   <ReviewSectionContent
-                    title={chapterTitles.yourQuestion}
                     editSection={editAll}
                     keys={chapter.pageKeys}
                     items={[


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Add prop types to component that renders a review page section
  - Make review page subsection titles conditional and update them to `h5` so they are correctly nested
  - Remove redundant title for "Your question"
- _(What is the solution, why is this the solution)_
  - The nesting headings need to be h5 because they fall within a section with h4 above them.
  - The conditional rendering stops empty `h5`'s from showing up in the DOM
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Ask VA owns all the changed code

## Related issue(s)

- department-of-veterans-affairs/ask-va#1843

## Testing done

- _Describe what the old behavior was prior to the change_
  - `h4`'s were being used as section _and_ subsection headings
  - The last section had "Your question" as both heading and subheading
- _Describe the steps required to verify your changes are working as expected_
  - Answer questions to get to review page (should be the same for all of them)
  - Inspect DOM inside `va-accordion`s and confirm `h4` and `h5` hierarchy
- _Describe the tests completed and the results_
  - No functional change other than conditionally rendering titles, all of which appear correctly in the DOM

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="337" height="322" alt="Mobile before" src="https://github.com/user-attachments/assets/31f63138-7c3a-4cdc-959c-bc6ca163013a" /> | <img width="333" height="323" alt="Mobile after" src="https://github.com/user-attachments/assets/558bccce-7bbd-4f30-aa4c-6888fbe2bc01" /> |
| Desktop | <img width="626" height="315" alt="Desktop before" src="https://github.com/user-attachments/assets/e8307ac8-5829-4fee-b6b6-d69914a1b9cd" /> | <img width="625" height="322" alt="Desktop after" src="https://github.com/user-attachments/assets/0f9069c8-e340-41ff-8f3c-ce843fbab47c" /> |

## What areas of the site does it impact?

Only Ask VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user