### PR TITLE
Add cancel modal for editing and adding expense

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/CancelExpenseModal.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/CancelExpenseModal.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  VaModal,
-  VaButton,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 
 const CancelExpenseModal = ({
@@ -10,31 +7,26 @@ const CancelExpenseModal = ({
   onCloseEvent,
   onPrimaryButtonClick,
   onSecondaryButtonClick,
-  onOpenModal,
+  isEditMode,
 }) => {
+  const cancelModalText = isEditMode ? 'editing' : 'adding';
   return (
     <>
       <VaModal
-        modalTitle="Cancel adding this expense"
+        modalTitle={`Cancel ${cancelModalText} this expense`}
         onCloseEvent={onCloseEvent}
         onPrimaryButtonClick={onPrimaryButtonClick}
         onSecondaryButtonClick={onSecondaryButtonClick}
-        primaryButtonText="Cancel adding"
-        secondaryButtonText="Keep adding"
+        primaryButtonText={`Cancel ${cancelModalText}`}
+        secondaryButtonText={`Keep ${cancelModalText}`}
         status="warning"
         visible={visible}
       >
         <p>
-          If you cancel, you’ll lose the information you entered about this
-          expense and will be returned to your unsubmitted expenses.
+          If you cancel, you’ll lose any changes you made on this screen. And
+          you’ll be returned to your unsubmitted expenses.
         </p>
       </VaModal>
-      <VaButton
-        secondary
-        text="Cancel adding this expense"
-        onClick={onOpenModal}
-        className="vads-u-display--flex vads-u-margin-y--2 travel-pay-complex-expense-cancel-btn"
-      />
     </>
   );
 };
@@ -42,9 +34,9 @@ const CancelExpenseModal = ({
 CancelExpenseModal.propTypes = {
   visible: PropTypes.bool.isRequired,
   onCloseEvent: PropTypes.func.isRequired,
-  onOpenModal: PropTypes.func.isRequired,
   onPrimaryButtonClick: PropTypes.func.isRequired,
   onSecondaryButtonClick: PropTypes.func.isRequired,
+  isEditMode: PropTypes.bool,
 };
 
 export default CancelExpenseModal;

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -160,17 +160,19 @@ const ExpensePage = () => {
     }));
   };
 
-  const openCancelModal = () => setIsCancelModalVisible(true);
-  const closeCancelModal = () => setIsCancelModalVisible(false);
-
+  const handleOpenCancelModal = () => setIsCancelModalVisible(true);
+  const handleCloseCancelModal = () => setIsCancelModalVisible(false);
   const handleConfirmCancel = () => {
+    handleCloseCancelModal();
     if (isEditMode) {
-      setIsCancelModalVisible(false);
+      // TODO: Add logic to determine where the user came from and direct them back to the correct location
+      // navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
+      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
     } else {
-      setIsCancelModalVisible(true);
+      // TODO: Add logic to determine where the user came from and direct them back to the correct location
+      navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
+      // navigate(`/file-new-claim/${apptId}/${claimId}/review`);
     }
-
-    navigate(`/file-new-claim/${apptId}/${claimId}/review`);
   };
 
   // Field names must match those expected by the expenses_controller in vets-api.
@@ -346,7 +348,7 @@ const ExpensePage = () => {
         <VaButton
           secondary
           text="Cancel adding this expense"
-          onClick={openCancelModal}
+          onClick={handleOpenCancelModal}
           className="vads-u-display--flex vads-u-margin-y--2 travel-pay-complex-expense-cancel-btn"
         />
       )}
@@ -360,9 +362,9 @@ const ExpensePage = () => {
       />
       <CancelExpenseModal
         visible={isCancelModalVisible}
-        onCloseEvent={closeCancelModal}
+        onCloseEvent={handleCloseCancelModal}
         onPrimaryButtonClick={handleConfirmCancel}
-        onSecondaryButtonClick={closeCancelModal}
+        onSecondaryButtonClick={handleCloseCancelModal}
         isEditMode={isEditMode}
       />
     </>

--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useDispatch, useSelector } from 'react-redux';
-import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaRadio,
+  VaButton,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import { createExpense, updateExpense } from '../../../redux/actions';
 import {
@@ -22,9 +25,10 @@ const Mileage = () => {
   const dispatch = useDispatch();
   const { apptId, claimId, expenseId } = useParams();
 
+  const isEditMode = !!expenseId;
   const isLoadingExpense = useSelector(
     state =>
-      expenseId
+      isEditMode
         ? selectExpenseUpdateLoadingState(state)
         : selectExpenseCreationLoadingState(state),
   );
@@ -53,9 +57,17 @@ const Mileage = () => {
     setIsModalVisible(false);
   };
 
-  const handleCancelModal = () => {
+  const handleConfirmCancel = () => {
     handleCloseModal();
-    navigate(`/file-new-claim/${apptId}/${claimId}/review`);
+    if (isEditMode) {
+      // TODO: Add logic to determine where the user came from and direct them back to the correct location
+      // navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
+      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
+    } else {
+      // TODO: Add logic to determine where the user came from and direct them back to the correct location
+      navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
+      // navigate(`/file-new-claim/${apptId}/${claimId}/review`);
+    }
   };
 
   const handleContinue = async () => {
@@ -72,7 +84,7 @@ const Mileage = () => {
       navigate(`/file-new-claim/${apptId}/${claimId}/unsupported`);
     } else {
       try {
-        if (expenseId) {
+        if (isEditMode) {
           await dispatch(
             updateExpense(
               claimId,
@@ -97,9 +109,11 @@ const Mileage = () => {
   };
 
   const handleBack = () => {
-    if (expenseId) {
-      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
+    if (isEditMode) {
+      setIsModalVisible(true);
     } else {
+      // TODO: Add logic to determine where the user came from and direct them back to the correct location
+      // navigate(`/file-new-claim/${apptId}/${claimId}/review`);
       navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
     }
   };
@@ -190,13 +204,13 @@ const Mileage = () => {
           checked={tripType === TRIP_TYPES.ONE_WAY.value}
         />
       </VaRadio>
-      {!expenseId && (
-        <CancelExpenseModal
-          visible={isModalVisible}
-          onCloseEvent={handleCloseModal}
-          onOpenModal={handleOpenModal}
-          onPrimaryButtonClick={handleCancelModal}
-          onSecondaryButtonClick={handleCloseModal}
+
+      {!isEditMode && (
+        <VaButton
+          secondary
+          text="Cancel adding this expense"
+          onClick={handleOpenModal}
+          className="vads-u-display--flex vads-u-margin-y--2 travel-pay-complex-expense-cancel-btn"
         />
       )}
       <TravelPayButtonPair
@@ -206,6 +220,13 @@ const Mileage = () => {
         onBack={handleBack}
         onContinue={handleContinue}
         loading={isLoadingExpense}
+      />
+      <CancelExpenseModal
+        visible={isModalVisible}
+        onCloseEvent={handleCloseModal}
+        onPrimaryButtonClick={handleConfirmCancel}
+        onSecondaryButtonClick={handleCloseModal}
+        isEditMode={isEditMode}
       />
     </>
   );

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/CancelExpenseModal.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/CancelExpenseModal.unit.spec.jsx
@@ -22,40 +22,20 @@ describe('CancelExpenseModal', () => {
     expect($('va-modal[visible="true"]', container)).to.exist;
     expect($('va-modal[modal-title="Cancel adding this expense"]', container))
       .to.exist;
-    expect($('va-modal[primary-button-text="Cancel adding"]', container)).to
-      .exist;
-    expect($('va-modal[secondary-button-text="Keep adding"]', container)).to
-      .exist;
     expect($('va-modal[status="warning"]', container)).to.exist;
-
     expect(
       getByText(
-        'If you cancel, you’ll lose the information you entered about this expense and will be returned to your unsubmitted expenses.',
+        'If you cancel, you’ll lose any changes you made on this screen. And you’ll be returned to your unsubmitted expenses.',
       ),
     ).to.exist;
   });
 
-  it('renders the cancel button', () => {
+  it('renders the modal with buttons', () => {
     const { container } = render(<CancelExpenseModal {...defaultProps} />);
-
-    expect($('va-button[text="Cancel adding this expense"]', container)).to
-      .exist;
-  });
-
-  it('calls onOpenModal when cancel button is clicked', async () => {
-    const onOpen = sinon.spy();
-
-    const { container } = render(
-      <CancelExpenseModal {...defaultProps} onOpenModal={onOpen} />,
-    );
-
-    const button = $('va-button[text="Cancel adding this expense"]', container);
-    expect(button).to.exist;
-    button.click();
-
-    await waitFor(() => {
-      expect(onOpen.calledOnce).to.be.true;
-    });
+    const modal = container.querySelector('va-modal');
+    expect(modal).to.exist;
+    expect(modal.getAttribute('primary-button-text')).to.equal('Cancel adding');
+    expect(modal.getAttribute('secondary-button-text')).to.equal('Keep adding');
   });
 
   it('calls onPrimaryButtonClick when "Cancel adding" button is clicked', async () => {
@@ -112,22 +92,5 @@ describe('CancelExpenseModal', () => {
     );
 
     expect($('va-modal[visible="false"]', container)).to.exist;
-  });
-
-  it('cancel button has correct CSS classes', () => {
-    const { container } = render(<CancelExpenseModal {...defaultProps} />);
-
-    const button = $(
-      'va-button.vads-u-display--flex.vads-u-margin-y--2.travel-pay-complex-expense-cancel-btn',
-      container,
-    );
-    expect(button).to.exist;
-  });
-
-  it('cancel button is secondary styled', () => {
-    const { container } = render(<CancelExpenseModal {...defaultProps} />);
-
-    const button = $('va-button[secondary]', container);
-    expect(button).to.exist;
   });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -656,7 +656,7 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
     expect(button).to.exist;
   });
 
-  it('does NOT render add-mode cancel button', () => {
+  it('does NOT render "Cancel adding this expense" button when in add mode', () => {
     const { container } = renderEditPage();
     const addCancelButton = Array.from(
       container.querySelectorAll('va-button'),
@@ -664,7 +664,7 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
     expect(addCancelButton).to.not.exist;
   });
 
-  it('back button opens cancel modal in edit mode', () => {
+  it('"Back" button opens modal in edit mode', () => {
     const { container } = renderEditPage();
     const backButton = Array.from(container.querySelectorAll('va-button')).find(
       btn => btn.getAttribute('text') === 'Cancel',

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -326,10 +326,20 @@ describe('Travel Pay – ExpensePage (Dynamic w/ EXPENSE_TYPES)', () => {
           }
         });
 
+        it('renders "Cancel adding this expense" button only in add mode', () => {
+          const { container } = renderPage(config);
+          const cancelButton = Array.from(
+            container.querySelectorAll('va-button'),
+          ).find(
+            btn => btn.getAttribute('text') === 'Cancel adding this expense',
+          );
+          expect(cancelButton).to.exist;
+        });
+
         it('renders correct buttons', () => {
           const { container } = renderPage(config);
 
-          // Get all buttons
+          // Get all buttons, will either see 3 or 2
           const buttons = container.querySelectorAll('va-button');
           expect(buttons.length).to.be.at.least(3);
 
@@ -349,7 +359,7 @@ describe('Travel Pay – ExpensePage (Dynamic w/ EXPENSE_TYPES)', () => {
           ).find(btn => btn.getAttribute('text') === 'Continue');
           expect(continueButton).to.exist;
 
-          // Find the cancel button
+          // Find "Cancel adding this expense" button - only in add mode
           const cancelButton = Array.from(buttons).find(
             btn => btn.getAttribute('text') === 'Cancel adding this expense',
           );
@@ -646,23 +656,22 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
     expect(button).to.exist;
   });
 
-  it('does NOT show the cancel modal in edit mode', () => {
+  it('does NOT render add-mode cancel button', () => {
     const { container } = renderEditPage();
-
-    const modal = container.querySelector('va-modal');
-    expect(modal).to.not.exist;
+    const addCancelButton = Array.from(
+      container.querySelectorAll('va-button'),
+    ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+    expect(addCancelButton).to.not.exist;
   });
 
-  it('navigates back to the review page when clicking Cancel', () => {
-    const { container, getByTestId } = renderEditPage();
-
+  it('back button opens cancel modal in edit mode', () => {
+    const { container } = renderEditPage();
     const backButton = Array.from(container.querySelectorAll('va-button')).find(
       btn => btn.getAttribute('text') === 'Cancel',
     );
-
     fireEvent.click(backButton);
-
-    expect(getByTestId('review-page')).to.exist;
+    const modal = container.querySelector('va-modal');
+    expect(modal.getAttribute('visible')).to.equal('true');
   });
 
   it('loads existing document when documentId is present', async () => {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
@@ -8,98 +8,79 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import Mileage from '../../../../components/complex-claims/pages/Mileage';
 import reducer from '../../../../redux/reducer';
 
-describe('Complex Claims Mileage', () => {
-  const defaultApptId = '12345';
-  const defaultClaimId = '67890';
+describe('Complex Claims Mileage - Add', () => {
+  const TEST_CLAIM_ID = 'abc123';
+  const TEST_APPT_ID = 'abc123';
 
-  const renderComponent = (
-    apptId = defaultApptId,
-    claimId = defaultClaimId,
-  ) => {
-    const initialState = {
-      travelPay: {
-        appointment: {
-          data: {
-            id: apptId,
-            facilityName: 'Test VA Medical Center',
-            facilityAddress: {
-              addressLine1: '123 Medical Center Drive',
-              city: 'Test City',
-              stateCode: 'TX',
-              zipCode: '12345',
-            },
-            appointmentDate: '2024-01-15',
-            appointmentTime: '10:00 AM',
+  const getAddState = () => ({
+    travelPay: {
+      appointment: {
+        data: {
+          id: TEST_APPT_ID,
+          facilityName: 'Test VA Medical Center',
+          facilityAddress: {
+            addressLine1: '123 Medical Center Drive',
+            city: 'Test City',
+            stateCode: 'TX',
+            zipCode: '12345',
           },
-          error: null,
-          isLoading: false,
+          appointmentDate: '2024-01-15',
+          appointmentTime: '10:00 AM',
         },
-        claimDetails: {
-          data: {
-            [claimId]: {
-              id: claimId,
-              status: 'InProgress',
-              expenses: [],
-              appointmentId: apptId,
-            },
-          },
-        },
-        complexClaim: {
-          claim: {
-            creation: {
-              isLoading: false,
-              error: null,
-            },
-            submission: {
-              id: '',
-              isSubmitting: false,
-              error: null,
-              data: null,
-            },
-            data: null,
-          },
-          expenses: {
-            creation: {
-              isLoading: false,
-              error: null,
-            },
-            update: {
-              id: '',
-              isLoading: false,
-              error: null,
-            },
-            delete: {
-              id: '',
-              isLoading: false,
-              error: null,
-            },
-            data: [],
-          },
-        },
-        expense: {
-          isLoading: false,
-        },
+        error: null,
+        isLoading: false,
       },
-      user: {
-        profile: {
-          vapContactInfo: {
-            residentialAddress: {
-              addressLine1: '123 Main St',
-              addressLine2: 'Apt 1',
-              addressLine3: '',
-              city: 'Test City',
-              stateCode: 'TX',
-              zipCode: '12345',
-              countryName: 'United States',
-            },
+      claimDetails: {
+        data: {
+          [TEST_CLAIM_ID]: {
+            id: TEST_CLAIM_ID,
+            status: 'InProgress',
+            expenses: [],
+            appointmentId: TEST_APPT_ID,
           },
         },
       },
-    };
+      claimSubmission: { isSubmitting: false, error: null, data: null },
+      complexClaim: {
+        claim: {
+          creation: { isLoading: false, error: null },
+          submission: { id: '', isSubmitting: false, error: null, data: null },
+          fetch: { isLoading: false, error: null },
+          data: {
+            documents: [],
+          },
+        },
+        expenses: {
+          creation: { isLoading: false, error: null },
+          update: { id: '', isLoading: false, error: null },
+          delete: { id: '', isLoading: false, error: null },
+          data: [],
+        },
+      },
+    },
+    user: {
+      profile: {
+        vapContactInfo: {
+          residentialAddress: {
+            addressLine1: '123 Main St',
+            addressLine2: 'Apt 1',
+            addressLine3: '',
+            city: 'Test City',
+            stateCode: 'TX',
+            zipCode: '12345',
+            countryName: 'United States',
+          },
+        },
+      },
+    },
+  });
 
-    return renderWithStoreAndRouter(
+  const renderComponent = () =>
+    renderWithStoreAndRouter(
       <MemoryRouter
-        initialEntries={[`/file-new-claim/${apptId}/${claimId}/mileage`]}
+        initialEntries={[
+          `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/`,
+        ]}
       >
         <Routes>
           <Route
@@ -108,12 +89,8 @@ describe('Complex Claims Mileage', () => {
           />
         </Routes>
       </MemoryRouter>,
-      {
-        initialState,
-        reducers: reducer,
-      },
+      { initialState: getAddState(), reducers: reducer },
     );
-  };
 
   it('renders the component with all elements', () => {
     const screen = renderComponent();
@@ -127,6 +104,7 @@ describe('Complex Claims Mileage', () => {
     expect($('va-radio[id="departure-address"]')).to.exist;
     expect($('va-radio[id="trip-type"]')).to.exist;
     expect($('.travel-pay-button-group')).to.exist;
+    expect($('va-modal')).to.exist;
   });
 
   it('renders mileage information in additional info component', () => {
@@ -242,7 +220,7 @@ describe('Complex Claims Mileage', () => {
     });
   });
 
-  describe('Button Pair', () => {
+  describe('Buttons', () => {
     it('renders button pair with correct properties', () => {
       renderComponent();
 
@@ -252,18 +230,11 @@ describe('Complex Claims Mileage', () => {
       const buttons = buttonGroup.querySelectorAll('va-button');
       expect(buttons).to.have.lengthOf(2);
 
-      // Check back button
-      const backButton = buttons[0];
-      expect(backButton).to.exist;
-      expect(backButton.hasAttribute('back')).to.be.true;
-
-      // Check continue button
-      const continueButton = buttons[1];
-      expect(continueButton).to.exist;
-      expect(continueButton.hasAttribute('continue')).to.be.true;
+      expect(buttons[0].hasAttribute('back')).to.be.true;
+      expect(buttons[1].hasAttribute('continue')).to.be.true;
     });
 
-    it('handles primary button click', () => {
+    it('handles primary "Continue" button click', () => {
       renderComponent();
 
       const buttonGroup = $('.travel-pay-button-group');
@@ -271,16 +242,13 @@ describe('Complex Claims Mileage', () => {
 
       const continueButton = buttonGroup.querySelectorAll('va-button')[1];
       expect(continueButton).to.exist;
+      expect(continueButton.getAttribute('text')).to.eq('Continue');
 
-      // Simulate continue button click
       fireEvent.click(continueButton);
-
-      // Since the handler is empty, we just verify the event can be fired
-      // In a real implementation, this would test navigation or form submission
       expect(continueButton).to.exist;
     });
 
-    it('handles secondary button click', () => {
+    it('handles secondary "Back" button click', () => {
       renderComponent();
 
       const buttonGroup = $('.travel-pay-button-group');
@@ -288,13 +256,20 @@ describe('Complex Claims Mileage', () => {
 
       const backButton = buttonGroup.querySelectorAll('va-button')[0];
       expect(backButton).to.exist;
+      expect(backButton.getAttribute('text')).to.eq('Back');
 
-      // Simulate back button click
       fireEvent.click(backButton);
 
-      // Since the handler is empty, we just verify the event can be fired
-      // In a real implementation, this would test back navigation
       expect(backButton).to.exist;
+    });
+
+    it('renders "Cancel adding this expense" button', () => {
+      const { container } = renderComponent();
+
+      const addCancelButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+      expect(addCancelButton).to.exist;
     });
   });
 
@@ -318,5 +293,202 @@ describe('Complex Claims Mileage', () => {
       expect(departureRadio.value).to.equal('');
       expect(tripTypeRadio.value).to.equal('');
     });
+  });
+
+  describe('CancelExpenseModal', () => {
+    it('"Cancel adding this expense" button opens cancel modal', () => {
+      const { container } = renderComponent();
+
+      const button = container.querySelector('va-button');
+      // Click Cancel button
+      fireEvent.click(button);
+
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.exist;
+      expect(modal.visible).to.be.true;
+    });
+  });
+});
+
+describe('Complex Claims Mileage - Edit', () => {
+  const TEST_CLAIM_ID = 'abc123';
+  const TEST_EXPENSE_ID = 'abc123';
+  const TEST_APPT_ID = 'abc123';
+
+  const getEditState = () => ({
+    travelPay: {
+      appointment: {
+        data: {
+          id: TEST_APPT_ID,
+          facilityName: 'Test VA Medical Center',
+          facilityAddress: {
+            addressLine1: '123 Medical Center Drive',
+            city: 'Test City',
+            stateCode: 'TX',
+            zipCode: '12345',
+          },
+          appointmentDate: '2024-01-15',
+          appointmentTime: '10:00 AM',
+        },
+        error: null,
+        isLoading: false,
+      },
+      claimDetails: {
+        data: {
+          [TEST_CLAIM_ID]: {
+            id: TEST_CLAIM_ID,
+            status: 'InProgress',
+            expenses: [],
+            appointmentId: TEST_APPT_ID,
+          },
+        },
+      },
+      claimSubmission: { isSubmitting: false, error: null, data: null },
+      complexClaim: {
+        claim: {
+          creation: { isLoading: false, error: null },
+          submission: { id: '', isSubmitting: false, error: null, data: null },
+          fetch: { isLoading: false, error: null },
+          data: {
+            documents: [],
+          },
+        },
+        expenses: {
+          creation: { isLoading: false, error: null },
+          update: { id: '', isLoading: false, error: null },
+          delete: { id: '', isLoading: false, error: null },
+          data: [
+            {
+              id: TEST_EXPENSE_ID,
+              expenseType: 'Meal',
+              vendorName: 'Saved Vendor',
+              dateIncurred: '2025-11-17',
+              costRequested: '10.50',
+            },
+          ],
+        },
+      },
+    },
+    user: {
+      profile: {
+        vapContactInfo: {
+          residentialAddress: {
+            addressLine1: '123 Main St',
+            addressLine2: 'Apt 1',
+            addressLine3: '',
+            city: 'Test City',
+            stateCode: 'TX',
+            zipCode: '12345',
+            countryName: 'United States',
+          },
+        },
+      },
+    },
+  });
+
+  const renderEditPage = () =>
+    renderWithStoreAndRouter(
+      <MemoryRouter
+        initialEntries={[
+          `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/${TEST_EXPENSE_ID}`,
+        ]}
+      >
+        <Routes>
+          <Route
+            path="/file-new-claim/:apptId/:claimId/mileage/:expenseId"
+            element={<Mileage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+      { initialState: getEditState(), reducers: reducer },
+    );
+
+  it('renders the component with all elements', () => {
+    const { getByRole } = renderEditPage();
+
+    expect(getByRole('heading', { level: 1 })).to.have.property(
+      'textContent',
+      'Mileage',
+    );
+    expect($('va-additional-info[trigger="How we calculate mileage"]')).to
+      .exist;
+    expect($('va-radio[id="departure-address"]')).to.exist;
+    expect($('va-radio[id="trip-type"]')).to.exist;
+    expect($('.travel-pay-button-group')).to.exist;
+    expect($('va-modal')).to.exist;
+  });
+
+  it('does NOT render "Cancel adding this expense" button', () => {
+    const { container } = renderEditPage();
+
+    const addCancelButton = Array.from(
+      container.querySelectorAll('va-button'),
+    ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+    expect(addCancelButton).to.not.exist;
+  });
+
+  it('the "Cancel" button opens modal in edit mode', () => {
+    renderEditPage();
+
+    const backButton = $('.travel-pay-button-group').querySelectorAll(
+      'va-button',
+    )[0];
+    fireEvent.click(backButton);
+
+    const modal = $('va-modal');
+    expect(modal.hasAttribute('visible')).to.be.true;
+  });
+
+  it('Cancel" button opens modal in edit mode', () => {
+    const { container } = renderEditPage();
+
+    const backButton = Array.from(container.querySelectorAll('va-button')).find(
+      btn => btn.getAttribute('text') === 'Cancel',
+    );
+    fireEvent.click(backButton);
+    const modal = container.querySelector('va-modal');
+    expect(modal.getAttribute('visible')).to.equal('true');
+  });
+
+  it('renders button pair with correct properties', () => {
+    renderEditPage();
+
+    const buttonGroup = $('.travel-pay-button-group');
+    expect(buttonGroup).to.exist;
+
+    const buttons = buttonGroup.querySelectorAll('va-button');
+    expect(buttons).to.have.lengthOf(2);
+
+    expect(buttons[0].hasAttribute('back')).to.be.true;
+    expect(buttons[1].hasAttribute('continue')).to.be.true;
+  });
+
+  it('handles primary "Save and continue" button click', () => {
+    renderEditPage();
+
+    const buttonGroup = $('.travel-pay-button-group');
+    expect(buttonGroup).to.exist;
+
+    const continueButton = buttonGroup.querySelectorAll('va-button')[1];
+    expect(continueButton).to.exist;
+    expect(continueButton.getAttribute('text')).to.eq('Save and continue');
+
+    fireEvent.click(continueButton);
+    expect(continueButton).to.exist;
+  });
+
+  it('handles secondary "Cancel" button click', () => {
+    renderEditPage();
+
+    const buttonGroup = $('.travel-pay-button-group');
+    expect(buttonGroup).to.exist;
+
+    const backButton = buttonGroup.querySelectorAll('va-button')[0];
+    expect(backButton).to.exist;
+    expect(backButton.getAttribute('text')).to.eq('Cancel');
+
+    fireEvent.click(backButton);
+
+    expect(backButton).to.exist;
   });
 });


### PR DESCRIPTION
## Summary

- Updated `src/applications/travel-pay/components/complex-claims/pages/CancelExpenseModal.jsx` so that it could work as the add and edit cancel modal
- Updated `src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx` so that the modal appears from clicking the"Back" button when editing an expense and also when clicking the "Cancel adding this expense" button when adding an expense.
- Updated `src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx` so that the modal appears from clicking the"Back" button when editing an expense and also when clicking the "Cancel adding this expense" button when adding an expense.
- Updated and added tests for `src/applications/travel-pay/tests/components/complex-claims/pages/CancelExpenseModal.unit.spec.jsx`
- Updated and added tests for `src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx`
- Updated and added tests for `src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125583

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Adding Mileage Expense  |        |   <img width="806" height="808" alt="Screenshot 2025-11-21 at 8 19 42 AM" src="https://github.com/user-attachments/assets/a651db96-f586-4386-bc22-0c90f47f0c00" />    |
| Cancel Adding Mileage Expense Modal |        |  <img width="806" height="808" alt="Screenshot 2025-11-21 at 8 19 52 AM" src="https://github.com/user-attachments/assets/60c330a0-658a-45b2-a045-346e5893e5d0" />     |
| Editing Mileage Expense  |        |   <img width="806" height="808" alt="Screenshot 2025-11-21 at 8 25 51 AM" src="https://github.com/user-attachments/assets/7b6b128f-8dc8-44ad-a8a4-c6f0758eca88" />    |
| Cancel Editing Mileage Expense Modal |        |    <img width="1142" height="808" alt="Screenshot 2025-11-21 at 8 25 57 AM" src="https://github.com/user-attachments/assets/5f07a8c9-4b6a-4efc-94fd-7caee3ff4998" />   |
| Adding Non-Mileage Expense  |        |  <img width="1142" height="1218" alt="Screenshot 2025-11-21 at 8 28 00 AM" src="https://github.com/user-attachments/assets/223f9e55-1474-4455-bb61-ec5e1f97dce8" />    |
| Cancel Adding Non-Mileage Expense Modal |        |  <img width="1142" height="1218" alt="Screenshot 2025-11-21 at 8 28 08 AM" src="https://github.com/user-attachments/assets/b1b680bd-fda6-4111-84e4-abb3dc70c476" />     |
| Editing Non-Mileage Expense  |        |    <img width="1142" height="1276" alt="Screenshot 2025-11-21 at 8 29 12 AM" src="https://github.com/user-attachments/assets/05b2d4bf-14d9-462d-af7e-010cb13345b0" />   |
| Cancel Editing Non-Mileage Expense Modal |        |   <img width="1142" height="1276" alt="Screenshot 2025-11-21 at 8 29 20 AM" src="https://github.com/user-attachments/assets/ea625d6a-b7f3-4f53-a57e-6e01f4722b83" />    |


## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
