### PR TITLE
Removed DS Logon References from AuthMetrics Tests

### DIFF
--- a/src/applications/auth/tests/AuthMetrics.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthMetrics.unit.spec.jsx
@@ -100,7 +100,7 @@ describe('AuthMetrics', () => {
     spy.restore();
   });
 
-  ['custom', 'mhv_verified', 'dslogon'].forEach(type => {
+  ['custom', 'mhv_verified'].forEach(type => {
     it(`should record the different recardGAAuthEvents for ${type}`, () => {
       const payload = createPayload(type);
       const authMetrics = new AuthMetrics(type, payload);
@@ -126,22 +126,22 @@ describe('AuthMetrics', () => {
   });
 
   it(`should record the loa.current if exists`, () => {
-    const payload = createPayload('dslogon', true);
-    const authMetrics = new AuthMetrics('dslogon', payload);
+    const payload = createPayload('idme', true);
+    const authMetrics = new AuthMetrics('idme', payload);
     authMetrics.recordGAAuthEvents();
     const [
       { event: firstEvent },
       { event: secondEvent },
     ] = global.window.dataLayer;
 
-    expect(firstEvent).to.eql(`login-success-dslogon`);
+    expect(firstEvent).to.eql(`login-success-idme`);
     expect(secondEvent).to.eql(`login-loa-current-3`);
   });
 
   it('should run if no session active', () => {
     localStorage.clear();
-    const payload = createPayload('dslogon', true);
-    const authMetrics = new AuthMetrics('dslogon', payload);
+    const payload = createPayload('idme', true);
+    const authMetrics = new AuthMetrics('idme', payload);
     const sessionSpy = sinon.spy(authMetrics, 'recordGAAuthEvents');
     authMetrics.run();
     expect(sessionSpy.called).to.be.true;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed and replaced references to DS Logon in `AuthMetrics.unit.spec.jsx`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/290)

## Testing done
- Updated and ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/applications/auth/tests/AuthMetrics.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `AuthMetrics.unit.spec.jsx`.

## Acceptance criteria
- [x] Remove and replace references to DS Logon in `AuthMetrics.unit.spec.jsx`.