### PR TITLE
Update error state to use warning alert on Files We Couldn't Receive page

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -78,129 +78,127 @@ const FilesWeCouldntReceive = () => {
     return <Navigate to="/your-claims/" replace />;
   }
 
-  const content = (
-    <>
-      <h1>Files we couldn’t receive</h1>
-      <p>
-        If we couldn’t receive files you submitted online, you’ll need to submit
-        them by mail or in person.
-      </p>
-      <VaLink
-        className="vads-u-display--block"
-        href="#other-ways-to-send-documents"
-        text="Learn about other ways to send your documents."
-        onClick={e => {
-          e.preventDefault();
-          setPageFocus('#other-ways-to-send');
-        }}
-      />
-      {(() => {
-        if (error) {
-          return (
-            <div className="error vads-u-margin-y--3">
+  let content;
+
+  if (error) {
+    content = (
+      <>
+        <h1>We encountered a problem</h1>
+        <va-alert
+          class="vads-u-margin-top--1 vads-u-margin-bottom--3"
+          status="warning"
+        >
+          <h2 slot="headline">Your files are temporarily unavailable</h2>
+          <p className="vads-u-margin-y--0">
+            We’re sorry. We’re having trouble loading your files right now. Try
+            again in an hour.
+          </p>
+        </va-alert>
+      </>
+    );
+  } else {
+    const hasFailedFiles = sortedFailedFiles && sortedFailedFiles.length > 0;
+
+    content = (
+      <>
+        <h1>Files we couldn’t receive</h1>
+        <p>
+          If we couldn’t receive files you submitted online, you’ll need to
+          submit them by mail or in person.
+        </p>
+        <VaLink
+          className="vads-u-display--block"
+          href="#other-ways-to-send-documents"
+          text="Learn about other ways to send your documents."
+          onClick={e => {
+            e.preventDefault();
+            setPageFocus('#other-ways-to-send');
+          }}
+        />
+
+        <div
+          id="files-not-received-section"
+          className="files-not-received-section"
+          data-testid="files-not-received-section"
+        >
+          <h2>Files not received</h2>
+
+          {hasFailedFiles ? (
+            <>
               <p>
-                Sorry, we couldn’t load your failed uploads. Please try again
-                later.
+                This is a list of files you submitted using this tool that we
+                couldn’t receive. You’ll need to resubmit these documents by
+                mail or in person. We’re sorry about this.
               </p>
-            </div>
-          );
-        }
+              <p>
+                <strong>Note:</strong> If you already resubmitted these files,
+                you don’t need to do anything else. Files submitted by mail or
+                in person, by you or by others, don’t appear in this tool.
+              </p>
 
-        const hasFailedFiles =
-          sortedFailedFiles && sortedFailedFiles.length > 0;
+              {shouldPaginate &&
+                (() => {
+                  const listLen = sortedFailedFiles.length;
+                  const start = (currentPage - 1) * ITEMS_PER_PAGE + 1;
+                  const end = Math.min(currentPage * ITEMS_PER_PAGE, listLen);
+                  const txt = `Showing ${start} \u2012 ${end} of ${listLen} items`;
+                  return <p id="pagination-info">{txt}</p>;
+                })()}
 
-        return (
-          <>
-            <div
-              id="files-not-received-section"
-              className="files-not-received-section"
-              data-testid="files-not-received-section"
-            >
-              <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--3">
-                Files not received
-              </h2>
-
-              {hasFailedFiles ? (
-                <>
-                  <p>
-                    This is a list of files you submitted using this tool that
-                    we couldn’t receive. You’ll need to resubmit these documents
-                    by mail or in person. We’re sorry about this.
-                  </p>
-                  <p>
-                    <strong>Note:</strong> If you already resubmitted these
-                    files, you don’t need to do anything else. Files submitted
-                    by mail or in person, by you or by others, don’t appear in
-                    this tool.
-                  </p>
-
-                  {shouldPaginate &&
-                    (() => {
-                      const listLen = sortedFailedFiles.length;
-                      const start = (currentPage - 1) * ITEMS_PER_PAGE + 1;
-                      const end = Math.min(
-                        currentPage * ITEMS_PER_PAGE,
-                        listLen,
-                      );
-                      const txt = `Showing ${start} \u2012 ${end} of ${listLen} items`;
-                      return <p id="pagination-info">{txt}</p>;
-                    })()}
-
-                  {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-                  <ul
-                    className="failed-files-list"
-                    data-testid="failed-files-list"
-                    role="list"
-                  >
-                    {currentPageItems.map(file => (
-                      <li key={file.id}>
-                        <VaCard
-                          className="vads-u-margin-y--3"
-                          data-testid={`failed-file-${file.id}`}
-                        >
-                          <h3
-                            className="filename-title vads-u-margin-y--0 vads-u-margin-bottom--2"
-                            data-dd-privacy="mask"
-                            data-dd-action-name="document filename"
-                          >
-                            File name: {file.fileName}
-                          </h3>
-                          <div>Request type: {file.trackedItemDisplayName}</div>
-                          <div>Date failed: {formatDate(file.failedDate)}</div>
-                          <div>File type: {file.documentType}</div>
-                          <VaLink
-                            active
-                            href={`/track-claims/your-claims/${
-                              file.claimId
-                            }/status`}
-                            text="Go to claim this file was uploaded for"
-                            label={`Go to the claim this file was uploaded for: ${
-                              file.fileName
-                            }`}
-                          />
-                        </VaCard>
-                      </li>
-                    ))}
-                  </ul>
-                  {shouldPaginate && (
-                    <VaPagination
-                      page={currentPage}
-                      pages={numPages}
-                      onPageSelect={e => handlePageSelect(e.detail.page)}
-                    />
-                  )}
-                </>
-              ) : (
-                <p>We’ve received all files you submitted online.</p>
+              {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+              <ul
+                className="failed-files-list"
+                data-testid="failed-files-list"
+                role="list"
+              >
+                {currentPageItems.map(file => (
+                  <li key={file.id}>
+                    <VaCard
+                      className="vads-u-margin-y--3"
+                      data-testid={`failed-file-${file.id}`}
+                    >
+                      <h3
+                        className="filename-title vads-u-margin-y--0 vads-u-margin-bottom--2"
+                        data-dd-privacy="mask"
+                        data-dd-action-name="document filename"
+                      >
+                        File name:
+                        {file.fileName}
+                      </h3>
+                      <div>Request type: {file.trackedItemDisplayName}</div>
+                      <div>Date failed: {formatDate(file.failedDate)}</div>
+                      <div>File type: {file.documentType}</div>
+                      <VaLink
+                        active
+                        href={`/track-claims/your-claims/${
+                          file.claimId
+                        }/status`}
+                        text="Go to claim this file was uploaded for"
+                        label={`Go to the claim this file was uploaded for: ${
+                          file.fileName
+                        }`}
+                      />
+                    </VaCard>
+                  </li>
+                ))}
+              </ul>
+              {shouldPaginate && (
+                <VaPagination
+                  page={currentPage}
+                  pages={numPages}
+                  onPageSelect={e => handlePageSelect(e.detail.page)}
+                />
               )}
-            </div>
+            </>
+          ) : (
+            <p>We’ve received all files you submitted online.</p>
+          )}
+        </div>
 
-            <OtherWaysToSendYourDocuments />
-          </>
-        );
-      })()}
-    </>
-  );
+        <OtherWaysToSendYourDocuments />
+      </>
+    );
+  }
 
   const breadcrumbs = [
     {

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -12,6 +12,7 @@ describe('<FilesWeCouldntReceive>', () => {
   const createMockStore = (
     failedUploadsData = null,
     featureFlagEnabled = true,
+    hasError = false,
   ) => {
     return createStore(
       () => ({
@@ -20,7 +21,7 @@ describe('<FilesWeCouldntReceive>', () => {
             failedUploads: {
               loading: false,
               data: failedUploadsData,
-              error: null,
+              error: hasError ? true : null,
             },
           },
         },
@@ -269,6 +270,59 @@ describe('<FilesWeCouldntReceive>', () => {
         }`;
         expect(link).to.have.attribute('label', expectedLabel);
       });
+    });
+  });
+
+  describe('Error State - API Failure', () => {
+    it('should render error alert and hide all normal page content when API fails', () => {
+      // Create store with API error: no data, feature flag enabled, error state
+      const store = createMockStore(null, true, true);
+      const {
+        getByRole,
+        getByText,
+        queryByText,
+        container,
+      } = renderWithCustomStore(<FilesWeCouldntReceive />, store);
+
+      // Verify error heading and alert are displayed
+      expect(
+        getByRole('heading', { level: 1, name: 'We encountered a problem' }),
+      ).to.exist;
+
+      const alert = container.querySelector('va-alert[status="warning"]');
+      expect(alert).to.exist;
+
+      expect(
+        getByRole('heading', {
+          level: 2,
+          name: 'Your files are temporarily unavailable',
+        }),
+      ).to.exist;
+
+      expect(
+        getByText(
+          'We’re sorry. We’re having trouble loading your files right now. Try again in an hour.',
+        ),
+      ).to.exist;
+
+      // Verify normal page content is NOT rendered
+      expect(queryByText('Files we couldn’t receive')).to.not.exist;
+      expect(queryByText('Files not received')).to.not.exist;
+      expect(queryByText('If we couldn’t receive files you submitted online'))
+        .to.not.exist;
+
+      // Verify no data-related components are rendered
+      expect(
+        container.querySelector('[data-testid="other-ways-to-send-documents"]'),
+      ).to.not.exist;
+      expect(container.querySelector('[data-testid="failed-files-list"]')).to
+        .not.exist;
+      expect(container.querySelector('va-loading-indicator')).to.not.exist;
+      expect(container.querySelector('va-pagination')).to.not.exist;
+      expect(container.querySelector('#pagination-info')).to.not.exist;
+      expect(container.querySelector('va-card')).to.not.exist;
+      expect(queryByText('We’ve received all files you submitted online.')).to
+        .not.exist;
     });
   });
 

--- a/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
@@ -501,6 +501,165 @@ describe('Failed Submissions in Progress Empty State', () => {
       );
       cy.axeCheck();
     });
+
+    it("should navigate to Files We Couldn't Receive page and display error state when API fails", () => {
+      // Intercept the failed uploads API call with error
+      cy.intercept(
+        'GET',
+        '/v0/benefits_claims/failed_upload_evidence_submissions',
+        {
+          statusCode: 500,
+          body: { errors: [{ title: 'Internal Server Error' }] },
+        },
+      ).as('failedUploadsError');
+
+      const trackClaimsPage = new TrackClaimsPageV2();
+      trackClaimsPage.loadPage(
+        claimsList,
+        claimDetailsOpenWithFailedSubmissions,
+        false,
+        false,
+        featureToggleDocumentUploadStatusEnabled,
+      );
+      trackClaimsPage.verifyInProgressClaim(false);
+      trackClaimsPage.navigateToFilesTab();
+
+      // Click link to navigate to Files We Couldn't Receive page
+      cy.get('[data-testid="files-we-couldnt-receive-entry-point"] va-link')
+        .shadow()
+        .find('a')
+        .click();
+
+      cy.wait('@failedUploadsError');
+
+      // Verify error state
+      cy.get('h1').should('contain.text', 'We encountered a problem');
+      cy.get('va-alert[status="warning"]').should('exist');
+
+      // Verify the slotted content (which is in light DOM, not shadow DOM)
+      cy.get('va-alert[status="warning"] h2[slot="headline"]').should(
+        'contain.text',
+        'Your files are temporarily unavailable',
+      );
+      cy.get('va-alert[status="warning"] p').should(
+        'contain.text',
+        'having trouble loading your files right now',
+      );
+
+      // Verify normal page content is NOT displayed (we expect "We encountered a problem" instead)
+      cy.get('h1').should('not.contain.text', 'Files we');
+      cy.get('[data-testid="files-not-received-section"]').should('not.exist');
+
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it("should navigate to Files We Couldn't Receive page and display empty state when no failed files", () => {
+      // Setup feature toggles and API intercepts
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles?*',
+        featureToggleDocumentUploadStatusEnabled,
+      );
+      cy.intercept('GET', '/v0/benefits_claims', claimsList);
+      cy.intercept(
+        'GET',
+        '/v0/benefits_claims/failed_upload_evidence_submissions',
+        {
+          statusCode: 200,
+          body: { data: [] },
+        },
+      ).as('failedUploadsEmpty');
+
+      cy.login();
+      cy.visit('/track-claims/your-claims/files-we-couldnt-receive');
+
+      cy.wait('@failedUploadsEmpty');
+
+      // Verify page heading
+      cy.get('h1').should('contain.text', 'Files we');
+
+      // Verify empty state message
+      cy.contains('received all files you submitted online').should('exist');
+
+      // Verify no failed files list
+      cy.get('[data-testid="failed-files-list"]').should('not.exist');
+
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it("should navigate to Files We Couldn't Receive page and display list of failed files", () => {
+      const mockFailedFiles = [
+        {
+          id: 1,
+          fileName: 'test-document-1.pdf',
+          trackedItemDisplayName: '21-4142',
+          failedDate: '2025-01-15T10:35:00.000Z',
+          documentType: 'VA Form 21-4142',
+          claimId: '123',
+        },
+        {
+          id: 2,
+          fileName: 'test-document-2.pdf',
+          trackedItemDisplayName: 'Additional Evidence',
+          failedDate: '2025-01-20T14:20:00.000Z',
+          documentType: 'Other',
+          claimId: '123',
+        },
+      ];
+
+      // Intercept the failed uploads API call with data
+      cy.intercept(
+        'GET',
+        '/v0/benefits_claims/failed_upload_evidence_submissions',
+        {
+          statusCode: 200,
+          body: { data: mockFailedFiles },
+        },
+      ).as('failedUploadsWithData');
+
+      const trackClaimsPage = new TrackClaimsPageV2();
+      trackClaimsPage.loadPage(
+        claimsList,
+        claimDetailsOpenWithFailedSubmissions,
+        false,
+        false,
+        featureToggleDocumentUploadStatusEnabled,
+      );
+      trackClaimsPage.verifyInProgressClaim(false);
+      trackClaimsPage.navigateToFilesTab();
+
+      // Click link to navigate to Files We Couldn't Receive page
+      cy.get('[data-testid="files-we-couldnt-receive-entry-point"] va-link')
+        .shadow()
+        .find('a')
+        .click();
+
+      cy.wait('@failedUploadsWithData');
+
+      // Verify page heading
+      cy.get('h1').should('contain.text', 'Files we');
+
+      // Verify instructions
+      cy.contains('receive files you submitted online').should('exist');
+
+      // Verify failed files list exists
+      cy.get('[data-testid="failed-files-list"]').should('exist');
+
+      // Verify both files are displayed
+      cy.get('[data-testid="failed-file-1"]').within(() => {
+        cy.contains('test-document-1.pdf').should('exist');
+        cy.contains('21-4142').should('exist');
+        cy.contains('VA Form 21-4142').should('exist');
+      });
+
+      cy.get('[data-testid="failed-file-2"]').within(() => {
+        cy.contains('test-document-2.pdf').should('exist');
+        cy.contains('Additional Evidence').should('exist');
+        cy.contains('Other').should('exist');
+      });
+
+      cy.injectAxeThenAxeCheck();
+    });
   });
 });
 

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -201,11 +201,6 @@ describe('Type 1 Error Alert', () => {
           }`,
         );
 
-      // Wait for page to be fully stable before accessibility check
-      cy.get('va-loading-indicator').should('not.exist');
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(100); // Allow animations/transitions to complete
-
       cy.injectAxeThenAxeCheck();
     });
   });

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -175,7 +175,7 @@ describe('Type 1 Error Alert', () => {
       // Verify old alert is present
       cy.get('.claims-alert').should('contain.text', 'Error uploading');
 
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
 
     it('should display duplicate error alert with documents-filed anchor link', () => {
@@ -206,7 +206,7 @@ describe('Type 1 Error Alert', () => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100); // Allow animations/transitions to complete
 
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
   });
 
@@ -225,7 +225,7 @@ describe('Type 1 Error Alert', () => {
           'We need you to submit files by mail or in person',
         );
 
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
 
     it('should display both the message alert and the type 1 unknown error alert when both error types exist', () => {
@@ -284,7 +284,7 @@ describe('Type 1 Error Alert', () => {
         'We need you to submit files by mail or in person',
       );
 
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
 
     it('should display duplicate error alert with files-received anchor link', () => {
@@ -310,7 +310,7 @@ describe('Type 1 Error Alert', () => {
           }`,
         );
 
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
   });
 });

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -201,6 +201,11 @@ describe('Type 1 Error Alert', () => {
           }`,
         );
 
+      // Wait for page to be fully stable before accessibility check
+      cy.get('va-loading-indicator').should('not.exist');
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(100); // Allow animations/transitions to complete
+
       cy.axeCheck();
     });
   });


### PR DESCRIPTION
## Summary

This PR updates the **API failure error state** for the Files We Couldn't Receive page. When the `/v0/benefits_claims/failed_upload_evidence_submissions` endpoint fails, users now see a consistent yellow warning alert instead of a pink error div, matching the error handling pattern used throughout the Claims Status Tool.

### Changes

- Updated `FilesWeCouldntReceive.jsx` to display a yellow warning alert (`va-alert` with `status="warning"`) when API fails
- Changed error message to content-approved copy: "Your files are temporarily unavailable"
- Restructured component to show only error state (heading + alert) when API fails, hiding all normal page content
- Added unit test for error state in `FilesWeCouldntReceive.unit.spec.jsx`
- Added e2e tests in `02.claim-files.v2.cypress.spec.js` covering error state, empty state, and populated state scenarios
- Fixed accessibility checks by using `injectAxeThenAxeCheck()` for new page navigations

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#125294

## How to Test Locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```

3. **Navigate to the Files We Couldn't Receive page:**
      http://localhost:3001/track-claims/your-claims/files-we-couldnt-receive Chrome DevTools (F12 or Cmd+Option+I)
   - Go to **Network** tab
   - Click **Network request blocking** icon (or Cmd+Shift+P → "Show Network request blocking")
   - Add pattern: `*/v0/benefits_claims/failed_upload_evidence_submissions`
   - Enable the checkbox
   - Refresh the page

4. **Verify the error state:**

   - Heading: "We encountered a problem"
   - Yellow warning alert with:
     - Title: "Your files are temporarily unavailable"
     - Message: "We're sorry. We're having trouble loading your files right now. Try again in an hour."
   - No normal page content displayed. Error state matches pattern used in `ClaimDetailLayout` and other CST pages

## Testing Done

- Added unit test to verify error heading, alert content, and absence of normal page elements
- Added e2e tests covering:
  - Error state when API fails (500 error)
  - Empty state when no failed files exist
  - Populated state displaying list of failed files
- Fixed accessibility checks for new page navigations
- **Manual Testing:** Confirmed error state displays correctly when API is blocked

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="824" height="374" alt="Screenshot 2025-11-21 at 12 54 28 PM" src="https://github.com/user-attachments/assets/6131acf6-6a13-4aa3-9bfa-44f506b208f7" /> | <img width="918" height="348" alt="Screenshot 2025-11-21 at 12 53 57 PM" src="https://github.com/user-attachments/assets/35412b43-268d-44c5-9e83-166db639bfef" /> |

| Files tab Page (Existing API Error State) |
| ------ |
| <img width="917" height="383" alt="Screenshot 2025-11-21 at 1 01 40 PM" src="https://github.com/user-attachments/assets/33b6d3c3-e948-4c69-842c-05244a4ab695" /> |
## What areas of the site does it impact?

- Files We Couldn't Receive page (`track-claims/your-claims/files-we-couldnt-receive`)

## Acceptance Criteria

- [x] Error state displays yellow warning alert (not pink error div)
- [x] Alert contains title and message (content approved)
- [x] Normal page content is hidden when error occurs
- [x] Error state matches pattern used in `ClaimDetailLayout` and other CST pages
- [x] Unit test covers error state comprehensively
- [x] E2e tests cover error, empty, and populated states

## Quality Assurance & Testing

- [x] I added unit test for API failure error state
- [x] Test verifies both positive (error shown) and negative (normal content hidden) assertions
- [x] Manual testing confirmed consistent error UX across Claims Status Tool

   