### PR TITLE
Refactor Blue button code into a seperate function and Create Unit.

### DIFF
--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -17,16 +17,10 @@ import {
 } from '~/platform/user/cerner-dsot/selectors';
 import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import NeedHelpSection from '../components/DownloadRecords/NeedHelpSection';
-import {
-  getFailedDomainList,
-  getLastSuccessfulUpdate,
-  sendDataDogAction,
-} from '../util/helpers';
+import { getLastSuccessfulUpdate, sendDataDogAction } from '../util/helpers';
 import {
   accessAlertTypes,
-  ALERT_TYPE_BB_ERROR,
   ALERT_TYPE_CCD_ERROR,
-  BB_DOMAIN_DISPLAY_MAP,
   CernerAlertContent,
   documentTypes,
   pageTitles,
@@ -45,6 +39,7 @@ import CCDAccordionItemV1 from './ccdAccordionItem/ccdAccordionItemV1';
 import CCDAccordionItemV2 from './ccdAccordionItem/ccdAccordionItemV2';
 import CCDAccordionItemOH from './ccdAccordionItem/ccdAccordionItemOH';
 import CCDAccordionItemDual from './ccdAccordionItem/ccdAccordionItemDual';
+import VaAlertBlueButtonDualUserSection from './vaAlerts/VaAlertBlueButtonSection';
 
 // --- Main component ---
 const DownloadReportPage = ({ runningUnitTest }) => {
@@ -312,68 +307,14 @@ const DownloadReportPage = ({ runningUnitTest }) => {
       )}
       {/* Blue Button section - hidden for Oracle Health-only users */}
       {!hasOHOnly && (
-        <>
-          {/* Explanatory message for users with both facility types */}
-          {hasBothDataSources &&
-            vistaFacilityNames.length > 0 &&
-            ohFacilityNames.length > 0 && (
-              <va-alert
-                status="info"
-                className="vads-u-margin-y--2"
-                data-testid="dual-facilities-blue-button-message"
-                visible
-                aria-live="polite"
-              >
-                <p className="vads-u-margin--0">
-                  For {vistaFacilityNames.join(', ')}, you can download your
-                  data in a Blue Button report.
-                </p>
-                <p className="vads-u-margin--0 vads-u-margin-top--1">
-                  Data for {ohFacilityNames.join(', ')} is not yet available in
-                  Blue Button.
-                </p>
-                <p className="vads-u-margin--0 vads-u-margin-top--1">
-                  You can access records for those by downloading a Continuity
-                  of Care Document, which is shown above.
-                </p>
-              </va-alert>
-            )}
-          <h2>Download your VA Blue Button report</h2>
-          {activeAlert?.type === ALERT_TYPE_BB_ERROR && (
-            <AccessTroubleAlertBox
-              alertType={accessAlertTypes.DOCUMENT}
-              documentType={documentTypes.BB}
-              className="vads-u-margin-bottom--1"
-            />
-          )}
-          {successfulBBDownload === true && (
-            <>
-              <MissingRecordsError
-                documentType="VA Blue Button report"
-                recordTypes={getFailedDomainList(
-                  failedBBDomains,
-                  BB_DOMAIN_DISPLAY_MAP,
-                )}
-              />
-              <DownloadSuccessAlert
-                type="Your VA Blue Button report download has"
-                className="vads-u-margin-bottom--1"
-              />
-            </>
-          )}
-          <p className="vads-u-margin--0 vads-u-margin-top--3 vads-u-margin-bottom--1">
-            First, select the types of records you want in your report. Then
-            download.
-          </p>
-          <va-link-action
-            href="/my-health/medical-records/download/date-range"
-            label="Select records and download report"
-            text="Select records and download report"
-            data-dd-action-name="Select records and download"
-            onClick={() => sendDataDogAction('Select records and download')}
-            data-testid="go-to-download-all"
-          />
-        </>
+        <VaAlertBlueButtonDualUserSection
+          hasBothDataSources={hasBothDataSources}
+          vistaFacilityNames={vistaFacilityNames}
+          ohFacilityNames={ohFacilityNames}
+          activeAlert={activeAlert}
+          successfulBBDownload={successfulBBDownload}
+          failedBBDomains={failedBBDomains}
+        />
       )}
 
       <h2>Other reports you can download</h2>

--- a/src/applications/mhv-medical-records/containers/vaAlerts/VaAlertBlueButtonSection.jsx
+++ b/src/applications/mhv-medical-records/containers/vaAlerts/VaAlertBlueButtonSection.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MissingRecordsError } from '@department-of-veterans-affairs/mhv/exports';
+import {
+  accessAlertTypes,
+  ALERT_TYPE_BB_ERROR,
+  BB_DOMAIN_DISPLAY_MAP,
+  documentTypes,
+} from '../../util/constants';
+import AccessTroubleAlertBox from '../../components/shared/AccessTroubleAlertBox';
+import { getFailedDomainList, sendDataDogAction } from '../../util/helpers';
+import DownloadSuccessAlert from '../../components/shared/DownloadSuccessAlert';
+
+/**
+ * Add conditional Blue Button section display based on facility types
+ */
+const VaAlertBlueButtonDualUserSection = ({
+  hasBothDataSources,
+  vistaFacilityNames,
+  ohFacilityNames,
+  activeAlert,
+  successfulBBDownload,
+  failedBBDomains,
+}) => {
+  return (
+    <>
+      {/* Explanatory message for users with both facility types */}
+      {hasBothDataSources &&
+        vistaFacilityNames.length > 0 &&
+        ohFacilityNames.length > 0 && (
+          <va-alert
+            status="info"
+            className="vads-u-margin-y--2"
+            data-testid="dual-facilities-blue-button-message"
+            visible
+            aria-live="polite"
+          >
+            <p className="vads-u-margin--0">
+              For {vistaFacilityNames.join(', ')}, you can download your data in
+              a Blue Button report.
+            </p>
+            <p className="vads-u-margin--0 vads-u-margin-top--1">
+              Data for {ohFacilityNames.join(', ')} is not yet available in Blue
+              Button.
+            </p>
+            <p className="vads-u-margin--0 vads-u-margin-top--1">
+              You can access records for those by downloading a Continuity of
+              Care Document, which is shown above.
+            </p>
+          </va-alert>
+        )}
+      <h2>Download your VA Blue Button report</h2>
+      {activeAlert?.type === ALERT_TYPE_BB_ERROR && (
+        <AccessTroubleAlertBox
+          alertType={accessAlertTypes.DOCUMENT}
+          documentType={documentTypes.BB}
+          className="vads-u-margin-bottom--1"
+        />
+      )}
+      {successfulBBDownload && (
+        <>
+          <MissingRecordsError
+            documentType="VA Blue Button report"
+            recordTypes={getFailedDomainList(
+              failedBBDomains,
+              BB_DOMAIN_DISPLAY_MAP,
+            )}
+          />
+          <DownloadSuccessAlert
+            type="Your VA Blue Button report download has"
+            className="vads-u-margin-bottom--1"
+          />
+        </>
+      )}
+      <p className="vads-u-margin--0 vads-u-margin-top--3 vads-u-margin-bottom--1">
+        First, select the types of records you want in your report. Then
+        download.
+      </p>
+      <va-link-action
+        href="/my-health/medical-records/download/date-range"
+        label="Select records and download report"
+        text="Select records and download report"
+        data-dd-action-name="Select records and download"
+        onClick={() => sendDataDogAction('Select records and download')}
+        data-testid="go-to-download-all"
+      />
+    </>
+  );
+};
+
+VaAlertBlueButtonDualUserSection.propTypes = {
+  failedBBDomains: PropTypes.array.isRequired,
+  hasBothDataSources: PropTypes.bool.isRequired,
+  ohFacilityNames: PropTypes.array.isRequired,
+  successfulBBDownload: PropTypes.bool.isRequired,
+  vistaFacilityNames: PropTypes.array.isRequired,
+  activeAlert: PropTypes.object,
+};
+
+export default VaAlertBlueButtonDualUserSection;

--- a/src/applications/mhv-medical-records/tests/containers/vaAlerts/VaAlertBlueButtonSection.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/vaAlerts/VaAlertBlueButtonSection.unit.spec.jsx
@@ -1,0 +1,431 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import VaAlertBlueButtonDualUserSection from '../../../containers/vaAlerts/VaAlertBlueButtonSection';
+import { ALERT_TYPE_BB_ERROR } from '../../../util/constants';
+import * as helpers from '../../../util/helpers';
+
+describe('VaAlertBlueButtonDualUserSection', () => {
+  let sandbox;
+
+  const defaultProps = {
+    hasBothDataSources: false,
+    vistaFacilityNames: [],
+    ohFacilityNames: [],
+    activeAlert: null,
+    successfulBBDownload: false,
+    failedBBDomains: [],
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('renders the Blue Button section heading', () => {
+    const { getByRole } = render(
+      <MemoryRouter>
+        <VaAlertBlueButtonDualUserSection {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      getByRole('heading', { name: /Download your VA Blue Button report/i }),
+    ).to.exist;
+  });
+
+  it('renders the explanatory paragraph about selecting records', () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <VaAlertBlueButtonDualUserSection {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      getByText(
+        /First, select the types of records you want in your report. Then download./i,
+      ),
+    ).to.exist;
+  });
+
+  it('renders the download link with correct href and attributes', () => {
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <VaAlertBlueButtonDualUserSection {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    const downloadLink = getByTestId('go-to-download-all');
+    expect(downloadLink).to.exist;
+    expect(downloadLink).to.have.attribute(
+      'href',
+      '/my-health/medical-records/download/date-range',
+    );
+    expect(downloadLink).to.have.attribute(
+      'label',
+      'Select records and download report',
+    );
+    expect(downloadLink).to.have.attribute(
+      'data-dd-action-name',
+      'Select records and download',
+    );
+  });
+
+  it('fires sendDataDogAction when download link is clicked', () => {
+    const actionStub = sandbox.stub(helpers, 'sendDataDogAction');
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <VaAlertBlueButtonDualUserSection {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    const downloadLink = getByTestId('go-to-download-all');
+    fireEvent.click(downloadLink);
+
+    expect(actionStub.calledOnce).to.be.true;
+    expect(actionStub.firstCall.args[0]).to.equal(
+      'Select records and download',
+    );
+  });
+
+  describe('dual facilities alert', () => {
+    it('renders dual facilities info alert when user has both data sources', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Western New York health care'],
+        ohFacilityNames: ['VA Central Ohio health care'],
+      };
+      const { getByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      const alert = getByTestId('dual-facilities-blue-button-message');
+      expect(alert).to.exist;
+      expect(alert).to.have.attribute('status', 'info');
+    });
+
+    it('displays VistA facility names in the alert message', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: [
+          'VA Western New York health care',
+          'VA Pacific Islands health care',
+        ],
+        ohFacilityNames: ['VA Central Ohio health care'],
+      };
+      const { getByText } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        getByText(
+          /For VA Western New York health care, VA Pacific Islands health care, you can download your data in a Blue Button report./i,
+        ),
+      ).to.exist;
+    });
+
+    it('displays Oracle Health facility names in the alert message', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Western New York health care'],
+        ohFacilityNames: [
+          'VA Central Ohio health care',
+          'VA Southern Nevada health care',
+        ],
+      };
+      const { getByText } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        getByText(
+          /Data for VA Central Ohio health care, VA Southern Nevada health care is not yet available in Blue Button./i,
+        ),
+      ).to.exist;
+    });
+
+    it('provides guidance to use CCD for Oracle Health facilities', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Western New York health care'],
+        ohFacilityNames: ['VA Central Ohio health care'],
+      };
+      const { getByText } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        getByText(
+          /You can access records for those by downloading a Continuity of Care Document, which is shown above./i,
+        ),
+      ).to.exist;
+    });
+
+    it('does not render dual facilities alert when hasBothDataSources is false', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: false,
+        vistaFacilityNames: ['VA Western New York health care'],
+        ohFacilityNames: [],
+      };
+      const { queryByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(queryByTestId('dual-facilities-blue-button-message')).to.not.exist;
+    });
+
+    it('does not render dual facilities alert when VistA facilities list is empty', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: [],
+        ohFacilityNames: ['VA Central Ohio health care'],
+      };
+      const { queryByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(queryByTestId('dual-facilities-blue-button-message')).to.not.exist;
+    });
+
+    it('does not render dual facilities alert when OH facilities list is empty', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Western New York health care'],
+        ohFacilityNames: [],
+      };
+      const { queryByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(queryByTestId('dual-facilities-blue-button-message')).to.not.exist;
+    });
+  });
+
+  describe('error alert', () => {
+    it('renders AccessTroubleAlertBox when activeAlert type is ALERT_TYPE_BB_ERROR', () => {
+      const props = {
+        ...defaultProps,
+        activeAlert: { type: ALERT_TYPE_BB_ERROR },
+      };
+      const { getByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(getByTestId('expired-alert-message')).to.exist;
+    });
+
+    it('does not render AccessTroubleAlertBox when activeAlert is null', () => {
+      const props = {
+        ...defaultProps,
+        activeAlert: null,
+      };
+      const { queryByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(queryByTestId('expired-alert-message')).to.not.exist;
+    });
+
+    it('does not render AccessTroubleAlertBox when activeAlert has different type', () => {
+      const props = {
+        ...defaultProps,
+        activeAlert: { type: 'some-other-error' },
+      };
+      const { queryByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(queryByTestId('expired-alert-message')).to.not.exist;
+    });
+  });
+
+  describe('success alert and missing records', () => {
+    it('renders DownloadSuccessAlert when successfulBBDownload is true', () => {
+      const props = {
+        ...defaultProps,
+        successfulBBDownload: true,
+        failedBBDomains: [],
+      };
+      const { getByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(getByTestId('alert-download-started')).to.exist;
+    });
+
+    it('displays correct success message type', () => {
+      const props = {
+        ...defaultProps,
+        successfulBBDownload: true,
+        failedBBDomains: [],
+      };
+      const { getByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        getByTestId('download-success-alert-message').textContent,
+      ).to.equal('Your VA Blue Button report download has started');
+    });
+
+    it('does not render DownloadSuccessAlert when successfulBBDownload is false', () => {
+      const props = {
+        ...defaultProps,
+        successfulBBDownload: false,
+        failedBBDomains: [],
+      };
+      const { queryByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(queryByTestId('alert-download-started')).to.not.exist;
+    });
+
+    it('renders MissingRecordsError when successfulBBDownload is true with failed domains', () => {
+      const props = {
+        ...defaultProps,
+        successfulBBDownload: true,
+        failedBBDomains: ['labsAndTests', 'vaccines'],
+      };
+      const { container } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      // MissingRecordsError component should be rendered
+      const alertContainer = container.querySelector('va-alert');
+      expect(alertContainer).to.exist;
+    });
+
+    it('passes correct documentType to MissingRecordsError', () => {
+      const props = {
+        ...defaultProps,
+        successfulBBDownload: true,
+        failedBBDomains: ['allergies'],
+      };
+      const { getByTestId } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      // The MissingRecordsError component should be rendered with correct testid
+      const missingRecordsAlert = getByTestId('missing-records-error-alert');
+      expect(missingRecordsAlert).to.exist;
+      // Check that it includes the text about VA Blue Button report
+      expect(missingRecordsAlert.textContent).to.include(
+        'VA Blue Button report',
+      );
+    });
+  });
+
+  describe('component renders without crashing with various prop combinations', () => {
+    it('renders with empty arrays', () => {
+      const { container } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...defaultProps} />
+        </MemoryRouter>,
+      );
+
+      expect(container).to.exist;
+    });
+
+    it('renders with all features enabled', () => {
+      const props = {
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Facility 1', 'VA Facility 2'],
+        ohFacilityNames: ['OH Facility 1'],
+        activeAlert: { type: ALERT_TYPE_BB_ERROR },
+        successfulBBDownload: true,
+        failedBBDomains: ['labsAndTests'],
+      };
+      const { container } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(container).to.exist;
+    });
+
+    it('renders with single VistA facility', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Single Facility'],
+        ohFacilityNames: ['OH Facility'],
+      };
+      const { getByText } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        getByText(
+          /For VA Single Facility, you can download your data in a Blue Button report./i,
+        ),
+      ).to.exist;
+    });
+
+    it('renders with multiple OH facilities', () => {
+      const props = {
+        ...defaultProps,
+        hasBothDataSources: true,
+        vistaFacilityNames: ['VA Facility'],
+        ohFacilityNames: ['OH Facility 1', 'OH Facility 2', 'OH Facility 3'],
+      };
+      const { getByText } = render(
+        <MemoryRouter>
+          <VaAlertBlueButtonDualUserSection {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        getByText(
+          /Data for OH Facility 1, OH Facility 2, OH Facility 3 is not yet available in Blue Button./i,
+        ),
+      ).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Updates `DownloadReportPage` to conditionally display the VA Blue Button section based on user facility types:

- **Oracle Health-only users (`hasOHOnly`)**: Blue Button section hidden entirely
- **Both facility types**: Info alert above Blue Button heading explaining VistA data is available in Blue Button, Oracle Health data requires CCD download
- **VistA-only users**: No change to existing behavior

```jsx
{!hasOHOnly && (
  <>
    {hasBothDataSources && vistaFacilityNames.length > 0 && ohFacilityNames.length > 0 && (
      <va-alert status="info" data-testid="dual-facilities-blue-button-message">
        <p>For {vistaFacilityNames.join(', ')}, you can download your data in a Blue Button report.</p>
        <p>Data for {ohFacilityNames.join(', ')} is not yet available in Blue Button.</p>
        <p>You can access records for those by downloading a Continuity of Care Document...</p>
      </va-alert>
    )}
    <h2>Download your VA Blue Button report</h2>
    {/* existing Blue Button UI */}
  </>
)}
```

### Logging and Metrics

Added tracking to monitor how often Blue Button content is filtered:

- **StatsD metrics (via `postRecordDatadogAction`):**
  - `mr.blue_button_filtered_oh_only` - when Blue Button section is hidden for Oracle Health-only users
  - `mr.blue_button_filtered_dual_facilities` - when dual facility info message is shown

- **DataDog RUM actions (via `sendDataDogAction`):**
  - "Blue Button section hidden - Oracle Health only"
  - "Blue Button section filtered - dual facility types"

- Added ref to prevent duplicate metric logging on re-renders

Team: MHV Medical Records

## Related issue(s)

- _Link to ticket created in va.gov-team repo_

## Testing done

- Added unit tests for all three facility scenarios
- Verified Oracle Health-only users don't see Blue Button section but still see Other Reports
- Verified dual-facility users see explanatory alert with correct facility names
- Verified VistA-only users see unchanged Blue Button section
- ESLint passes with no warnings

## Screenshots


###  1

<img width="845" height="804" alt="Screenshot 2025-12-05 at 11 12 02 AM" src="https://github.com/user-attachments/assets/5e610db0-49fb-4475-98b3-c889fe322d71" />


### 2

<img width="751" height="765" alt="Screenshot 2025-12-05 at 11 09 41 AM" src="https://github.com/user-attachments/assets/d9cdf29f-6fda-4bec-a731-dba09756654c" />


### 3

<img width="855" height="623" alt="Screenshot 2025-12-05 at 11 08 51 AM" src="https://github.com/user-attachments/assets/3cf0f686-68d4-42da-ac5f-0d203856d5a3" />



### 4

<img width="758" height="748" alt="Screenshot 2025-12-05 at 11 08 36 AM" src="https://github.com/user-attachments/assets/6382c47d-766c-4404-bbf1-3fb35862c886" />



_Unable to capture screenshots due to Node.js version mismatch in build environment._

## What areas of the site does it impact?

Medical Records Download page (`/my-health/medical-records/download/`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Defensive checks added for empty facility name arrays per code review. The `hasBothDataSources` condition should prevent this case, but guards ensure no malformed messages render.

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> On DownloadReportPage.jsx:285-285, **Prompt:**  
> Update the `DownloadReportPage` component to make the display of the VA Blue Button section conditional, depending on the types of facilities associated with the user's account. Follow these three conditions:
> 
> **1. User only has Oracle Health facilities (`hasOHOnly` is true):**  
> - Do **not** show any Blue Button information/content or UI elements.
> 
> **2. User has both Oracle Health and VistA facilities (`hasOHFacilities` and `hasVistAFacilities` are true):**  
> - Add a message above the Blue Button section with this format:  
>   - "For `[name of each VistA facility]`, you can download your data in a Blue Button report.  
>     Data for `[name(s) of each Oracle Health facility]` is not yet available in Blue Button.  
>     You can access records for those by downloading a Continuity of Care Document, which is shown above."
>   - Use the existing code's arrays `vistaFacilityNames` and `ohFacilityNames` for the names.
> 
> **3. User only has VistA facilities (`hasOHOnly` is false, and `facilities.length > 0`):**  
> - Show the Blue Button section exactly as it currently is (no changes).
> 
> **Additional requirements:**  
> - Make sure all existing Blue Button UI, alerts, and actions are suppressed from view entirely for Oracle Health–only users.
> - The explanatory message for users with both facility types should be prominently placed just above the Blue Button heading.
> - All other report/accordion sections should continue displaying as they currently do.
> 
> ---
> 
> Please update the relevant JSX and conditional logic in the component to meet these requirements.


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/department-of-veterans-affairs/vets-website/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
