### PR TITLE
Set sessionReplaySampleRate to 50

### DIFF
--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -11,6 +11,7 @@ import backendServices from '@department-of-veterans-affairs/platform-user/profi
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 
+import environment from 'platform/utilities/environment';
 import { setLastPage } from '../actions';
 import ServiceUnavailableAlert from '../components/ServiceUnavailableAlert';
 import { isLoadingFeatures } from '../selectors';
@@ -80,7 +81,8 @@ function ClaimsStatusApp({
     clientToken: 'pub21bfd23fdfb656231f24906ea91ccb01',
     service: 'benefits-claim-status-tool',
     version: '1.0.0',
-    sessionReplaySampleRate: 50,
+    sessionReplaySampleRate:
+      environment.vspEnvironment() === 'staging' ? 100 : 50,
   });
 
   return (

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -80,6 +80,7 @@ function ClaimsStatusApp({
     clientToken: 'pub21bfd23fdfb656231f24906ea91ccb01',
     service: 'benefits-claim-status-tool',
     version: '1.0.0',
+    sessionReplaySampleRate: 50,
   });
 
   return (

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -262,6 +262,7 @@ describe('<ClaimsStatusApp> - Platform DataDog RUM Integration', () => {
       clientToken: 'pub21bfd23fdfb656231f24906ea91ccb01',
       service: 'benefits-claim-status-tool',
       version: '1.0.0',
+      sessionReplaySampleRate: 50,
     });
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Due the high volume of traffic in CST we were unable to use retention filters to get our retention of sessions with replays to an acceptable number. As a result I have modified the Datadog RUM configuration in the Claims Status Tool to reduce the session replay sample rate from 100% to 50%. This will prevent over retention and allow us to better control cost as it pertains to sessions with replays. 

NOTE: Our current retention of sessions with replays is too high. Since we have  sessionReplaySampleRate: 100 in our config and are already, retaining the lowest % possible (1%) the only way we can further reduce the number of session replays retained is to reduce the sessionReplaySampleRate in our config.

The following retention filter queries are going to produce the same results in our case where `sessionReplaySampleRate:100` is set.
`@session.is_active:false env:production @session.has_replay:true`
`@session.is_active:false env:production`

I think `@session.has_replay:true` may be a viable option for other teams whose retention filters aren't already at the lowest retention rate possible (1%).


