### PR TITLE
Conditionally display "Business email" label on ReviewPage

### DIFF
--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -1116,7 +1116,11 @@ const ReviewPage = props => {
                           key: 'yourContactInformation',
                         },
                         {
-                          name: 'Email address',
+                          name:
+                            props.formData.relationshipToVeteran ===
+                            relationshipOptionsSomeoneElse.WORK
+                              ? 'Business email'
+                              : 'Email address',
                           data:
                             props.formData.relationshipToVeteran ===
                             relationshipOptionsSomeoneElse.WORK

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -1107,7 +1107,11 @@ const ReviewPage = props => {
                       keys={chapter.pageKeys}
                       items={[
                         {
-                          name: 'Phone number',
+                          name:
+                            props.formData.relationshipToVeteran ===
+                            relationshipOptionsSomeoneElse.WORK
+                              ? 'Business phone'
+                              : 'Phone number',
                           data:
                             props.formData.relationshipToVeteran ===
                             relationshipOptionsSomeoneElse.WORK


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders 

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Add conditional logic to label the relevant contact info as business email / phone
- _(What is the solution, why is this the solution)_
  - This conditional check looks at whether the user identified as an SCO, WSSS, etc. and labels the user-submitted contact info as "Business phone" and "Business email," or "Phone number" and "Email address," respectively.
  - The phone and email values shown were already using this exact logic, so the only change was to make the labels consistent with the values.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Ask VA owns this code.

## Related issue(s)

- department-of-veterans-affairs/ask-va#1792

## Testing done

- _Describe what the old behavior was prior to the change_
  - Labels had hard-coded text, now they show either the old label or a business version of it.
- _Describe the steps required to verify your changes are working as expected_
  - Repro steps [available here](https://github.com/department-of-veterans-affairs/ask-va/issues/1792#issuecomment-3598779323)
- _Describe the tests completed and the results_
  - Manually observe changes in local environment
  - All tests (unit and e2e) still passing
  - As with my last PR for `ReviewPage.jsx`, I noted that there's almost no testing of the actual functionality of the component, just that it renders. A small PR like this is not the place to suddenly add a whole series of tests for a 1500-line file full of unrelated functionality. We should note this as significant tech debt and plan to break up and test `ReviewPage`.

## Screenshots

Note the overflowing text in the mobile screenshots – this is a bug already present and will need to be addressed in another ticket.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="289" height="296" alt="Mobile before" src="https://github.com/user-attachments/assets/620fb5f5-240e-4387-ad49-4a75d15b0031" />  |  <img width="288" height="291" alt="Mobile after" src="https://github.com/user-attachments/assets/d48af5c4-dabe-45a3-933d-f7ec7fe59149" />  |
| Desktop | <img width="618" height="220" alt="Desktop before" src="https://github.com/user-attachments/assets/ade2976a-b120-43bb-b0e8-02f416cf5d69" /> | <img width="617" height="218" alt="Desktop after" src="https://github.com/user-attachments/assets/c437da43-3ae8-48cb-ba1a-53e4c6c42890" /> |

## What areas of the site does it impact?

Only Ask VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/c

redentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
  - [x] Color contrast
  - [x] axe devtools auto check
  - [x] Zoom issues (screen width: 1200px, zoom to 200%, 300%, 400%)
  - [x] Keyboard navigation
    - It's possible to navigate by keyboard, but the experience is unnecessarily long, likely because we use definition lists instead of normal `<p>`'s and `<span>`'s.

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user