### PR TITLE
VEBT-3841: Agreement type "Withdraw" steps reformation

### DIFF
--- a/src/applications/edu-benefits/0839/config/form.js
+++ b/src/applications/edu-benefits/0839/config/form.js
@@ -102,6 +102,7 @@ const formConfig = {
               goPath('acknowledgements');
             }
           },
+          updateFormData: agreementType.updateFormData,
         },
       },
     },
@@ -114,6 +115,8 @@ const formConfig = {
           uiSchema: acknowledgements.uiSchema,
           schema: acknowledgements.schema,
           pageClass: 'acknowledgements-page',
+          depends: formData =>
+            formData?.agreementType !== 'withdrawFromYellowRibbonProgram',
         },
       },
     },
@@ -168,25 +171,33 @@ const formConfig = {
             path: 'yellow-ribbon-program-request',
             uiSchema: yellowRibbonProgramRequest.uiSchema,
             schema: yellowRibbonProgramRequest.schema,
+            depends: formData =>
+              formData?.agreementType !== 'withdrawFromYellowRibbonProgram',
           }),
           yellowRibbonProgramRequestSummary: pageBuilder.summaryPage({
             title: 'Yellow Ribbon Program contributions',
             path: 'yellow-ribbon-program-request/summary',
             uiSchema: yellowRibbonProgramRequestSummary.uiSchema,
             schema: yellowRibbonProgramRequestSummary.schema,
+            depends: formData =>
+              formData?.agreementType !== 'withdrawFromYellowRibbonProgram',
           }),
           yellowRibbonProgramContribution: pageBuilder.itemPage({
             title: 'Add a Yellow Ribbon Program contribution',
             path: 'yellow-ribbon-program-request/:index',
             uiSchema: eligibleIndividualsSupported.uiSchema,
             schema: eligibleIndividualsSupported.schema,
+            depends: formData =>
+              formData?.agreementType !== 'withdrawFromYellowRibbonProgram',
           }),
           contributionLimitsAndDegreeLevel: pageBuilder.itemPage({
             title: 'Contribution limits and degree level',
             path: 'yellow-ribbon-program-request/:index/contribution-limits',
             uiSchema: contributionLimitsAndDegreeLevel.uiSchema,
             schema: contributionLimitsAndDegreeLevel.schema,
-            depends: formData => !!formData?.institutionDetails?.isUsaSchool,
+            depends: formData =>
+              formData?.agreementType !== 'withdrawFromYellowRibbonProgram' &&
+              !!formData?.institutionDetails?.isUsaSchool,
             pageClass: 'ypr-no-expander-border',
           }),
           foreignContributionLimitsAndDegreeLevel: pageBuilder.itemPage({
@@ -196,7 +207,10 @@ const formConfig = {
             uiSchema: foreignContributionLimitsAndDegreeLevel.uiSchema,
             schema: foreignContributionLimitsAndDegreeLevel.schema,
             depends: formData => {
-              return formData?.institutionDetails?.isUsaSchool === false;
+              return (
+                formData?.agreementType !== 'withdrawFromYellowRibbonProgram' &&
+                formData?.institutionDetails?.isUsaSchool === false
+              );
             },
             pageClass: 'ypr-no-expander-border',
           }),
@@ -211,13 +225,17 @@ const formConfig = {
           title: 'Points of contact',
           uiSchema: pointsOfContanct.uiSchema,
           schema: pointsOfContanct.schema,
+          depends: formData =>
+            formData?.agreementType !== 'withdrawFromYellowRibbonProgram',
         },
         additionalPointsOfContact: {
           path: 'additional-points-of-contact',
           title: 'additional points of contact',
           uiSchema: additionalPointsOfContact.uiSchema,
           schema: additionalPointsOfContact.schema,
-          depends: formData => showAdditionalPointsOfContact(formData),
+          depends: formData =>
+            formData?.agreementType !== 'withdrawFromYellowRibbonProgram' &&
+            showAdditionalPointsOfContact(formData),
         },
       },
     },

--- a/src/applications/edu-benefits/0839/pages/agreementType.js
+++ b/src/applications/edu-benefits/0839/pages/agreementType.js
@@ -38,6 +38,7 @@ const updateFormData = (oldData, formData) => {
 
   if (prev !== curr) {
     return {
+      authorizedOfficial: oldData?.authorizedOfficial,
       agreementType: curr,
       acknowledgements: {},
       institutionDetails: {},

--- a/src/applications/edu-benefits/0839/pages/agreementType.js
+++ b/src/applications/edu-benefits/0839/pages/agreementType.js
@@ -32,4 +32,22 @@ const schema = {
   required: ['agreementType'],
 };
 
-export { schema, uiSchema };
+const updateFormData = (oldData, formData) => {
+  const prev = oldData?.agreementType;
+  const curr = formData?.agreementType;
+
+  if (prev !== curr) {
+    return {
+      agreementType: curr,
+      acknowledgements: {},
+      institutionDetails: {},
+      additionalInstitutionDetails: [],
+      yellowRibbonProgramRequest: [],
+      pointsOfContact: [],
+    };
+  }
+
+  return formData;
+};
+
+export { uiSchema, schema, updateFormData };

--- a/src/applications/edu-benefits/0839/tests/pages/agreementType.unit.spec.jsx
+++ b/src/applications/edu-benefits/0839/tests/pages/agreementType.unit.spec.jsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import * as page from '../../pages/agreementType';
 
+const { updateFormData } = page;
+
 const renderPage = (formData = {}) =>
   render(
     <DefinitionTester
@@ -48,5 +50,51 @@ describe('22-0839 agreementType page', () => {
     const vaRadio = container.querySelector('va-radio');
     expect(vaRadio).to.exist;
     expect(vaRadio.getAttribute('error')).to.equal('Please make a selection');
+  });
+
+  describe('updateFormData', () => {
+    it('should return formData unchanged when agreementType has not changed', () => {
+      const oldData = {
+        agreementType: 'startNewOpenEndedAgreement',
+        acknowledgements: { someData: true },
+        institutionDetails: { name: 'Test' },
+      };
+      const formData = {
+        agreementType: 'startNewOpenEndedAgreement',
+        acknowledgements: { someData: true },
+        institutionDetails: { name: 'Test' },
+      };
+
+      expect(updateFormData(oldData, formData)).to.deep.equal(formData);
+    });
+
+    it('should clear related fields when agreementType changes', () => {
+      const oldData = {
+        agreementType: 'startNewOpenEndedAgreement',
+        acknowledgements: { someData: true },
+        institutionDetails: { name: 'Test' },
+        additionalInstitutionDetails: [{ id: 1 }],
+        yellowRibbonProgramRequest: [{ request: 'test' }],
+        pointsOfContact: [{ contact: 'test' }],
+      };
+      const formData = {
+        agreementType: 'modifyExistingAgreement',
+        acknowledgements: { someData: true },
+        institutionDetails: { name: 'Test' },
+        additionalInstitutionDetails: [{ id: 1 }],
+        yellowRibbonProgramRequest: [{ request: 'test' }],
+        pointsOfContact: [{ contact: 'test' }],
+      };
+
+      const result = updateFormData(oldData, formData);
+      expect(result).to.deep.equal({
+        agreementType: 'modifyExistingAgreement',
+        acknowledgements: {},
+        institutionDetails: {},
+        additionalInstitutionDetails: [],
+        yellowRibbonProgramRequest: [],
+        pointsOfContact: [],
+      });
+    });
   });
 });

--- a/src/applications/edu-benefits/0839/tests/pages/agreementType.unit.spec.jsx
+++ b/src/applications/edu-benefits/0839/tests/pages/agreementType.unit.spec.jsx
@@ -71,6 +71,13 @@ describe('22-0839 agreementType page', () => {
     it('should clear related fields when agreementType changes', () => {
       const oldData = {
         agreementType: 'startNewOpenEndedAgreement',
+        authorizedOfficial: [
+          {
+            officialName: 'John Doe',
+            officialTitle: 'Director',
+            officialEmail: 'john@example.com',
+          },
+        ],
         acknowledgements: { someData: true },
         institutionDetails: { name: 'Test' },
         additionalInstitutionDetails: [{ id: 1 }],
@@ -88,6 +95,13 @@ describe('22-0839 agreementType page', () => {
 
       const result = updateFormData(oldData, formData);
       expect(result).to.deep.equal({
+        authorizedOfficial: [
+          {
+            officialName: 'John Doe',
+            officialTitle: 'Director',
+            officialEmail: 'john@example.com',
+          },
+        ],
         agreementType: 'modifyExistingAgreement',
         acknowledgements: {},
         institutionDetails: {},


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Dynamically change the chapters rendered when selecting the withdraw option in agreement type step.

## Related issue(s)
https://jira.devops.va.gov/browse/VEBT-3841

## Testing done
<img width="1438" height="731" alt="Screenshot 2025-12-01 at 12 20 48 PM" src="https://github.com/user-attachments/assets/57fdf6c9-5b21-4cd4-a224-2811bf9fdef0" />


## Screenshots

Before
<img width="769" height="568" alt="Screenshot 2025-12-01 at 12 26 47 PM" src="https://github.com/user-attachments/assets/13c558ca-a3b6-4556-a0cd-ab47f1902c86" />

After
<img width="845" height="569" alt="Screenshot 2025-12-01 at 12 27 06 PM" src="https://github.com/user-attachments/assets/037904f1-ef08-44d9-b219-a0362fd01fc7" />

## What areas of the site does it impact?

edu-benefits/0839

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
