### PR TITLE
[CVE 2189] fix bug where users on review-information Contact Info Flo…

### DIFF
--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -191,6 +191,15 @@ class ProfileInformationFieldController extends React.Component {
         document,
         50,
       );
+
+      if (
+        forceEditView &&
+        typeof successCallback === 'function' &&
+        showUpdateSuccessAlert &&
+        !prevProps.showUpdateSuccessAlert
+      ) {
+        successCallback();
+      }
     } else if (
       forceEditView &&
       typeof successCallback === 'function' &&

--- a/src/platform/user/profile/vap-svc/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/ContactInformationField.unit.spec.jsx
@@ -190,6 +190,36 @@ describe('<ProfileInformationFieldController/>', () => {
 
     component.unmount();
   });
+
+  it('calls successCallback when success alert appears in forceEditView flow', () => {
+    const successCallbackSpy = sinon.spy();
+
+    const initialProps = {
+      ...props,
+      forceEditView: true,
+      successCallback: successCallbackSpy,
+      showUpdateSuccessAlert: false,
+      showEditView: false,
+      showRemoveModal: false,
+      showValidationView: false,
+      transactionRequest: null,
+    };
+
+    component = enzyme.shallow(
+      <ProfileInformationFieldController {...initialProps} />,
+    );
+
+    const updatedProps = {
+      ...initialProps,
+      showUpdateSuccessAlert: true,
+    };
+
+    component.setProps(updatedProps);
+
+    expect(successCallbackSpy.calledOnce, 'successCallback called').to.be.true;
+
+    component.unmount();
+  });
 });
 
 describe('mapStateToProps', () => {


### PR DESCRIPTION
…w would edit profile fields but not be redirected to the main contact-info page

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This is work for the CVE team that affects some of the AuthEx portion of the codebase.
- **Issue:** User edits phone/email/address from “[Add your contact information](http://staging.va.gov/my-va/welcome-va-setup)” then clicks Update and data saves in VA Profile, but they stay on the edit screen and never see the success state back on the contact info page.
- **Likely cause:** In this flow we render ProfileInformationFieldController (through [profileContactInfo](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/src/js/definitions/profileContactInfo.js) and its [EditContactInfo](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/src/js/components/EditContactInfo.jsx) pages) with forceEditView and successCallback, but those functions don’t use the usual VAP modals. The controller never calls successCallback, so the embedding form app (review-information) doesn’t know the save is done and doesn’t navigate back/show the success alert.
- **Fix is this PR.**

## Steps to Verify

- Simultaneously run the commands `yarn watch --env entry=welcome-va-setup-review-information` and `yarn mock-api --responses src/applications/personalization/profile/mocks/server.js`
- Visit "http://localhost:3001/my-va/welcome-va-setup/"
- Click one of the "Edit" links
- Update the field
- Click Update
- It should redirect you to the initial page with a success message

## Related issue(s)

- CVE team t[icket # 2189](https://github.com/orgs/department-of-veterans-affairs/projects/1360/views/20?sliceBy%5Bvalue%5D=john-rodriguez-adhocteam&pane=issue&itemId=138445777&issue=department-of-veterans-affairs%7Cva-iir%7C2189)

## What areas of the site does it impact?

- AuthEx (requesting AuthEx eng review)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
