### PR TITLE
MHV SM 125724 - OH maintenance dedicated feature toggle

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
@@ -41,7 +41,10 @@ const FolderHeader = props => {
     state => state.sm.recipients,
   );
 
-  const { cernerPilotSmFeatureFlag } = useFeatureToggles();
+  const {
+    cernerPilotSmFeatureFlag,
+    mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag,
+  } = useFeatureToggles();
 
   const cernerFacilities = useMemo(
     () => {
@@ -103,7 +106,11 @@ const FolderHeader = props => {
 
   const OracleHealthMessagingAlert = useCallback(
     () => {
-      if (cernerPilotSmFeatureFlag) return <OracleHealthMessagingIssuesAlert />;
+      if (
+        cernerPilotSmFeatureFlag &&
+        mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag
+      )
+        return <OracleHealthMessagingIssuesAlert />;
       if (
         folder.folderId === Folders.INBOX.id &&
         cernerFacilities?.length > 0
@@ -112,7 +119,12 @@ const FolderHeader = props => {
       }
       return null;
     },
-    [cernerPilotSmFeatureFlag, folder.folderId, cernerFacilities],
+    [
+      cernerPilotSmFeatureFlag,
+      mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag,
+      folder.folderId,
+      cernerFacilities,
+    ],
   );
 
   return (

--- a/src/applications/mhv-secure-messaging/hooks/useFeatureToggles.js
+++ b/src/applications/mhv-secure-messaging/hooks/useFeatureToggles.js
@@ -13,6 +13,7 @@ const useFeatureToggles = () => {
     cernerPilotSmFeatureFlag,
     mhvSecureMessagingCuratedListFlow,
     mhvSecureMessagingRecentRecipients,
+    mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag,
     mhvMockSessionFlag,
   } = useSelector(
     state => {
@@ -54,6 +55,11 @@ const useFeatureToggles = () => {
           state.featureToggles[
             FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients
           ],
+        mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag:
+          state.featureToggles[
+            FEATURE_FLAG_NAMES
+              .mhvSecureMessagingCernerPilotSystemMaintenanceBanner
+          ],
         mhvMockSessionFlag: state.featureToggles['mhv-mock-session'],
       };
     },
@@ -74,6 +80,7 @@ const useFeatureToggles = () => {
     cernerPilotSmFeatureFlag,
     mhvSecureMessagingCuratedListFlow,
     mhvSecureMessagingRecentRecipients,
+    mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag,
     mhvMockSessionFlag,
   };
 };

--- a/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
@@ -425,6 +425,7 @@ describe('Folder Header component', () => {
         featureToggles: {
           loading: false,
           [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot]: true,
+          [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilotSystemMaintenanceBanner]: true,
         },
       };
 
@@ -436,8 +437,35 @@ describe('Folder Header component', () => {
       expect(alert).to.exist;
       const headline = alert.querySelector('[slot="headline"]');
       expect(headline.textContent).to.contain(
-        `We${String.fromCharCode(8217)}re working on messages right now`,
+        `We’re working on messages right now`,
       );
+    });
+
+    it('does not render OracleHealthMessagingIssuesAlert when mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag is false', () => {
+      const stateWithFeatureFlag = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          folders: {
+            folder: inbox,
+            folderList,
+          },
+        },
+        featureToggles: {
+          loading: false,
+          [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot]: true,
+          [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilotSystemMaintenanceBanner]: false,
+        },
+      };
+
+      const { queryByText } = setup(
+        stateWithFeatureFlag,
+        Paths.INBOX,
+        1,
+        inbox,
+      );
+
+      expect(queryByText('We’re working on messages right now')).to.be.null;
     });
 
     it('renders CernerFacilityAlert when user has Cerner facilities and feature flag is false', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-recent-recipients.cypress.spec.js
@@ -38,6 +38,7 @@ describe('SM CURATED LIST MAIN FLOW WITH RECENT RECIPIENTS', () => {
     PatientInboxPage.clickCreateNewMessage();
     cy.wait('@recentRecipients');
     PatientInterstitialPage.getStartMessageLink().click();
+    cy.wait('@recentRecipients');
     GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
     GeneralFunctionsPage.verifyPageTitle(
       'Recently Messaged Care Teams - Start Message | Veterans Affairs',
@@ -78,6 +79,7 @@ describe('SM CURATED LIST MAIN FLOW WITH RECENT RECIPIENTS', () => {
     PatientInboxPage.clickCreateNewMessage();
     cy.wait('@recentRecipients');
     PatientInterstitialPage.getStartMessageLink().click();
+    cy.wait('@recentRecipients');
     GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
     cy.findByTestId(Locators.EMERGENCY_USE_EXPANDABLE_DATA_TEST_ID).should(
@@ -111,8 +113,12 @@ describe('SM CURATED LIST MAIN FLOW WITH RECENT RECIPIENTS', () => {
     PatientInboxPage.clickCreateNewMessage();
     cy.wait('@recentRecipients');
     PatientInterstitialPage.getStartMessageLink().click();
+    cy.wait('@recentRecipients');
     GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
+    cy.findByLabelText(`${recentCareTeams[0]}VA Madison health care`).should(
+      'be.visible',
+    );
     cy.findByTestId(
       Locators.RECENT_CARE_TEAMS_CONTINUE_BUTTON_DATA_TEST_ID,
     ).click();
@@ -124,11 +130,10 @@ describe('SM CURATED LIST MAIN FLOW WITH RECENT RECIPIENTS', () => {
       .should('be.visible');
 
     // validate the first va-radio-option is focused
-    // Give the focus action time to complete after error shows
-    cy.findByLabelText(`${recentCareTeams[0]}VA Madison health care`)
-      .should('exist')
-      .and('be.visible')
-      .should('have.focus');
+    // Use a longer timeout to allow focus to be applied after validation
+    cy.findByLabelText(`${recentCareTeams[0]}VA Madison health care`).should(
+      'have.focus',
+    );
     cy.injectAxeThenAxeCheck(AXE_CONTEXT);
   });
 
@@ -178,6 +183,7 @@ describe('SM CURATED LIST MAIN FLOW WITH RECENT RECIPIENTS', () => {
     PatientInboxPage.clickCreateNewMessage();
     cy.wait('@recentRecipients');
     PatientInterstitialPage.getStartMessageLink().click();
+    cy.wait('@recentRecipients');
     GeneralFunctionsPage.verifyPageHeader(Data.RECENT_RECIPIENTS_HEADER);
 
     // Select the first recent care team

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-oracle-health-messaging-alert.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-oracle-health-messaging-alert.cypress.spec.js
@@ -1,0 +1,439 @@
+import PatientInboxPage from './pages/PatientInboxPage';
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import mockMessages from './fixtures/threads-response.json';
+import mockSingleMessage from './fixtures/inboxResponse/single-message-response.json';
+import mockRecipients from './fixtures/recipientsResponse/recipients-response.json';
+import mockToggles from './fixtures/toggles-response.json';
+import mockCernerFacilities from './fixtures/facilityResponse/cerner-facility-mock-data.json';
+import mockNoCernerFacilities from './fixtures/facilityResponse/facilities-no-cerner.json';
+import mockVamcEhr from './fixtures/vamc-ehr.json';
+import mockUser from './fixtures/userResponse/user.json';
+import mockSentFolderMetaResponse from './fixtures/sentResponse/folder-sent-metadata.json';
+import mockDraftsFolderMetaResponse from './fixtures/draftsResponse/folder-drafts-metadata.json';
+import { AXE_CONTEXT, Paths } from './utils/constants';
+
+describe('Secure Messaging - Oracle Health Messaging Alert', () => {
+  const folderIds = [
+    { id: '0', name: 'Inbox', path: Paths.INBOX },
+    { id: '-1', name: 'Sent', path: Paths.SENT },
+    { id: '-2', name: 'Drafts', path: Paths.DRAFTS },
+  ];
+
+  const testScenarios = [
+    {
+      name: 'both flags disabled',
+      toggles: {
+        ...mockToggles,
+        data: {
+          ...mockToggles.data,
+          features: [
+            ...mockToggles.data.features,
+            {
+              name: 'mhv_secure_messaging_cerner_pilot',
+              value: false,
+            },
+            {
+              name:
+                'mhv_secure_messaging_cerner_pilot_system_maintenance_banner',
+              value: false,
+            },
+          ],
+        },
+      },
+      expectOracleHealthAlert: false,
+      expectCernerFacilityAlert: true, // Cerner alert shows in Inbox if there are Cerner facilities (regardless of flags)
+    },
+    {
+      name: 'only cernerPilotSmFeatureFlag enabled',
+      toggles: {
+        ...mockToggles,
+        data: {
+          ...mockToggles.data,
+          features: [
+            ...mockToggles.data.features,
+            {
+              name: 'mhv_secure_messaging_cerner_pilot',
+              value: true,
+            },
+            {
+              name:
+                'mhv_secure_messaging_cerner_pilot_system_maintenance_banner',
+              value: false,
+            },
+          ],
+        },
+      },
+      expectOracleHealthAlert: false,
+      expectCernerFacilityAlert: true, // Cerner alert shows in Inbox if there are Cerner facilities (regardless of flags)
+    },
+    {
+      name: 'only maintenanceBannerFlag enabled',
+      toggles: {
+        ...mockToggles,
+        data: {
+          ...mockToggles.data,
+          features: [
+            ...mockToggles.data.features,
+            {
+              name: 'mhv_secure_messaging_cerner_pilot',
+              value: false,
+            },
+            {
+              name:
+                'mhv_secure_messaging_cerner_pilot_system_maintenance_banner',
+              value: true,
+            },
+          ],
+        },
+      },
+      expectOracleHealthAlert: false,
+      expectCernerFacilityAlert: true, // Cerner alert shows in Inbox if there are Cerner facilities (regardless of flags)
+    },
+    {
+      name: 'both flags enabled',
+      toggles: {
+        ...mockToggles,
+        data: {
+          ...mockToggles.data,
+          features: [
+            ...mockToggles.data.features,
+            {
+              name: 'mhv_secure_messaging_cerner_pilot',
+              value: true,
+            },
+            {
+              name:
+                'mhv_secure_messaging_cerner_pilot_system_maintenance_banner',
+              value: true,
+            },
+          ],
+        },
+      },
+      expectOracleHealthAlert: true,
+      expectCernerFacilityAlert: false,
+    },
+  ];
+
+  // Create a user with a Cerner facility (vha_687) that matches vamc-ehr.json
+  const mockUserWithCernerFacility = {
+    ...mockUser,
+    data: {
+      ...mockUser.data,
+      attributes: {
+        ...mockUser.data.attributes,
+        vaProfile: {
+          ...mockUser.data.attributes.vaProfile,
+          facilities: [
+            ...(mockUser.data.attributes.vaProfile?.facilities || []),
+            { facilityId: '687', isCerner: true },
+          ],
+        },
+      },
+    },
+  };
+
+  // Test with Cerner facilities in user profile
+  describe('User with Cerner facilities', () => {
+    testScenarios.forEach(scenario => {
+      folderIds.forEach(folder => {
+        it(`${scenario.name} - ${folder.name} folder`, () => {
+          SecureMessagingSite.login(
+            scenario.toggles,
+            mockVamcEhr,
+            true,
+            mockUserWithCernerFacility,
+            mockCernerFacilities,
+          );
+
+          PatientInboxPage.loadInboxMessages(
+            mockMessages,
+            mockSingleMessage,
+            mockRecipients,
+          );
+
+          if (folder.id === '-1') {
+            // Set up intercepts for Sent folder
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-1*`,
+              mockSentFolderMetaResponse,
+            ).as('sentFolder');
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-1/threads**`,
+              mockMessages,
+            ).as('sentFolderMessages');
+          } else if (folder.id === '-2') {
+            // Set up intercepts for Drafts folder
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-2*`,
+              mockDraftsFolderMetaResponse,
+            ).as('draftsFolder');
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-2/threads**`,
+              mockMessages,
+            ).as('draftsFolderMessages');
+          }
+
+          cy.visit(`${Paths.UI_MAIN}${folder.path}`);
+
+          // Wait for the correct folder messages to load
+          if (folder.id === '-1') {
+            cy.wait('@sentFolderMessages');
+          } else if (folder.id === '-2') {
+            cy.wait('@draftsFolderMessages');
+          } else {
+            cy.wait('@inboxMessages');
+          }
+
+          if (scenario.expectOracleHealthAlert) {
+            // Oracle Health Messaging Issues Alert should be visible
+            cy.get('va-alert[status="warning"]', { timeout: 10000 })
+              .should('be.visible')
+              .within(() => {
+                cy.get('h2[slot="headline"]')
+                  .should('contain.text', 'We')
+                  .and('contain.text', 'working on messages right now');
+                cy.contains('Some of your messages might not be here').should(
+                  'be.visible',
+                );
+                cy.contains(
+                  'To review all your messages, go to My VA Health',
+                ).should('be.visible');
+                cy.get('va-link')
+                  .should('be.visible')
+                  .and('have.attr', 'text', 'Go to My VA Health');
+              });
+
+            // Cerner Facility Alert should NOT be visible when Oracle Health Alert is shown
+            cy.get('[data-testid="cerner-facilities-alert"]').should(
+              'not.exist',
+            );
+          } else if (scenario.expectCernerFacilityAlert && folder.id === '0') {
+            // Cerner Facility Alert should be visible only in Inbox
+            cy.get('[data-testid="cerner-facilities-alert"]').should(
+              'be.visible',
+            );
+
+            // Oracle Health Messaging Issues Alert should NOT be visible
+            cy.contains(`We're working on messages right now`).should(
+              'not.exist',
+            );
+          } else {
+            // No alerts should be visible
+            cy.contains(`We're working on messages right now`).should(
+              'not.exist',
+            );
+            // Only check for Cerner alert absence if we're not expecting it
+            if (folder.id === '0') {
+              cy.get('[data-testid="cerner-facilities-alert"]').should(
+                'not.exist',
+              );
+            }
+          }
+
+          // Run accessibility check
+          cy.injectAxe();
+          cy.axeCheck(AXE_CONTEXT);
+        });
+      });
+    });
+  });
+
+  // Test with NO Cerner facilities in user profile
+  describe('User without Cerner facilities', () => {
+    testScenarios.forEach(scenario => {
+      folderIds.forEach(folder => {
+        it(`${scenario.name} - ${folder.name} folder`, () => {
+          SecureMessagingSite.login(
+            scenario.toggles,
+            mockVamcEhr,
+            true,
+            mockUser,
+            mockNoCernerFacilities,
+          );
+
+          PatientInboxPage.loadInboxMessages(
+            mockMessages,
+            mockSingleMessage,
+            mockRecipients,
+          );
+
+          if (folder.id === '-1') {
+            // Set up intercepts for Sent folder
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-1*`,
+              mockSentFolderMetaResponse,
+            ).as('sentFolder');
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-1/threads**`,
+              mockMessages,
+            ).as('sentFolderMessages');
+          } else if (folder.id === '-2') {
+            // Set up intercepts for Drafts folder
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-2*`,
+              mockDraftsFolderMetaResponse,
+            ).as('draftsFolder');
+            cy.intercept(
+              'GET',
+              `${Paths.SM_API_BASE}/folders/-2/threads**`,
+              mockMessages,
+            ).as('draftsFolderMessages');
+          }
+
+          cy.visit(`${Paths.UI_MAIN}${folder.path}`);
+
+          // Wait for the correct folder messages to load
+          if (folder.id === '-1') {
+            cy.wait('@sentFolderMessages');
+          } else if (folder.id === '-2') {
+            cy.wait('@draftsFolderMessages');
+          } else {
+            cy.wait('@inboxMessages');
+          }
+
+          if (scenario.expectOracleHealthAlert) {
+            // Oracle Health Messaging Issues Alert should be visible
+            cy.get('va-alert[status="warning"]', { timeout: 10000 })
+              .should('be.visible')
+              .within(() => {
+                cy.get('h2[slot="headline"]')
+                  .should('contain.text', 'We')
+                  .and('contain.text', 'working on messages right now');
+                cy.contains('Some of your messages might not be here').should(
+                  'be.visible',
+                );
+                cy.contains(
+                  'To review all your messages, go to My VA Health',
+                ).should('be.visible');
+                cy.get('va-link')
+                  .should('be.visible')
+                  .and('have.attr', 'text', 'Go to My VA Health');
+              });
+          } else {
+            // No Oracle Health alert should be visible
+            cy.get('h2')
+              .contains('working on messages right now')
+              .should('not.exist');
+          }
+
+          // Cerner Facility Alert should never be visible without Cerner facilities
+          cy.get('[data-testid="cerner-facilities-alert"]').should('not.exist');
+
+          // Run accessibility check
+          cy.injectAxe();
+          cy.axeCheck(AXE_CONTEXT);
+        });
+      });
+    });
+  });
+
+  // Additional edge case: Verify alert precedence
+  describe('Alert precedence', () => {
+    it('Oracle Health Issues Alert takes precedence over Cerner Facility Alert when both flags are enabled', () => {
+      const bothFlagsEnabled = {
+        ...mockToggles,
+        data: {
+          ...mockToggles.data,
+          features: [
+            ...mockToggles.data.features,
+            {
+              name: 'mhv_secure_messaging_cerner_pilot',
+              value: true,
+            },
+            {
+              name:
+                'mhv_secure_messaging_cerner_pilot_system_maintenance_banner',
+              value: true,
+            },
+          ],
+        },
+      };
+
+      SecureMessagingSite.login(
+        bothFlagsEnabled,
+        mockVamcEhr,
+        true,
+        mockUserWithCernerFacility,
+        mockCernerFacilities,
+      );
+
+      PatientInboxPage.loadInboxMessages(
+        mockMessages,
+        mockSingleMessage,
+        mockRecipients,
+      );
+
+      cy.visit(`${Paths.UI_MAIN}${Paths.INBOX}`);
+      cy.wait('@inboxMessages');
+
+      // Oracle Health Messaging Issues Alert should be visible
+      cy.get('h2[slot="headline"]', { timeout: 10000 })
+        .should('contain.text', 'We')
+        .and('contain.text', 'working on messages right now');
+
+      // Cerner Facility Alert should NOT be visible
+      cy.get('[data-testid="cerner-facilities-alert"]').should('not.exist');
+
+      cy.injectAxe();
+      cy.axeCheck(AXE_CONTEXT);
+    });
+  });
+
+  // Test link functionality
+  describe('Alert link functionality', () => {
+    it('Oracle Health alert link has correct attributes', () => {
+      const bothFlagsEnabled = {
+        ...mockToggles,
+        data: {
+          ...mockToggles.data,
+          features: [
+            ...mockToggles.data.features,
+            {
+              name: 'mhv_secure_messaging_cerner_pilot',
+              value: true,
+            },
+            {
+              name:
+                'mhv_secure_messaging_cerner_pilot_system_maintenance_banner',
+              value: true,
+            },
+          ],
+        },
+      };
+
+      SecureMessagingSite.login(
+        bothFlagsEnabled,
+        mockVamcEhr,
+        true,
+        mockUser,
+        mockCernerFacilities,
+      );
+
+      PatientInboxPage.loadInboxMessages(
+        mockMessages,
+        mockSingleMessage,
+        mockRecipients,
+      );
+
+      cy.visit(`${Paths.UI_MAIN}${Paths.INBOX}`);
+
+      // Verify link attributes
+      cy.get('va-alert[status="warning"]')
+        .find('va-link')
+        .should('have.attr', 'text', 'Go to My VA Health')
+        .and('have.attr', 'rel', 'noopener noreferrer')
+        .and('have.attr', 'href')
+        .and('include', '/pages/messaging/inbox');
+
+      cy.injectAxe();
+      cy.axeCheck(AXE_CONTEXT);
+    });
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/hooks/useFeatureToggles.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/hooks/useFeatureToggles.unit.spec.jsx
@@ -22,6 +22,7 @@ describe('useFeatureToggles', () => {
         [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot]: false,
         [FEATURE_FLAG_NAMES.mhvSecureMessagingCuratedListFlow]: false,
         [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: false,
+        [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilotSystemMaintenanceBanner]: false,
         'mhv-mock-session': false,
       },
     };
@@ -45,6 +46,7 @@ describe('useFeatureToggles', () => {
         [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot]: true,
         [FEATURE_FLAG_NAMES.mhvSecureMessagingCuratedListFlow]: true,
         [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: true,
+        [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilotSystemMaintenanceBanner]: true,
         'mhv-mock-session': true,
       },
     };
@@ -63,6 +65,7 @@ describe('useFeatureToggles', () => {
       cernerPilotSmFeatureFlag: true,
       mhvSecureMessagingCuratedListFlow: true,
       mhvSecureMessagingRecentRecipients: true,
+      mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag: true,
       mhvMockSessionFlag: true,
     });
   });

--- a/src/applications/mhv-secure-messaging/util/formHelpers.js
+++ b/src/applications/mhv-secure-messaging/util/formHelpers.js
@@ -11,8 +11,11 @@ export const focusOnErrorField = () => {
     const firstErrorElement = errors[0];
     let firstError = null;
 
-    // Check for input or textarea inside shadowRoot
-    if (firstErrorElement.shadowRoot) {
+    if (firstErrorElement.tagName === 'VA-RADIO') {
+      firstError = firstErrorElement
+        .querySelector('va-radio-option')
+        ?.querySelector('input');
+    } else if (firstErrorElement.shadowRoot) {
       firstError = firstErrorElement.shadowRoot.querySelector(
         'input, textarea',
       );

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -183,6 +183,7 @@
   "mhvMilestone2ChangesEnabled": "mhv_milestone_2_changes_enabled",
   "mhvModernCtaLinks": "mhv_modern_cta_links",
   "mhvSecureMessagingCernerPilot": "mhv_secure_messaging_cerner_pilot",
+  "mhvSecureMessagingCernerPilotSystemMaintenanceBanner": "mhv_secure_messaging_cerner_pilot_system_maintenance_banner",
   "mhvSecureMessagingFilterAccordion": "mhv_secure_messaging_filter_accordion",
   "mhvSecureMessagingTriageGroupPlainLanguage": "mhv_secure_messaging_triage_group_plain_language",
   "mhvSecureMessagingRecipientOptGroups": "mhv_secure_messaging_recipient_opt_groups",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request adds support for a new feature flag, `mhvSecureMessagingCernerPilotSystemMaintenanceBanner`, to control the display of the Oracle Health Messaging system maintenance banner in the secure messaging application. The changes ensure that the maintenance banner is only shown when both the Cerner pilot and the new maintenance banner feature flags are enabled. Unit tests have also been updated to cover the new logic.

**Feature flag integration:**

* Added the `mhvSecureMessagingCernerPilotSystemMaintenanceBanner` flag to `featureFlagNames.json` and integrated it into the `useFeatureToggles` hook, making it available throughout the application. [[1]](diffhunk://#diff-dd0d0ea85b2741bb70a428d6d62788694aedf62e624eb758f65800d421147082R186) [[2]](diffhunk://#diff-33c82f540bb69ed5e4177619e78711d32cb0754749cf75a6321f31dce40f8924R16) [[3]](diffhunk://#diff-33c82f540bb69ed5e4177619e78711d32cb0754749cf75a6321f31dce40f8924R58-R62) [[4]](diffhunk://#diff-33c82f540bb69ed5e4177619e78711d32cb0754749cf75a6321f31dce40f8924R83)

**Component logic update:**

* Updated the `FolderHeader` component to check both `cernerPilotSmFeatureFlag` and `mhvSecureMessagingCernerPilotSystemMaintenanceBannerFlag` before rendering the `OracleHealthMessagingIssuesAlert` banner. [[1]](diffhunk://#diff-bfbec0b20ba7849d542445f22d37e9281719c352464c34f8d18df2b2c7112cebL44-R47) [[2]](diffhunk://#diff-bfbec0b20ba7849d542445f22d37e9281719c352464c34f8d18df2b2c7112cebL106-R113) [[3]](diffhunk://#diff-bfbec0b20ba7849d542445f22d37e9281719c352464c34f8d18df2b2c7112cebL115-R127)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125724
- https://github.com/department-of-veterans-affairs/vets-api/pull/25263
- https://github.com/department-of-veterans-affairs/vets-website/pull/40264

## Testing done

* Modified and expanded unit tests in `folderHeader.unit.spec.jsx` to verify correct banner rendering behavior based on the new feature flag, including cases where the banner should not appear. [[1]](diffhunk://#diff-cd28a6537e4ca12e42c95e3e4c089433942336a7cd137e49510e6ddee855842aR428) [[2]](diffhunk://#diff-cd28a6537e4ca12e42c95e3e4c089433942336a7cd137e49510e6ddee855842aL439-R470)
* e2e test coverage

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
