### PR TITLE
Facilities/Sitewide/121790: Facility Locator (Heading level content is read in pieces)

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -25,7 +25,6 @@ export const ResultsList = ({
 }) => {
   const [resultsData, setResultsData] = useState(null);
   const currentPage = pagination ? pagination.currentPage : 1;
-
   useEffect(
     () => {
       setResultsData(

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -25,6 +25,7 @@ export const ResultsList = ({
 }) => {
   const [resultsData, setResultsData] = useState(null);
   const currentPage = pagination ? pagination.currentPage : 1;
+
   useEffect(
     () => {
       setResultsData(

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -136,7 +136,7 @@ export const SearchResultsHeader = ({
     return (
       <>
         {`${resultsPrefix}`}
-        <b>{`"${facilityTypes[facilityType]}" `}</b>
+        <b>{`"${facilityTypes[facilityType]}"`}</b>
         <FormattedServiceTypeText />
         <FormattedLocationText />
       </>

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -97,6 +97,38 @@ export const SearchResultsHeader = ({
     return 'Results';
   };
 
+  const isSpecialCategory = [
+    LocationType.URGENT_CARE,
+    LocationType.EMERGENCY_CARE,
+  ].includes(facilityType);
+
+  const resultsPrefix = isSpecialCategory
+    ? `${messagePrefix}`
+    : `${handleNumberOfResults()}`;
+
+  // for "${facilityTypes[facilityType]}" ${formattedServiceType && `"${formattedServiceType}"`} ${location && `near "${location}"`}`
+
+  const MessageResults = () => {
+    return (
+      <>
+        {`${resultsPrefix} for `}
+        <b>{`"${facilityTypes[facilityType]}" `}</b>
+        {formattedServiceType && (
+          <>
+            {`, `}
+            <b>{`"${formattedServiceType}"`}</b>
+          </>
+        )}
+        {location && (
+          <>
+            {` near `}
+            <b>{`"${location}"`}</b>
+          </>
+        )}
+      </>
+    );
+  };
+
   return (
     <div>
       <h2
@@ -104,28 +136,29 @@ export const SearchResultsHeader = ({
         className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
         tabIndex="-1"
       >
-        {[LocationType.URGENT_CARE, LocationType.EMERGENCY_CARE].includes(
+        <MessageResults />
+        {/* {[LocationType.URGENT_CARE, LocationType.EMERGENCY_CARE].includes(
           facilityType,
         )
           ? messagePrefix
           : handleNumberOfResults()}{' '}
-        for &quot;
+        for {""}
         <b>{facilityTypes[facilityType]}</b>
-        &quot;
+        {""}
         {formattedServiceType && (
           <>
-            ,&nbsp;&quot;
+            ,{""};
             <b>{formattedServiceType}</b>
-            &quot;
+            {""}
           </>
         )}
         {location && (
           <>
-            &nbsp;near &quot;
+            {""}near {""}
             <b>{location}</b>
-            &quot;
+            {""}
           </>
-        )}
+        )} */}
       </h2>
     </div>
   );

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -118,6 +118,7 @@ export const SearchResultsHeader = ({
         </>
       );
     }
+    return null;
   }
   function FormattedLocationText() {
     if (formattedServiceType) {
@@ -128,6 +129,7 @@ export const SearchResultsHeader = ({
         </>
       );
     }
+    return null;
   }
 
   function MessageResults() {

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -109,39 +109,21 @@ export const SearchResultsHeader = ({
     ? `${messagePrefix} for `
     : `${handleNumberOfResults()} for `;
 
-  function FormattedServiceTypeText() {
-    if (formattedServiceType) {
-      return (
-        <>
-          {`, `}
-          <b>{`"${formattedServiceType}"`}</b>
-        </>
-      );
-    }
-    return null;
-  }
-  function FormattedLocationText() {
-    if (location) {
-      return (
-        <>
-          {` near `}
-          <b>{`"${location}"`}</b>
-        </>
-      );
-    }
-    return null;
-  }
-
-  function MessageResults() {
-    return (
+  const FormattedServiceTypeText = () =>
+    formattedServiceType ? (
       <>
-        {`${resultsPrefix}`}
-        <b>{`"${facilityTypes[facilityType]}"`}</b>
-        <FormattedServiceTypeText />
-        <FormattedLocationText />
+        {`, `}
+        <b>{`"${formattedServiceType}"`}</b>
       </>
-    );
-  }
+    ) : null;
+
+  const FormattedLocationText = () =>
+    location ? (
+      <>
+        {` near `}
+        <b>{`"${location}"`}</b>
+      </>
+    ) : null;
 
   return (
     <div>
@@ -150,7 +132,10 @@ export const SearchResultsHeader = ({
         className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
         tabIndex="-1"
       >
-        <MessageResults />
+        {`${resultsPrefix}`}
+        <b>{`"${facilityTypes[facilityType] || ''}"`}</b>
+        {FormattedServiceTypeText()}
+        {FormattedLocationText()}
       </h2>
     </div>
   );

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -97,14 +97,11 @@ export const SearchResultsHeader = ({
     return 'Results';
   };
 
-  // Determine if facility type is Urgent Care or Emergency Care
-  // to adjust message format accordingly
   const isSpecialCategory = [
     LocationType.URGENT_CARE,
     LocationType.EMERGENCY_CARE,
   ].includes(facilityType);
 
-  // Set results prefix based on facility type
   const resultsPrefix = isSpecialCategory
     ? `${messagePrefix} for `
     : `${handleNumberOfResults()} for `;

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -97,37 +97,49 @@ export const SearchResultsHeader = ({
     return 'Results';
   };
 
+  // Determine if facility type is Urgent Care or Emergency Care
+  // to adjust message format accordingly
   const isSpecialCategory = [
     LocationType.URGENT_CARE,
     LocationType.EMERGENCY_CARE,
   ].includes(facilityType);
 
+  // Set results prefix based on facility type
   const resultsPrefix = isSpecialCategory
-    ? `${messagePrefix}`
-    : `${handleNumberOfResults()}`;
+    ? `${messagePrefix} for `
+    : `${handleNumberOfResults()} for `;
 
-  // for "${facilityTypes[facilityType]}" ${formattedServiceType && `"${formattedServiceType}"`} ${location && `near "${location}"`}`
+  function FormattedServiceTypeText() {
+    if (formattedServiceType) {
+      return (
+        <>
+          {`, `}
+          <b>{`"${formattedServiceType}"`}</b>
+        </>
+      );
+    }
+  }
+  function FormattedLocationText() {
+    if (formattedServiceType) {
+      return (
+        <>
+          {` near `}
+          <b>{`"${location}"`}</b>
+        </>
+      );
+    }
+  }
 
-  const MessageResults = () => {
+  function MessageResults() {
     return (
       <>
-        {`${resultsPrefix} for `}
+        {`${resultsPrefix}`}
         <b>{`"${facilityTypes[facilityType]}" `}</b>
-        {formattedServiceType && (
-          <>
-            {`, `}
-            <b>{`"${formattedServiceType}"`}</b>
-          </>
-        )}
-        {location && (
-          <>
-            {` near `}
-            <b>{`"${location}"`}</b>
-          </>
-        )}
+        <FormattedServiceTypeText />
+        <FormattedLocationText />
       </>
     );
-  };
+  }
 
   return (
     <div>
@@ -137,28 +149,6 @@ export const SearchResultsHeader = ({
         tabIndex="-1"
       >
         <MessageResults />
-        {/* {[LocationType.URGENT_CARE, LocationType.EMERGENCY_CARE].includes(
-          facilityType,
-        )
-          ? messagePrefix
-          : handleNumberOfResults()}{' '}
-        for {""}
-        <b>{facilityTypes[facilityType]}</b>
-        {""}
-        {formattedServiceType && (
-          <>
-            ,{""};
-            <b>{formattedServiceType}</b>
-            {""}
-          </>
-        )}
-        {location && (
-          <>
-            {""}near {""}
-            <b>{location}</b>
-            {""}
-          </>
-        )} */}
       </h2>
     </div>
   );

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -121,7 +121,7 @@ export const SearchResultsHeader = ({
     return null;
   }
   function FormattedLocationText() {
-    if (formattedServiceType) {
+    if (location) {
       return (
         <>
           {` near `}

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -153,6 +153,8 @@ describe('Facility VA search', () => {
       meta: { pagination: { totalEntries: 0 } },
     }).as('searchFacilities');
 
+    cy.injectAxeThenAxeCheck();
+
     cy.get('#street-city-state-zip').type('27606');
     cy.get('#facility-type-dropdown')
       .shadow()
@@ -223,6 +225,8 @@ describe('Facility VA search', () => {
 
   it('should not trigger Use My Location when pressing enter in the input field', () => {
     cy.visit('/find-locations');
+
+    cy.injectAxeThenAxeCheck();
 
     cy.get('#street-city-state-zip').type('27606{enter}');
     // Wait for Use My Location to be triggered (it should not be)

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -167,9 +167,11 @@ describe('Facility VA search', () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(3000);
 
-    cy.focused().contains(
+    cy.focused().should(
+      'contain.text',
       'No results found for "Community providers (in VA’s network)", "General Acute Care Hospital" near "Raleigh, North Carolina 27606"',
     );
+
     cy.get('#other-tools').should('exist');
   });
 

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -164,8 +164,7 @@ describe('Facility VA search', () => {
     cy.get('#downshift-1-item-0').click({ waitForAnimations: true });
 
     cy.get('#facility-search').click({ waitForAnimations: true });
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(3000);
+    cy.wait('@searchFacilities');
 
     cy.focused().should(
       'contain.text',
@@ -290,7 +289,7 @@ describe('Facility VA search', () => {
     cy.get('#facility-type-dropdown')
       .shadow()
       .find('select')
-      .select('VA health');
+      .select('VA health', { force: true });
     cy.get('#service-type-dropdown').select('Primary care');
     cy.get('#facility-search').click({ waitForAnimations: true });
     cy.get('#facility-search').click({ waitForAnimations: true });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- For the facility locator, the string depicting the results of the facility locator search form were refactored to be displayed in one line, in order to be effectively read by screenreaders
- To reproduce:
- 1.  Enter a search in the facility locator form, while having a screenreader open.
- 2. Press search.
- 3. Observe that the heading level being read multiple times throughout the content

- Solution: adjust the way that these results are rendered, by using object literals and different conditionals, to ensure the results are on one line
- Done for the Facilities team

## Related issue(s)
- [[ADE Research - Feedback] - Facilities - Sitewide: Facility Locator (Heading level content is read in pieces)](https://github.com/department-of-veterans-affairs/va.gov-team/issues/121790)

## Testing done

- In the previous phenotype, a confusing output was generated by the screenreader, wherein the heading level was read multiple times 
- On a Mac, the output of the screen reader was observed in Safari and Chrome for the results phrase after a facility locator search
- After the changes in this PR were made, the results read as expected, narrating the text content of the search string and not other extraneous information


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After in Chrome | After in Safari |
| ------- | ------ | ----- | ----- |
| Desktop | <img width="750" height="205" alt="499434147-cbf45910-73a1-4b5b-8412-9516134ebe94" src="https://github.com/user-attachments/assets/b5c9ee85-2292-4569-b8d3-c0888c409bdc" />  | <img width="663" height="240" alt="Screenshot 2025-11-26 at 11 25 24 AM" src="https://github.com/user-attachments/assets/aa4a3913-255c-4b72-9500-5d3b48d1f77c" /> |<img width="1062" height="476" alt="Screenshot 2025-11-26 at 11 26 00 AM" src="https://github.com/user-attachments/assets/23684611-6e66-4675-8fa7-cae6edc597db" />|


## What areas of the site does it impact?
- Affects the Facility Locator page

### Quality Assurance & Testing

- NA // I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [NA] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [NA] Events are being sent to the appropriate logging solution
- [NA] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [NA] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA
