### PR TITLE
chore(ci): limit continuous integration to postinstall-local-build-fix branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,8 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - "security-scan"
-      - "oidc-conversion"
+      - "postinstall-local-build-fix"
     tags-ignore:
       - "**"
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR limits the Continuous Integration workflow to only run on the `postinstall-local-build-fix` branch. This allows us to safely test the postinstall script changes on that branch without reopening CI to all other branches.

## Changes

- Modified `.github/workflows/continuous-integration.yml` to only trigger on pushes to the `postinstall-local-build-fix` branch
- Removed `security-scan` and `oidc-conversion` from the branch list

## Purpose

This is a temporary measure to:
1. Allow safe testing of the postinstall-local-build-fix branch changes
2. Prevent CI from running on other branches until postinstall changes are validated
3. Once postinstall-local-build-fix is proven safe and merged, this can be reverted to restore normal CI operation

## Related Issue

- Related to postinstall script refactoring PR #40487

## Testing done

- Verified workflow YAML syntax is valid
- Confirmed CI will only trigger on postinstall-local-build-fix branch

## Screenshots

N/A - This is CI configuration with no UI changes.

## What areas of the site does it impact?

This impacts the CI/CD pipeline by limiting which branches trigger the continuous integration workflow.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (if necessary)
- [x] Screenshot of the developed feature is added (N/A for CI changes)
- [x] Accessibility testing has been performed (N/A for CI changes)

### Error Handling

- [x] Browser console contains no warnings or errors (N/A for CI changes)
- [x] Events are being sent to the appropriate logging solution (GitHub Actions provides native logging)
- [x] Feature/bug has a monitor built into Datadog or Grafana (GitHub Actions monitoring is built-in)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A for CI changes)

## Requested Feedback

This temporarily limits CI to only the postinstall-local-build-fix branch for safe testing before reopening to all branches.