### PR TITLE
fix: add job dependencies to prevent deployment during holiday freeze

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -49,6 +49,9 @@ jobs:
       workflow_enabled_content_build: ${{ steps.check-status.outputs.workflow_enabled_content_build }}
       reenabled: ${{ steps.enable-workflows.outputs.reenabled }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+
       - name: Get bot token from Parameter Store (bypass)
         if: ${{ github.event.inputs.bypass_freeze == 'true' }}
         uses: ./.github/workflows/inject-secrets
@@ -235,8 +238,23 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  holiday-decision-gate:
+    name: Holiday Decision Gate
+    runs-on: ubuntu-latest
+    needs: [holiday-checker, cancel-run-if-holiday, main-deployment]
+    if: always() && !cancelled()
+    steps:
+      - name: Check if deployment should proceed
+        run: |
+          if [[ "${{ needs.holiday-checker.outputs.is_holiday }}" == "true" && "${{ github.event.inputs.bypass_freeze }}" != "true" ]]; then
+            echo "Deployment blocked: Today is a holiday and bypass is not enabled"
+            exit 1
+          fi
+          echo "Deployment approved: Proceeding with deployment"
+
   get-workflow-environment:
     runs-on: ubuntu-latest
+    needs: holiday-decision-gate
     outputs:
       environment_name: ${{ steps.check-environment.outputs.env_name }}
     steps:
@@ -251,6 +269,7 @@ jobs:
   set-env:
     name: Set Env Variables
     runs-on: ubuntu-latest
+    needs: holiday-decision-gate
     outputs:
       LATEST_TAG_VERSION: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}
       RELEASE_WAIT: ${{ env.RELEASE_WAIT }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -241,8 +241,7 @@ jobs:
   holiday-decision-gate:
     name: Holiday Decision Gate
     runs-on: ubuntu-latest
-    needs: [holiday-checker, cancel-run-if-holiday, main-deployment]
-    if: always() && !cancelled()
+    needs: [holiday-checker, main-deployment]
     steps:
       - name: Check if deployment should proceed
         run: |


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR fixes a race condition in the daily production deployment workflow where deployment jobs would start before holiday checking logic completed, allowing deployments to proceed even when they should be blocked by holiday freezes.

**What changed:**
- Added a `holiday-decision-gate` job that waits for all holiday-related jobs to complete (`holiday-checker` and `main-deployment`)
- Updated `set-env` and `get-workflow-environment` jobs to depend on the gate job
- The gate validates deployment should proceed and fails if it's a holiday without bypass enabled
- Added missing checkout step to `main-deployment` job that was causing the bypass logic to fail when activated (the inject-secrets action requires the repository to be checked out)
- Removed `cancel-run-if-holiday` from gate dependencies to prevent transitive skip behavior in downstream jobs

**Why this approach:**
The initial implementation had no job dependencies between holiday logic and deployment jobs, causing them to run in parallel. The gate job solves this by waiting for holiday decisions to complete and explicitly validating deployment should proceed.

The gate only depends on jobs that always complete with success/failure (`holiday-checker` and `main-deployment`), not on conditional jobs that may skip (`cancel-run-if-holiday`). This prevents GitHub Actions' transitive skip behavior where downstream jobs skip if any ancestor in the dependency tree was skipped, even when the direct dependency succeeded.

If it's a holiday without bypass, `cancel-run-if-holiday` will still run and cancel the entire workflow - we just don't wait for it in the dependency chain since its skip status would cause all deployment jobs to skip.

This ensures deployment only starts after all holiday decisions are made and only when appropriate (non-holiday or bypass enabled).

## Related issue(s)

N/A - Internal workflow improvement

## Testing done

- Reviewed workflow logic to ensure proper job dependency chain
- Verified gate job conditions cover all scenarios:
  - Holiday without bypass: gate fails, blocking deployment
  - Holiday with bypass: gate succeeds, allowing deployment
  - Non-holiday: gate succeeds, allowing deployment
- Confirmed removal of `cancel-run-if-holiday` from gate dependencies prevents transitive skip while still allowing the cancel job to function when needed
- Verified checkout step placement fixes bypass workflow failure

## Screenshots

N/A - GitHub Actions workflow change (no UI)

## What areas of the site does it impact?

This only affects the daily production deployment workflow. No user-facing site changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). - N/A for workflow changes
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, workflow is self-documenting
- [ ] Screenshot of the developed feature is added - N/A for workflow
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - N/A for workflow

### Error Handling

- [x] Browser console contains no warnings or errors. - N/A for workflow
- [x] Events are being sent to the appropriate logging solution - Workflow uses existing Slack notifications
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A, workflow failures visible in GitHub Actions

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A for workflow

## Requested Feedback

Please review the job dependency chain to ensure the logic properly gates deployment behind holiday checks while handling all three scenarios (holiday with/without bypass, non-holiday). Special attention to the removal of `cancel-run-if-holiday` from the gate's dependencies to prevent transitive skip behavior.