### PR TITLE
MHV SM - redirect to inbox if no care teams

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
@@ -35,9 +35,11 @@ const FolderHeader = props => {
 
   const drupalCernerFacilities = useSelector(selectCernerFacilities);
 
-  const { noAssociations, allTriageGroupsBlocked } = useSelector(
-    state => state.sm.recipients,
-  );
+  const {
+    noAssociations,
+    allTriageGroupsBlocked,
+    error: recipientsError,
+  } = useSelector(state => state.sm.recipients);
 
   const cernerFacilities = useMemo(
     () => {
@@ -97,6 +99,18 @@ const FolderHeader = props => {
 
   const { folderName, ddTitle, ddPrivacy } = handleHeader(folder);
 
+  const RecipientListErrorAlert = () => {
+    return (
+      <va-alert status="warning" data-testid="">
+        <h2 slot="headline">We can’t load your care team list right now</h2>
+        <p>
+          We’re sorry. Something went wrong on our end. Please refresh this page
+          or try again later.
+        </p>
+      </va-alert>
+    );
+  };
+
   return (
     <>
       <h1
@@ -139,8 +153,9 @@ const FolderHeader = props => {
           )}
 
         <>{handleFolderDescription()}</>
+        {recipientsError && <RecipientListErrorAlert />}
         {showInnerNav &&
-          (!noAssociations && !allTriageGroupsBlocked) && (
+          (!noAssociations && !allTriageGroupsBlocked && !recipientsError) && (
             <ComposeMessageButton />
           )}
 

--- a/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
@@ -101,7 +101,7 @@ const FolderHeader = props => {
 
   const RecipientListErrorAlert = () => {
     return (
-      <va-alert status="warning" data-testid="">
+      <va-alert status="warning" data-testid="recipients-error-alert">
         <h2 slot="headline">We can’t load your care team list right now</h2>
         <p>
           We’re sorry. Something went wrong on our end. Please refresh this page

--- a/src/applications/mhv-secure-messaging/containers/InterstitialPage.jsx
+++ b/src/applications/mhv-secure-messaging/containers/InterstitialPage.jsx
@@ -26,16 +26,17 @@ const InterstitialPage = props => {
   const {
     allRecipients,
     recentRecipients,
+    noAssociations,
     error: recipientsError,
   } = useSelector(state => state.sm.recipients);
 
   useEffect(
     () => {
-      if (recipientsError) {
+      if (recipientsError || noAssociations) {
         history.push(Paths.INBOX);
       }
     },
-    [recipientsError, history],
+    [recipientsError, noAssociations, history],
   );
 
   useEffect(

--- a/src/applications/mhv-secure-messaging/containers/InterstitialPage.jsx
+++ b/src/applications/mhv-secure-messaging/containers/InterstitialPage.jsx
@@ -23,8 +23,19 @@ const InterstitialPage = props => {
   const dispatch = useDispatch();
 
   const h1Ref = useRef(null);
-  const { allRecipients, recentRecipients } = useSelector(
-    state => state.sm.recipients,
+  const {
+    allRecipients,
+    recentRecipients,
+    error: recipientsError,
+  } = useSelector(state => state.sm.recipients);
+
+  useEffect(
+    () => {
+      if (recipientsError) {
+        history.push(Paths.INBOX);
+      }
+    },
+    [recipientsError, history],
   );
 
   useEffect(

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -31,6 +31,7 @@ const RecentCareTeams = () => {
   const {
     recentRecipients,
     allRecipients,
+    noAssociations,
     error: recipientsError,
   } = recipients;
   const h1Ref = useRef(null);
@@ -41,11 +42,11 @@ const RecentCareTeams = () => {
 
   useEffect(
     () => {
-      if (recipientsError) {
+      if (recipientsError || noAssociations) {
         history.push(Paths.INBOX);
       }
     },
-    [recipientsError, history],
+    [recipientsError, noAssociations, history],
   );
 
   useEffect(

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -28,12 +28,25 @@ const RecentCareTeams = () => {
   const [error, setError] = useState(null);
   const { recipients, threadDetails } = useSelector(state => state.sm);
   const { acceptInterstitial } = threadDetails;
-  const { recentRecipients, allRecipients } = recipients;
+  const {
+    recentRecipients,
+    allRecipients,
+    error: recipientsError,
+  } = recipients;
   const h1Ref = useRef(null);
   const {
     mhvSecureMessagingRecentRecipients,
     featureTogglesLoading,
   } = useFeatureToggles();
+
+  useEffect(
+    () => {
+      if (recipientsError) {
+        history.push(Paths.INBOX);
+      }
+    },
+    [recipientsError, history],
+  );
 
   useEffect(
     () => {

--- a/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
+++ b/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
@@ -36,6 +36,7 @@ const SelectCareTeam = () => {
     allTriageGroupsBlocked,
     allowedRecipients,
     vistaFacilities,
+    error: recipientsError,
   } = useSelector(state => state.sm.recipients);
   const ehrDataByVhaId = useSelector(selectEhrDataByVhaId);
   const { draftInProgress, acceptInterstitial } = useSelector(
@@ -57,6 +58,15 @@ const SelectCareTeam = () => {
   const MAX_RADIO_OPTIONS = 6;
 
   const h1Ref = useRef(null);
+
+  useEffect(
+    () => {
+      if (recipientsError) {
+        history.push(Paths.INBOX);
+      }
+    },
+    [recipientsError, history],
+  );
 
   useEffect(
     () => {

--- a/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
+++ b/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
@@ -61,11 +61,11 @@ const SelectCareTeam = () => {
 
   useEffect(
     () => {
-      if (recipientsError) {
+      if (recipientsError || noAssociations) {
         history.push(Paths.INBOX);
       }
     },
-    [recipientsError, history],
+    [recipientsError, noAssociations, history],
   );
 
   useEffect(

--- a/src/applications/mhv-secure-messaging/reducers/recipients.js
+++ b/src/applications/mhv-secure-messaging/reducers/recipients.js
@@ -36,7 +36,8 @@ export const recipientsReducer = (state = initialState, action) => {
         associatedTriageGroups,
         associatedBlockedTriageGroups,
       } = action.response.meta;
-      const noAssociations = associatedTriageGroups === 0;
+      const noAssociations =
+        associatedTriageGroups === 0 || action.response?.data?.length === 0;
       const allTriageGroupsBlocked =
         !noAssociations &&
         associatedTriageGroups === associatedBlockedTriageGroups;

--- a/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
@@ -259,6 +259,115 @@ describe('Folder Header component', () => {
         ),
       ).to.exist;
     });
+
+    it('renders RecipientListErrorAlert when recipientsError is true', () => {
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            allowedRecipients: [],
+            blockedRecipients: [],
+            noAssociations: false,
+            allTriageGroupsBlocked: false,
+            error: true,
+          },
+        },
+      };
+
+      const screen = setup(customState, Paths.INBOX, initialThreadCount, inbox);
+      const alert = screen.container.querySelector(
+        'va-alert[status="warning"]',
+      );
+      expect(alert).to.exist;
+
+      // Check content within the alert component
+      const headline = alert.querySelector('h2[slot="headline"]');
+      expect(headline).to.exist;
+      expect(headline.textContent).to.contain('load your care team list');
+
+      const paragraph = alert.querySelector('p');
+      expect(paragraph).to.exist;
+      expect(paragraph.textContent).to.contain(
+        'Something went wrong on our end',
+      );
+    });
+
+    it('does not render ComposeMessageButton when recipientsError is true', () => {
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            allowedRecipients: [],
+            blockedRecipients: [],
+            noAssociations: false,
+            allTriageGroupsBlocked: false,
+            error: true,
+          },
+        },
+      };
+
+      const screen = setup(customState, Paths.INBOX, initialThreadCount, inbox);
+      expect(screen.queryByTestId('compose-message-link')).to.not.exist;
+    });
+
+    it('does not render ComposeMessageButton when noAssociations is true', () => {
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            allowedRecipients: noAssociationsAtAll.mockAllowedRecipients,
+            blockedRecipients: noAssociationsAtAll.mockBlockedRecipients,
+            noAssociations: true,
+            allTriageGroupsBlocked: false,
+            error: false,
+          },
+        },
+      };
+
+      const screen = setup(customState, Paths.INBOX, initialThreadCount, inbox);
+      expect(screen.queryByTestId('compose-message-link')).to.not.exist;
+    });
+
+    it('does not render ComposeMessageButton when allTriageGroupsBlocked is true', () => {
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            allowedRecipients: allAssociationsBlocked.mockAllowedRecipients,
+            blockedRecipients: allAssociationsBlocked.mockBlockedRecipients,
+            noAssociations: false,
+            allTriageGroupsBlocked: true,
+            error: false,
+          },
+        },
+      };
+
+      const screen = setup(customState, Paths.INBOX, initialThreadCount, inbox);
+      expect(screen.queryByTestId('compose-message-link')).to.not.exist;
+    });
+
+    it('renders ComposeMessageButton when no recipient errors exist', () => {
+      const customState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            allowedRecipients: [],
+            blockedRecipients: [],
+            noAssociations: false,
+            allTriageGroupsBlocked: false,
+            error: false,
+          },
+        },
+      };
+
+      const screen = setup(customState, Paths.INBOX, initialThreadCount, inbox);
+      expect(screen.queryByTestId('compose-message-link')).to.exist;
+    });
   });
 
   describe('Folder Header component displays DRAFTS folder and children components', () => {

--- a/src/applications/mhv-secure-messaging/tests/containers/InterstitialPage.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/InterstitialPage.unit.spec.jsx
@@ -488,4 +488,50 @@ describe('Interstitial page', () => {
 
     redirectPathSpy.restore();
   });
+
+  it('redirects to inbox when recipientsError is true', async () => {
+    const stateWithRecipientsError = {
+      ...initialState(true),
+      sm: {
+        recipients: {
+          allRecipients: [],
+          recentRecipients: undefined,
+          error: true,
+        },
+      },
+    };
+
+    const { history } = renderWithStoreAndRouter(<InterstitialPage />, {
+      initialState: stateWithRecipientsError,
+      reducers: reducer,
+      path: '/new-message/',
+    });
+
+    await waitFor(() => {
+      expect(history.location.pathname).to.equal(Paths.INBOX);
+    });
+  });
+
+  it('does not redirect to inbox when recipientsError is false', async () => {
+    const stateWithoutRecipientsError = {
+      ...initialState(true),
+      sm: {
+        recipients: {
+          allRecipients: [{ id: 1, name: 'Team 1' }],
+          recentRecipients: undefined,
+          error: false,
+        },
+      },
+    };
+
+    const { history } = renderWithStoreAndRouter(<InterstitialPage />, {
+      initialState: stateWithoutRecipientsError,
+      reducers: reducer,
+      path: '/new-message/',
+    });
+
+    // Wait a bit to ensure no redirect happens
+    await new Promise(resolve => setTimeout(resolve, 100));
+    expect(history.location.pathname).to.equal('/new-message/');
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
@@ -886,4 +886,87 @@ describe('SelectCareTeam', () => {
       ).to.be.true;
     });
   });
+
+  describe('Error Handling', () => {
+    it('should redirect to inbox when recipientsError is true', async () => {
+      const stateWithRecipientsError = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            error: true,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: stateWithRecipientsError,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      await waitFor(() => {
+        expect(screen.history.location.pathname).to.equal(Paths.INBOX);
+      });
+    });
+
+    it('should not redirect to inbox when recipientsError is false', async () => {
+      const stateWithoutRecipientsError = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            error: false,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: stateWithoutRecipientsError,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Wait a bit to ensure no redirect happens
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(screen.history.location.pathname).to.equal(Paths.SELECT_CARE_TEAM);
+    });
+
+    it('should not redirect to inbox when recipientsError is undefined', async () => {
+      const stateWithoutRecipientsError = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            error: undefined,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: stateWithoutRecipientsError,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Wait a bit to ensure no redirect happens
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(screen.history.location.pathname).to.equal(Paths.SELECT_CARE_TEAM);
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientInboxPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientInboxPage.js
@@ -8,7 +8,7 @@ import mockSpecialCharsMessage from '../fixtures/message-response-specialchars.j
 import mockMessageDetails from '../fixtures/message-response.json';
 import mockThread from '../fixtures/thread-response.json';
 import PatientInterstitialPage from './PatientInterstitialPage';
-import { AXE_CONTEXT, Locators, Paths } from '../utils/constants';
+import { Alerts, AXE_CONTEXT, Locators, Paths } from '../utils/constants';
 import mockSingleMessage from '../fixtures/inboxResponse/single-message-response.json';
 import mockSentThreads from '../fixtures/sentResponse/sent-messages-response.json';
 
@@ -610,6 +610,18 @@ class PatientInboxPage {
         },
       ],
     };
+  };
+
+  validateNoRecipientsAlert = () => {
+    cy.get(Locators.ALERTS.BLOCKED_GROUP)
+      .find('h2')
+      .should('have.text', Alerts.NO_ASSOCIATION.AT_ALL_HEADER);
+  };
+
+  validateRecipientsErrorAlert = () => {
+    cy.findByTestId(Locators.ALERTS.RECIPIENTS_ERROR)
+      .find('h2')
+      .should('have.text', Alerts.ERROR_LOADING_RECIPIENTS_HEADER);
   };
 }
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-no-care-teams-redirect.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-no-care-teams-redirect.cypress.spec.js
@@ -1,0 +1,102 @@
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import PatientInboxPage from './pages/PatientInboxPage';
+import { AXE_CONTEXT, Paths } from './utils/constants';
+import mockNoRecipients from './fixtures/recipientsResponse/no-recipients-response.json';
+import GeneralFunctionsPage from './pages/GeneralFunctionsPage';
+
+describe('Secure Messaging - No Care Teams Redirection', () => {
+  beforeEach(() => {
+    const updatedFeatureToggles = GeneralFunctionsPage.updateFeatureToggles([
+      {
+        name: 'mhv_secure_messaging_curated_list_flow',
+        value: true,
+      },
+      {
+        name: 'mhv_secure_messaging_recent_recipients',
+        value: true,
+      },
+    ]);
+    SecureMessagingSite.login(updatedFeatureToggles);
+  });
+
+  describe(' when there are no care teams', () => {
+    it('redirects to inbox when accessing Interstitial Page with no care teams', () => {
+      PatientInboxPage.loadInboxMessages(
+        undefined,
+        undefined,
+        mockNoRecipients,
+      );
+
+      cy.visit('/my-health/secure-messages/new-message');
+
+      cy.location('pathname').should('include', Paths.INBOX);
+      PatientInboxPage.validateNoRecipientsAlert();
+
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+    });
+    it('redirects to inbox when accessing Recent Care Teams with no care teams', () => {
+      PatientInboxPage.loadInboxMessages(
+        undefined,
+        undefined,
+        mockNoRecipients,
+      );
+
+      cy.visit('/my-health/secure-messages/new-message/recent');
+      cy.location('pathname').should('include', Paths.INBOX);
+      PatientInboxPage.validateNoRecipientsAlert();
+
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+    });
+    it('redirects to inbox when accessing Select Care Teams with no care teams', () => {
+      PatientInboxPage.loadInboxMessages(
+        undefined,
+        undefined,
+        mockNoRecipients,
+      );
+
+      cy.visit('/my-health/secure-messages/new-message/select-care-team');
+      cy.location('pathname').should('include', Paths.INBOX);
+      PatientInboxPage.validateNoRecipientsAlert();
+
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+    });
+  });
+
+  describe('when recipients request returns error', () => {
+    beforeEach(() => {
+      const mockRecipientsError = {
+        statusCode: 500,
+        body: {
+          errors: [{ code: 'SM999', detail: 'Error fetching recipients' }],
+        },
+      };
+
+      PatientInboxPage.loadInboxMessages(
+        undefined,
+        undefined,
+        mockRecipientsError,
+      );
+    });
+    it('redirects from Interstitial to inbox when there is an error fetching recipients', () => {
+      cy.visit('/my-health/secure-messages/new-message');
+
+      cy.location('pathname').should('include', Paths.INBOX);
+      PatientInboxPage.validateRecipientsErrorAlert();
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+    });
+    it('redirects from Recent Teams to inbox when there is an error fetching recipients', () => {
+      cy.visit('/my-health/secure-messages/new-message/recent');
+
+      cy.location('pathname').should('include', Paths.INBOX);
+      PatientInboxPage.validateRecipientsErrorAlert();
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+    });
+    it('redirects from Select Care Teams to inbox when there is an error fetching recipients', () => {
+      cy.visit('/my-health/secure-messages/new-message/select-care-team');
+
+      cy.location('pathname').should('include', Paths.INBOX);
+      PatientInboxPage.validateRecipientsErrorAlert();
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+    });
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-all-groups-alerts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-all-groups-alerts.cypress.spec.js
@@ -1,6 +1,7 @@
 import PatientInboxPage from '../pages/PatientInboxPage';
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import mockNoRecipients from '../fixtures/recipientsResponse/no-recipients-response.json';
+import allRecipientsBlocked from '../fixtures/recipientsResponse/all-TG-blocked-recipients-response.json';
 import { AXE_CONTEXT, Locators, Paths, Alerts } from '../utils/constants';
 
 describe('SM TRIAGE GROUPS ALERTS', () => {
@@ -33,12 +34,7 @@ describe('SM TRIAGE GROUPS ALERTS', () => {
 
   it('user blocked from all groups', () => {
     const allBlockedResponse = {
-      ...mockNoRecipients,
-      meta: {
-        ...mockNoRecipients.meta,
-        associatedTriageGroups: 7,
-        associatedBlockedTriageGroups: 7,
-      },
+      ...allRecipientsBlocked,
     };
 
     SecureMessagingSite.login();

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -219,6 +219,7 @@ export const Locators = {
     BACK_TOP: 'va-back-to-top',
     CERNER_ALERT: '[data-testid="cerner-facilities-alert"]',
     BLOCKED_GROUP: '[data-testid="blocked-triage-group-alert"]',
+    RECIPIENTS_ERROR: 'recipients-error-alert',
     RECIP_SELECT: '[data-testid="compose-recipient-select"]',
     MESS_CATAGO: '[data-testid="compose-message-categories"]',
     LIST_HEADER: '.sidebar-navigation-messages-list-header > a',
@@ -368,6 +369,8 @@ export const Alerts = {
   SAVE_DRAFT: `Do you want to save your draft message?`,
   SAVE_CHANGES: `Do you want to save your changes to this draft?`,
   SEARCH_TERM_REQUIRED: 'Please enter a search term.',
+  ERROR_LOADING_RECIPIENTS_HEADER:
+    'We can’t load your care team list right now',
 };
 
 export const Data = {

--- a/src/applications/mhv-secure-messaging/tests/reducers/allRecipients.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/reducers/allRecipients.unit.spec.jsx
@@ -138,4 +138,104 @@ describe('allRecipients reducers', () => {
     await store.dispatch(getAllTriageTeamRecipients());
     expect(store.getState().vistaFacilities).to.deep.equal(['123', '456']);
   });
+
+  it('should set noAssociations to true when data array is empty', async () => {
+    const store = mockStore();
+    const emptyMockResponse = {
+      data: [],
+      meta: {
+        associatedTriageGroups: 0,
+        associatedBlockedTriageGroups: 0,
+      },
+    };
+    mockApiRequest(emptyMockResponse);
+    await store.dispatch(getAllTriageTeamRecipients());
+    expect(store.getState().noAssociations).to.equal(true);
+    expect(store.getState().allRecipients).to.deep.equal([]);
+  });
+
+  it('should set noAssociations to true when associatedTriageGroups is 0 even with data', async () => {
+    const store = mockStore();
+    const customMockResponse = {
+      data: [
+        {
+          id: '1',
+          type: 'al_triage_teams',
+          attributes: {
+            triageTeamId: 1,
+            name: 'Team 1',
+            stationNumber: '123',
+            blockedStatus: false,
+            relationshipType: 'PATIENT',
+            preferredTeam: true,
+            ohTriageGroup: false,
+          },
+        },
+      ],
+      meta: {
+        associatedTriageGroups: 0,
+        associatedBlockedTriageGroups: 0,
+      },
+    };
+    mockApiRequest(customMockResponse);
+    await store.dispatch(getAllTriageTeamRecipients());
+    expect(store.getState().noAssociations).to.equal(true);
+  });
+
+  it('should set noAssociations to false when data exists and associatedTriageGroups > 0', async () => {
+    const store = mockStore();
+    const customMockResponse = {
+      data: [
+        {
+          id: '1',
+          type: 'al_triage_teams',
+          attributes: {
+            triageTeamId: 1,
+            name: 'Team 1',
+            stationNumber: '123',
+            blockedStatus: false,
+            relationshipType: 'PATIENT',
+            preferredTeam: true,
+            ohTriageGroup: false,
+          },
+        },
+      ],
+      meta: {
+        associatedTriageGroups: 1,
+        associatedBlockedTriageGroups: 0,
+      },
+    };
+    mockApiRequest(customMockResponse);
+    await store.dispatch(getAllTriageTeamRecipients());
+    expect(store.getState().noAssociations).to.equal(false);
+    expect(store.getState().allRecipients).to.have.lengthOf(1);
+  });
+
+  it('should set noAssociations to true when associatedTriageGroups is 0', async () => {
+    const store = mockStore();
+    const mockResponse = {
+      data: [],
+      meta: {
+        associatedTriageGroups: 0,
+        associatedBlockedTriageGroups: 0,
+      },
+    };
+    mockApiRequest(mockResponse);
+    await store.dispatch(getAllTriageTeamRecipients());
+    expect(store.getState().noAssociations).to.be.true;
+  });
+
+  it('should set noAssociations to true when data length is 0', async () => {
+    const store = mockStore();
+    const mockResponse = {
+      data: [],
+      meta: {
+        associatedTriageGroups: 5,
+        associatedBlockedTriageGroups: 0,
+      },
+    };
+    mockApiRequest(mockResponse);
+    await store.dispatch(getAllTriageTeamRecipients());
+    expect(store.getState().noAssociations).to.be.true;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request improves error handling and user feedback in the secure messaging application's care team selection and message composition flows. It introduces a new `recipientsError` state to track errors when loading care team data, ensures users are redirected to the inbox if an error occurs, and updates UI components and tests to reflect these changes.

**Error Handling and User Feedback:**

* Added a new `recipientsError` property to the Redux recipients state, and updated selectors in `FolderHeader.jsx`, `InterstitialPage.jsx`, `RecentCareTeams.jsx`, and `SelectCareTeam.jsx` to use it. When an error is detected, users are redirected to the inbox page. [[1]](diffhunk://#diff-bfbec0b20ba7849d542445f22d37e9281719c352464c34f8d18df2b2c7112cebL38-R42) [[2]](diffhunk://#diff-b71db58c298381abe605175f89847292bfe72f68c769d39acb7935ae9c114891L26-R38) [[3]](diffhunk://#diff-667f8705f38954723c2004c1eee4f1d388ebad8b5542e8c1b79c733c1192176dL31-R50) [[4]](diffhunk://#diff-bac517ad4c5a26d12c6577e01c90d03970f17ef75372404abb9b039caa6ddbd2R39) [[5]](diffhunk://#diff-bac517ad4c5a26d12c6577e01c90d03970f17ef75372404abb9b039caa6ddbd2R62-R70)
* Displayed a warning alert (`RecipientListErrorAlert`) in `FolderHeader.jsx` when care team data fails to load, providing clear feedback to the user. [[1]](diffhunk://#diff-bfbec0b20ba7849d542445f22d37e9281719c352464c34f8d18df2b2c7112cebR102-R113) [[2]](diffhunk://#diff-bfbec0b20ba7849d542445f22d37e9281719c352464c34f8d18df2b2c7112cebR156-R158)

**Business Logic Updates:**

* Updated the recipients reducer logic to set `noAssociations` to true if the care team data array is empty, ensuring more accurate representation of user associations.

**UI Behavior Changes:**

* Modified the logic in `FolderHeader.jsx` to prevent showing the compose message button when there is a recipients error, no associations, or all triage groups are blocked.

**Test Coverage Enhancements:**

* Added and updated unit tests for all affected components (`FolderHeader`, `InterstitialPage`, `RecentCareTeams`, and `SelectCareTeam`) to verify error handling, UI changes, and redirect behavior. [[1]](diffhunk://#diff-cd28a6537e4ca12e42c95e3e4c089433942336a7cd137e49510e6ddee855842aR262-R370) [[2]](diffhunk://#diff-8d5269f38710bb54327017696b2081dbd677faea3545edfb4871b619b81a231bR491-R536) [[3]](diffhunk://#diff-d9ffae9a0895b66c46e05bf9fd405f8902c07dc3010522dca577bbf4ec7b043dR721-R808) [[4]](diffhunk://#diff-331142c9738f9057415638552d907d357263b94008b07cd08454904df9001083R889-R971)
* Expanded reducer tests to cover new logic for setting `noAssociations` based on empty data arrays or zero associations.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125844

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
