### PR TITLE
chore(ci): limit continuous integration to security-scan branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "security-scan"
+      - "oidc-conversion"
     tags-ignore:
       - "**"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - "**"
+      - "security-scan"
     tags-ignore:
       - "**"
 


### PR DESCRIPTION
## Summary

This PR limits the Continuous Integration workflow to only run on the `security-scan` branch. This allows us to safely test the Shai Hulud 2.0 security mitigation changes on that branch without reopening CI to the public on all other branches.

## Changes

- Modified `.github/workflows/continuous-integration.yml` to only trigger on pushes to the `security-scan` branch
- Previously the workflow ran on all branches (`"**"`)
- Now it only runs on `security-scan`

## Purpose

This is a temporary measure to:
1. Allow safe testing of the security-scan branch changes
2. Prevent CI from running on public branches until security measures are validated
3. Once security-scan is proven safe, this can be reverted to restore normal CI operation

## Related Issue

- department-of-veterans-affairs/va.gov-team#126489