### PR TITLE
LoginButton DS Logon deprecation refactor 292

### DIFF
--- a/src/platform/user/authentication/components/LoginButton.jsx
+++ b/src/platform/user/authentication/components/LoginButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import * as authUtilities from 'platform/user/authentication/utilities';
-import { ACTIVE_SERVICE_PROVIDERS, TEST_APPS } from '../constants';
+import { SERVICE_PROVIDERS, TEST_APPS } from '../constants';
 import { createOktaOAuthRequest } from '../../../utilities/oauth/utilities';
 
 export function loginHandler(loginType, isOAuth, oktaParams = {}) {
@@ -48,7 +48,7 @@ export default function LoginButton({
       onClick={() => onClick(csp, useOAuth, queryParams)}
       aria-describedby={ariaDescribedBy}
     >
-      {ACTIVE_SERVICE_PROVIDERS[csp].image}
+      {SERVICE_PROVIDERS[csp].image}
     </button>
   );
 }

--- a/src/platform/user/authentication/components/LoginButton.jsx
+++ b/src/platform/user/authentication/components/LoginButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import * as authUtilities from 'platform/user/authentication/utilities';
-import { SERVICE_PROVIDERS, TEST_APPS } from '../constants';
+import { ACTIVE_SERVICE_PROVIDERS, TEST_APPS } from '../constants';
 import { createOktaOAuthRequest } from '../../../utilities/oauth/utilities';
 
 export function loginHandler(loginType, isOAuth, oktaParams = {}) {
@@ -48,16 +48,16 @@ export default function LoginButton({
       onClick={() => onClick(csp, useOAuth, queryParams)}
       aria-describedby={ariaDescribedBy}
     >
-      {SERVICE_PROVIDERS[csp].image}
+      {ACTIVE_SERVICE_PROVIDERS[csp].image}
     </button>
   );
 }
 
 LoginButton.propTypes = {
-  csp: PropTypes.string,
-  onClick: PropTypes.func,
-  useOAuth: PropTypes.bool,
-  ariaDescribedBy: PropTypes.string,
   actionLocation: PropTypes.string,
+  ariaDescribedBy: PropTypes.string,
+  csp: PropTypes.string,
   queryParams: PropTypes.object,
+  useOAuth: PropTypes.bool,
+  onClick: PropTypes.func,
 };

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -44,6 +44,24 @@ export const CSP_IDS = {
   VAMOCK: 'vamock',
 };
 
+export const ACTIVE_SERVICE_PROVIDERS = {
+  [CSP_IDS.ID_ME]: {
+    label: 'ID.me',
+    link: 'https://wallet.id.me/settings',
+    image: <img src="/img/idme.svg" alt="ID.me" />,
+    altImage: <img src="/img/idme.svg" alt="ID.me" />,
+    policy: 'idme',
+    className: 'idme-button',
+  },
+  [CSP_IDS.LOGIN_GOV]: {
+    label: 'Login.gov',
+    link: 'https://secure.login.gov/account',
+    image: <img src="/img/logingov.svg" alt="Login.gov" />,
+    policy: 'logingov',
+    className: `logingov-button`,
+  },
+};
+
 export const SERVICE_PROVIDERS = {
   [CSP_IDS.ID_ME]: {
     label: 'ID.me',

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -44,24 +44,6 @@ export const CSP_IDS = {
   VAMOCK: 'vamock',
 };
 
-export const ACTIVE_SERVICE_PROVIDERS = {
-  [CSP_IDS.ID_ME]: {
-    label: 'ID.me',
-    link: 'https://wallet.id.me/settings',
-    image: <img src="/img/idme.svg" alt="ID.me" />,
-    altImage: <img src="/img/idme.svg" alt="ID.me" />,
-    policy: 'idme',
-    className: 'idme-button',
-  },
-  [CSP_IDS.LOGIN_GOV]: {
-    label: 'Login.gov',
-    link: 'https://secure.login.gov/account',
-    image: <img src="/img/logingov.svg" alt="Login.gov" />,
-    policy: 'logingov',
-    className: `logingov-button`,
-  },
-};
-
 export const SERVICE_PROVIDERS = {
   [CSP_IDS.ID_ME]: {
     label: 'ID.me',
@@ -92,6 +74,11 @@ export const SERVICE_PROVIDERS = {
     policy: 'mhv',
     className: 'mhv-button',
   },
+};
+
+export const ACTIVE_SERVICE_PROVIDERS = {
+  [CSP_IDS.ID_ME]: SERVICE_PROVIDERS[CSP_IDS.ID_ME],
+  [CSP_IDS.LOGIN_GOV]: SERVICE_PROVIDERS[CSP_IDS.LOGIN_GOV],
 };
 
 export const AUTHN_SETTINGS = {

--- a/src/platform/user/tests/authentication/components/LoginButton.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/LoginButton.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SERVICE_PROVIDERS } from 'platform/user/authentication/constants';
+import { ACTIVE_SERVICE_PROVIDERS } from 'platform/user/authentication/constants';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { render } from '@testing-library/react';
@@ -10,7 +10,7 @@ import LoginButton, {
   loginHandler,
 } from 'platform/user/authentication/components/LoginButton';
 
-const csps = Object.values(SERVICE_PROVIDERS);
+const csps = Object.values(ACTIVE_SERVICE_PROVIDERS);
 
 describe('LoginButton', () => {
   it('should not render with a `csp`', () => {
@@ -27,7 +27,7 @@ describe('LoginButton', () => {
   it('should call the `loginHandler` function on click', () => {
     const loginHandlerSpy = sinon.spy();
     const wrapper = shallow(
-      <LoginButton csp="dslogon" onClick={loginHandlerSpy} />,
+      <LoginButton csp="idme" onClick={loginHandlerSpy} />,
     );
 
     wrapper.find('button').simulate('click');


### PR DESCRIPTION
Note: Delete the description statements, complete each step. None are optional, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR introduces a new `ACTIVE_SERVICE_PROVIDERS` constant (Login.gov + ID.me only) and updates the `LoginButton` component and its unit tests to use it. All DS Logon and MHV-related logic has been removed from the test suite. Button type ordering was also cleaned up to match the modern provider set. No UI changes were introduced; this is a logic and test refactor aligned with ongoing CSP deprecation work.


## Related issue(s)
[#292
](https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/12?pane=issue&itemId=111418189&issue=department-of-veterans-affairs%7Cidentity-documentation%7C292)

## Testing done
- Verified that `LoginButton.unit.spec.jsx` runs successfully after removing DS Logon/MHV logic and updating tests to use `ACTIVE_SERVICE_PROVIDERS`.
- Confirmed the `LoginButton` component loads as expected in a local build and only displays modern providers (Login.gov and ID.me).
- Manually inspected the updated provider ordering to ensure consistency with product expectations.
- Ran the full unit test suite to confirm no regressions were introduced.
- Linting passed without new warnings.

