### PR TITLE
Update determineAuthBroker to work with plain text cookies

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -458,32 +458,43 @@ export const logoutUrl = () => {
  * @returns {Boolean} Returns a boolean to determine AuthBroker
  */
 export const determineAuthBroker = featureFlagEnabled => {
-  if (featureFlagEnabled) {
-    const cookieValue = Cookies.get('CERNER_ELIGIBLE');
-    const rawCookie = cookieValue?.split('--')[0];
+  if (!featureFlagEnabled) return false;
+
+  const cookieValue = Cookies.get('CERNER_ELIGIBLE');
+
+  /**
+   * @returns true if cookie doesn't exist or if cookie does exist with no value
+   */
+  if (!cookieValue) return true;
+
+  if (cookieValue.includes('--')) {
+    const [signedCookie] = cookieValue.split('--');
 
     /**
-     * @returns false if cookie doesn't exist or if cookie does exist with no value
+     * @returns true if parsed signed cookie is 'F', false if 'T'. If malformed, return true
      */
-    if (!cookieValue || !rawCookie) return false;
+    if (signedCookie) {
+      try {
+        const parsedJson = JSON.parse(atob(signedCookie));
+        const message = parsedJson?._rails?.message;
 
-    const parsedJson = JSON.parse(atob(rawCookie));
-    const message = parsedJson?._rails?.message;
+        if (message) {
+          const secondDecode = atob(message);
+          const parsedCookie = secondDecode?.charAt(2);
 
-    /**
-     * @returns false when no message or malformed
-     */
-    if (!message) return false;
-
-    const secondDecode = atob(message);
-    const parsedCookie = secondDecode?.charAt(2);
-
-    /**
-     * @returns false if parsed cookie contains a value other than `T` or `F`
-     */
-    if (!['T', 'F']?.includes(parsedCookie)) return false;
-
-    return parsedCookie === 'F';
+          if (['T', 'F'].includes(parsedCookie)) {
+            return parsedCookie === 'F';
+          }
+        }
+      } catch (e) {
+        return true;
+      }
+    }
   }
-  return false;
+
+  /**
+   * @returns true if plain text cookie is 'false', false if 'true'
+   */
+  const plainTextCookie = cookieValue.trim().toLowerCase();
+  return plainTextCookie === 'false';
 };

--- a/src/platform/user/tests/authentication/utilities.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.jsx
@@ -755,8 +755,8 @@ describe('Authentication Utilities', () => {
       expect(authUtilities.determineAuthBroker(false)).to.be.false;
     });
 
-    it('should return `false` when no cookie is found', () => {
-      expect(authUtilities.determineAuthBroker(true)).to.be.false;
+    it('should return `true` when no cookie is found', () => {
+      expect(authUtilities.determineAuthBroker(true)).to.be.true;
     });
 
     it('should return `false` when parsed cookie is `T`', () => {
@@ -766,6 +766,26 @@ describe('Authentication Utilities', () => {
 
     it('should return `true` when parsed cookie is `F`', () => {
       Cookies.set('CERNER_ELIGIBLE', parsedCookieF);
+      expect(authUtilities.determineAuthBroker(true)).to.be.true;
+    });
+
+    it('should return `true` when cookie is plain text "false"', () => {
+      Cookies.set('CERNER_ELIGIBLE', 'false');
+      expect(authUtilities.determineAuthBroker(true)).to.be.true;
+    });
+
+    it('should return `false` when cookie is plain text "true"', () => {
+      Cookies.set('CERNER_ELIGIBLE', 'true');
+      expect(authUtilities.determineAuthBroker(true)).to.be.false;
+    });
+
+    it('should handle casing and whitespace for plain text "false"', () => {
+      Cookies.set('CERNER_ELIGIBLE', '  FALSE  ');
+      expect(authUtilities.determineAuthBroker(true)).to.be.true;
+    });
+
+    it('should fall back to plain text and return `true` for malformed signed cookie', () => {
+      Cookies.set('CERNER_ELIGIBLE', 'not-base64--sig');
       expect(authUtilities.determineAuthBroker(true)).to.be.true;
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Update determineAuthBroker to work with both signed cookies and plain text cookies

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/920
- https://github.com/department-of-veterans-affairs/vets-api/pull/25396
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/933

## Testing 
- Testing instructions in vets-api PR


## What areas of the site does it impact?

Authentication

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.


### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
