### PR TITLE
Fixed Session Timeout Banner Bug

### DIFF
--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -329,6 +329,7 @@ export const logoutEvent = async (signInServiceName, wait = {}) => {
   };
   recordEvent({ event: `${AUTH_EVENTS.OAUTH_LOGOUT}-${signInServiceName}` });
 
+  sessionStorage.removeItem('shouldRedirectExpiredSession');
   updateLoggedInStatus(false);
 
   if (shouldWait) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed bug related to the Session Timeout Banner appearing after logging out of an SiS session.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/908)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/platform/utilities/tests/oauth/utilities.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `src/platform/utilities/oauth/utilities.js`.

## Acceptance criteria
- [x] Session Timeout Banner bug is resolved