### PR TITLE
Fix prescription caching for string IDs and update v2 mocks

### DIFF
--- a/src/applications/mhv-medications/components/shared/DelayedRefillAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/DelayedRefillAlert.jsx
@@ -54,7 +54,8 @@ DelayedRefillAlert.propTypes = {
   dataDogActionName: PropTypes.string,
   refillAlertList: PropTypes.arrayOf(
     PropTypes.shape({
-      prescriptionId: PropTypes.number.isRequired,
+      prescriptionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+        .isRequired,
       prescriptionName: PropTypes.string.isRequired,
     }),
   ),

--- a/src/applications/mhv-medications/components/shared/FillRefillButton.jsx
+++ b/src/applications/mhv-medications/components/shared/FillRefillButton.jsx
@@ -84,7 +84,7 @@ FillRefillButton.propTypes = {
   rx: PropTypes.shape({
     dispensedDate: PropTypes.string,
     error: PropTypes.object,
-    prescriptionId: PropTypes.number,
+    prescriptionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     refillRemaining: PropTypes.number,
     success: PropTypes.bool,
     dispStatus: PropTypes.string,

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -63,11 +63,11 @@ const RefillPrescriptions = () => {
         prescriptions.find(prescription => {
           if (isOracleHealthPilot) {
             return (
-              prescription.prescriptionId === Number(id.id) &&
+              String(prescription.prescriptionId) === String(id.id) &&
               prescription.stationNumber === id.stationNumber
             );
           }
-          return prescription.prescriptionId === Number(id);
+          return String(prescription.prescriptionId) === String(id);
         }),
       );
     },

--- a/src/applications/mhv-medications/hooks/usePrescriptionData.js
+++ b/src/applications/mhv-medications/hooks/usePrescriptionData.js
@@ -23,7 +23,7 @@ export const usePrescriptionData = (prescriptionId, queryParams) => {
   const cachedPrescription = getPrescriptionsList.useQueryState(queryParams, {
     selectFromResult: ({ data: prescriptionsList }) => {
       return prescriptionsList?.prescriptions?.find(
-        item => item.prescriptionId === Number(prescriptionId),
+        item => String(item.prescriptionId) === String(prescriptionId),
       );
     },
   });

--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -48,7 +48,7 @@ const responses = {
   },
   'GET /my_health/v2/prescriptions': (_req, res) => {
     delaySingleResponse(
-      () => res.json(prescriptions.generateMockPrescriptions(_req)),
+      () => res.json(prescriptions.generateMockPrescriptions(_req, 20, true)),
       2250,
     );
   },
@@ -162,9 +162,13 @@ const responses = {
   'GET /my_health/v2/prescriptions/:id': (req, res) => {
     const { id } = req.params;
     const data = {
-      data: prescriptions.mockPrescription(id, {
-        cmopNdcNumber: '00093721410',
-      }),
+      data: prescriptions.mockPrescription(
+        id,
+        {
+          cmopNdcNumber: '00093721410',
+        },
+        true,
+      ),
       meta: {
         sort: {
           dispStatus: 'DESC',

--- a/src/applications/mhv-medications/mocks/api/mhv-api/prescriptions/index.js
+++ b/src/applications/mhv-medications/mocks/api/mhv-api/prescriptions/index.js
@@ -14,10 +14,12 @@ const dispStatusObj = {
   ON_HOLD: 'Active: On Hold',
   ACTIVE_PARKED: 'Active: Parked',
 };
-function mockPrescription(n = 0, attrs = {}) {
+function mockPrescription(n = 0, attrs = {}, isV2 = false) {
   // Generate some refillable, some not
-  const isRefillable = n % 3 === 0;
-  const refillRemaining = isRefillable ? Math.ceil(Math.log(n + 1)) : 0;
+  const isRefillable = typeof n === 'number' && n % 3 === 0;
+  const refillRemaining = isRefillable
+    ? Math.ceil(Math.log((typeof n === 'number' ? n : 0) + 1))
+    : 0;
   const {
     cmopNdcNumber,
     cmopDivisionPhone = '(555) 555-5555',
@@ -26,12 +28,20 @@ function mockPrescription(n = 0, attrs = {}) {
   } = attrs;
   const prescriptionName = `Fake ${n}`;
   const newCmopNdcNumber =
-    n % 3 === 0 && !cmopNdcNumber ? `000${n}000000` : cmopNdcNumber;
+    typeof n === 'number' && n % 3 === 0 && !cmopNdcNumber
+      ? `000${n}000000`
+      : cmopNdcNumber;
+
+  let prescriptionId = n;
+  if (isV2 && typeof n === 'number') {
+    prescriptionId = `fake-${n}`;
+  }
+
   return {
-    id: `fake-${n}`,
+    id: isV2 ? prescriptionId : `fake-${n}`,
     type: 'prescriptions',
     attributes: {
-      prescriptionId: n,
+      prescriptionId,
       prescriptionNumber: `${n}`,
       prescriptionName,
       refillStatus: 'active',
@@ -109,7 +119,7 @@ function mockPrescription(n = 0, attrs = {}) {
   };
 }
 
-function mockPrescriptionArray(n = 20) {
+function mockPrescriptionArray(n = 20, isV2 = false) {
   const realPrescriptions = prescriptionsList.data;
 
   return [...Array(n)].map((_, i) => {
@@ -126,43 +136,49 @@ function mockPrescriptionArray(n = 20) {
     const realPrescription =
       realPrescriptions[i % realPrescriptions.length].attributes;
 
-    return mockPrescription(i, {
-      prescriptionName: realPrescription.prescriptionName,
-      refillStatus: realPrescription.refillStatus,
-      refillSubmitDate:
-        realPrescription.refillSubmitDate || formatISO(oneWeekAgo),
-      refillDate: realPrescription.refillDate || recentlyISOString,
-      refillRemaining: realPrescription.refillRemaining,
-      facilityName: realPrescription.facilityName,
-      orderedDate: realPrescription.orderedDate || formatISO(monthsAgo),
-      quantity: realPrescription.quantity,
-      expirationDate: realPrescription.expirationDate,
-      dispensedDate: realPrescription.dispensedDate || recentlyISOString,
-      stationNumber: realPrescription.stationNumber,
-      isRefillable: realPrescription.isRefillable,
-      isTrackable: realPrescription.isTrackable,
-      sig: realPrescription.sig,
-      cmopDivisionPhone: realPrescription.cmopDivisionPhone || '(555) 555-5555',
-      dialCmopDivisionPhone:
-        realPrescription.dialCmopDivisionPhone || '5555555555',
-      pharmacyPhoneNumber:
-        realPrescription.pharmacyPhoneNumber || '(555) 555-5555',
-      notRefillableDisplayMessage: realPrescription.notRefillableDisplayMessage,
-      providerFirstName: realPrescription.providerFirstName,
-      providerLastName: realPrescription.providerLastName,
-      remarks: realPrescription.remarks,
-      divisionName: realPrescription.divisionName,
-      dispStatus: realPrescription.dispStatus || statusString,
-      ndc: realPrescription.ndc,
-      reason: realPrescription.reason,
-      prescriptionSource: realPrescription.prescriptionSource,
-      indicationForUse: realPrescription.indicationForUse,
-      category: realPrescription.category,
-    });
+    return mockPrescription(
+      i,
+      {
+        prescriptionName: realPrescription.prescriptionName,
+        refillStatus: realPrescription.refillStatus,
+        refillSubmitDate:
+          realPrescription.refillSubmitDate || formatISO(oneWeekAgo),
+        refillDate: realPrescription.refillDate || recentlyISOString,
+        refillRemaining: realPrescription.refillRemaining,
+        facilityName: realPrescription.facilityName,
+        orderedDate: realPrescription.orderedDate || formatISO(monthsAgo),
+        quantity: realPrescription.quantity,
+        expirationDate: realPrescription.expirationDate,
+        dispensedDate: realPrescription.dispensedDate || recentlyISOString,
+        stationNumber: realPrescription.stationNumber,
+        isRefillable: realPrescription.isRefillable,
+        isTrackable: realPrescription.isTrackable,
+        sig: realPrescription.sig,
+        cmopDivisionPhone:
+          realPrescription.cmopDivisionPhone || '(555) 555-5555',
+        dialCmopDivisionPhone:
+          realPrescription.dialCmopDivisionPhone || '5555555555',
+        pharmacyPhoneNumber:
+          realPrescription.pharmacyPhoneNumber || '(555) 555-5555',
+        notRefillableDisplayMessage:
+          realPrescription.notRefillableDisplayMessage,
+        providerFirstName: realPrescription.providerFirstName,
+        providerLastName: realPrescription.providerLastName,
+        remarks: realPrescription.remarks,
+        divisionName: realPrescription.divisionName,
+        dispStatus: realPrescription.dispStatus || statusString,
+        ndc: realPrescription.ndc,
+        reason: realPrescription.reason,
+        prescriptionSource: realPrescription.prescriptionSource,
+        indicationForUse: realPrescription.indicationForUse,
+        category: realPrescription.category,
+      },
+      isV2,
+    );
   });
 }
 
-function generateMockPrescriptions(req, n = 20) {
+function generateMockPrescriptions(req, n = 20, isV2 = false) {
   function edgeCasePrescription({
     prescriptionId,
     prescriptionName,
@@ -171,13 +187,17 @@ function generateMockPrescriptions(req, n = 20) {
     refillSubmitDate,
     rxRfRecords,
   }) {
-    return mockPrescription(prescriptionId, {
-      prescriptionName,
-      dispStatus,
-      refillDate,
-      refillSubmitDate,
-      rxRfRecords,
-    });
+    return mockPrescription(
+      prescriptionId,
+      {
+        prescriptionName,
+        dispStatus,
+        refillDate,
+        refillSubmitDate,
+        rxRfRecords,
+      },
+      isV2,
+    );
   }
   const now = new Date();
   const sevenDaysAgo = new Date(
@@ -290,19 +310,23 @@ function generateMockPrescriptions(req, n = 20) {
   ];
 
   const generatedPrescriptions = [
-    ...mockPrescriptionArray(n),
-    mockPrescription(99, {
-      dispStatus: dispStatusObj.NON_VA,
-      dispensedDate: null,
-      facilityName: null,
-      indicationForUse: null,
-      prescriptionName: 'TACROLIMUS 1MG CAP',
-      prescriptionSource: 'NV',
-      providerFirstName: null,
-      providerLastName: null,
-      sig: null,
-      trackingList: [],
-    }),
+    ...mockPrescriptionArray(n, isV2),
+    mockPrescription(
+      99,
+      {
+        dispStatus: dispStatusObj.NON_VA,
+        dispensedDate: null,
+        facilityName: null,
+        indicationForUse: null,
+        prescriptionName: 'TACROLIMUS 1MG CAP',
+        prescriptionSource: 'NV',
+        providerFirstName: null,
+        providerLastName: null,
+        sig: null,
+        trackingList: [],
+      },
+      isV2,
+    ),
   ];
 
   const filterKey = req.query['filter[']?.disp_status?.eq || ''; // e.g., "filter[[disp_status][eq]]=Active,Expired"


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR fixes a bug where prescription details were not being correctly retrieved from the Redux cache when the prescription ID was a string (or a numeric string).

Previously, the `usePrescriptionData` hook and `RefillPrescriptions` container were casting IDs to `Number` for comparison. This caused cache lookups to fail for prescriptions with string IDs, resulting in unnecessary redundant API calls to fetch individual prescription details.

### Changes
Hooks: Updated `usePrescriptionData.js` to compare IDs as strings instead of numbers.
Containers: Updated `RefillPrescriptions.jsx` to handle string ID comparisons when filtering successful/failed refills.
Tests: Added a unit test case to `usePrescriptionData.unit.spec.jsx` to verify that a prescription with a numeric string ID is correctly retrieved from the cache.
Mocks: Updated local development mocks to generate string IDs for V2 endpoints, better simulating the environment where this issue occurs.

### Verification
Unit Tests: Ran yarn test:unit src/applications/mhv-medications/tests/hooks/usePrescriptionData.unit.spec.jsx - All tests passed, including the new test case for numeric string IDs.
Unit Tests: Ran yarn test:unit src/applications/mhv-medications/containers/RefillPrescriptions.unit.spec.jsx - All tests passed.
