### PR TITLE
[124897] Handle empty rated disabilities array at submit

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -343,7 +343,6 @@ export const removeExtraData = formData => {
       }, {}),
     );
   } else {
-    // NEW: if there are no rated disabilities, don't send the field at all
     delete clonedData.ratedDisabilities;
   }
 

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -342,7 +342,11 @@ export const removeExtraData = formData => {
         return acc;
       }, {}),
     );
+  } else {
+    // NEW: if there are no rated disabilities, don't send the field at all
+    delete clonedData.ratedDisabilities;
   }
+
   return clonedData;
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When a user in the staging environment has no rated disabilities, attempting to submit a form containing only new conditions results in a 422 error. This occurs because the payload includes an empty ratedDisabilities array, which the backend rejects.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/124897

## Steps to Reproduce

1. Log in as user 23 with rated disabilities (vets.gov.user+23@gmail.com) where the feature flag is enabled in the **staging** environment 
2. Navigate to the Conditions section
3. Add a new condition
4. Navigate to the Review and Submit page
5. Expand the Conditions accordion and confirm the entry is present
6. Scroll to the Claim and Certification section
7. Enter a signature and select the certification checkbox
8. Click submit application

**Expected behavior:**

The form submits successfully when the feature flag is enabled.

**Actual behavior:**

Submission fails with a 422 status because the payload includes an empty ratedDisabilities array.

## Root Cause

In the submit.js file, the removeExtraData function checks:

```
  if (disabilities?.length) { … }
```

If ratedDisabilities is present but empty ([]), the conditional evaluates to false, but no action is taken. As a result, the empty array remains in the payload and leads to a 422 error.

To prevent this, the function should explicitly delete ratedDisabilities when it contains no items.

### Code change required

Add an else clause to remove the field when no rated disabilities are present:

```
 else {
    delete clonedData.ratedDisabilities;
  }
```

Unit tests were added for this scenario.

## Screenshots

### Before

**Payload with Empty Rated Disabilities Array**

<img width="808" height="520" alt="payload-error" src="https://github.com/user-attachments/assets/488d4054-a306-4ac0-9a25-1a76c4074cdb" />

### After

**Payload without Empty Rated Disabilities Array**

<img width="523" height="577" alt="success-payl" src="https://github.com/user-attachments/assets/51a4391b-7a96-4ca4-91f3-a0d6ad758987" />

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please run the application locally and verify that submitting forms containing new conditions—with or without rated disabilities—works correctly across both the existing disabilities workflow and the new conditions workflow.

Use this [gist](https://gist.github.com/sdbars/baf1da55b2ba5c2ed837510c01a733b8) to seed application with rated disabilities data if desired.