### PR TITLE
0969 | Post MVP - Hide supporting docs pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/supportingDocuments.jsx
+++ b/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/supportingDocuments.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import { showUpdatedContent } from '../../../helpers';
 
 const Documents = ({ formData }) => {
   const hasFarm = formData?.ownedAssets?.some(
@@ -107,6 +108,7 @@ Documents.propTypes = {
 export default {
   title: 'Supporting documents',
   path: 'additional-information/supporting-documents',
+  depends: () => !showUpdatedContent(),
   uiSchema: {
     ...titleUI('Supporting documents'),
     'ui:description': Documents,

--- a/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/uploadDocuments.jsx
+++ b/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/uploadDocuments.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import environment from 'platform/utilities/environment';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
+import { showUpdatedContent } from '../../../helpers';
 
 const MAX_FILE_SIZE_MB = 20;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2;
@@ -31,6 +32,7 @@ const UploadMessage = (
 export default {
   title: 'Upload documents',
   path: 'additional-information/upload-documents',
+  depends: () => !showUpdatedContent(),
   uiSchema: {
     ...titleUI('Upload supporting documents'),
     'ui:description': Description,


### PR DESCRIPTION
## Summary

This PR updates conditionally hides the **Supporting documents** pages in the **Income and Asset Statement form (VA Form 21P-0969)**.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125656

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the form at:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`

## How to verify
### Post MVP enabled
1. Verify that the 'Supporting documents' chapter is not included for Post MVP

### Post MVP disabled
1. Verify that the 'Supporting documents' chapter is included for MVP

## What areas of the site does it impact?
- Income and Asset Statement (VA Form 21P-0969)  

## Screenshots
| MVP | Post MVP  |
|---------------|--------|
|<img width="707" height="966" alt="0969-review-and-submit-13-chapters" src="https://github.com/user-attachments/assets/812ffc9c-6a53-4115-9326-b28e5c5cb6d5" />|<img width="708" height="911" alt="0969-review-and-submit-12-chapters" src="https://github.com/user-attachments/assets/970b32db-c7ab-4507-a38e-4dee2cb10412" />|

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

- Post-MVP improvements for 0969  
- Behind `income_and_assets_content_updates` feature toggle
