### PR TITLE
[ARC/125647] - fixing logo link on representative form upload

### DIFF
--- a/src/applications/representative-form-upload/components/Header/Nav.jsx
+++ b/src/applications/representative-form-upload/components/Header/Nav.jsx
@@ -25,7 +25,7 @@ export const Nav = () => {
           data-testid="nav-home-link"
           aria-label="VA Accredited Representative Portal"
           className="nav__link vads-u-display--flex"
-          to="/"
+          href="/representative"
         >
           <img
             data-testid="mobile-logo"


### PR DESCRIPTION
Fixing broken logo link within representative fold upload, see ticket
https://github.com/department-of-veterans-affairs/va.gov-team/issues/125647