### PR TITLE
PBB | Update forms to LOA3 requirement

### DIFF
--- a/src/applications/burials-ez/components/IntroductionPage.jsx
+++ b/src/applications/burials-ez/components/IntroductionPage.jsx
@@ -132,6 +132,13 @@ const IntroductionPage = ({ route }) => {
         </va-process-list-item>
       </va-process-list>
 
+      {/* Only show the verify alert if all of the following are true:
+        - the user is logged in
+        - the feature toggle is enabled
+        - the user is NOT LOA3 verified
+        - the user does not have an in-progress form (we want LOA1 users to be
+          able to continue their form)
+      */}
       {loggedIn && pbbFormsRequireLoa3 && !isVerified && !hasInProgressForm ? (
         <>
           <VerifyAlert />

--- a/src/applications/burials-ez/components/IntroductionPage.jsx
+++ b/src/applications/burials-ez/components/IntroductionPage.jsx
@@ -21,7 +21,9 @@ const IntroductionPage = ({ route }) => {
     state => selectProfile(state)?.verified || false,
   );
   const hasInProgressForm = useSelector(state =>
-    selectProfile(state)?.savedForms?.includes(route.formConfig.formId),
+    selectProfile(state)?.savedForms?.some(
+      form => form.form === route.formConfig.formId,
+    ),
   );
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();

--- a/src/applications/burials-ez/tests/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/components/IntroductionPage.unit.spec.jsx
@@ -45,22 +45,22 @@ const getStore = ({
   dispatch: () => {},
 });
 
-const mockRoute = {
-  pageList: [{ path: 'wrong-path' }, { path: 'testing' }],
-  formConfig: {
-    prefillEnabled: true,
-    formId: formConfig.formId,
+const props = {
+  route: {
+    pageList: [{ path: 'wrong-path' }, { path: 'testing' }],
+    formConfig: {
+      prefillEnabled: true,
+      formId: formConfig.formId,
+    },
   },
+  location: { basename: '/some-path' },
 };
 
 describe('IntroductionPage', () => {
   it('renders the IntroductionPage component', () => {
     const screen = render(
       <Provider store={getStore({ loggedIn: false })}>
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+        <IntroductionPage {...props} />
       </Provider>,
     );
 
@@ -84,10 +84,7 @@ describe('IntroductionPage', () => {
     // logged in false, toggle true, verified false, saved form false
     const { container } = render(
       <Provider store={getStore({ loggedIn: false, toggle: true })}>
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+        <IntroductionPage {...props} />
       </Provider>,
     );
     expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
@@ -97,10 +94,7 @@ describe('IntroductionPage', () => {
     // logged in true, toggle false, verified false, saved form false
     const { container } = render(
       <Provider store={getStore()}>
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+        <IntroductionPage {...props} />
       </Provider>,
     );
     expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
@@ -110,38 +104,43 @@ describe('IntroductionPage', () => {
     // logged in true, toggle false, verified false, saved form true
     const { container } = render(
       <Provider store={getStore({ savedForm: true })}>
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+        <IntroductionPage {...props} />
       </Provider>,
     );
     expect($('[data-testid="continue-your-application"]', container)).to.exist;
   });
 
-  it('renders the IntroductionPage component (logged in, toggle on & not verified)', () => {
+  it('renders the verify alert (logged in, toggle on, not verified, no in progress)', () => {
     // logged in true, toggle true, verified false, saved form false
     const { container } = render(
       <Provider store={getStore({ toggle: true })}>
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+        <IntroductionPage {...props} />
       </Provider>,
     );
     expect($('va-alert-sign-in[variant="verifyIdMe"]', container)).to.exist;
   });
 
+  it('renders the continue app button (logged in, toggle on, not verified & has in progress)', () => {
+    // logged in true, toggle true, verified false, saved form true
+    const mockStore = getStore({ toggle: true, savedForm: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
   it('renders continue app button when logged in, with saved form, verified & toggle on', () => {
     // logged in true, toggle true, verified true, saved form true
+    const mockStore = getStore({
+      toggle: true,
+      savedForm: true,
+      verified: true,
+    });
     const { container } = render(
-      <Provider
-        store={getStore({ toggle: true, savedForm: true, verified: true })}
-      >
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
       </Provider>,
     );
     expect($('[data-testid="continue-your-application"]', container)).to.exist;
@@ -157,10 +156,7 @@ describe('IntroductionPage', () => {
     });
     const { container } = render(
       <Provider store={mockStore}>
-        <IntroductionPage
-          route={mockRoute}
-          location={{ basename: '/some-path' }}
-        />
+        <IntroductionPage {...props} />
       </Provider>,
     );
     expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;

--- a/src/applications/burials-ez/tests/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/components/IntroductionPage.unit.spec.jsx
@@ -2,56 +2,61 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import IntroductionPage from '../../components/IntroductionPage';
 
-const store = {
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import IntroductionPage from '../../components/IntroductionPage';
+import formConfig from '../../config/form';
+
+const getStore = ({
+  loggedIn = true,
+  toggle = false,
+  verified = false,
+  savedForm = false,
+} = {}) => ({
   getState: () => ({
     user: {
       login: {
-        currentlyLoggedIn: true,
+        currentlyLoggedIn: loggedIn,
       },
       profile: {
-        savedForms: [],
+        savedForms: savedForm
+          ? [{ form: formConfig.formId, metadata: { expiresAt: 9999999999 } }]
+          : [],
         prefillsAvailable: [],
+        verified,
       },
     },
     form: {
-      formId: '21P-530',
+      formId: formConfig.formId,
       savedStatus: '',
       loadedData: {
         metadata: {},
       },
       data: {},
-      contestedIssues: {},
     },
     featureToggles: {
       loading: false,
       [`burials_form_enabled`]: true,
+      [`pbb_forms_require_loa3`]: toggle,
     },
   }),
   subscribe: () => {},
   dispatch: () => {},
-};
+});
 
 const mockRoute = {
-  pageList: [
-    {
-      path: 'wrong-path',
-    },
-    {
-      path: 'testing',
-    },
-  ],
+  pageList: [{ path: 'wrong-path' }, { path: 'testing' }],
   formConfig: {
-    prefillEnabled: false,
-    downtime: false,
+    prefillEnabled: true,
+    formId: formConfig.formId,
   },
 };
 
 describe('IntroductionPage', () => {
   it('renders the IntroductionPage component', () => {
     const screen = render(
-      <Provider store={store}>
+      <Provider store={getStore({ loggedIn: false })}>
         <IntroductionPage
           route={mockRoute}
           location={{ basename: '/some-path' }}
@@ -69,5 +74,95 @@ describe('IntroductionPage', () => {
         'Follow these steps to apply for a burial allowance and transportation benefits',
       ),
     ).to.exist;
+
+    // logged in false, toggle false, verified false, saved form false
+    expect($('va-alert-sign-in[variant="signInOptional"]', screen.container)).to
+      .exist;
+  });
+
+  it('renders sign in required alert when not logged in & toggle on', () => {
+    // logged in false, toggle true, verified false, saved form false
+    const { container } = render(
+      <Provider store={getStore({ loggedIn: false, toggle: true })}>
+        <IntroductionPage
+          route={mockRoute}
+          location={{ basename: '/some-path' }}
+        />
+      </Provider>,
+    );
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
+  });
+
+  it('renders start action link when logged in, no saved form & toggle off', () => {
+    // logged in true, toggle false, verified false, saved form false
+    const { container } = render(
+      <Provider store={getStore()}>
+        <IntroductionPage
+          route={mockRoute}
+          location={{ basename: '/some-path' }}
+        />
+      </Provider>,
+    );
+    expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
+  });
+
+  it('renders continue app button when logged in, with saved form & toggle off', () => {
+    // logged in true, toggle false, verified false, saved form true
+    const { container } = render(
+      <Provider store={getStore({ savedForm: true })}>
+        <IntroductionPage
+          route={mockRoute}
+          location={{ basename: '/some-path' }}
+        />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
+  it('renders the IntroductionPage component (logged in, toggle on & not verified)', () => {
+    // logged in true, toggle true, verified false, saved form false
+    const { container } = render(
+      <Provider store={getStore({ toggle: true })}>
+        <IntroductionPage
+          route={mockRoute}
+          location={{ basename: '/some-path' }}
+        />
+      </Provider>,
+    );
+    expect($('va-alert-sign-in[variant="verifyIdMe"]', container)).to.exist;
+  });
+
+  it('renders continue app button when logged in, with saved form, verified & toggle on', () => {
+    // logged in true, toggle true, verified true, saved form true
+    const { container } = render(
+      <Provider
+        store={getStore({ toggle: true, savedForm: true, verified: true })}
+      >
+        <IntroductionPage
+          route={mockRoute}
+          location={{ basename: '/some-path' }}
+        />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
+  it('renders start action link when logged in & toggle on', () => {
+    // logged in true, toggle true, verified true, saved form false
+    const mockStore = getStore({
+      loggedIn: true,
+      toggle: true,
+      verified: true,
+      savedForm: false,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage
+          route={mockRoute}
+          location={{ basename: '/some-path' }}
+        />
+      </Provider>,
+    );
+    expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
   });
 });

--- a/src/applications/income-and-asset-statement/containers/IntroductionPage.jsx
+++ b/src/applications/income-and-asset-statement/containers/IntroductionPage.jsx
@@ -180,6 +180,13 @@ export const IntroductionPage = ({ route }) => {
         turned 18 unless custody is legally removed.
       </va-additional-info>
 
+      {/* Only show the verify alert if all of the following are true:
+        - the user is logged in
+        - the feature toggle is enabled
+        - the user is NOT LOA3 verified
+        - the user does not have an in-progress form (we want LOA1 users to be
+          able to continue their form)
+      */}
       {loggedIn && pbbFormsRequireLoa3 && !isVerified && !hasInProgressForm ? (
         <>
           <VerifyAlert />

--- a/src/applications/income-and-asset-statement/containers/IntroductionPage.jsx
+++ b/src/applications/income-and-asset-statement/containers/IntroductionPage.jsx
@@ -17,7 +17,9 @@ export const IntroductionPage = ({ route }) => {
     state => selectProfile(state)?.verified || false,
   );
   const hasInProgressForm = useSelector(state =>
-    selectProfile(state)?.savedForms?.includes(formConfig.formId),
+    selectProfile(state)?.savedForms?.some(
+      form => form.form === route.formConfig.formId,
+    ),
   );
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();

--- a/src/applications/income-and-asset-statement/tests/unit/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/containers/IntroductionPage.unit.spec.jsx
@@ -6,7 +6,12 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import IntroductionPage from '../../../containers/IntroductionPage';
 import formConfig from '../../../config/form';
 
-const getData = ({ loggedIn = true } = {}) => ({
+const getData = ({
+  loggedIn = true,
+  toggle = false,
+  verified = false,
+  savedForm = false,
+} = {}) => ({
   props: {
     route: {
       formConfig,
@@ -20,9 +25,11 @@ const getData = ({ loggedIn = true } = {}) => ({
           currentlyLoggedIn: loggedIn,
         },
         profile: {
-          savedForms: [],
+          savedForms: savedForm
+            ? [{ form: formConfig.formId, metadata: { expiresAt: 9999999999 } }]
+            : [],
           prefillsAvailable: [],
-          verified: false,
+          verified,
         },
       },
       form: {
@@ -33,6 +40,10 @@ const getData = ({ loggedIn = true } = {}) => ({
           metadata: {},
         },
         data: {},
+      },
+      featureToggles: {
+        loading: false,
+        [`pbb_forms_require_loa3`]: toggle,
       },
     }),
     subscribe: () => {},
@@ -64,6 +75,8 @@ describe('<IntroductionPage />', () => {
     expect(container.innerHTML).to.include(
       'Find out if you’re eligible for VA Dependency and Indemnity Compensation',
     );
+    // logged in false, toggle false, verified false, saved form false
+    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
   });
 
   it('should not show DIC eligibility link when logged in', () => {
@@ -121,5 +134,81 @@ describe('<IntroductionPage />', () => {
     );
     expect(container.querySelector('va-accordion')).to.exist;
     expect(container.innerHTML).to.include('If you’re the Veteran');
+  });
+
+  // Checking LOA3 toggle
+  it('renders sign in required alert when not logged in & toggle on', () => {
+    // logged in false, toggle true, verified false, saved form false
+    const { props, mockStore } = getData({ loggedIn: false, toggle: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
+  });
+
+  it('renders start action link when logged in, no saved form & toggle off', () => {
+    // logged in true, toggle false, verified false, saved form false
+    const { props, mockStore } = getData();
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
+  });
+
+  it('renders continue app button when logged in, with saved form & toggle off', () => {
+    // logged in true, toggle false, verified false, saved form true
+    const { props, mockStore } = getData({ savedForm: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
+  it('renders the IntroductionPage component (logged in, toggle on & not verified)', () => {
+    // logged in true, toggle true, verified false, saved form false
+    const { props, mockStore } = getData({ toggle: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-alert-sign-in[variant="verifyIdMe"]', container)).to.exist;
+  });
+
+  it('renders continue app button when logged in, with saved form, verified & toggle on', () => {
+    // logged in true, toggle true, verified true, saved form true
+    const { props, mockStore } = getData({
+      toggle: true,
+      savedForm: true,
+      verified: true,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
+  it('renders start action link when logged in & toggle on', () => {
+    // logged in true, toggle true, verified true, saved form false
+    const { props, mockStore } = getData({
+      loggedIn: true,
+      toggle: true,
+      verified: true,
+      savedForm: false,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
   });
 });

--- a/src/applications/income-and-asset-statement/tests/unit/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/containers/IntroductionPage.unit.spec.jsx
@@ -170,7 +170,7 @@ describe('<IntroductionPage />', () => {
     expect($('[data-testid="continue-your-application"]', container)).to.exist;
   });
 
-  it('renders the IntroductionPage component (logged in, toggle on & not verified)', () => {
+  it('renders the verify alert (logged in, toggle on, not verified, no in progress)', () => {
     // logged in true, toggle true, verified false, saved form false
     const { props, mockStore } = getData({ toggle: true });
     const { container } = render(
@@ -179,6 +179,17 @@ describe('<IntroductionPage />', () => {
       </Provider>,
     );
     expect($('va-alert-sign-in[variant="verifyIdMe"]', container)).to.exist;
+  });
+
+  it('renders the continue app button (logged in, toggle on, not verified & has in progress)', () => {
+    // logged in true, toggle true, verified false, saved form true
+    const { props, mockStore } = getData({ toggle: true, savedForm: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
   });
 
   it('renders continue app button when logged in, with saved form, verified & toggle on', () => {

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { isLoggedIn, selectProfile } from 'platform/user/selectors';
+import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+
 import { FormReactivationAlert } from './FormAlerts';
 
 const IntroductionPage = props => {
@@ -11,6 +16,15 @@ const IntroductionPage = props => {
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const pbbFormsRequireLoa3 = useToggleValue(TOGGLE_NAMES.pbbFormsRequireLoa3);
+
+  const loggedIn = useSelector(isLoggedIn);
+  // LOA3 Verified?
+  const isVerified = useSelector(
+    state => selectProfile(state)?.verified || false,
+  );
+  const hasInProgressForm = useSelector(state =>
+    selectProfile(state)?.savedForms?.includes(formConfig.formId),
+  );
 
   return (
     <article className="schemaform-intro">
@@ -165,17 +179,36 @@ const IntroductionPage = props => {
           </va-additional-info>
         </va-process-list-item>
       </va-process-list>
-      <SaveInProgressIntro
-        hideUnauthedStartLink={pbbFormsRequireLoa3}
-        formConfig={formConfig}
-        prefillEnabled={formConfig.prefillEnabled}
-        pageList={pageList}
-        downtime={route.formConfig.downtime}
-        startText="Start the pension application"
-        retentionPeriod="one year"
-        retentionPeriodStart="when you start"
-        continueMsg={<FormReactivationAlert />}
-      />
+      {loggedIn && pbbFormsRequireLoa3 && !isVerified && !hasInProgressForm ? (
+        <>
+          <VerifyAlert />
+          <p>
+            If you don’t want to verify your identity right now, you can still
+            download and complete the PDF version of this application.
+          </p>
+          <p className="vads-u-margin-bottom--4">
+            <va-link
+              href="http://www.vba.va.gov/pubs/forms/VBA-21P-527EZ-ARE.pdf"
+              download
+              filetype="PDF"
+              text="Get VA Form 21P-527EZ form to download"
+              pages="17"
+            />
+          </p>
+        </>
+      ) : (
+        <SaveInProgressIntro
+          hideUnauthedStartLink={pbbFormsRequireLoa3}
+          formConfig={formConfig}
+          prefillEnabled={formConfig.prefillEnabled}
+          pageList={pageList}
+          downtime={route.formConfig.downtime}
+          startText="Start the pension application"
+          retentionPeriod="one year"
+          retentionPeriodStart="when you start"
+          continueMsg={<FormReactivationAlert />}
+        />
+      )}
       <div className="vads-u-margin-top--2">
         <va-omb-info
           res-burden={30}
@@ -190,6 +223,7 @@ const IntroductionPage = props => {
 IntroductionPage.propTypes = {
   route: PropTypes.shape({
     formConfig: PropTypes.shape({
+      formId: PropTypes.string,
       prefillEnabled: PropTypes.bool,
       savedFormMessages: PropTypes.object,
       title: PropTypes.string,

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -23,7 +23,9 @@ const IntroductionPage = props => {
     state => selectProfile(state)?.verified || false,
   );
   const hasInProgressForm = useSelector(state =>
-    selectProfile(state)?.savedForms?.includes(formConfig.formId),
+    selectProfile(state)?.savedForms?.some(
+      form => form.form === route.formConfig.formId,
+    ),
   );
 
   return (

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -181,6 +181,14 @@ const IntroductionPage = props => {
           </va-additional-info>
         </va-process-list-item>
       </va-process-list>
+
+      {/* Only show the verify alert if all of the following are true:
+        - the user is logged in
+        - the feature toggle is enabled
+        - the user is NOT LOA3 verified
+        - the user does not have an in-progress form (we want LOA1 users to be
+          able to continue their form)
+      */}
       {loggedIn && pbbFormsRequireLoa3 && !isVerified && !hasInProgressForm ? (
         <>
           <VerifyAlert />

--- a/src/applications/pensions/tests/unit/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/components/IntroductionPage.unit.spec.jsx
@@ -107,7 +107,7 @@ describe('<IntroductionPage />', () => {
     expect($('[data-testid="continue-your-application"]', container)).to.exist;
   });
 
-  it('renders the IntroductionPage component (logged in, toggle on & not verified)', () => {
+  it('renders the verify alert (logged in, toggle on, not verified, no in progress)', () => {
     // logged in true, toggle true, verified false, saved form false
     const { props, mockStore } = getData({ toggle: true });
     const { container } = render(
@@ -116,6 +116,17 @@ describe('<IntroductionPage />', () => {
       </Provider>,
     );
     expect($('va-alert-sign-in[variant="verifyIdMe"]', container)).to.exist;
+  });
+
+  it('renders the continue app button (logged in, toggle on, not verified & has in progress)', () => {
+    // logged in true, toggle true, verified false, saved form true
+    const { props, mockStore } = getData({ toggle: true, savedForm: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
   });
 
   it('renders continue app button when logged in, with saved form, verified & toggle on', () => {

--- a/src/applications/pensions/tests/unit/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/components/IntroductionPage.unit.spec.jsx
@@ -6,11 +6,19 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import IntroductionPage from '../../../components/IntroductionPage';
 import formConfig from '../../../config/form';
 
-const getData = ({ loggedIn = true } = {}) => ({
+const getData = ({
+  loggedIn = true,
+  toggle = false,
+  verified = false,
+  savedForm = false,
+} = {}) => ({
   props: {
     loggedIn,
     route: {
-      formConfig,
+      formConfig: {
+        prefillEnabled: true,
+        formId: formConfig.formId,
+      },
       pageList: [{ path: '/introduction' }, { path: '/next', formConfig }],
     },
     location: {
@@ -24,9 +32,11 @@ const getData = ({ loggedIn = true } = {}) => ({
           currentlyLoggedIn: loggedIn,
         },
         profile: {
-          savedForms: [],
+          savedForms: savedForm
+            ? [{ form: formConfig.formId, metadata: { expiresAt: 9999999999 } }]
+            : [],
           prefillsAvailable: [],
-          verified: false,
+          verified,
         },
       },
       form: {
@@ -38,6 +48,10 @@ const getData = ({ loggedIn = true } = {}) => ({
         },
         data: {},
       },
+      featureToggles: {
+        loading: false,
+        [`pbb_forms_require_loa3`]: toggle,
+      },
     }),
     subscribe: () => {},
     dispatch: () => {},
@@ -46,7 +60,7 @@ const getData = ({ loggedIn = true } = {}) => ({
 
 describe('<IntroductionPage />', () => {
   it('should render', () => {
-    const { props, mockStore } = getData();
+    const { props, mockStore } = getData({ loggedIn: false });
     const { container } = render(
       <Provider store={mockStore}>
         <IntroductionPage {...props} />
@@ -56,5 +70,82 @@ describe('<IntroductionPage />', () => {
     expect($('h1', container).textContent).to.eql(
       'Apply for Veterans Pension benefits',
     );
+    // logged in false, toggle false, verified false, saved form false
+    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
+  });
+
+  it('renders sign in required alert when not logged in & toggle on', () => {
+    // logged in false, toggle true, verified false, saved form false
+    const { props, mockStore } = getData({ loggedIn: false, toggle: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
+  });
+
+  it('renders start action link when logged in, no saved form & toggle off', () => {
+    // logged in true, toggle false, verified false, saved form false
+    const { props, mockStore } = getData({ loggedIn: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
+  });
+
+  it('renders continue app button when logged in, with saved form & toggle off', () => {
+    // logged in true, toggle false, verified false, saved form true
+    const { props, mockStore } = getData({ savedForm: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
+  it('renders the IntroductionPage component (logged in, toggle on & not verified)', () => {
+    // logged in true, toggle true, verified false, saved form false
+    const { props, mockStore } = getData({ toggle: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-alert-sign-in[variant="verifyIdMe"]', container)).to.exist;
+  });
+
+  it('renders continue app button when logged in, with saved form, verified & toggle on', () => {
+    // logged in true, toggle true, verified true, saved form true
+    const { props, mockStore } = getData({
+      toggle: true,
+      savedForm: true,
+      verified: true,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('[data-testid="continue-your-application"]', container)).to.exist;
+  });
+
+  it('renders start action link when logged in & toggle on', () => {
+    // logged in true, toggle true, verified true, saved form false
+    const { props, mockStore } = getData({
+      loggedIn: true,
+      toggle: true,
+      verified: true,
+      savedForm: false,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Changes:
  > - Updated Burials-EZ, Income and Asset Statement, and Pensions forms to show a get verified alert if not LOA3 behind feature toggle
  > - New code does not block Veterans that are not verified and have an in-progress form
  > &nbsp;
  >
  > Showing the logic that has been implemented:
  > 
  > | Logged in | Toggle | Verified (LOA3) | Has saved form | What you'll see |
  > |:---:|:---:|:---:|:---:|---|
  > | No | Off | No | No | Optional Sign in (unauthenticated link) |
  > | No | On | No | No | Required Sign in |
  > | Yes | Off | No | Yes | Continue application button |
  > | Yes | On | No | Yes | Continue application button |
  > | Yes | On | Yes | Yes | Continue application button |
  > | Yes | Off | No | No | Start form action link |
  > | Yes | On | Yes | No | Start form action link |
  > | Yes | On | No | No | Verify alert |

- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  > Using `pbb_forms_require_loa3`

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/124115

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated introduction page unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Toggle on & not verified
| ------- | ------ |
| Pensions | <img width="788" height="769" alt="Screenshot 2025-11-20 at 1 17 51 PM" src="https://github.com/user-attachments/assets/f41eb095-ccaa-4e1a-bc41-cfd89358edcd" /> |
| Burials  | <img width="768" height="830" alt="Screenshot 2025-11-20 at 1 28 28 PM" src="https://github.com/user-attachments/assets/70bffda2-f99f-42bf-aff7-f8488156e5fb" /> |
| Income and assets statement | <img width="768" height="754" alt="Screenshot 2025-11-20 at 1 24 02 PM" src="https://github.com/user-attachments/assets/b5618bce-062a-4374-bad3-9ddaaaa13196" /> |

## What areas of the site does it impact?

- Pensions
- Burials
- Income and Assets Statement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
