### PR TITLE
123908 BIO - Add prefill to form 21P-0537

### DIFF
--- a/src/applications/simple-forms/21p-0537/config/prefill-transformer.js
+++ b/src/applications/simple-forms/21p-0537/config/prefill-transformer.js
@@ -1,15 +1,15 @@
-export default function prefillTransformer(pages, _formData, metadata, state) {
+export default function prefillTransformer(pages, formData, metadata, state) {
   const { profile = {} } = state?.user || {};
-  const { userFullName, email, phoneNumber } = profile;
+  const { userFullName } = profile;
 
   return {
     pages,
     formData: {
+      ...formData,
       recipientName: userFullName || { first: '', last: '' },
-      primaryPhone: phoneNumber || '',
-      emailAddress: email || '',
+      primaryPhone: formData.claimantPhone || '',
+      emailAddress: formData.claimantEmail || '',
     },
     metadata,
-    state,
   };
 }

--- a/src/applications/simple-forms/21p-0537/tests/e2e/fixtures/mocks/sip-get.json
+++ b/src/applications/simple-forms/21p-0537/tests/e2e/fixtures/mocks/sip-get.json
@@ -1,38 +1,5 @@
 {
-  "formData": {
-    "veteranFullName": {
-      "first": "John",
-      "middle": "Robert",
-      "last": "Deceased"
-    },
-    "veteranIdentification": {
-      "ssn": "123456789"
-    },
-    "hasRemarried": true,
-    "remarriage": {
-      "dateOfMarriage": "2020-05-15",
-      "spouseName": {
-        "first": "Robert",
-        "middle": "James",
-        "last": "Smith"
-      },
-      "spouseDateOfBirth": "1980-08-20",
-      "ageAtMarriage": 35,
-      "spouseIsVeteran": true,
-      "spouseVeteranId": {
-        "vaFileNumber": "123456789"
-      },
-      "hasTerminated": false
-    },
-    "primaryPhone": "555-123-4567",
-    "secondaryPhone": "555-987-6543",
-    "emailAddress": "jane.spouse@example.com",
-    "recipientName": {
-      "first": "Jane",
-      "middle": "M",
-      "last": "Spouse"
-    }
-  },
+  "formData": {},
   "metadata": {
     "version": 0,
     "prefill": true,

--- a/src/applications/simple-forms/21p-0537/tests/unit/prefill-transformer.unit.spec.jsx
+++ b/src/applications/simple-forms/21p-0537/tests/unit/prefill-transformer.unit.spec.jsx
@@ -16,13 +16,21 @@ describe('21P-0537 prefillTransformer', () => {
               middle: 'Marie',
               last: 'Smith',
             },
-            email: 'jennifer.smith@example.com',
-            phoneNumber: '5551234567',
           },
         },
       };
 
-      const result = prefillTransformer(pages, formData, metadata, state);
+      const prefilledformData = {
+        claimantEmail: 'jennifer.smith@example.com',
+        claimantPhone: '5551234567',
+      };
+
+      const result = prefillTransformer(
+        pages,
+        prefilledformData,
+        metadata,
+        state,
+      );
 
       expect(result.formData.recipientName.first).to.include('Jennifer');
       expect(result.formData.recipientName.middle).to.include('Marie');
@@ -91,12 +99,17 @@ describe('21P-0537 prefillTransformer', () => {
               first: 'John',
               last: 'Doe',
             },
-            phoneNumber: '5551234567',
           },
         },
       };
 
-      const result = prefillTransformer(pages, formData, metadata, state);
+      const prefilledFormData = { claimantPhone: '5551234567' };
+      const result = prefillTransformer(
+        pages,
+        prefilledFormData,
+        metadata,
+        state,
+      );
 
       expect(result.formData.recipientName.first).to.include('John');
       expect(result.formData.recipientName.last).to.include('Doe');
@@ -112,12 +125,19 @@ describe('21P-0537 prefillTransformer', () => {
               first: 'John',
               last: 'Doe',
             },
-            email: 'john.doe@example.com',
           },
         },
       };
+      const prefilledFormData = {
+        claimantEmail: 'john.doe@example.com',
+      };
 
-      const result = prefillTransformer(pages, formData, metadata, state);
+      const result = prefillTransformer(
+        pages,
+        prefilledFormData,
+        metadata,
+        state,
+      );
 
       expect(result.formData.recipientName.first).to.include('John');
       expect(result.formData.recipientName.last).to.include('Doe');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds prefill to form 21P-0537. It also updates some unit tests to compensate for changes to the prefill transformer.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/25274

## Testing done

- Manual
- Unit

## Screenshots

|Prefilled phone/email|
|-|
|<img width="639" height="636" alt="prefilled" src="https://github.com/user-attachments/assets/fea8665f-7b55-4653-96d6-5e1af7a0a428" />|

## What areas of the site does it impact?

```
src/applications/simple-forms/21p-0537/config/prefill-transformer.js
src/applications/simple-forms/21p-0537/tests/e2e/fixtures/mocks/sip-get.json
src/applications/simple-forms/21p-0537/tests/unit/prefill-transformer.unit.spec.jsx
```

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA