### PR TITLE
chore(ci): restore continuous integration to all branches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - "postinstall-local-build-fix"
+      - "**"
     tags-ignore:
       - "**"
 
@@ -14,40 +14,39 @@ concurrency:
 jobs:
   # TEMPORARY: This check will be removed once Shai Hulud 2.0 is no longer a moving target
   # Fails and cancels the workflow if package.json or yarn.lock are modified
-  # TEMPORARILY COMMENTED OUT TO ALLOW POSTINSTALL SCRIPT TESTING
-  # check-dependency-files:
-  #   name: Check for Dependency File Changes
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-  #       with:
-  #         fetch-depth: 0
-  #
-  #     - name: Check for package.json or yarn.lock changes
-  #       run: |
-  #         # Fetch main branch for comparison
-  #         git fetch origin main
-  #
-  #         # Check if package.json or yarn.lock have been modified
-  #         if git diff --name-only origin/main...HEAD | grep -qE '^(package\.json|yarn\.lock)$'; then
-  #           echo "❌ ERROR: package.json or yarn.lock has been modified."
-  #           echo "This is temporarily blocked to prevent Shai Hulud 2.0 vulnerabilities."
-  #           echo "Once Shai Hulud 2.0 is no longer a moving target, this check will be removed."
-  #           exit 1
-  #         fi
-  #         echo "✓ No dependency file changes detected."
-  #
-  #     - name: Cancel workflow on failure
-  #       if: failure()
-  #       uses: actions/github-script@v7
-  #       with:
-  #         script: |
-  #           await github.rest.actions.cancelWorkflowRun({
-  #             owner: context.repo.owner,
-  #             repo: context.repo.repo,
-  #             run_id: context.runId
-  #           });
+  check-dependency-files:
+    name: Check for Dependency File Changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+        with:
+          fetch-depth: 0
+
+      - name: Check for package.json or yarn.lock changes
+        run: |
+          # Fetch main branch for comparison
+          git fetch origin main
+
+          # Check if package.json or yarn.lock have been modified
+          if git diff --name-only origin/main...HEAD | grep -qE '^(package\.json|yarn\.lock)$'; then
+            echo "❌ ERROR: package.json or yarn.lock has been modified."
+            echo "This is temporarily blocked to prevent Shai Hulud 2.0 vulnerabilities."
+            echo "Once Shai Hulud 2.0 is no longer a moving target, this check will be removed."
+            exit 1
+          fi
+          echo "✓ No dependency file changes detected."
+
+      - name: Cancel workflow on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
 
   build:
     name: Build


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Restores continuous integration workflow to run on all branches instead of being limited to specific test branches
- Re-enables the dependency file check job that was temporarily disabled during Shai Hulud 2.0 mitigation testing
- Completes the CI workflow restoration after validating postinstall script changes work correctly
- This is part of the Platform team's work to mitigate Shai Hulud 2.0 NPM vulnerabilities

## Related issue(s)

- Related to Shai Hulud 2.0 mitigation efforts
department-of-veterans-affairs/va.gov-team#126489

## Testing done

- Old behavior: CI was limited to run only on `postinstall-local-build-fix` branch for testing, dependency check was commented out
- New behavior: CI runs on all branches (`**`), dependency check is active and will fail if package.json or yarn.lock are modified
- Testing steps:
  1. Verify CI triggers on all branches after merge
  2. Verify dependency file check properly blocks PRs that modify package.json or yarn.lock
  3. Confirm all existing CI jobs continue to function normally
- This change has been tested on the `postinstall-local-build-fix` branch where the postinstall scripts were validated

## Screenshots

N/A - CI/CD configuration changes only

## What areas of the site does it impact?

This impacts the CI/CD pipeline only. No user-facing changes. All branches will now have CI run on them, and any PRs attempting to modify package.json or yarn.lock will be blocked until Shai Hulud 2.0 mitigation is complete.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A for CI workflow changes)
- [ ] Screenshot of the developed feature is added (N/A for CI changes)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A for CI changes)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A for CI changes)
- [x] Events are being sent to the appropriate logging solution (N/A for CI changes)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A for CI changes)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A for CI changes)

## Requested Feedback

This PR should be merged after PR #40487 (postinstall-local-build-fix) is validated and merged, as it restores normal CI operation across all branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)