### PR TITLE
Adjusted depends config to show/skip treatment pages

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -120,24 +120,28 @@ export const treatmentPages = arrayBuilderPages(options, pageBuilder => ({
   dicBenefitsIntro: pageBuilder.introPage({
     title: 'Treatment at VA medical centers',
     path: 'claim-information/dic/treatment',
+    depends: formData => formData?.claims?.dependencyIndemnityComp === true,
     uiSchema: introPage.uiSchema,
     schema: introPage.schema,
   }),
   dicBenefitsSummary: pageBuilder.summaryPage({
     title: 'DIC benefits',
     path: 'claim-information/dic/add',
+    depends: formData => formData?.claims?.dependencyIndemnityComp === true,
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,
   }),
   dicNameLocationPage: pageBuilder.itemPage({
     title: 'VA medical center name and location',
     path: 'claim-information/dic/:index/name-location',
+    depends: formData => formData?.claims?.dependencyIndemnityComp === true,
     uiSchema: nameLocationPage.uiSchema,
     schema: nameLocationPage.schema,
   }),
   dicTreatmentDates: pageBuilder.itemPage({
     title: 'Dates of treatment',
     path: 'claim-information/dic/:index/dates',
+    depends: formData => formData?.claims?.dependencyIndemnityComp === true,
     uiSchema: treatmentDatePage.uiSchema,
     schema: treatmentDatePage.schema,
   }),

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -120,28 +120,24 @@ export const treatmentPages = arrayBuilderPages(options, pageBuilder => ({
   dicBenefitsIntro: pageBuilder.introPage({
     title: 'Treatment at VA medical centers',
     path: 'claim-information/dic/treatment',
-    depends: formData => formData?.dicType === 'DIC',
     uiSchema: introPage.uiSchema,
     schema: introPage.schema,
   }),
   dicBenefitsSummary: pageBuilder.summaryPage({
     title: 'DIC benefits',
     path: 'claim-information/dic/add',
-    depends: formData => formData?.dicType === 'DIC',
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,
   }),
   dicNameLocationPage: pageBuilder.itemPage({
     title: 'VA medical center name and location',
     path: 'claim-information/dic/:index/name-location',
-    depends: formData => formData?.dicType === 'DIC',
     uiSchema: nameLocationPage.uiSchema,
     schema: nameLocationPage.schema,
   }),
   dicTreatmentDates: pageBuilder.itemPage({
     title: 'Dates of treatment',
     path: 'claim-information/dic/:index/dates',
-    depends: formData => formData?.dicType === 'DIC',
     uiSchema: treatmentDatePage.uiSchema,
     schema: treatmentDatePage.schema,
   }),

--- a/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/treatmentPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/05-claim-information/treatmentPages.unit.spec.jsx
@@ -133,8 +133,19 @@ describe('Treatment Pages', () => {
       dicTreatmentDates,
     } = treatmentPages;
 
-    const formDataTrue = { dicType: 'DIC' };
-    const formDataFalse = { dicType: 'NOT_DIC' };
+    // Test data with dependencyIndemnityComp set to true
+    const formDataTrue = {
+      claims: {
+        dependencyIndemnityComp: true,
+      },
+    };
+
+    // Test data with dependencyIndemnityComp set to false
+    const formDataFalse = {
+      claims: {
+        dependencyIndemnityComp: false,
+      },
+    };
 
     expect(dicBenefitsIntro.depends(formDataTrue)).to.be.true;
     expect(dicBenefitsIntro.depends(formDataFalse)).to.be.false;


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/125487

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request makes a small change to the `treatmentPages.js` configuration for the survivors benefits application. The change removes conditional logic that restricted several DIC-related pages to only display when the `dicType` field was set to `DIC`. This means those pages will now always be included, regardless of the value of `dicType`.

([src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.jsL123-L144](diffhunk://#diff-c4274da4b5e0b3d17474114f9b83b2e73d52d72a171a3839bb6ddb85d9b4f5b2L123-L144))

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/125487

## Testing done
All unit tests and cypress tests pass.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |
<img width="650" height="784" alt="Screenshot 2025-11-20 at 3 15 08 PM" src="https://github.com/user-attachments/assets/4838a923-d369-444f-a970-d1337a8c0122" />
<img width="562" height="701" alt="Screenshot 2025-11-20 at 3 15 29 PM" src="https://github.com/user-attachments/assets/3e1fb9f4-d5f9-4e0c-a4d1-2c20f683ed27" /> 
<img width="562" height="688" alt="Screenshot 2025-11-20 at 3 31 16 PM" src="https://github.com/user-attachments/assets/59d9e4fe-a536-4a1c-a7a1-68e8b5cf2e09" />
<img width="557" height="224" alt="Screenshot 2025-11-20 at 3 31 30 PM" src="https://github.com/user-attachments/assets/e42bfc27-494e-4cc1-b67f-2f27152335fc" />
|

## What areas of the site does it impact?
534EZ Form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
