### PR TITLE
Form 21-0779 submit

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/README.md
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/README.md
@@ -152,7 +152,7 @@ yarn test:unit:coverage --app-folder benefits-optimization-aquia/21-0779-nursing
 yarn test:unit src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/form/form.unit.spec.jsx
 
 # Run Cypress E2E tests (requires yarn watch to be running)
-yarn cy:run --spec "src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/*.cypress.spec.js"
+yarn cy:run --spec "src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/e2e/21-0779-nursing-home-information.cypress.spec.js"
 
 # Open Cypress test runner
 yarn cy:open

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/transform.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/transform.js
@@ -81,5 +81,8 @@ export const transform = (formConfig, form) => {
     },
   };
 
-  return JSON.stringify(submissionData);
+  // Return the data as a JSON string wrapped in an object with a 'form' key
+  // The backend expects the entire payload to be a stringified JSON object,
+  // we do this because we don't want the form data modified by the inflection header
+  return JSON.stringify({ form: JSON.stringify(submissionData) });
 };

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx
@@ -3,6 +3,10 @@ import { expect } from 'chai';
 import { transform } from '@bio-aquia/21-0779-nursing-home-information/config/transform';
 import formData from '../fixtures/data/maximal-test.json';
 
+function parseResult(result) {
+  return JSON.parse(JSON.parse(result).form);
+}
+
 describe('Transform Function', () => {
   const createMockFormData = (overrides = {}) => ({
     data: {
@@ -14,7 +18,7 @@ describe('Transform Function', () => {
   it('should transform complete form data correctly', () => {
     const mockForm = createMockFormData();
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult).to.have.property('veteranInformation');
     expect(parsedResult.veteranInformation.fullName).to.deep.equal({
@@ -34,7 +38,7 @@ describe('Transform Function', () => {
       claimantQuestion: { patientType: 'veteran' },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.claimantInformation).to.not.be.null;
     expect(parsedResult.claimantInformation).to.be.an('object');
@@ -49,7 +53,7 @@ describe('Transform Function', () => {
       claimantQuestion: { patientType: 'spouseOrParent' },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.claimantInformation).to.not.be.null;
     expect(parsedResult.claimantInformation.fullName).to.deep.equal({
@@ -67,7 +71,7 @@ describe('Transform Function', () => {
   it('should transform nursing home information correctly', () => {
     const mockForm = createMockFormData();
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.nursingHomeInformation).to.deep.equal({
       nursingHomeName: 'Coruscant Veterans Medical Center',
@@ -85,7 +89,7 @@ describe('Transform Function', () => {
   it('should transform general information correctly', () => {
     const mockForm = createMockFormData();
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.generalInformation).to.include({
       admissionDate: '2019-05-04',
@@ -106,7 +110,7 @@ describe('Transform Function', () => {
       nursingHomeDetails: null,
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.nursingHomeInformation.nursingHomeName).to.be.undefined;
   });
@@ -116,7 +120,7 @@ describe('Transform Function', () => {
       nursingOfficialInformation: null,
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.generalInformation.nursingOfficialName).to.equal('');
   });
@@ -132,7 +136,7 @@ describe('Transform Function', () => {
       },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.generalInformation.nursingOfficialName).to.equal(
       'Beru',
@@ -147,7 +151,7 @@ describe('Transform Function', () => {
       certificationLevelOfCare: { levelOfCare: 'intermediate' },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(JSON.parse(result).form);
+    const parsedResult = parseResult(result);
 
     expect(parsedResult.generalInformation).to.include({
       medicaidFacility: false,

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx
@@ -14,7 +14,7 @@ describe('Transform Function', () => {
   it('should transform complete form data correctly', () => {
     const mockForm = createMockFormData();
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult).to.have.property('veteranInformation');
     expect(parsedResult.veteranInformation.fullName).to.deep.equal({
@@ -34,7 +34,7 @@ describe('Transform Function', () => {
       claimantQuestion: { patientType: 'veteran' },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.claimantInformation).to.not.be.null;
     expect(parsedResult.claimantInformation).to.be.an('object');
@@ -49,7 +49,7 @@ describe('Transform Function', () => {
       claimantQuestion: { patientType: 'spouseOrParent' },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.claimantInformation).to.not.be.null;
     expect(parsedResult.claimantInformation.fullName).to.deep.equal({
@@ -67,7 +67,7 @@ describe('Transform Function', () => {
   it('should transform nursing home information correctly', () => {
     const mockForm = createMockFormData();
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.nursingHomeInformation).to.deep.equal({
       nursingHomeName: 'Coruscant Veterans Medical Center',
@@ -85,7 +85,7 @@ describe('Transform Function', () => {
   it('should transform general information correctly', () => {
     const mockForm = createMockFormData();
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.generalInformation).to.include({
       admissionDate: '2019-05-04',
@@ -106,7 +106,7 @@ describe('Transform Function', () => {
       nursingHomeDetails: null,
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.nursingHomeInformation.nursingHomeName).to.be.undefined;
   });
@@ -116,7 +116,7 @@ describe('Transform Function', () => {
       nursingOfficialInformation: null,
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.generalInformation.nursingOfficialName).to.equal('');
   });
@@ -132,7 +132,7 @@ describe('Transform Function', () => {
       },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.generalInformation.nursingOfficialName).to.equal(
       'Beru',
@@ -147,7 +147,7 @@ describe('Transform Function', () => {
       certificationLevelOfCare: { levelOfCare: 'intermediate' },
     });
     const result = transform({}, mockForm);
-    const parsedResult = JSON.parse(result);
+    const parsedResult = JSON.parse(JSON.parse(result).form);
 
     expect(parsedResult.generalInformation).to.include({
       medicaidFacility: false,


### PR DESCRIPTION
## Summary
To accommodate api changes made in https://github.com/department-of-veterans-affairs/vets-api/pull/25319
The new form submit post is body structure is {form: "stringified_json_form_data"}

## Related issue(s)
This accommodates api changes made in https://github.com/department-of-veterans-affairs/vets-api/pull/25319

## Testing done

- updated unit tests to test new api structure
- Manually tested form submission to api and successfully downloaded pdf.

## Screenshots
no ui changes

## What areas of the site does it impact?
just form 21-0779 form submission

## Acceptance criteria
### Quality Assurance & Testing

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Linting warnings have been addressed
- [x]  Documentation has been updated ([link to documentation](https://github.com/annaswims/vets-website/pull/3#) *if necessary)
- n/a Screenshot of the developed feature is added
- n/a [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling
 Bro

- [x] wser console contains no warnings or errors.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Featu

re/bug has a monitor built into Datadog or Grafana (if applicable)
### Authentication
 Did you login to a local build and 

- [x] verify all authenticated routes work as expected with a test user