### PR TITLE
534 ez Chapter 4 - Update Previous Marriages (Spouse & Veteran) flow

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -46,6 +46,7 @@ const COUNTRY_NAMES = constants.countries
   .map(country => country.label);
 
 /** @type {ArrayBuilderOptions} */
+// arrayPath is spouseMarriages because it's the spouse's previous marriages
 const options = {
   arrayPath: 'spouseMarriages',
   nounSingular: 'previous marriage',
@@ -187,13 +188,13 @@ const marriageDateAndLocationPage = {
       state: {
         ...selectUI('State'),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
           return !(item?.marriedOutsideUS || currentPageData?.marriedOutsideUS);
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.spouseMarriages?.[index];
             const currentPageData = formData;
             return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
           },
@@ -209,13 +210,13 @@ const marriageDateAndLocationPage = {
       country: {
         ...selectUI('Country'),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
           return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.spouseMarriages?.[index];
             const currentPageData = formData;
             return !(
               item?.marriedOutsideUS || currentPageData?.marriedOutsideUS
@@ -279,7 +280,7 @@ const marriageEndDateAndLocationPage = {
       state: {
         ...selectUI('State'),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
           return !(
             item?.marriageEndedOutsideUS ||
@@ -288,7 +289,7 @@ const marriageEndDateAndLocationPage = {
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.spouseMarriages?.[index];
             const currentPageData = formData;
             return (
               item?.marriageEndedOutsideUS ||
@@ -307,7 +308,7 @@ const marriageEndDateAndLocationPage = {
       country: {
         ...selectUI('Country'),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
           return (
             item?.marriageEndedOutsideUS ||
@@ -316,7 +317,7 @@ const marriageEndDateAndLocationPage = {
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.spouseMarriages?.[index];
             const currentPageData = formData;
             return !(
               item?.marriageEndedOutsideUS ||
@@ -375,7 +376,7 @@ const marriageEndPage = {
       ...textUI({
         title: 'Tell us how the marriage ended',
         required: (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
           return (
             item?.marriageEndReason === 'OTHER' ||
@@ -384,7 +385,7 @@ const marriageEndPage = {
         },
       }),
       'ui:required': (formData, index) => {
-        const item = formData?.previousMarriages?.[index];
+        const item = formData?.spouseMarriages?.[index];
         const currentPageData = formData;
         return (
           item?.marriageEndReason === 'OTHER' ||

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -20,21 +20,10 @@ import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-b
 import { previousMarriageEndOptions } from '../../../utils/labels';
 import { handleAlertMaxItems } from '../../../components/FormAlerts';
 
-// Helper function to determine if previous marriages section should be shown
-const shouldShowPreviousMarriages = formData => {
-  // Skip if YES recognized as spouse AND NO only ever married to each other
-  if (
-    formData.recognizedAsSpouse === true &&
-    formData.hadPreviousMarriages === false
-  ) {
-    return false;
-  }
-  // Show if NO not recognized as spouse OR YES have been married before
-  return (
-    formData.recognizedAsSpouse === false ||
-    formData.hadPreviousMarriages === true
-  );
-};
+// Show previous marriages pages ONLY if user answered YES to hadPreviousMarriages
+// Ansering NO skips all previous marriage flows and jumps to Dependents
+const shouldShowPreviousMarriages = formData =>
+  formData.hadPreviousMarriages === true;
 
 // Get military states to filter them out
 const MILITARY_STATE_VALUES = constants.militaryStates.map(
@@ -58,7 +47,7 @@ const COUNTRY_NAMES = constants.countries
 
 /** @type {ArrayBuilderOptions} */
 const options = {
-  arrayPath: 'previousMarriages',
+  arrayPath: 'spouseMarriages',
   nounSingular: 'previous marriage',
   nounPlural: 'previous marriages',
   required: false,

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/spouseMarriages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/spouseMarriages.js
@@ -7,7 +7,7 @@ import {
 /** @type {PageSchema} */
 export default {
   title: 'Previous marriages',
-  path: 'household/previous-marriage-question',
+  path: 'household/spouse-marriage-question',
   depends: formData => formData.claimantRelationship === 'SPOUSE',
   uiSchema: {
     ...titleUI('Previous marriages'),

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranChildren.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranChildren.js
@@ -30,6 +30,10 @@ const schema = {
 const veteranChildren = {
   path: 'household/children-of-veteran',
   title: 'Children of Veteran',
+  // Skip this page when spouse answers NO to hadPreviousMarriages so flow jumps to dependents
+  depends: formData =>
+    formData.claimantRelationship !== 'SPOUSE' ||
+    formData.hadPreviousMarriages === true,
   uiSchema,
   schema,
 };

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -330,6 +330,9 @@ export const veteranMarriagesPages = arrayBuilderPages(
     veteranMarriagesIntro: pageBuilder.introPage({
       title: 'Veteran’s previous marriages',
       path: 'household/veteran-previous-marriages',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        formData.hadPreviousMarriages === true,
       uiSchema: introPage.uiSchema,
       schema: introPage.schema,
     }),
@@ -337,24 +340,36 @@ export const veteranMarriagesPages = arrayBuilderPages(
       title:
         'Was the Veteran married to someone else before being married to you?',
       path: 'household/veteran-previous-marriages/add',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        formData.hadPreviousMarriages === true,
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
     veteranPreviousSpouseName: pageBuilder.itemPage({
       title: "Veteran's previous spouse's name",
       path: 'household/veteran-previous-marriages/:index/spouse-name',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        formData.hadPreviousMarriages === true,
       uiSchema: namePage.uiSchema,
       schema: namePage.schema,
     }),
     veteranMarriageDatePlace: pageBuilder.itemPage({
       title: 'When and where did they get married?',
       path: 'household/veteran-previous-marriages/:index/marriage-date-place',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        formData.hadPreviousMarriages === true,
       uiSchema: marriageDatePlacePage.uiSchema,
       schema: marriageDatePlacePage.schema,
     }),
     veteranMarriageEnded: pageBuilder.itemPage({
       title: 'How did the marriage end?',
       path: 'household/veteran-previous-marriages/:index/marriage-ended',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        formData.hadPreviousMarriages === true,
       uiSchema: endedPage.uiSchema,
       schema: endedPage.schema,
     }),
@@ -362,6 +377,9 @@ export const veteranMarriagesPages = arrayBuilderPages(
       title: 'When and where did their marriage end?',
       path:
         'household/veteran-previous-marriages/:index/marriage-end-date-location',
+      depends: formData =>
+        formData.claimantRelationship === 'SPOUSE' &&
+        formData.hadPreviousMarriages === true,
       uiSchema: marriageEndDateLocationPage.uiSchema,
       schema: marriageEndDateLocationPage.schema,
     }),

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -43,9 +43,9 @@ function introDescription() {
 }
 /** @type {ArrayBuilderOptions} */
 const options = {
-  arrayPath: 'previousMarriages',
-  nounSingular: 'previous marriage',
-  nounPlural: 'previous marriages',
+  arrayPath: 'veteranMarriages',
+  nounSingular: 'veteran marriage',
+  nounPlural: 'veteran marriages',
   required: false,
   maxItems: 2,
   isItemIncomplete: item =>
@@ -139,13 +139,13 @@ const marriageDatePlacePage = {
       state: {
         ...selectUI('State', STATE_VALUES, STATE_NAMES),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.veteranMarriages?.[index];
           const currentPageData = formData;
           return !(item?.marriedOutsideUS || currentPageData?.marriedOutsideUS);
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.veteranMarriages?.[index];
             const currentPageData = formData;
             return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
           },
@@ -154,13 +154,13 @@ const marriageDatePlacePage = {
       country: {
         ...selectUI('Country', COUNTRY_VALUES, COUNTRY_NAMES),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.veteranMarriages?.[index];
           const currentPageData = formData;
           return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.veteranMarriages?.[index];
             const currentPageData = formData;
             return !(
               item?.marriedOutsideUS || currentPageData?.marriedOutsideUS
@@ -249,7 +249,7 @@ const marriageEndDateLocationPage = {
       state: {
         ...selectUI('State', STATE_VALUES, STATE_NAMES),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.veteranMarriages?.[index];
           const currentPageData = formData;
           return !(
             item?.marriageEndedOutsideUS ||
@@ -258,7 +258,7 @@ const marriageEndDateLocationPage = {
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.veteranMarriages?.[index];
             const currentPageData = formData;
             return (
               item?.marriageEndedOutsideUS ||
@@ -270,7 +270,7 @@ const marriageEndDateLocationPage = {
       country: {
         ...selectUI('Country', COUNTRY_VALUES, COUNTRY_NAMES),
         'ui:required': (formData, index) => {
-          const item = formData?.previousMarriages?.[index];
+          const item = formData?.veteranMarriages?.[index];
           const currentPageData = formData;
           return (
             item?.marriageEndedOutsideUS ||
@@ -279,7 +279,7 @@ const marriageEndDateLocationPage = {
         },
         'ui:options': {
           hideIf: (formData, index) => {
-            const item = formData?.previousMarriages?.[index];
+            const item = formData?.veteranMarriages?.[index];
             const currentPageData = formData;
             return !(
               item?.marriageEndedOutsideUS ||

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -33,7 +33,7 @@ import separationDetails from './chapters/04-household-information/separationDet
 import remarriage from './chapters/04-household-information/remarriage';
 import remarriageDetails from './chapters/04-household-information/remarriageDetails';
 import additionalMarriages from './chapters/04-household-information/additionalMarriages';
-import previousMarriages from './chapters/04-household-information/previousMarriages';
+import spouseMarriages from './chapters/04-household-information/spouseMarriages';
 import { previousMarriagesPages } from './chapters/04-household-information/previousMarriagesPages';
 import { veteranMarriagesPages } from './chapters/04-household-information/veteranMarriagesPages';
 import veteranChildren from './chapters/04-household-information/veteranChildren';
@@ -292,12 +292,12 @@ const formConfig = {
           uiSchema: additionalMarriages.uiSchema,
           schema: additionalMarriages.schema,
         },
-        previousMarriages: {
-          path: 'household/previous-marriage-question',
+        spouseMarriages: {
+          path: 'household/spouse-marriage-question',
           title: 'Previous marriages',
           depends: formData => formData.claimantRelationship === 'SPOUSE',
-          uiSchema: previousMarriages.uiSchema,
-          schema: previousMarriages.schema,
+          uiSchema: spouseMarriages.uiSchema,
+          schema: spouseMarriages.schema,
         },
         ...previousMarriagesPages,
         ...veteranMarriagesPages,

--- a/src/applications/survivors-benefits/tests/unit/fixtures/options-mocks/spouse-options.js
+++ b/src/applications/survivors-benefits/tests/unit/fixtures/options-mocks/spouse-options.js
@@ -1,0 +1,49 @@
+import { handleAlertMaxItems } from '../../../../components/FormAlerts';
+
+export const options = {
+  arrayPath: 'spouseMarriages',
+  nounSingular: 'previous marriage',
+  nounPlural: 'previous marriages',
+  required: false,
+  minItems: 0,
+  isItemIncomplete: item =>
+    !item?.previousSpouseName?.first ||
+    !item?.previousSpouseName?.last ||
+    !item?.marriageToVeteranDate ||
+    !item?.marriageLocation?.city ||
+    (!item?.marriedOutsideUS && !item?.marriageLocation?.state) ||
+    (item?.marriedOutsideUS && !item?.marriageLocation?.country) ||
+    !item?.marriageEndReason ||
+    (item?.marriageEndReason === 'OTHER' && !item?.marriageEndOtherExplanation),
+  maxItems: 2,
+  text: {
+    cancelAddTitle: 'Cancel adding this previous marriage?',
+    cancelEditTitle: 'Cancel editing this previous marriage?',
+    cancelAddDescription:
+      'If you cancel, we won’t add this previous marriage to your list of marriages. You’ll return to a page where you can add another previous marriage.',
+    cancelEditDescription:
+      'If you cancel, you’ll lose any changes you made to this previous marriage and you will be returned to the previous marriage review page.',
+    cancelAddYes: 'Yes, cancel adding',
+    cancelAddNo: 'No, continue adding',
+    cancelEditYes: 'Yes, cancel editing',
+    cancelEditNo: 'No, continue editing',
+    deleteDescription:
+      'This will delete the information from your list of previous marriages. You’ll return to a page where you can add a new previous marriage.',
+    deleteNo: 'No, keep',
+    deleteTitle: 'Delete this previous marriage?',
+    deleteYes: 'Yes, delete',
+    alertMaxItems: handleAlertMaxItems,
+    getItemName: item => {
+      const name = item?.previousSpouseName;
+      if (!name?.first && !name?.last) return '';
+
+      const parts = [];
+      if (name?.first) parts.push(name.first);
+      if (name?.middle) parts.push(name.middle);
+      if (name?.last) parts.push(name.last);
+      if (name?.suffix) parts.push(name.suffix);
+
+      return parts.join(' ');
+    },
+  },
+};

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/previousMarriagesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/previousMarriagesPages.unit.spec.jsx
@@ -1,0 +1,447 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { previousMarriagesPages } from '../../../../config/chapters/04-household-information/previousMarriagesPages';
+import { options } from '../../fixtures/options-mocks/spouse-options';
+
+describe('Previous marriages pages', () => {
+  const {
+    previousMarriagesIntro,
+    previousMarriagesSummary,
+    previousMarriageItemPage,
+    previousMarriageDateAndLocationPage,
+    previousMarriageEndPage,
+    previousMarriageEndDateAndLocationPage,
+  } = previousMarriagesPages;
+
+  const findItemUi = page => {
+    if (!page || !page.uiSchema) return null;
+    const wrapper = Object.values(page.uiSchema).find(
+      val => val && typeof val === 'object' && val.items,
+    );
+    return wrapper ? wrapper.items : null;
+  };
+
+  it('renders intro and summary only when spouse answered Yes to previous marriages', () => {
+    // when recognizedAsSpouse true and hadPreviousMarriages true => should show
+    const formData1 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: true,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriagesIntro.depends(formData1)).to.equal(true);
+    expect(previousMarriagesSummary.depends(formData1)).to.equal(true);
+
+    // when not recognized as spouse and hadPreviousMarriages false => shouldn't show
+    const formData2 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: false, // Answered NO
+    };
+    expect(previousMarriagesIntro.depends(formData2)).to.equal(false);
+    expect(previousMarriagesSummary.depends(formData2)).to.equal(false);
+
+    // when claimantRelationship not SPOUSE => shouldn't show
+    const formData3 = {
+      claimantRelationship: 'CHILD',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriagesIntro.depends(formData3)).to.equal(false);
+    expect(previousMarriagesSummary.depends(formData3)).to.equal(false);
+
+    // when spouse has been married before => should show
+    const formData4 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: true,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriagesIntro.depends(formData4)).to.equal(true);
+    expect(previousMarriagesSummary.depends(formData4)).to.equal(true);
+  });
+
+  it('shows Previous Spouse Name page only when spouse answered Yes to previous marriages', () => {
+    // when recognizedAsSpouse true and hadPreviousMarriages false => shouldn't show
+    const formData1 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: true,
+      hadPreviousMarriages: false, // Answered NO
+    };
+    expect(previousMarriageItemPage.depends(formData1)).to.be.false;
+    // console.log('dependentsIntro', dependentsIntro);
+
+    // when not recognized as spouse => shouldn't show
+    const formData2 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageItemPage.depends(formData2)).to.be.false;
+
+    // when claimantRelationship not SPOUSE => shouldn't show
+    const formData3 = {
+      claimantRelationship: 'CHILD',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriageItemPage.depends(formData3)).to.be.false;
+  });
+
+  it('shows Marriage Date and Location page only when spouse answered Yes to previous marriages', () => {
+    // when recognizedAsSpouse true and hadPreviousMarriages false => shouldn't show
+    const formData1 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: true,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageDateAndLocationPage.depends(formData1)).to.be.false;
+
+    // when not recognized as spouse => shouldn't show
+    const formData2 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageDateAndLocationPage.depends(formData2)).to.be.false;
+
+    // when claimantRelationship not SPOUSE => shouldn't show
+    const formData3 = {
+      claimantRelationship: 'CHILD',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriageDateAndLocationPage.depends(formData3)).to.be.false;
+  });
+
+  it('shows Marriage End Reason page only when spouse answered Yes to previous marriages', () => {
+    // when recognizedAsSpouse true and hadPreviousMarriages false => shouldn't show
+    const formData1 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: true,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageEndPage.depends(formData1)).to.be.false;
+
+    // when not recognized as spouse => shouldn't show
+    const formData2 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageEndPage.depends(formData2)).to.be.false;
+
+    // when claimantRelationship not SPOUSE => shouldn't show
+    const formData3 = {
+      claimantRelationship: 'CHILD',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriageEndPage.depends(formData3)).to.be.false;
+  });
+
+  it('shows Marriage End Date and Location page only when spouse answered Yes to previous marriages', () => {
+    // when recognizedAsSpouse true and hadPreviousMarriages false => shouldn't show
+    const formData1 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: true,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageEndDateAndLocationPage.depends(formData1)).to.be
+      .false;
+
+    // when not recognized as spouse => shouldn't show
+    const formData2 = {
+      claimantRelationship: 'SPOUSE',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: false,
+    };
+    expect(previousMarriageEndDateAndLocationPage.depends(formData2)).to.be
+      .false;
+
+    // when claimantRelationship not SPOUSE => shouldn't show
+    const formData3 = {
+      claimantRelationship: 'CHILD',
+      recognizedAsSpouse: false,
+      hadPreviousMarriages: true,
+    };
+    expect(previousMarriageEndDateAndLocationPage.depends(formData3)).to.be
+      .false;
+  });
+
+  it('toggles state/country visibility and requiredness based on marriedOutsideUS', () => {
+    const itemUi = findItemUi(previousMarriageDateAndLocationPage);
+    expect(itemUi, 'marriage date/location item UI not found').to.exist;
+    const stateOptions = itemUi.marriageLocation.state['ui:options'];
+    const stateRequired = itemUi.marriageLocation.state['ui:required'];
+    const countryOptions = itemUi.marriageLocation.country['ui:options'];
+    const countryRequired = itemUi.marriageLocation.country['ui:required'];
+
+    const itemBornOutside = { spouseMarriages: [{ marriedOutsideUS: true }] };
+    expect(stateOptions.hideIf(itemBornOutside, 0)).to.be.true;
+    expect(Boolean(stateRequired(itemBornOutside, 0))).to.be.false;
+    expect(countryOptions.hideIf(itemBornOutside, 0)).to.be.false;
+    expect(Boolean(countryRequired(itemBornOutside, 0))).to.be.true;
+
+    const topBornOutside = { marriedOutsideUS: true };
+    expect(stateOptions.hideIf(topBornOutside, 0)).to.be.true;
+    expect(Boolean(stateRequired(topBornOutside, 0))).to.be.false;
+    expect(countryOptions.hideIf(topBornOutside, 0)).to.be.false;
+    expect(Boolean(countryRequired(topBornOutside, 0))).to.be.true;
+  });
+
+  it("requires 'Tell us how the marriage ended' when reason is OTHER", () => {
+    const endItemUi = findItemUi(previousMarriageEndPage);
+    expect(endItemUi, 'marriage end item UI not found').to.exist;
+    const otherRequired = endItemUi.marriageEndOtherExplanation['ui:required'];
+    expect(otherRequired).to.be.a('function');
+
+    const itemOther = { spouseMarriages: [{ marriageEndReason: 'OTHER' }] };
+    expect(Boolean(otherRequired(itemOther, 0))).to.be.true;
+
+    const itemNotOther = {
+      spouseßMarriages: [{ marriageEndReason: 'DIVORCE' }],
+    };
+    expect(Boolean(otherRequired(itemNotOther, 0))).to.be.false;
+  });
+
+  it("expands 'Tell us how the marriage ended' input when reason is OTHER", () => {
+    const { previousMarriageEndPage: marriageEndPage } = previousMarriagesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath="spouseMarriages"
+        schema={marriageEndPage.schema}
+        uiSchema={marriageEndPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ spouseMarriages: [formData] }}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    const vaRadio = $('va-radio[label*="How did the marriage end?"]', formDOM);
+    expect(vaRadio).to.exist;
+
+    // select OTHER option
+    vaRadio.__events.vaValueChange({ detail: { value: 'OTHER' } });
+
+    expect($('va-text-input[label="Tell us how the marriage ended"]', formDOM))
+      .to.exist;
+  });
+
+  it('marriage end location state and city display when marriageEndedOutsideUS is false or missing', () => {
+    // no marriageEndedOutsideUS present -> state and city should show
+    const formData1 = {};
+    const form1 = render(
+      <DefinitionTester
+        arrayPath="spouseMarriages"
+        schema={previousMarriageEndDateAndLocationPage.schema}
+        uiSchema={previousMarriageEndDateAndLocationPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ spouseMarriages: [formData1] }}
+      />,
+    );
+    const formDOM1 = getFormDOM(form1);
+    expect($('va-text-input[label="City"]', formDOM1)).to.exist;
+    expect($('va-select[label="State"]', formDOM1)).to.exist;
+
+    // marriageEndedOutsideUS explicitly false -> state and city should show
+    const formData2 = { marriageEndedOutsideUS: false };
+    const form2 = render(
+      <DefinitionTester
+        arrayPath="spouseMarriages"
+        schema={previousMarriageEndDateAndLocationPage.schema}
+        uiSchema={previousMarriageEndDateAndLocationPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ spouseMarriages: [formData2] }}
+      />,
+    );
+    const formDOM2 = getFormDOM(form2);
+    expect($('va-text-input[label="City"]', formDOM2)).to.exist;
+    expect($('va-select[label="State"]', formDOM2)).to.exist;
+  });
+
+  it('marriage end location city and country display when marriageEndedOutsideUS is true', () => {
+    // marriageEndedOutsideUS explicitly true -> city and country should show, state should be hidden
+    const formData = { marriageEndedOutsideUS: true };
+    const form = render(
+      <DefinitionTester
+        arrayPath="spouseMarriages"
+        schema={previousMarriageEndDateAndLocationPage.schema}
+        uiSchema={previousMarriageEndDateAndLocationPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ spouseMarriages: [formData] }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    expect($('va-text-input[label="City"]', formDOM)).to.exist;
+    expect($('va-select[label="Country"]', formDOM)).to.exist;
+    // state should be hidden when marriageEndedOutsideUS is true
+    expect($('va-select[label="State"]', formDOM)).to.not.exist;
+  });
+
+  it('does NOT show the "Tell us how the marriage ended" input when marriageEndReason is DIVORCE or DEATH', () => {
+    const { previousMarriageEndPage: marriageEndPage } = previousMarriagesPages;
+    const formData = {};
+    const form = render(
+      <DefinitionTester
+        arrayPath="spouseMarriages"
+        schema={marriageEndPage.schema}
+        uiSchema={marriageEndPage.uiSchema}
+        pagePerItemIndex={0}
+        data={{ spouseMarriages: [formData] }}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    const vaRadio = $('va-radio[label*="How did the marriage end?"]', formDOM);
+    expect(vaRadio).to.exist;
+
+    // select DIVORCE
+    vaRadio.__events.vaValueChange({ detail: { value: 'DIVORCE' } });
+    expect($('va-text-input[label="Tell us how the marriage ended"]', formDOM))
+      .to.not.exist;
+
+    // select DEATH
+    vaRadio.__events.vaValueChange({ detail: { value: 'DEATH' } });
+    expect($('va-text-input[label="Tell us how the marriage ended"]', formDOM))
+      .to.not.exist;
+  });
+
+  it('marks a previous marriage item incomplete when required fields are missing', () => {
+    const completeItem = {
+      previousSpouseName: { first: 'John', last: 'Doe' },
+      marriageToVeteranDate: '2000-01-01',
+      marriageLocation: { city: 'Somewhere', state: 'VA' },
+      marriedOutsideUS: false,
+      marriageEndReason: 'DIVORCE',
+    };
+
+    const missingName = {
+      previousSpouseName: { first: '', last: 'Doe' },
+      marriageToVeteranDate: '2000-01-01',
+      marriageLocation: { city: 'Somewhere', state: 'VA' },
+      marriedOutsideUS: false,
+      marriageEndReason: 'DIVORCE',
+    };
+
+    const missingState = {
+      previousSpouseName: { first: 'John', last: 'Doe' },
+      marriageToVeteranDate: '2000-01-01',
+      marriageLocation: { city: 'Somewhere' }, // missing state when marriedOutsideUS false
+      marriedOutsideUS: false,
+      marriageEndReason: 'DIVORCE',
+    };
+
+    const missingCountry = {
+      previousSpouseName: { first: 'John', last: 'Doe' },
+      marriageToVeteranDate: '2000-01-01',
+      marriageLocation: { city: 'Somewhere' }, // missing country when marriedOutsideUS true
+      marriedOutsideUS: true,
+      marriageEndReason: 'DIVORCE',
+    };
+
+    const otherMissingExplanation = {
+      previousSpouseName: { first: 'John', last: 'Doe' },
+      marriageToVeteranDate: '2000-01-01',
+      marriageLocation: { city: 'Somewhere', state: 'VA' },
+      marriedOutsideUS: false,
+      marriageEndReason: 'OTHER',
+      marriageEndOtherExplanation: '',
+    };
+
+    expect(options.isItemIncomplete(completeItem)).to.be.false;
+    expect(options.isItemIncomplete(missingName)).to.be.true;
+    expect(options.isItemIncomplete(missingState)).to.be.true;
+    expect(options.isItemIncomplete(missingCountry)).to.be.true;
+    expect(options.isItemIncomplete(otherMissingExplanation)).to.be.true;
+  });
+
+  it('renders the expected intro description content', () => {
+    const intro = previousMarriagesIntro.uiSchema['ui:description'];
+    const { container } = render(intro());
+
+    // Normalize whitespace to avoid line-break/indentation differences
+    const text = container.textContent.replace(/\s+/g, ' ').trim();
+
+    const firstParagraph =
+      "Next we'll ask you about your previous marriages before your marriage to the Veteran. You may add up to 2 marriages.";
+    const noteParagraph =
+      'Note: We usually don’t need to contact a previous spouse. In very rare cases where we need information from this person, we’ll contact you first.';
+
+    expect(text).to.include(firstParagraph);
+    expect(text).to.include(noteParagraph);
+  });
+
+  it('formats a previous spouse name for card titles using getItemName()', () => {
+    const { text } = options;
+    const completeName = {
+      previousSpouseName: {
+        first: 'Jane',
+        middle: 'A.',
+        last: 'Smith',
+        suffix: 'Jr.',
+      },
+    };
+    const missingName = {
+      previousSpouseName: {
+        first: '',
+        middle: 'A.',
+        last: '',
+        suffix: 'Jr.',
+      },
+    };
+    const emptyName = {
+      previousSpouseName: {
+        first: '',
+        middle: '',
+        last: '',
+        suffix: '',
+      },
+    };
+
+    const itemName = text.getItemName(completeName);
+    expect(itemName).to.equal('Jane A. Smith Jr.');
+
+    const missingItemName = text.getItemName(missingName);
+    expect(missingItemName).to.equal('');
+
+    const emptyItemName = text.getItemName(emptyName);
+    expect(emptyItemName).to.equal('');
+
+    // Partial-name cases: ensure missing parts are skipped and order preserved
+    const lastOnly = {
+      previousSpouseName: {
+        first: '',
+        middle: '',
+        last: 'Smith',
+        suffix: '',
+      },
+    };
+    expect(text.getItemName(lastOnly)).to.equal('Smith');
+
+    const firstOnly = {
+      previousSpouseName: {
+        first: 'Alex',
+        middle: '',
+        last: '',
+        suffix: '',
+      },
+    };
+    expect(text.getItemName(firstOnly)).to.equal('Alex');
+
+    const middleAndLast = {
+      previousSpouseName: {
+        first: '',
+        middle: 'A.',
+        last: 'Johnson',
+        suffix: '',
+      },
+    };
+    expect(text.getItemName(middleAndLast)).to.equal('A. Johnson');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Renamed and refactored of the spouse's previous marriages from `previousMarriages` to `spouseMarriages`
- Updated the conditional logic for when these pages are shown. 
- Ensures that veteran marriages use a distinct array and that dependent pages are skipped appropriately based on user responses.
- 
**Conditional Flow Improvements**
* Updated the logic for displaying previous marriages pages: now, these pages are only shown if the user explicitly answers "YES" to `hadPreviousMarriages`, ensuring that answering "NO" skips all related flows and jumps directly to dependents.
* Added conditional `depends` logic to all veteran marriages pages so they only appear if the claimant is the spouse and has indicated previous marriages, preventing unnecessary navigation for users who answered "NO".

**Veteran Marriages Data Separation**
* Refactored all references in veteran marriages pages to use `veteranMarriages` instead of `previousMarriages`, ensuring clear separation between the spouse's and veteran's marriage histories. 

**File and Path Updates**
* Renamed the spouse marriages configuration file from `previousMarriages.js` to `spouseMarriages.js`, and updated the route path from `household/previous-marriage-question` to `household/spouse-marriage-question` for clarity. 

**Test and Fixture Updates**
* Added a new fixture for spouse marriages options, reflecting the updated array path and text labels, to ensure unit tests align with the new data model.

## Related issue(s)

- [[Update Previous Marriages flow]](https://github.com/department-of-veterans-affairs/va.gov-team/issues/124189)

## Testing done

- unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*BIO - 534 ez - Survivors Benefits*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
