### PR TITLE
0538 | Remove "env" from Datadog init code

### DIFF
--- a/src/applications/dependents/dependents-verification/containers/App.jsx
+++ b/src/applications/dependents/dependents-verification/containers/App.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
-import environment from 'platform/utilities/environment';
+
 import formConfig from '../config/form';
 import NoFormPage from '../components/NoFormPage';
 import manifest from '../manifest.json';
@@ -67,7 +67,6 @@ export default function App({ location, children }) {
     sessionSampleRate: 100,
     defaultPrivacyLevel: 'mask-user-input',
     trackBfcacheViews: true,
-    env: environment.isProduction(),
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Datadog RUM sessions for 0538 aren't showing "production" in the environment column. After investigating, it appears that including the `env` variable set as a boolean value may be the cause of the issue. This PR completely remove the `env` variable as it is already set within the platform Datadog initialization code. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team 
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127040

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Dependents Verification form (21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] ~Linting warnings have been addressed~ linting will be addressed in a separate PR
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
