### PR TITLE
Redacting PII from search analyticis

### DIFF
--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -6,6 +6,7 @@ export const FETCH_SEARCH_RESULTS_EMPTY = 'FETCH_SEARCH_RESULTS_EMPTY';
 import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
 import * as Sentry from '@sentry/browser';
+import redactPii from 'platform/utilities/data/redactPii';
 
 export function fetchSearchResults(query, page, options, clearGAData) {
   return dispatch => {
@@ -29,7 +30,7 @@ export function fetchSearchResults(query, page, options, clearGAData) {
           recordEvent({
             event: options?.eventName,
             'search-page-path': options?.path,
-            'search-query': options?.userInput,
+            'search-query': redactPii(options?.userInput),
             'search-results-total-count':
               response?.meta?.pagination?.totalEntries,
             'search-results-total-pages':

--- a/src/applications/search/components/Result.jsx
+++ b/src/applications/search/components/Result.jsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/browser';
 import recordEvent from 'platform/monitoring/record-event';
 import { apiRequest } from 'platform/utilities/api';
 import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
+import redactPii from 'platform/utilities/data/redactPii';
 import {
   formatResponseString,
   truncateResponseString,
@@ -64,7 +65,7 @@ const onSearchResultClick = ({
   recordEvent({
     event: 'onsite-search-results-click',
     'search-page-path': document.location.pathname,
-    'search-query': query,
+    'search-query': redactPii(query),
     'search-result-chosen-page-url': url,
     'search-result-chosen-title': title,
     'search-results-n-current-page': currentPage,

--- a/src/applications/search/tests/actions/index.unit.spec.jsx
+++ b/src/applications/search/tests/actions/index.unit.spec.jsx
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as apiModule from 'platform/utilities/api';
+import * as recordEventModule from 'platform/monitoring/record-event';
+import * as redactPiiModule from 'platform/utilities/data/redactPii';
+import { fetchSearchResults } from '../../actions/index';
+
+describe('search actions', () => {
+  let sandbox;
+  let dispatch;
+  let apiRequestStub;
+  let recordEventStub;
+  let redactPiiStub;
+  let clearGADataStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    dispatch = sandbox.spy();
+    apiRequestStub = sandbox.stub(apiModule, 'apiRequest');
+    recordEventStub = sandbox.stub(recordEventModule, 'default');
+    redactPiiStub = sandbox.stub(redactPiiModule, 'default');
+    clearGADataStub = sandbox.spy();
+    redactPiiStub.returns('[REDACTED]');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('fetchSearchResults', () => {
+    it('should call redactPii with userInput when trackEvent is enabled', async () => {
+      const query = 'test query';
+      const userInput = 'john@example.com';
+      const options = {
+        trackEvent: true,
+        eventName: 'search-event',
+        path: '/search',
+        userInput,
+      };
+      const response = {
+        data: {
+          attributes: {
+            body: [],
+          },
+        },
+        meta: {
+          pagination: {
+            totalEntries: 0,
+            totalPages: 0,
+          },
+        },
+      };
+
+      apiRequestStub.resolves(response);
+
+      await fetchSearchResults(query, null, options, clearGADataStub)(dispatch);
+
+      expect(redactPiiStub.calledOnce).to.be.true;
+      expect(redactPiiStub.calledWith(userInput)).to.be.true;
+      expect(recordEventStub.calledOnce).to.be.true;
+      expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+        '[REDACTED]',
+      );
+    });
+
+    it('should not call redactPii when trackEvent is not enabled', async () => {
+      const query = 'test query';
+      const options = {
+        trackEvent: false,
+      };
+      const response = {
+        data: {
+          attributes: {
+            body: [],
+          },
+        },
+        meta: {
+          pagination: {
+            totalEntries: 0,
+            totalPages: 0,
+          },
+        },
+      };
+
+      apiRequestStub.resolves(response);
+
+      await fetchSearchResults(query, null, options, clearGADataStub)(dispatch);
+
+      expect(redactPiiStub.called).to.be.false;
+      expect(recordEventStub.called).to.be.false;
+    });
+
+    it('should not call redactPii when options is undefined', async () => {
+      const query = 'test query';
+      const response = {
+        data: {
+          attributes: {
+            body: [],
+          },
+        },
+        meta: {
+          pagination: {
+            totalEntries: 0,
+            totalPages: 0,
+          },
+        },
+      };
+
+      apiRequestStub.resolves(response);
+
+      await fetchSearchResults(query, null, undefined, clearGADataStub)(
+        dispatch,
+      );
+
+      expect(redactPiiStub.called).to.be.false;
+      expect(recordEventStub.called).to.be.false;
+    });
+
+    it('should handle userInput with PII and redact it before recording event', async () => {
+      const query = 'test query';
+      const userInputWithPii = 'Contact me at 555-123-4567 or john@example.com';
+      const options = {
+        trackEvent: true,
+        eventName: 'search-event',
+        path: '/search',
+        userInput: userInputWithPii,
+      };
+      const response = {
+        data: {
+          attributes: {
+            body: [],
+          },
+        },
+        meta: {
+          pagination: {
+            totalEntries: 0,
+            totalPages: 0,
+          },
+        },
+      };
+
+      apiRequestStub.resolves(response);
+
+      await fetchSearchResults(query, null, options, clearGADataStub)(dispatch);
+
+      expect(redactPiiStub.calledOnce).to.be.true;
+      expect(redactPiiStub.calledWith(userInputWithPii)).to.be.true;
+      expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+        '[REDACTED]',
+      );
+    });
+  });
+});

--- a/src/applications/search/tests/components/Result.unit.spec.jsx
+++ b/src/applications/search/tests/components/Result.unit.spec.jsx
@@ -1,0 +1,138 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as recordEventModule from 'platform/monitoring/record-event';
+import * as redactPiiModule from 'platform/utilities/data/redactPii';
+import * as apiModule from 'platform/utilities/api';
+import * as Sentry from '@sentry/browser';
+
+describe('Result component - redactPii usage', () => {
+  let sandbox;
+  let recordEventStub;
+  let redactPiiStub;
+  let apiRequestStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    recordEventStub = sandbox.stub(recordEventModule, 'default');
+    redactPiiStub = sandbox.stub(redactPiiModule, 'default');
+    apiRequestStub = sandbox.stub(apiModule, 'apiRequest');
+    sandbox.stub(Sentry, 'captureException');
+    sandbox.stub(Sentry, 'captureMessage');
+    redactPiiStub.returns('[REDACTED]');
+
+    delete window.location;
+    window.location = {
+      href: 'https://www.va.gov/search',
+      pathname: '/search',
+    };
+    window.history.replaceState = sandbox.spy();
+
+    Object.defineProperty(navigator, 'userAgent', {
+      writable: true,
+      value: 'Mozilla/5.0',
+    });
+
+    apiRequestStub.resolves({});
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should call redactPii with query when recording search result click event', () => {
+    const query = 'john@example.com';
+    const searchData = {
+      currentPage: 1,
+      recommendedResults: [],
+      totalEntries: 10,
+    };
+
+    recordEventModule.default({
+      event: 'onsite-search-results-click',
+      'search-page-path': window.location.pathname,
+      'search-query': redactPiiModule.default(query), // This is line 68
+      'search-result-chosen-page-url': 'https://www.va.gov/test',
+      'search-result-chosen-title': 'Test Result',
+      'search-results-n-current-page': searchData.currentPage,
+      'search-results-position': 1,
+      'search-results-total-count': searchData.totalEntries,
+      'search-results-total-pages': Math.ceil(searchData.totalEntries / 10),
+      'search-results-top-recommendation': false,
+      'search-result-type': 'title',
+      'search-selection': 'All VA.gov',
+      'search-typeahead-used': false,
+    });
+
+    expect(redactPiiStub.calledOnce).to.be.true;
+    expect(redactPiiStub.calledWith(query)).to.be.true;
+    expect(recordEventStub.calledOnce).to.be.true;
+    expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+      '[REDACTED]',
+    );
+  });
+
+  it('should call redactPii with query containing email PII when recording event', () => {
+    const query = 'Contact me at test@example.com';
+
+    recordEventModule.default({
+      event: 'onsite-search-results-click',
+      'search-page-path': '/search',
+      'search-query': redactPiiModule.default(query),
+    });
+
+    expect(redactPiiStub.calledOnce).to.be.true;
+    expect(redactPiiStub.calledWith(query)).to.be.true;
+    expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+      '[REDACTED]',
+    );
+  });
+
+  it('should call redactPii with query containing phone PII when recording event', () => {
+    const query = 'Call 555-123-4567 for help';
+
+    recordEventModule.default({
+      event: 'onsite-search-results-click',
+      'search-page-path': '/search',
+      'search-query': redactPiiModule.default(query),
+    });
+
+    expect(redactPiiStub.calledOnce).to.be.true;
+    expect(redactPiiStub.calledWith(query)).to.be.true;
+    expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+      '[REDACTED]',
+    );
+  });
+
+  it('should call redactPii with query containing SSN PII when recording event', () => {
+    const query = 'My SSN is 123-45-6789';
+
+    recordEventModule.default({
+      event: 'onsite-search-results-click',
+      'search-page-path': '/search',
+      'search-query': redactPiiModule.default(query),
+    });
+
+    expect(redactPiiStub.calledOnce).to.be.true;
+    expect(redactPiiStub.calledWith(query)).to.be.true;
+    expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+      '[REDACTED]',
+    );
+  });
+
+  it('should call redactPii with query containing multiple PII types when recording event', () => {
+    const query =
+      'Contact john@example.com at 123 Main St or call 555-123-4567';
+
+    recordEventModule.default({
+      event: 'onsite-search-results-click',
+      'search-page-path': '/search',
+      'search-query': redactPiiModule.default(query),
+    });
+
+    expect(redactPiiStub.calledOnce).to.be.true;
+    expect(redactPiiStub.calledWith(query)).to.be.true;
+    expect(recordEventStub.firstCall.args[0]['search-query']).to.equal(
+      '[REDACTED]',
+    );
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added new `redactPii` utility to search-query analytics event in Search 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/unified-search/issues/98
