### PR TITLE
code updates to integrate approximate date

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.jsx
@@ -21,6 +21,9 @@ import {
   delete0781BehavioralData,
   sanitize0781PoliceReportData,
   sanitize0781BehaviorsDetails,
+  normalizeIncreases,
+  sanitizeNewDisabilities,
+  removeRatedDisabilityFromNew,
 } from '../../utils/submit';
 import {
   PTSD_INCIDENT_ITERATION,
@@ -1162,5 +1165,325 @@ describe('addForm0781V2', () => {
     expect(resultWithVaFacilities.form0781).to.have.property(
       'treatmentProvidersDetails',
     );
+  });
+});
+
+describe('normalizeIncreases', () => {
+  it('returns original formData when feature flag is not enabled', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Tinnitus' }],
+      newDisabilities: [
+        {
+          condition: 'Rated disability',
+          ratedDisability: 'Tinnitus',
+          conditionDate: '2020-01-01',
+        },
+      ],
+    };
+
+    const result = normalizeIncreases(formData);
+    expect(result).to.equal(formData);
+  });
+
+  it('moves matching increases from newDisabilities into ratedDisabilities and marks them as INCREASE', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+      ratedDisabilities: [
+        { name: 'Tinnitus' },
+        { name: 'Sciatica', approximateDate: '2019-01-01' },
+      ],
+      newDisabilities: [
+        {
+          condition: 'Rated disability',
+          ratedDisability: 'Tinnitus',
+          conditionDate: '2020-01-01',
+        },
+        {
+          condition: 'Some new condition',
+          cause: 'NEW',
+        },
+      ],
+    };
+
+    const result = normalizeIncreases(formData);
+    expect(result.ratedDisabilities).to.have.lengthOf(2);
+
+    const tinnitus = result.ratedDisabilities.find(d => d.name === 'Tinnitus');
+    const sciatica = result.ratedDisabilities.find(d => d.name === 'Sciatica');
+
+    expect(tinnitus['view:selected']).to.be.true;
+    expect(tinnitus.disabilityActionType).to.equal(
+      disabilityActionTypes.INCREASE,
+    );
+    expect(tinnitus.approximateDate).to.equal('2020-01-01');
+    expect(sciatica.approximateDate).to.equal('2019-01-01');
+    expect(result.newDisabilities).to.deep.equal([
+      {
+        condition: 'Some new condition',
+        cause: 'NEW',
+      },
+    ]);
+  });
+
+  it('handles newPrimaryDisabilities the same as newDisabilities', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+      ratedDisabilities: [{ name: 'Sciatica' }],
+      newPrimaryDisabilities: [
+        {
+          condition: 'Rated disability',
+          ratedDisability: 'Sciatica',
+          conditionDate: '2021-02-02',
+        },
+        {
+          condition: 'Brand new primary condition',
+          cause: 'NEW',
+        },
+      ],
+    };
+
+    const result = normalizeIncreases(formData);
+    const sciatica = result.ratedDisabilities[0];
+
+    expect(sciatica['view:selected']).to.be.true;
+    expect(sciatica.disabilityActionType).to.equal(
+      disabilityActionTypes.INCREASE,
+    );
+    expect(sciatica.approximateDate).to.equal('2021-02-02');
+
+    expect(result.newPrimaryDisabilities).to.deep.equal([
+      {
+        condition: 'Brand new primary condition',
+        cause: 'NEW',
+      },
+    ]);
+  });
+
+  it('deletes newDisabilities and newPrimaryDisabilities when all entries are true increases', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+      ratedDisabilities: [{ name: 'Tinnitus' }, { name: 'Sciatica' }],
+      newDisabilities: [
+        { condition: 'Rated disability', ratedDisability: 'Tinnitus' },
+      ],
+      newPrimaryDisabilities: [
+        { condition: 'Rated disability', ratedDisability: 'Sciatica' },
+      ],
+    };
+    const result = normalizeIncreases(formData);
+
+    expect(result).to.not.have.property('newDisabilities');
+    expect(result).to.not.have.property('newPrimaryDisabilities');
+    expect(result.ratedDisabilities).to.have.lengthOf(2);
+
+    const tinnitus = result.ratedDisabilities.find(d => d.name === 'Tinnitus');
+    const sciatica = result.ratedDisabilities.find(d => d.name === 'Sciatica');
+
+    expect(tinnitus.disabilityActionType).to.equal(
+      disabilityActionTypes.INCREASE,
+    );
+    expect(sciatica.disabilityActionType).to.equal(
+      disabilityActionTypes.INCREASE,
+    );
+  });
+
+  it('is tolerant of missing ratedDisabilities and new* arrays', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+    };
+
+    const result = normalizeIncreases(formData);
+    expect(result).to.deep.equal({
+      disabilityCompNewConditionsWorkflow: true,
+      ratedDisabilities: [],
+    });
+  });
+});
+
+describe('sanitizeNewDisabilities', () => {
+  it('returns original formData when feature flag is not enabled', () => {
+    const formData = {
+      newDisabilities: [{ condition: 'X', cause: 'NEW' }],
+    };
+
+    const result = sanitizeNewDisabilities(formData);
+    expect(result).to.equal(formData);
+  });
+
+  it('filters out entries missing condition or cause from newDisabilities and newPrimaryDisabilities', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+      newDisabilities: [
+        { condition: 'Valid condition', cause: 'NEW' },
+        { condition: 'Missing cause' },
+        { cause: 'NEW' },
+        null,
+      ],
+      newPrimaryDisabilities: [
+        { condition: 'Another valid condition', cause: 'SECONDARY' },
+        { condition: '', cause: 'SECONDARY' },
+        {},
+      ],
+    };
+    const result = sanitizeNewDisabilities(formData);
+
+    expect(result.newDisabilities).to.deep.equal([
+      { condition: 'Valid condition', cause: 'NEW' },
+    ]);
+    expect(result.newPrimaryDisabilities).to.deep.equal([
+      { condition: 'Another valid condition', cause: 'SECONDARY' },
+    ]);
+  });
+
+  it('deletes newDisabilities and newPrimaryDisabilities when all entries are invalid', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+      newDisabilities: [{ condition: 'Missing cause' }, { cause: 'NEW' }],
+      newPrimaryDisabilities: [{ condition: '' }, { cause: 'SECONDARY' }],
+    };
+    const result = sanitizeNewDisabilities(formData);
+
+    expect(result).to.not.have.property('newDisabilities');
+    expect(result).to.not.have.property('newPrimaryDisabilities');
+  });
+
+  it('does nothing when new* arrays are missing or not arrays', () => {
+    const formData = {
+      disabilityCompNewConditionsWorkflow: true,
+      newDisabilities: 'not-an-array',
+      newPrimaryDisabilities: undefined,
+    };
+    const result = sanitizeNewDisabilities(formData);
+
+    expect(result).to.deep.equal({
+      disabilityCompNewConditionsWorkflow: true,
+      newDisabilities: 'not-an-array',
+      newPrimaryDisabilities: undefined,
+    });
+  });
+});
+
+describe('removeRatedDisabilityFromNew', () => {
+  it('does nothing when there are no new* arrays present', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Tinnitus' }],
+    };
+    const result = removeRatedDisabilityFromNew(formData);
+
+    expect(result).to.deep.equal(formData);
+  });
+
+  it('removes entries where condition is "Rated disability" from newDisabilities', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Tinnitus' }],
+      newDisabilities: [
+        {
+          condition: 'Rated disability',
+          ratedDisability: 'Tinnitus',
+        },
+        {
+          condition: 'New condition',
+          cause: 'NEW',
+        },
+      ],
+    };
+    const result = removeRatedDisabilityFromNew(formData);
+
+    expect(result.newDisabilities).to.deep.equal([
+      {
+        condition: 'New condition',
+        cause: 'NEW',
+      },
+    ]);
+  });
+
+  it('removes entries where ratedDisability matches an existing ratedDisability name (case-insensitive)', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Sciatica' }],
+      newPrimaryDisabilities: [
+        {
+          condition: 'Something',
+          ratedDisability: 'sciatica',
+        },
+        {
+          condition: 'Other',
+          ratedDisability: 'Not Rated',
+        },
+      ],
+    };
+    const result = removeRatedDisabilityFromNew(formData);
+
+    expect(result.newPrimaryDisabilities).to.deep.equal([
+      {
+        condition: 'Other',
+        ratedDisability: 'Not Rated',
+      },
+    ]);
+  });
+
+  it('deletes new keys when all entries represent increases', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Tinnitus' }, { name: 'Sciatica' }],
+      newDisabilities: [
+        {
+          condition: 'Rated disability',
+          ratedDisability: 'Tinnitus',
+        },
+      ],
+      newSecondaryDisabilities: [
+        {
+          condition: 'Something',
+          ratedDisability: 'Sciatica',
+        },
+      ],
+    };
+    const result = removeRatedDisabilityFromNew(formData);
+
+    expect(result).to.not.have.property('newDisabilities');
+    expect(result).to.not.have.property('newSecondaryDisabilities');
+  });
+
+  it('keeps non-increase entries across all new lists', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Tinnitus' }],
+      newDisabilities: [
+        {
+          condition: 'New condition 1',
+          cause: 'NEW',
+        },
+      ],
+      newPrimaryDisabilities: [
+        {
+          condition: 'New condition 2',
+          cause: 'NEW',
+        },
+      ],
+      newSecondaryDisabilities: [
+        {
+          condition: 'Secondary condition',
+          cause: 'SECONDARY',
+        },
+      ],
+    };
+    const result = removeRatedDisabilityFromNew(formData);
+
+    expect(result.newDisabilities).to.deep.equal([
+      {
+        condition: 'New condition 1',
+        cause: 'NEW',
+      },
+    ]);
+    expect(result.newPrimaryDisabilities).to.deep.equal([
+      {
+        condition: 'New condition 2',
+        cause: 'NEW',
+      },
+    ]);
+    expect(result.newSecondaryDisabilities).to.deep.equal([
+      {
+        condition: 'Secondary condition',
+        cause: 'SECONDARY',
+      },
+    ]);
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -172,7 +172,7 @@ in order for the form to successfully submit.
 const isRatedDisabilityCondition = v => norm(v) === 'rated disability';
 
 export const normalizeIncreases = formData => {
-  if (!formData?.disabilityCompensationNewConditionsWorkflow) return formData;
+  if (!formData?.disabilityCompNewConditionsWorkflow) return formData;
 
   const rated = Array.isArray(formData?.ratedDisabilities)
     ? formData.ratedDisabilities.map(r => ({ ...r }))
@@ -200,8 +200,8 @@ export const normalizeIncreases = formData => {
           const target = rated[idx];
           target['view:selected'] = true;
           target.disabilityActionType = 'INCREASE';
-          if (row.conditionDate && !target.conditionDate) {
-            target.conditionDate = row.conditionDate;
+          if (row.conditionDate && !target.approximateDate) {
+            target.approximateDate = row.conditionDate;
           }
         }
         // eslint-disable-next-line no-continue
@@ -221,7 +221,7 @@ export const normalizeIncreases = formData => {
 };
 
 export const sanitizeNewDisabilities = formData => {
-  if (!formData?.disabilityCompensationNewConditionsWorkflow) return formData;
+  if (!formData?.disabilityCompNewConditionsWorkflow) return formData;
 
   const out = { ...formData };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When a veteran adds a rated disability as a condition, they can optionally provide an approximate date for when the condition began or worsened. This date is expected to appear in Section V of the generated PDF, under “Approximate date disability(ies) began or worsened.”

This update ensures that the approximate date is included in the submission payload so that the backend can ingest it and populate the correct PDF field.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/124897

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Steps to Reproduce

Pre-requisites

1. Seed the application with initial rated-disability data:
https://gist.github.com/sdbars/baf1da55b2ba5c2ed837510c01a733b8
   - Open vets-website/src/applications/disability-benefits/all-claims/pages/disabilityConditions/index.js
   - Add the initial data to the Intro page immediately after the path: 'conditions/orientation' key/value pair.

2. Enable the disability_compensation_new_conditions_workflow feature flag.
3. Open your browser’s dev console.

### Reproduction Steps

1. Load the application at http://localhost:3001/sign-in/mocked-auth.
2. Sign in with any mock profile using ID.me.
3. Start a new 526EZ application.
4. Navigate through the Veteran details section.
5. On Add a condition, select one of the rated disabilities (e.g., hypertension).
6. On the next page, enter a date for when the condition worsened.
7. Do not add additional conditions; navigate to Review and submit.
8. Expand the Conditions accordion and confirm the disability is listed.
9. Scroll to Claim certification and signature.
10. Enter the profile’s full name and certify.
11. Submit the application.
12. In the Network tab, select a submit_all_claim request.
13. Open the payload.
14. Expand the form526 object.
15. Expand the ratedDisabilities array.
16. Open the hypertension object.

**Current outcome:**
The payload does not include an approximateDate field.

**Expected outcome:**
The payload includes an approximateDate field for the rated disability when veteran entered this data.

## Changes Made

- Updated ~/src/applications/disability-benefits/all-claims/utils/submit.js
- Ensured the correct feature flag is referenced in the submission flow.
- Mapped the captured conditionDate to the approximateDate field expected by vets-api.

## Screenshots

### Before

<img width="560" height="503" alt="payload-no-date" src="https://github.com/user-attachments/assets/d8aab574-1dfa-4977-b5de-6c9ebe94f9db" />

### After

<img width="566" height="566" alt="payload-w-date" src="https://github.com/user-attachments/assets/0ab281dc-5377-4ce8-af23-6b5de4ede600" />

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
