### PR TITLE
Refactor MHV Medications feature toggle usage and tests

### DIFF
--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -136,9 +136,12 @@ export const prescriptionsApi = createApi({
       },
     }),
     getPrescriptionById: builder.query({
-      query: id => ({
-        path: `/prescriptions/${id}`,
-      }),
+      query: id => {
+        const prescriptionId = typeof id === 'object' ? id.id : id;
+        return {
+          path: `/prescriptions/${prescriptionId}`,
+        };
+      },
       providesTags: ['Prescription'],
       transformResponse: response => {
         // If it's a single prescription (not in an entry array)

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -101,6 +101,8 @@ export const prescriptionsApi = createApi({
             .API_ENDPOINT,
           filterOption = '',
           includeImage = false,
+          // eslint-disable-next-line no-unused-vars
+          isOracleHealthPilot,
         } = params;
 
         let queryParams = `page=${page}&per_page=${perPage}`;
@@ -155,7 +157,8 @@ export const prescriptionsApi = createApi({
       },
     }),
     getRefillablePrescriptions: builder.query({
-      query: () => ({
+      // eslint-disable-next-line no-unused-vars
+      query: ({ isOracleHealthPilot } = {}) => ({
         path: `/prescriptions/list_refillable_prescriptions`,
       }),
       providesTags: ['Prescription'],

--- a/src/applications/mhv-medications/api/prescriptionsApi.js
+++ b/src/applications/mhv-medications/api/prescriptionsApi.js
@@ -206,7 +206,7 @@ export const prescriptionsApi = createApi({
       },
     }),
     refillPrescription: builder.mutation({
-      queryFn: async (id, isAcceleratingMedications = false) => {
+      queryFn: async ({ id, isAcceleratingMedications = false }) => {
         const apiBasePath = getApiBasePath(isAcceleratingMedications);
         const method = getRefillMethod(isAcceleratingMedications);
 
@@ -232,7 +232,7 @@ export const prescriptionsApi = createApi({
       },
     }),
     bulkRefillPrescriptions: builder.mutation({
-      queryFn: async (ids, isAcceleratingMedications = false) => {
+      queryFn: async ({ ids, isAcceleratingMedications = false }) => {
         const apiBasePath = getApiBasePath(isAcceleratingMedications);
         const method = getRefillMethod(isAcceleratingMedications);
 

--- a/src/applications/mhv-medications/components/shared/FillRefillButton.jsx
+++ b/src/applications/mhv-medications/components/shared/FillRefillButton.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { pharmacyPhoneNumber } from '@department-of-veterans-affairs/mhv/exports';
+import useAcceleratedData from '~/platform/mhv/hooks/useAcceleratedData';
 import { useRefillPrescriptionMutation } from '../../api/prescriptionsApi';
 import CallPharmacyPhone from './CallPharmacyPhone';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 
 const FillRefillButton = rx => {
+  const { isAcceleratingMedications } = useAcceleratedData();
   const [refillPrescription, { isLoading }] = useRefillPrescriptionMutation();
 
   const { dispensedDate, error, prescriptionId, success, isRefillable } = rx;
@@ -69,7 +71,10 @@ const FillRefillButton = rx => {
           data-testid="refill-request-button"
           hidden={success || isLoading}
           onClick={() => {
-            refillPrescription(prescriptionId);
+            refillPrescription({
+              id: prescriptionId,
+              isAcceleratingMedications,
+            });
           }}
           text={`Request ${hasBeenDispensed ? 'a refill' : 'the first fill'}`}
         />

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -74,7 +74,9 @@ const PrescriptionDetails = () => {
   const selectedFilterOption = useSelector(selectFilterOption);
   const currentPage = useSelector(selectPageNumber);
   // OH feature flag
-  const isCernerPilot = useSelector(selectCernerPilotFlag);
+  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
+  const isCernerPilot = isOracleHealthPilot;
+
   // Consolidate query parameters into a single state object to avoid multiple re-renders
   const [queryParams] = useState({
     page: currentPage || 1,
@@ -88,7 +90,7 @@ const PrescriptionDetails = () => {
   // Use the custom hook to fetch prescription data
   const { prescription, prescriptionApiError, isLoading } = usePrescriptionData(
     prescriptionId,
-    queryParams,
+    { ...queryParams, isOracleHealthPilot },
   );
 
   const nonVaPrescription =

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -75,6 +75,7 @@ import {
   selectSortOption,
   selectFilterOption,
 } from '../selectors/selectPreferences';
+import { selectCernerPilotFlag } from '../util/selectors';
 import { buildPdfData } from '../util/buildPdfData';
 import { generateMedicationsPdfFile } from '../util/generateMedicationsPdfFile';
 import FilterAriaRegion from '../components/MedicationsList/FilterAriaRegion';
@@ -103,6 +104,10 @@ const Prescriptions = () => {
   // Get sort/filter selections from store.
   const selectedSortOption = useSelector(selectSortOption);
   const selectedFilterOption = useSelector(selectFilterOption);
+  const featureTogglesLoading = useSelector(
+    state => state.featureToggles.loading,
+  );
+  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
 
   const { currentPage, handlePageChange } = useURLPagination();
 
@@ -132,7 +137,10 @@ const Prescriptions = () => {
     error: prescriptionsApiError,
     isLoading: isPrescriptionsLoading,
     isFetching: isPrescriptionsFetching,
-  } = useGetPrescriptionsListQuery(queryParams);
+  } = useGetPrescriptionsListQuery(
+    { ...queryParams, isOracleHealthPilot },
+    { skip: featureTogglesLoading },
+  );
 
   const isLoading = isPrescriptionsLoading || isPrescriptionsFetching;
 

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -75,24 +75,22 @@ import {
   selectSortOption,
   selectFilterOption,
 } from '../selectors/selectPreferences';
-import { selectCernerPilotFlag } from '../util/selectors';
 import { buildPdfData } from '../util/buildPdfData';
 import { generateMedicationsPdfFile } from '../util/generateMedicationsPdfFile';
 import FilterAriaRegion from '../components/MedicationsList/FilterAriaRegion';
 import RxRenewalDeleteDraftSuccessAlert from '../components/shared/RxRenewalDeleteDraftSuccessAlert';
 import { useURLPagination } from '../hooks/useURLPagination';
 import { usePageTitle } from '../hooks/usePageTitle';
-import { selectCernerPilotFlag } from '../util/selectors';
 
 const Prescriptions = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const isCernerPilot = useSelector(selectCernerPilotFlag);
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const userName = useSelector(selectUserFullName);
   const dob = useSelector(selectUserDob);
   const hasMedsByMailFacility = useSelector(selectHasMedsByMailFacility);
   const {
+    isAcceleratingMedications,
     isAcceleratingAllergies,
     isCerner,
     isLoading: isAcceleratedDataLoading,
@@ -104,10 +102,6 @@ const Prescriptions = () => {
   // Get sort/filter selections from store.
   const selectedSortOption = useSelector(selectSortOption);
   const selectedFilterOption = useSelector(selectFilterOption);
-  const featureTogglesLoading = useSelector(
-    state => state.featureToggles.loading,
-  );
-  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
 
   const { currentPage, handlePageChange } = useURLPagination();
 
@@ -138,8 +132,8 @@ const Prescriptions = () => {
     isLoading: isPrescriptionsLoading,
     isFetching: isPrescriptionsFetching,
   } = useGetPrescriptionsListQuery(
-    { ...queryParams, isOracleHealthPilot },
-    { skip: featureTogglesLoading },
+    { ...queryParams, isAcceleratingMedications },
+    { skip: isAcceleratedDataLoading },
   );
 
   const isLoading = isPrescriptionsLoading || isPrescriptionsFetching;
@@ -380,12 +374,18 @@ const Prescriptions = () => {
 
       if (format === DOWNLOAD_FORMAT.PDF) {
         generatePDF(
-          buildPrescriptionsPDFList(prescriptionsExportList, isCernerPilot),
+          buildPrescriptionsPDFList(
+            prescriptionsExportList,
+            isAcceleratingMedications,
+          ),
           buildAllergiesPDFList(allergies),
         );
       } else if (format === DOWNLOAD_FORMAT.TXT) {
         generateTXT(
-          buildPrescriptionsTXT(prescriptionsExportList, isCernerPilot),
+          buildPrescriptionsTXT(
+            prescriptionsExportList,
+            isAcceleratingMedications,
+          ),
           buildAllergiesTXT(allergies),
         );
       } else if (format === PRINT_FORMAT.PRINT) {
@@ -404,7 +404,7 @@ const Prescriptions = () => {
       pdfTxtGenerateStatus,
       generatePDF,
       generateTXT,
-      isCernerPilot,
+      isAcceleratingMedications,
     ],
   );
 

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -35,24 +35,24 @@ import ProcessList from '../components/shared/ProcessList';
 import { refillProcessStepGuide } from '../util/processListData';
 import { useGetAllergiesQuery } from '../api/allergiesApi';
 import { selectUserDob, selectUserFullName } from '../selectors/selectUser';
-import { selectCernerPilotFlag } from '../util/selectors';
-
 import { selectSortOption } from '../selectors/selectPreferences';
 
 const RefillPrescriptions = () => {
-  const featureTogglesLoading = useSelector(
-    state => state.featureToggles.loading,
-  );
-  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
-  const isCernerPilot = isOracleHealthPilot;
+  const {
+    isAcceleratingMedications,
+    isAcceleratingAllergies,
+    isCerner,
+    isLoading: isAcceleratedDataLoading,
+  } = useAcceleratedData();
+  const isCernerPilot = isAcceleratingMedications;
 
   const {
     data: refillableData,
     isLoading,
     error: refillableError,
   } = useGetRefillablePrescriptionsQuery(
-    { isOracleHealthPilot },
-    { skip: featureTogglesLoading },
+    { isAcceleratingMedications },
+    { skip: isAcceleratedDataLoading },
   );
 
   const [
@@ -121,11 +121,6 @@ const RefillPrescriptions = () => {
 
   // Selectors
   const selectedSortOption = useSelector(selectSortOption);
-  const {
-    isAcceleratingAllergies,
-    isCerner,
-    isLoading: isAcceleratedDataLoading,
-  } = useAcceleratedData();
 
   // Get refillable list from RTK Query result
   // Filter out successfully refilled prescriptions to provide immediate UI feedback
@@ -175,7 +170,7 @@ const RefillPrescriptions = () => {
 
       // Get just the prescription IDs for the bulk refill
       const prescriptionIds = selectedRefillList.map(rx => {
-        if (isCernerPilot) {
+        if (isAcceleratingMedications) {
           return { id: rx.prescriptionId, stationNumber: rx.stationNumber };
         }
         return rx.prescriptionId;

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -40,13 +40,20 @@ import { selectCernerPilotFlag } from '../util/selectors';
 import { selectSortOption } from '../selectors/selectPreferences';
 
 const RefillPrescriptions = () => {
+  const featureTogglesLoading = useSelector(
+    state => state.featureToggles.loading,
+  );
+  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
+  const isCernerPilot = isOracleHealthPilot;
+
   const {
     data: refillableData,
     isLoading,
     error: refillableError,
-  } = useGetRefillablePrescriptionsQuery();
-
-  const isCernerPilot = useSelector(selectCernerPilotFlag);
+  } = useGetRefillablePrescriptionsQuery(
+    { isOracleHealthPilot },
+    { skip: featureTogglesLoading },
+  );
 
   const [
     bulkRefillPrescriptions,

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -177,7 +177,10 @@ const RefillPrescriptions = () => {
       });
 
       try {
-        await bulkRefillPrescriptions(prescriptionIds).unwrap();
+        await bulkRefillPrescriptions({
+          ids: prescriptionIds,
+          isAcceleratingMedications,
+        }).unwrap();
         setRefillStatus(REFILL_STATUS.FINISHED);
         setSelectedRefillList([]);
       } catch (error) {

--- a/src/applications/mhv-medications/hooks/usePrescriptionData.js
+++ b/src/applications/mhv-medications/hooks/usePrescriptionData.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   getPrescriptionsList,
   getPrescriptionById,
@@ -11,6 +12,9 @@ import {
  * @returns {object} - The prescription data, loading state, and error state
  */
 export const usePrescriptionData = (prescriptionId, queryParams) => {
+  const featureTogglesLoading = useSelector(
+    state => state.featureToggles.loading,
+  );
   const [
     cachedPrescriptionAvailable,
     setCachedPrescriptionAvailable,
@@ -30,8 +34,11 @@ export const usePrescriptionData = (prescriptionId, queryParams) => {
 
   // Fetch individual prescription when needed
   const { data, error, isLoading: queryLoading } = getPrescriptionById.useQuery(
-    prescriptionId,
-    { skip: cachedPrescriptionAvailable },
+    {
+      id: prescriptionId,
+      isOracleHealthPilot: queryParams.isOracleHealthPilot,
+    },
+    { skip: cachedPrescriptionAvailable || featureTogglesLoading },
   );
 
   // Handle prescription data from either source

--- a/src/applications/mhv-medications/tests/api/prescriptionsApi.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/api/prescriptionsApi.unit.spec.jsx
@@ -1,122 +1,55 @@
 import { expect } from 'chai';
 import { environment } from '@department-of-veterans-affairs/platform-utilities/exports';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { getApiBasePath, getRefillMethod } from '../../api/prescriptionsApi';
 
 describe('prescriptionsApi', () => {
   describe('getApiBasePath', () => {
-    it('should return v2 path when Cerner pilot flag is enabled', () => {
-      const mockState = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
-          loading: false,
-        },
-      };
-
-      const result = getApiBasePath(mockState);
+    it('should return v2 path when isAcceleratingMedications is true', () => {
+      const result = getApiBasePath(true);
 
       expect(result).to.equal(`${environment.API_URL}/my_health/v2`);
     });
 
-    it('should return v1 path when Cerner pilot flag is disabled', () => {
-      const mockState = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: false,
-          loading: false,
-        },
-      };
-
-      const result = getApiBasePath(mockState);
+    it('should return v1 path when isAcceleratingMedications is false', () => {
+      const result = getApiBasePath(false);
 
       expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
     });
 
-    it('should default to v1 path when feature toggles are loading', () => {
-      const mockState = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
-          loading: true,
-        },
-      };
-
-      const result = getApiBasePath(mockState);
+    it('should default to v1 path when isAcceleratingMedications is missing', () => {
+      const result = getApiBasePath();
 
       expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
     });
 
-    it('should default to v1 path when featureToggles object is missing', () => {
-      const mockState = {};
-
-      const result = getApiBasePath(mockState);
-
-      expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
-    });
-
-    it('should default to v1 path when featureToggles is null', () => {
-      const mockState = {
-        featureToggles: null,
-      };
-
-      const result = getApiBasePath(mockState);
+    it('should default to v1 path when isAcceleratingMedications is null', () => {
+      const result = getApiBasePath(null);
 
       expect(result).to.equal(`${environment.API_URL}/my_health/v1`);
     });
   });
 
   describe('getRefillMethod', () => {
-    it('should return POST when Cerner pilot flag is enabled', () => {
-      const mockState = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
-          loading: false,
-        },
-      };
-
-      const result = getRefillMethod(mockState);
+    it('should return POST when isAcceleratingMedications is true', () => {
+      const result = getRefillMethod(true);
 
       expect(result).to.equal('POST');
     });
 
-    it('should return PATCH when Cerner pilot flag is disabled', () => {
-      const mockState = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: false,
-          loading: false,
-        },
-      };
-
-      const result = getRefillMethod(mockState);
+    it('should return PATCH when isAcceleratingMedications is false', () => {
+      const result = getRefillMethod(false);
 
       expect(result).to.equal('PATCH');
     });
 
-    it('should default to PATCH when feature toggles are loading', () => {
-      const mockState = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
-          loading: true,
-        },
-      };
-
-      const result = getRefillMethod(mockState);
+    it('should default to PATCH when isAcceleratingMedications is missing', () => {
+      const result = getRefillMethod();
 
       expect(result).to.equal('PATCH');
     });
 
-    it('should default to PATCH when featureToggles is missing', () => {
-      const mockState = {};
-
-      const result = getRefillMethod(mockState);
-
-      expect(result).to.equal('PATCH');
-    });
-
-    it('should default to PATCH when featureToggles is null', () => {
-      const mockState = {
-        featureToggles: null,
-      };
-
-      const result = getRefillMethod(mockState);
+    it('should default to PATCH when isAcceleratingMedications is null', () => {
+      const result = getRefillMethod(null);
 
       expect(result).to.equal('PATCH');
     });

--- a/src/applications/mhv-medications/tests/containers/PrescriptionDetails.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/PrescriptionDetails.unit.spec.jsx
@@ -4,6 +4,9 @@ import React from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { commonReducer } from 'platform/startup/store';
 import * as prescriptionsApiModule from '../../api/prescriptionsApi';
 import {
   stubAllergiesApi,
@@ -25,6 +28,22 @@ let sandbox;
 
 describe('Prescription details container', () => {
   const setup = (state = {}) => {
+    const testStore = createStore(
+      combineReducers({
+        ...commonReducer,
+        ...reducer,
+      }),
+      {
+        featureToggles: { loading: false },
+        ...state,
+      },
+      applyMiddleware(
+        thunk,
+        allergiesApi.middleware,
+        prescriptionsApi.middleware,
+      ),
+    );
+
     return renderWithStoreAndRouterV6(
       <Routes>
         <Route
@@ -33,13 +52,8 @@ describe('Prescription details container', () => {
         />
       </Routes>,
       {
-        initialState: state,
-        reducers: reducer,
+        store: testStore,
         initialEntries: ['/prescriptions/1234567891'],
-        additionalMiddlewares: [
-          allergiesApi.middleware,
-          prescriptionsApi.middleware,
-        ],
       },
     );
   };

--- a/src/applications/mhv-medications/tests/containers/PrescriptionDetails.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/PrescriptionDetails.unit.spec.jsx
@@ -204,7 +204,6 @@ describe('Prescription details container', () => {
 
   it('does not display "Not filled yet" when accelerating medications and no dispense date', async () => {
     sandbox.restore();
-    sandbox = sinon.createSandbox();
 
     // Mock useAcceleratedData to return isAcceleratingMedications: true
     sandbox.stub(useAcceleratedDataModule, 'default').returns({

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -65,7 +65,9 @@ describe('Refill Prescriptions Component', () => {
         ],
       },
     },
-    featureToggles: {},
+    featureToggles: {
+      loading: false,
+    },
     user: {
       login: {
         currentlyLoggedIn: true,

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -3,6 +3,9 @@ import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/plat
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/react';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { commonReducer } from 'platform/startup/store';
 import * as allergiesApiModule from '../../api/allergiesApi';
 import * as prescriptionsApiModule from '../../api/prescriptionsApi';
 import { stubAllergiesApi } from '../testing-utils';
@@ -71,14 +74,22 @@ describe('Refill Prescriptions Component', () => {
   };
 
   const setup = (state = initialState) => {
-    return renderWithStoreAndRouterV6(<RefillPrescriptions />, {
-      initialState: state,
-      reducers: reducer,
-      initialEntries: ['/refill'],
-      additionalMiddlewares: [
+    const testStore = createStore(
+      combineReducers({
+        ...commonReducer,
+        ...reducer,
+      }),
+      state,
+      applyMiddleware(
+        thunk,
         allergiesApiModule.allergiesApi.middleware,
         prescriptionsApiModule.prescriptionsApi.middleware,
-      ],
+      ),
+    );
+
+    return renderWithStoreAndRouterV6(<RefillPrescriptions />, {
+      store: testStore,
+      initialEntries: ['/refill'],
     });
   };
 

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -380,8 +380,11 @@ describe('Refill Prescriptions Component', () => {
 
       await waitFor(() => {
         expect(bulkRefillStub.calledOnce).to.be.true;
-        // Should pass array of simple IDs when not accelerating medications
-        expect(bulkRefillStub.firstCall.args[0]).to.deep.equal([22377956]);
+        // Should pass object with ids array and isAcceleratingMedications flag
+        expect(bulkRefillStub.firstCall.args[0]).to.deep.equal({
+          ids: [22377956],
+          isAcceleratingMedications: false,
+        });
       });
     });
 
@@ -435,10 +438,11 @@ describe('Refill Prescriptions Component', () => {
 
       await waitFor(() => {
         expect(bulkRefillStub.calledOnce).to.be.true;
-        // Should pass array of ID objects with stationNumber when accelerating medications
-        expect(bulkRefillStub.firstCall.args[0]).to.deep.equal([
-          { id: 22377956, stationNumber: '989' },
-        ]);
+        // Should pass object with ids array of ID objects and isAcceleratingMedications flag
+        expect(bulkRefillStub.firstCall.args[0]).to.deep.equal({
+          ids: [{ id: 22377956, stationNumber: '989' }],
+          isAcceleratingMedications: true,
+        });
       });
     });
 

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -213,25 +213,25 @@ describe('Refill Prescriptions Component', () => {
       );
   });
 
-  it('does not show "Not filled yet" when Cerner pilot is enabled', async () => {
+  it('does not show "Not filled yet" when accelerating medications', async () => {
     sandbox.restore();
+    sandbox = sinon.createSandbox();
+
     // Create a prescription with no dispense date
     const rxWithNoDispenseDate = {
       ...refillablePrescriptions[0],
       dispensedDate: null,
       sortedDispensedDate: null,
     };
+
+    // Initialize mocks with accelerating medications enabled
     initMockApis({
       sinonSandbox: sandbox,
       prescriptions: [rxWithNoDispenseDate],
+      isAcceleratingMedications: true,
     });
-    const screen = setup({
-      ...initialState,
-      featureToggles: {
-        // eslint-disable-next-line camelcase
-        mhv_medications_cerner_pilot: true,
-      },
-    });
+
+    const screen = setup(initialState);
     const lastFilledEl = await screen.findByTestId(
       'refill-prescription-checkbox-0',
     );

--- a/src/applications/mhv-medications/tests/e2e/fixtures/toggles-accelerated-delivery.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/toggles-accelerated-delivery.json
@@ -27,6 +27,10 @@
         "value": true
       },
       {
+        "name": "mhv_medications_cerner_pilot",
+        "value": true
+      },
+      {
         "name": "mhv_accelerated_delivery_enabled",
         "value": true
       },

--- a/src/applications/mhv-medications/tests/e2e/med_site/MedicationsSite.js
+++ b/src/applications/mhv-medications/tests/e2e/med_site/MedicationsSite.js
@@ -16,9 +16,10 @@ class MedicationsSite {
   login = (
     isMedicationsUser = true,
     isAcceleratingAllergies = false,
+    isAcceleratingMedications = false,
     user = mockUser,
   ) => {
-    this.mockFeatureToggles(isAcceleratingAllergies);
+    this.mockFeatureToggles(isAcceleratingAllergies, isAcceleratingMedications);
     this.mockVamcEhr();
 
     if (isMedicationsUser) {
@@ -214,11 +215,16 @@ class MedicationsSite {
     });
   };
 
-  mockFeatureToggles = (isAcceleratingAllergies = false) => {
+  mockFeatureToggles = (
+    isAcceleratingAllergies = false,
+    isAcceleratingMedications = false,
+  ) => {
     cy.intercept(
       'GET',
       '/v0/feature_toggles?*',
-      isAcceleratingAllergies ? mockTogglesAccelerated : mockToggles,
+      isAcceleratingAllergies || isAcceleratingMedications
+        ? mockTogglesAccelerated
+        : mockToggles,
     ).as('featureToggles');
   };
 

--- a/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
@@ -3,39 +3,22 @@ import pendingPrescriptions from './fixtures/pending-prescriptions-med-list.json
 import pendingRxDetails from './fixtures/pending-prescriptions-details.json';
 import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsListPage from './pages/MedicationsListPage';
-import mockToggles from './fixtures/toggles-response.json';
 import allergies from './fixtures/allergies.json';
 import { medicationsUrls } from '../../util/constants';
 
-describe('Medications Details Page - Cerner Pilot Enabled - Not Filled Yet Hidden', () => {
+describe('Medications Details Page - Accelerating Medications - Not Filled Yet Hidden', () => {
   const site = new MedicationsSite();
   const detailsPage = new MedicationsDetailsPage();
   const listPage = new MedicationsListPage();
   const updatedOrderDate = listPage.updatedOrderDates(pendingPrescriptions);
 
-  // Create mock toggles with Cerner pilot enabled
-  const baseFeatures = mockToggles.data.features.filter(
-    f => f.name !== 'mhv_medications_cerner_pilot',
-  );
-  const mockTogglesWithCernerPilot = {
-    data: {
-      type: 'feature_toggles',
-      features: [
-        ...baseFeatures,
-        { name: 'mhv_medications_cerner_pilot', value: true },
-      ],
-    },
-  };
-
   beforeEach(() => {
-    site.login();
-    cy.intercept('GET', '/v0/feature_toggles?*', mockTogglesWithCernerPilot).as(
-      'featureToggles',
-    );
+    // Login with accelerated medications enabled (which includes the Cerner pilot toggle)
+    site.login(true, false, true);
   });
 
-  it('does not display "Not filled yet" text when Cerner pilot is enabled', () => {
-    // When Cerner pilot is enabled, the app uses v2 endpoints
+  it('does not display "Not filled yet" text when accelerating medications', () => {
+    // When accelerating medications, the app uses v2 endpoints
     cy.intercept(
       'GET',
       '/my_health/v2/prescriptions?page=1&per_page=10&sort=alphabetical-status',
@@ -69,7 +52,7 @@ describe('Medications Details Page - Cerner Pilot Enabled - Not Filled Yet Hidde
 
     detailsPage.verifyHeaderTextOnDetailsPage('About this prescription');
 
-    // Verify "Last filled on" section is NOT displayed when Cerner pilot is enabled
+    // Verify "Last filled on" section is NOT displayed when accelerating medications
     // and there is no dispense date
     detailsPage.verifyLastFilledDateNotDisplayedOnDetailsPage();
 

--- a/src/applications/mhv-medications/tests/e2e/medications-list-page-meds-by-mail-content.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-list-page-meds-by-mail-content.cypress.spec.js
@@ -19,7 +19,7 @@ describe('Medications List Page Meds by Mail content', () => {
   it('shows correct content for Meds by Mail users', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
-    site.login(true, false, mockUserMedsByMail);
+    site.login(true, false, false, mockUserMedsByMail);
     listPage.visitMedicationsListPageURL(rxList);
     cy.get('[data-testid="meds-by-mail-header"]').should('exist');
     cy.get('[data-testid="meds-by-mail-top-level-text"]').should('exist');

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-request-success-alert-link-to-list-page-v2.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-request-success-alert-link-to-list-page-v2.cypress.spec.js
@@ -2,35 +2,20 @@ import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsRefillPage from './pages/MedicationsRefillPage';
 import prescriptions from './fixtures/listOfPrescriptions.json';
 import successRequest from './fixtures/refill-success.v2.json';
-import mockToggles from './fixtures/toggles-response.json';
 
 describe('Medications Refill Success Alert Message Link (v2)', () => {
   beforeEach(() => {
     const site = new MedicationsSite();
-    // Mock feature flag for v2 endpoint
-    const baseFeatures = mockToggles.data.features.filter(
-      f => f.name !== 'mhv_medications_cerner_pilot',
-    );
-    const mockTogglesV2 = {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          ...baseFeatures,
-          { name: 'mhv_medications_cerner_pilot', value: true },
-        ],
-      },
-    };
 
     cy.intercept('GET', `my_health/v1/prescriptions/*`, () => {
       // fail the test if v1 endpoint is called
       throw new Error(
-        'v1 endpoint should not be called when Cerner pilot flag is enabled',
+        'v1 endpoint should not be called when accelerating medications',
       );
     });
-    site.login();
-    cy.intercept('GET', '/v0/feature_toggles?*', mockTogglesV2).as(
-      'featureToggles',
-    );
+
+    // Login with accelerated medications enabled (which includes the Cerner pilot toggle)
+    site.login(true, false, true);
   });
 
   it('visits Medications List Link on Success Alert with v2 endpoint', () => {

--- a/src/applications/mhv-medications/tests/hooks/usePrescriptionData.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/usePrescriptionData.unit.spec.jsx
@@ -48,6 +48,8 @@ describe('usePrescriptionData', () => {
   let wrapper;
   let useQueryStateStub;
   let useQueryStub;
+  let getPrescriptionsListStub;
+  let getPrescriptionByIdStub;
 
   beforeEach(() => {
     // Create a basic mock prescription
@@ -86,16 +88,24 @@ describe('usePrescriptionData', () => {
     });
 
     // Replace the real hooks with our stubs
-    sinon.stub(prescriptionsApi, 'getPrescriptionsList').value({
-      useQueryState: useQueryStateStub,
-    });
+    getPrescriptionsListStub = sinon
+      .stub(prescriptionsApi, 'getPrescriptionsList')
+      .value({
+        useQueryState: useQueryStateStub,
+      });
 
-    sinon.stub(prescriptionsApi, 'getPrescriptionById').value({
-      useQuery: useQueryStub,
-    });
+    getPrescriptionByIdStub = sinon
+      .stub(prescriptionsApi, 'getPrescriptionById')
+      .value({
+        useQuery: useQueryStub,
+      });
 
     // Create mock store for provider
-    mockStore = configureStore([])({});
+    mockStore = configureStore([])({
+      featureToggles: {
+        loading: false,
+      },
+    });
 
     // Create wrapper without PropTypes to avoid validation errors
     wrapper = ({ children }) => (
@@ -105,11 +115,11 @@ describe('usePrescriptionData', () => {
 
   afterEach(() => {
     // Restore individual stubs
-    if (prescriptionsApi.getPrescriptionsList.restore) {
-      prescriptionsApi.getPrescriptionsList.restore();
+    if (getPrescriptionsListStub) {
+      getPrescriptionsListStub.restore();
     }
-    if (prescriptionsApi.getPrescriptionById.restore) {
-      prescriptionsApi.getPrescriptionById.restore();
+    if (getPrescriptionByIdStub) {
+      getPrescriptionByIdStub.restore();
     }
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR standardizes how feature toggles are handled in the MHV Medications application's unit tests and refactors the `usePrescriptionData` hook. This fixes a bug where v1 endpoints are sometimes incorrectly called when the Cerner pilot toggle is enabled.

### Key Changes
- Refactored `usePrescriptionData` to select feature toggle state directly from Redux instead of requiring it as a prop.
- Updated unit tests to use the platform's `commonReducer` for feature toggles, replacing a custom ad-hoc reducer pattern.
- Fixed Sinon stub leakage in hook tests that was causing failures in other test files.
- Simplified container components by removing the need to pass feature toggle loading state to the hook.
