### PR TITLE
Updated gate for expiry alert logic

### DIFF
--- a/src/applications/virtual-agent/components/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/Chatbox.jsx
@@ -1,10 +1,18 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import useBotOutgoingActivityEventListener from '../hooks/useBotOutgoingActivityEventListener';
 import useWebMessageActivityEventListener from '../hooks/useWebMessageActivityEventListener';
 import Bot from './Bot';
 
 export default function Chatbox() {
-  const [chatBotLoadTime] = useState(Date.now());
+  const [chatBotLoadTime, setChatBotLoadTime] = useState(Date.now());
+
+  // Reset chatBotLoadTime when user starts a new chat after session expiry
+  // This prevents the 60-minute reload guard from triggering on the first message
+  useEffect(() => {
+    const onReset = () => setChatBotLoadTime(Date.now());
+    window.addEventListener('va-chatbot-reset', onReset);
+    return () => window.removeEventListener('va-chatbot-reset', onReset);
+  }, []);
 
   useBotOutgoingActivityEventListener(chatBotLoadTime);
   useWebMessageActivityEventListener();

--- a/src/applications/virtual-agent/hooks/useBotOutgoingActivityEventListener.js
+++ b/src/applications/virtual-agent/hooks/useBotOutgoingActivityEventListener.js
@@ -16,12 +16,22 @@ function reloadWindow(lastMessageTime, setLastMessageTime, chatBotLoadTime) {
   }
 }
 
-export default function useBotOutgoingActivityEventListener(chatBotLoadTime) {
+export default function useBotOutgoingActivityEventListener(
+  chatBotLoadTime,
+  enabled = true,
+) {
   const [lastMessageTime, setLastMessageTime] = useState(0);
 
-  useEffect(() => {
-    window.addEventListener('bot-outgoing-activity', () =>
-      reloadWindow(lastMessageTime, setLastMessageTime, chatBotLoadTime),
-    );
-  });
+  useEffect(
+    () => {
+      // Skip listener registration when disabled (e.g., session persistence is on)
+      if (!enabled) return undefined;
+
+      const handler = () =>
+        reloadWindow(lastMessageTime, setLastMessageTime, chatBotLoadTime);
+      window.addEventListener('bot-outgoing-activity', handler);
+      return () => window.removeEventListener('bot-outgoing-activity', handler);
+    },
+    [enabled, lastMessageTime, chatBotLoadTime],
+  );
 }

--- a/src/applications/virtual-agent/tests/hooks/useBotOutGoingActivityEventListener.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useBotOutGoingActivityEventListener.unit.spec.jsx
@@ -50,7 +50,7 @@ describe('useBotOutgoingActivityEventListener', () => {
     global.window = originalWindow;
   });
 
-  it('should call addEventListener', () => {
+  it('should call addEventListener when enabled (default)', () => {
     const addEventListenerStub = sandbox.stub(window, 'addEventListener');
 
     renderHook(() => useBotOutgoingActivityEventListener(now));
@@ -61,6 +61,15 @@ describe('useBotOutgoingActivityEventListener', () => {
         sinon.match.func,
       ),
     ).to.be.true;
+  });
+
+  it('should NOT call addEventListener when enabled=false', () => {
+    const addEventListenerStub = sandbox.stub(window, 'addEventListener');
+
+    renderHook(() => useBotOutgoingActivityEventListener(now, false));
+
+    expect(addEventListenerStub.calledWith('bot-outgoing-activity')).to.be
+      .false;
   });
 
   it('should reload when last message was more than 30 minutes ago', async () => {


### PR DESCRIPTION
**🔍 Found the root cause of the browser reload after "Start new chat"**

When QA waits for the 1-hour token expiry and clicks "Start new chat", the page reloads on the first message. Here's why:

**The issue:**
[Chatbox.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/components/Chatbox.jsx:0:0-0:0) sets `chatBotLoadTime = Date.now()` on mount and never resets it. There's a 60-minute reload guard in [useBotOutgoingActivityEventListener](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useBotOutgoingActivityEventListener.js:18:0-26:1) that forces a page refresh if `Date.now() - chatBotLoadTime > 60 min`.

When the user clicks "Start new chat":
- `App.jsx` remounts [WebChat](cci:1://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/components/WebChat.jsx:59:0-168:2) and fetches a fresh token ✓
- But [Chatbox.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/components/Chatbox.jsx:0:0-0:0) is *not* remounted, so `chatBotLoadTime` stays stale
- First message triggers the 60-min check → reload 💥

**The fix:**
Added a listener in [Chatbox.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/components/Chatbox.jsx:0:0-0:0) that resets `chatBotLoadTime` when `va-chatbot-reset` fires:

```jsx
useEffect(() => {
  const onReset = () => setChatBotLoadTime(Date.now());
  window.addEventListener('va-chatbot-reset', onReset);
  return () => window.removeEventListener('va-chatbot-reset', onReset);
}, []);
```

This syncs the reload guard with the new session persistence flow.