### PR TITLE
[DBC] Confirmation page -> retirement pay (approach C)

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/confirmationFields/ConfirmationRetirementPay.jsx
+++ b/src/applications/disability-benefits/all-claims/components/confirmationFields/ConfirmationRetirementPay.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const ConfirmationRetirementPay = (title, yesNoTitle, branchTitle) => ({
+  formData,
+}) => {
+  const branchValue = formData.militaryRetiredPayBranch;
+  const yesNoValue = branchValue ? 'Yes' : 'No';
+
+  return (
+    <li>
+      <h4>{title}</h4>
+      <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
+        <li>
+          <div className="vads-u-color--gray">{yesNoTitle}</div>
+          <div>{yesNoValue}</div>
+        </li>
+        {branchValue && (
+          <li>
+            <div className="vads-u-color--gray">{branchTitle}</div>
+            <div>{branchValue}</div>
+          </li>
+        )}
+      </ul>
+    </li>
+  );
+};
+
+export default ConfirmationRetirementPay;

--- a/src/applications/disability-benefits/all-claims/pages/retirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/retirementPay.js
@@ -1,21 +1,32 @@
 import set from 'platform/utilities/data/set';
+import { yesNoUI } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+
 import { hasMilitaryRetiredPay } from '../validations';
 import { getBranches } from '../utils/serviceBranches';
+import ConfirmationRetirementPay from '../components/confirmationFields/ConfirmationRetirementPay';
 
 const {
   militaryRetiredPayBranch: militaryRetiredPayBranchSchema,
 } = fullSchema.properties;
 
+const TITLE = 'Retirement pay'; // duplicated from top-level `config/form.js`
+const YES_NO_TITLE = 'Have you ever received military retirement pay?';
+const BRANCH_TITLE =
+  'Please choose the branch of service that gave you military retired pay ';
+
+const ConfirmationField = ConfirmationRetirementPay(
+  TITLE,
+  YES_NO_TITLE,
+  BRANCH_TITLE,
+);
+
 export const uiSchema = {
-  'view:hasMilitaryRetiredPay': {
-    'ui:title': 'Have you ever received military retirement pay?',
-    'ui:widget': 'yesNo',
-    'ui:options': {},
-  },
+  'view:hasMilitaryRetiredPay': yesNoUI({
+    title: YES_NO_TITLE,
+  }),
   militaryRetiredPayBranch: {
-    'ui:title':
-      'Please choose the branch of service that gave you military retired pay ',
+    'ui:title': BRANCH_TITLE,
     'ui:options': {
       expandUnder: 'view:hasMilitaryRetiredPay',
       updateSchema: (_formData, schema) => {
@@ -28,6 +39,7 @@ export const uiSchema = {
     },
     'ui:required': hasMilitaryRetiredPay,
   },
+  'ui:confirmationField': ConfirmationField,
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/tests/confirmation-page.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/confirmation-page.cypress.spec.js
@@ -14,7 +14,7 @@ const testConfig = createTestConfig(
     dataPrefix: 'data',
     useWebComponentFields: true,
 
-    dataSets: ['confirmation-test'],
+    dataSets: ['confirmation-pay-test', 'confirmation-test'],
 
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -12,7 +12,12 @@ import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUpload from './fixtures/mocks/document-upload.json';
 import mockServiceBranches from './fixtures/mocks/service-branches.json';
 import mockUser from './fixtures/mocks/user.json';
-import { capitalizeEachWord, showSeparationLocation } from '../utils';
+import {
+  capitalizeEachWord,
+  showSeparationLocation,
+  isBDD,
+  hasRatedDisabilities,
+} from '../utils';
 
 import {
   MOCK_SIPS_API,
@@ -338,6 +343,16 @@ Cypress.Commands.add('verifyVeteranDetails', data => {
     if (showSeparationLocation(data) === true) {
       cy.contains(/separation location/i).should('exist');
       cy.contains(data.serviceInformation.separationLocation.label).should(
+        'exist',
+      );
+    }
+
+    if (
+      !hasRatedDisabilities(data) &&
+      !isBDD(data) &&
+      data['view:isBddData'] !== true
+    ) {
+      cy.contains(/have you ever received military retirement pay/i).should(
         'exist',
       );
     }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/confirmation-pay-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/confirmation-pay-test.json
@@ -1,0 +1,262 @@
+{
+  "data": {
+    "view:claimType": {
+      "view:claimingIncrease": true,
+      "view:claimingNew": true
+    },
+    "standardClaim": true,
+    "view:fdcWarning": {},
+    "isVaEmployee": true,
+    "isTerminallyIll": false,
+    "homelessOrAtRisk": "homeless",
+    "view:isHomeless": {
+      "homelessHousingSituation": "other",
+      "otherHomelessHousing": "Under a bridge",
+      "needToLeaveHousing": true
+    },
+    "homelessnessContact": {
+      "name": "John Doe",
+      "phoneNumber": "1231231234"
+    },
+    "view:bankAccount": {
+      "bankAccountType": "Checking",
+      "bankAccountNumber": "1233",
+      "bankRoutingNumber": "123123123",
+      "bankName": "Bigbank Co."
+    },
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "view:livesOnMilitaryBase": false,
+      "type": "MILITARY",
+      "militaryPostOfficeTypeCode": "APO",
+      "militaryStateCode": "AA",
+      "zipFirstFive": "27103",
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "view:hasForwardingAddress": true,
+    "forwardingAddress": {
+      "country": "USA",
+      "addressLine1": "321 Secondary",
+      "city": "Smallcity",
+      "state": "NY",
+      "zipCode": "54321",
+      "effectiveDate": {
+        "from": "2099-12-01",
+        "to": "2100-01-01"
+      }
+    },
+    "view:contactInfoDescription": {},
+    "hasSeparationPay": false,
+    "hasTrainingPay": false,
+    "view:hasMilitaryRetiredPay": false,
+    "waiveRetirementPay": false,
+    "additionalDocuments": [
+      {
+        "name": "test-document.pdf",
+        "confirmationCode": "552067b2-9c5d-4bd8-bcd8-bc621b51a145",
+        "attachmentId": "L015"
+      }
+    ],
+    "view:hasEvidence": true,
+    "view:selectableEvidenceTypes": {
+      "view:hasVaMedicalRecords": true,
+      "view:hasPrivateMedicalRecords": true,
+      "view:hasOtherEvidence": true
+    },
+    "view:uploadPrivateRecordsQualifier": {
+      "view:hasPrivateRecordsToUpload": false
+    },
+    "vaTreatmentFacilities": [
+      {
+        "treatmentCenterName": "VA Medical Center",
+        "treatmentDateRange": {
+          "from": "2018-06-XX"
+        },
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": "Washington",
+          "state": "DC"
+        },
+        "treatedDisabilityNames": {
+          "diabetesmellitus0": true,
+          "hearingloss": true
+        }
+      }
+    ],
+    "providerFacility": [
+      {
+        "providerFacilityName": "Test Medical Center",
+        "providerFacilityAddress": {
+          "street": "123 Medical Dr",
+          "city": "Medical City",
+          "state": "VA",
+          "postalCode": "12345",
+          "country": "USA"
+        },
+        "treatedDisabilityNames": {
+          "hearingloss": true
+        },
+        "treatmentDateRange": {
+          "from": "2020-01-01",
+          "to": "2023-12-31"
+        }
+      }
+    ],
+    "view:evidenceTypeHelp": {},
+    "view:unemployable": false,
+    "view:aidAndAttendance": true,
+    "view:modifyingHome": true,
+    "view:modifyingCar": true,
+    "view:needsCarHelp": {
+      "view:alreadyClaimedVehicleAllowance": false
+    },
+    "toxicExposure": {
+      "conditions": {
+        "asthma": true,
+        "hearingloss": true
+      },
+      "gulfWar1990": {
+        "iraq": true,
+        "kuwait": true
+      },
+      "gulfWar1990Details": {
+        "iraq": {
+          "startDate": "1991-01-15",
+          "endDate": "1991-03-31"
+        },
+        "kuwait": {
+          "startDate": "1991-02-01",
+          "endDate": "1991-04-15"
+        }
+      },
+      "herbicide": {
+        "vietnam": true
+      },
+      "herbicideDetails": {
+        "vietnam": {
+          "startDate": "1968-05-01",
+          "endDate": "1969-12-31"
+        }
+      },
+      "otherExposures": {
+        "asbestos": true,
+        "radiation": true
+      },
+      "otherExposuresDetails": {
+        "asbestos": {
+          "startDate": "2000-01-01",
+          "endDate": "2000-12-31"
+        },
+        "radiation": {
+          "startDate": "2001-01-01",
+          "endDate": "2001-06-30"
+        }
+      }
+    },
+    "view:powStatus": false,
+    "newDisabilities": [
+      {
+        "condition": "Hearing Loss",
+        "cause": "NEW",
+        "primaryDescription": "Hearing loss due to loud noises during service",
+        "view:descriptionInfo": {}
+      },
+      {
+        "condition": "Asthma",
+        "cause": "NEW",
+        "primaryDescription": "Asthma caused by toxic exposure during service",
+        "view:descriptionInfo": {}
+      }
+    ],
+    "view:disabilitiesClarification": {},
+    "serviceInformation": {
+      "servicePeriods": [
+        {
+          "serviceBranch": "Army",
+          "dateRange": {
+            "from": "1967-01-01",
+            "to": "2004-01-01"
+          }
+        }
+      ],
+      "view:militaryHistoryNote": {}
+    },
+    "view:selectablePtsdTypes": {},
+    "view:ptsdTypeHelp": {},
+    "view:upload781ChoiceHelp": {},
+    "incident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "view:upload781aChoiceHelp": {},
+    "secondaryIncident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "view:otherSourcesHelp": {},
+    "secondaryIncident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "secondaryIncident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "physicalChanges": {},
+    "mentalChanges": {},
+    "workBehaviorChanges": {},
+    "socialBehaviorChanges": {},
+    "view:ancillaryFormsWizardIntro": {},
+    "view:unemployabilityHelp": {},
+    "unemployability": {
+      "view:recordsInfo": {},
+      "view:unemployabilityDatesDesc": {},
+      "view:grossIncomeAdditionalInfo": {},
+      "view:supplementalBenefitsHelp": {},
+      "view:substantiallyGainfulEmploymentInfo": {},
+      "view:statementsAreTrue": {},
+      "view:informOfReturnToWork": {}
+    },
+    "view:privateMedicalFacility": {},
+    "view:upload4192Choice": {},
+    "view:downloadInfo": {},
+    "view:privateRecordsChoiceHelp": {},
+    "view:faqAccordion": {},
+    "view:originalBankAccount": {
+      "view:bankAccountType": "Checking",
+      "view:bankAccountNumber": "*********1234",
+      "view:bankRoutingNumber": "*****2115",
+      "view:bankName": "Comerica"
+    }
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/confirmation-pay-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/confirmation-pay-test.json
@@ -1,0 +1,156 @@
+{
+  "form526": {
+    "standardClaim": true,
+    "isVaEmployee": true,
+    "isTerminallyIll": false,
+    "homelessOrAtRisk": "homeless",
+    "homelessHousingSituation": "other",
+    "otherHomelessHousing": "Under a bridge",
+    "needToLeaveHousing": true,
+    "homelessnessContact": {
+      "name": "John Doe",
+      "phoneNumber": "1231231234"
+    },
+    "bankAccountType": "Checking",
+    "bankAccountNumber": "1233",
+    "bankRoutingNumber": "123123123",
+    "bankName": "Bigbank Co.",
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "forwardingAddress": {
+      "country": "USA",
+      "addressLine1": "321 Secondary",
+      "city": "Smallcity",
+      "state": "NY",
+      "zipCode": "54321",
+      "effectiveDate": {
+        "from": "2099-12-01",
+        "to": "2100-01-01"
+      }
+    },
+    "hasSeparationPay": false,
+    "hasTrainingPay": false,
+    "vaTreatmentFacilities": [
+      {
+        "treatmentCenterName": "VA Medical Center",
+        "treatmentDateRange": {
+          "from": "2018-06-XX"
+        },
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": "Washington",
+          "state": "DC"
+        },
+        "treatedDisabilityNames": [
+          "Hearing Loss"
+        ]
+      }
+    ],
+    "toxicExposure": {
+      "conditions": {
+        "asthma": true,
+        "hearingloss": true
+      },
+      "gulfWar1990": {
+        "iraq": true,
+        "kuwait": true
+      },
+      "gulfWar1990Details": {
+        "iraq": {
+          "startDate": "1991-01-15",
+          "endDate": "1991-03-31"
+        },
+        "kuwait": {
+          "startDate": "1991-02-01",
+          "endDate": "1991-04-15"
+        }
+      },
+      "herbicide": {
+        "vietnam": true
+      },
+      "herbicideDetails": {
+        "vietnam": {
+          "startDate": "1968-05-01",
+          "endDate": "1969-12-31"
+        }
+      },
+      "otherExposures": {
+        "asbestos": true,
+        "radiation": true
+      },
+      "otherExposuresDetails": {
+        "asbestos": {
+          "startDate": "2000-01-01",
+          "endDate": "2000-12-31"
+        },
+        "radiation": {
+          "startDate": "2001-01-01",
+          "endDate": "2001-06-30"
+        }
+      }
+    },
+    "serviceInformation": {
+      "servicePeriods": [
+        {
+          "serviceBranch": "Army",
+          "dateRange": {
+            "from": "1967-01-01",
+            "to": "2004-01-01"
+          }
+        }
+      ]
+    },
+    "newPrimaryDisabilities": [
+      {
+        "condition": "Hearing Loss",
+        "cause": "NEW",
+        "primaryDescription": "Hearing loss due to loud noises during service"
+      },
+      {
+        "condition": "Asthma",
+        "cause": "NEW",
+        "primaryDescription": "Asthma caused by toxic exposure during service"
+      }
+    ],
+    "form4142": {
+      "completed2024Form": false,
+      "providerFacility": [
+        {
+          "providerFacilityName": "Test Medical Center",
+          "providerFacilityAddress": {
+            "street": "123 Medical Dr",
+            "city": "Medical City",
+            "state": "VA",
+            "postalCode": "12345",
+            "country": "USA"
+          },
+          "treatedDisabilityNames": [
+            "Hearing Loss"
+          ],
+          "treatmentDateRange": [
+            {
+              "from": "2020-01-01",
+              "to": "2023-12-31"
+            }
+          ]
+        }
+      ]
+    },
+    "attachments": [
+      {
+        "name": "test-document.pdf",
+        "confirmationCode": "552067b2-9c5d-4bd8-bcd8-bc621b51a145",
+        "attachmentId": "L015"
+      }
+    ]
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
@@ -24,7 +24,8 @@ describe('Retirement Pay', () => {
       />,
     );
 
-    expect(form.find('input[type="radio"]').length).to.equal(2);
+    expect(form.find('VaRadio').length).to.equal(1);
+    expect(form.find('va-radio-option').length).to.equal(2);
     form.unmount();
   });
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/122800

Renders retirement pay yes/no question on the confirmation page, even though it's a `view:` field, by implementing a page-level confirmation page customization. The customization duplicates markup from platform internals rather than pursuing more code reuse (coupling) or refactoring of the confirmation page paradigm.