### PR TITLE
Add support for removeDateHint

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/VaMemorableDateField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaMemorableDateField.jsx
@@ -14,6 +14,7 @@ export default function VaMemorableDateField(props) {
   } = useVaDateCommon(props);
 
   const customYearErrorMessage = props.uiOptions?.customYearErrorMessage;
+  const removeDateHint = props.uiOptions?.removeDateHint;
 
   return (
     <VaMemorableDate
@@ -25,6 +26,9 @@ export default function VaMemorableDateField(props) {
       value={formattedValue}
       {...customYearErrorMessage && {
         customYearErrorMessage,
+      }}
+      {...removeDateHint && {
+        removeDateHint,
       }}
     />
   );

--- a/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
@@ -29,6 +29,8 @@ import {
  *     required?: string
  *   },
  *   dataDogHidden?: boolean,
+ *   monthYearOnly?: boolean,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for title, or an object of options
  * @returns {UISchemaOptions} uiSchema
  */
@@ -107,6 +109,7 @@ const currentOrPastDateUI = options => {
  *     pattern?: string,
  *     required?: string
  *   },
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for title, or an object of options
  * @returns {UISchemaOptions} uiSchema
  */
@@ -138,10 +141,12 @@ const currentOrPastMonthYearDateUI = options => {
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for start/from date title, or an object of options
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for to/end date title, or an object of options
  * @param {string} [errorMessage] - Optional custom error message for the date range validation
  * @returns {UISchemaOptions} uiSchema
@@ -207,10 +212,12 @@ const currentOrPastDateRangeUI = (fromOptions, toOptions, errorMessage) => {
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for start/from date title, or an object of options
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for to/end date title, or an object of options
  * @param {string} [errorMessage] - Optional custom error message for the date range validation
  * @returns {UISchemaOptions} uiSchema
@@ -249,6 +256,8 @@ const currentOrPastMonthYearDateRangeUI = (
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   monthYearOnly?: boolean,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for title, or an object of options
  * @returns {UISchemaOptions} uiSchema
  */
@@ -277,6 +286,8 @@ const currentOrPastDateDigitsUI = options => {
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   monthYearOnly?: boolean,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for title, or an object of options
  * @returns {UISchemaOptions} uiSchema
  */
@@ -308,6 +319,8 @@ const dateOfBirthUI = options => {
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   monthYearOnly?: boolean,
+ *   removeDateHint?: boolean,
  * }} [options] accepts a single string for title, or an object of options
  * @returns {UISchemaOptions} uiSchema
  */


### PR DESCRIPTION
## Summary

- Adds support for the `removeDateHint` prop to date patterns

```js
dateWCV3: currentOrPastDateUI('Current or past date'),
```
<img width="411" height="165" alt="image" src="https://github.com/user-attachments/assets/6073546f-714f-4701-89cd-405f6db033a1" />

```js
dateWCV3: currentOrPastDateUI({
      title: 'Current or past date',
      removeDateHint: true,
    }),
```
<img width="395" height="126" alt="image" src="https://github.com/user-attachments/assets/33a37ce0-e9fa-4511-aa83-b9ce74d8f59b" />


## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5284

## What areas of the site does it impact?

currentOrPastDateUI and related patterns

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
