### PR TITLE
[FL autosuggest prototype] text doesn’t enlarge when browser text settings are set to enlarge #22514

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -132,7 +132,7 @@ $text-color: rgba(27, 27, 27, 1);
   }
 
   @media screen and (max-width: $small-screen) {
-    .facility-result + .facility-result {
+    .facility-result+.facility-result {
       border-top: solid 1px var(--vads-color-base-light);
     }
   }
@@ -188,7 +188,7 @@ $text-color: rgba(27, 27, 27, 1);
     padding: 0;
   }
 
-  .react-tabs__tab + .react-tabs__tab {
+  .react-tabs__tab+.react-tabs__tab {
     border-left: none;
   }
 
@@ -346,6 +346,14 @@ $text-color: rgba(27, 27, 27, 1);
     .service-type-dropdown-desktop {
       flex-basis: 100%;
       width: 100%;
+    }
+
+    .service-type-dropdown-mobile>select,
+    .service-type-dropdown-tablet>select,
+    .service-type-dropdown-desktop>select {
+      font-size: 1rem;
+      height: auto;
+
     }
 
     .usa-input-error {

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -353,7 +353,6 @@ $text-color: rgba(27, 27, 27, 1);
     .service-type-dropdown-desktop>select {
       font-size: 1rem;
       height: auto;
-
     }
 
     .usa-input-error {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The attributes font-size: 1rem & height: auto were explicitly added to the select elements of the autosuggest service-type drop down, to allow them to respond to changing the font size in Chrome
- To reproduce:
  1. Using Chrome, go to the Settings, search for “font,” and increase the font size to “Very Large.”
  2. Go to [autosuggest prototype](https://staging.va.gov/find-locations/)
  3. Select 'Urgent care' in the facility type field.
  4. Open the service type select.
  5. See that the select options are not scaled like the surrounding text is.
  6. Same for Facility type('Emergency care') > Service type

-  By specifying these attributes, the select elements now become responsive to the font setting changes in Chrome, allowing them to increase in size when 'Very Large' is selected
- Facilities team

## Related issue(s)

- [[FL autosuggest prototype] <select> text doesn’t enlarge when browser text settings are set to enlarge #22514](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22514)

## Testing done

- Prior to the change, the font size of the <select> elements would not grow in response to updating the font size setting in Chrome to 'Very large'
- The site was viewed in desktop and mobile to ascertain that the changes were generating the desired phenotype
 - In mobile in Chrome, there is no setting to enlarge the texts. The mobile phenotype was reviewed to ensure that no undesirable changes occurred 
- Changing the settings in Chrome and navigating to the select elements resulted in text that was enlarged, similar to most other text on the page


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="353" height="618" alt="Screenshot 2025-11-25 at 10 55 16 AM" src="https://github.com/user-attachments/assets/3f45b2ab-263c-45c3-83dc-259cc5029e78" /> |<img width="398" height="653" alt="Screenshot 2025-11-25 at 10 55 43 AM" src="https://github.com/user-attachments/assets/fba2edba-3eba-4b74-8e2e-fde02b25ee54" /> <img width="446" height="659" alt="Screenshot 2025-11-25 at 10 55 49 AM" src="https://github.com/user-attachments/assets/98e9a978-8af3-4428-8408-9874074a4683" />|

## What areas of the site does it impact?
- Facilities Locator page
## Acceptance criteria

### Quality Assurance & Testing

- [NA] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [NA] Events are being sent to the appropriate logging solution
- [NA] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [NA] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA