### PR TITLE
0969 | Remap discontinued income type on submit

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/09-unreported-assets/unreportedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/09-unreported-assets/unreportedAssetPages.js
@@ -94,7 +94,7 @@ export const options = {
 
 // Shared summary page text
 const updatedTitleNoItems =
-  'Did you or your dependents have any assets you haven’t already reported?';
+  'Do you or your dependents have any assets you haven’t already reported?';
 const updatedTitleWithItems = 'Do you have more assets to report?';
 const summaryPageTitle = 'Other Assets';
 const incomeRecipientPageTitle = 'Unreported asset relationship information';

--- a/src/applications/income-and-asset-statement/config/submit-helpers.js
+++ b/src/applications/income-and-asset-statement/config/submit-helpers.js
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash';
+import { discontinuedIncomeTypeLabels } from '../labels';
 
 /**
  * Build a full name string from an object containing first/middle/last
@@ -106,6 +107,40 @@ export function remapOtherVeteranFields(data = {}) {
   }
 
   return updated;
+}
+
+/**
+ * Remap the incomeType field of a discontinued income object
+ * to its human-readable label for submission.
+ *
+ * Special case:
+ * - If `incomeType` is "OTHER", the value will be replaced with
+ *   the value of the `view:otherIncomeType` field instead of the default label.
+ *
+ * This is intended to be used as an iterator inside transform logic, e.g.:
+ *   form.data.discontinuedIncomes.map(remapIncomeTypeFields)
+ *
+ * @param {Object} itemData - A single discontinued income object
+ * @param {string} itemData.incomeType - The raw income type key
+ * @param {string} [itemData['view:otherIncomeType'] - Required description if incomeType is OTHER
+ * @returns {Object} A new object with incomeType replaced by its label or 'view:otherIncomeType'
+ */
+export function remapIncomeTypeFields(itemData = {}) {
+  const { incomeType } = itemData;
+  const otherValue = itemData['view:otherIncomeType'];
+
+  let mappedIncomeType;
+
+  if (incomeType === 'OTHER' && otherValue) {
+    mappedIncomeType = otherValue;
+  } else {
+    mappedIncomeType = discontinuedIncomeTypeLabels[incomeType] ?? incomeType;
+  }
+
+  return {
+    ...itemData,
+    incomeType: mappedIncomeType,
+  };
 }
 
 /**

--- a/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data-post-mvp.json
+++ b/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data-post-mvp.json
@@ -143,6 +143,16 @@
         "incomeFrequency": "RECURRING",
         "incomeLastReceivedDate": "2023-05-15",
         "grossAnnualAmount": 18000.0
+      },
+      {
+        "recipientRelationship": "CHILD",
+        "recipientName": { "first": "Jane", "last": "Smith" },
+        "payer": "Social Security Administration",
+        "incomeType": "OTHER",
+        "incomeFrequency": "RECURRING",
+        "incomeLastReceivedDate": "2023-05-15",
+        "grossAnnualAmount": 18000.0,
+        "view:otherIncomeType": "other income type"
       }
     ],
     "view:isAddingIncomeReceiptWaivers": true,

--- a/src/applications/income-and-asset-statement/tests/unit/config/submit-helpers.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/config/submit-helpers.unit.spec.jsx
@@ -5,6 +5,7 @@ import {
   pruneFields,
   pruneFieldsInArray,
   pruneConfiguredArrays,
+  remapIncomeTypeFields,
   remapOtherVeteranFields,
   removeDisallowedFields,
   removeInvalidFields,
@@ -150,6 +151,138 @@ describe('submit-helpers.js', () => {
       remapOtherVeteranFields(input);
 
       expect(input).to.deep.equal(original);
+    });
+  });
+
+  describe('remapIncomeTypeFields', () => {
+    it('should remap "WAGES" `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'WAGES',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Wages',
+        anotherUnrelatedField: 'RECURRING',
+      });
+    });
+
+    it('should remap "INTEREST" `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'INTEREST',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Interest',
+        anotherUnrelatedField: 'RECURRING',
+      });
+    });
+
+    it('should remap "UNEMPLOYMENT_BENEFITS" `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'UNEMPLOYMENT_BENEFITS',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Unemployment benefits',
+        anotherUnrelatedField: 'RECURRING',
+      });
+    });
+
+    it('should remap "LOTTERY_WINNINGS" `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'LOTTERY_WINNINGS',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Lottery winnings',
+        anotherUnrelatedField: 'RECURRING',
+      });
+    });
+
+    it('should remap "OTHER" `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'OTHER',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Another type of income',
+        anotherUnrelatedField: 'RECURRING',
+      });
+    });
+
+    it('should remap "OTHER" `incomeType` field to `view:otherIncomeType`', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'OTHER',
+        anotherUnrelatedField: 'RECURRING',
+        'view:otherIncomeType': 'other income type description',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'other income type description',
+        anotherUnrelatedField: 'RECURRING',
+        'view:otherIncomeType': 'other income type description',
+      });
+    });
+
+    it('should NOT remap `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'Wages',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Wages',
+        anotherUnrelatedField: 'RECURRING',
+      });
+    });
+
+    it('should NOT remap `incomeType` field to human-readable', () => {
+      const input = {
+        unrelatedField: 'keep me',
+        incomeType: 'Does not match any key',
+        anotherUnrelatedField: 'RECURRING',
+      };
+
+      const output = remapIncomeTypeFields(input);
+
+      expect(output).to.deep.equal({
+        unrelatedField: 'keep me',
+        incomeType: 'Does not match any key',
+        anotherUnrelatedField: 'RECURRING',
+      });
     });
   });
 


### PR DESCRIPTION
### Summary of Changes
This update remaps the **Discontinued Income `incomeType`** value during form submission for the 0969 form when Post MVP is enabled.  The submit transformer will correctly map the discontinued income `incomeType` field to the appropriate backend-aligned value for MVP and Post MVP.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124490

### How to Set Up in Local Environment
1. Start the application locally
2. Enable Post MVP via the feature toggle: http://localhost:3000/flipper/features/income_and_assets_content_updates
3. Open the 0969 form URL: http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/

### How to Test
1. Go to the **Discontinued Income** list-and-loop chapter 10.  
2. Add a discontinued income item and select any valid income type accept 'Another type of income'.  
3. Add another discontinued income item and select 'Another type of income' and add  a custom text description
4. Submit the form
6. Observe the submit payload in the network tab:  
   - Confirm that `incomeType` under discontinued incomes is correctly remapped to the expected API value.  
   - Ensure no regressions for other Post MVP income types.  

### Feature Flag Note
- Change applies to the Post-MVP content updates and relies on existing logic enabled by:  
  - `income_and_assets_content_updates`

### Acceptance Criteria
- Discontinued Income `incomeType` is correctly remapped in the transformed submission payload.  
- No regressions in existing income chapters.  
- Logic applies only within submit transformation and does not alter on-form values.  

### Definition of Done
- [ ] Code reviewed and approved.  
- [ ] Tested locally with accurate payload mapping.  
- [ ] All automated tests passing.