### PR TITLE
added 989 test facility to profile constants for MHV testing purposes

### DIFF
--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -155,6 +155,7 @@ export const RX_TRACKING_SUPPORTING_FACILITIES = new Set([
   '695', // Clement J. Zablocki Veterans Affairs Medical Center
   '756', // El Paso VA Health Care System
   '983', // test-only facility ID, used by user 36 among others
+  '989', // test-only facility ID, used by MHV team among others
 ]);
 
 export const NOT_SET_TEXT = 'This information is not available right now.';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR adds a new test facility id to constants of the va.gov profile at the request of the MHV team. 
- Team MyVA and AuthExp


## Testing done

- Prior to adding this, the MHV team was using facility id that was not whitelisted.  This caused them to be unable to see RX prescriptions when testing
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Profile Healthcare subsection of profile is minorly affected

## Acceptance criteria

### Quality Assurance & Testing

- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed

### Error Handling

- [X] Browser console contains no warnings or errors.

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user


