### PR TITLE
Fixed AuthApp Helper for MHV Portal Redirect

### DIFF
--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -119,9 +119,8 @@ export const checkPortalRequirements = ({
   userAttributes,
   isMyVAHealth,
 }) => {
-  const {
-    vaProfile: { vaPatient = false, facilities = [] } = {},
-  } = userAttributes;
+  const { vaPatient = false, facilities = [] } =
+    userAttributes?.vaProfile || {};
   const redirectElligible =
     isPortalNoticeInterstitialEnabled && isMyVAHealth && vaPatient;
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed an issue with one of the `AuthApp.jsx` helpers where it couldn't handle `null` values.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/878)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running ` yarn test:unit --app-folder auth`.

## What areas of the site does it impact?
This only impacts  `AuthApp.jsx` and its related tests.

## Acceptance criteria
- [x] Ensure `checkPortalRequirements` can handle `null` values.