### PR TITLE
21P-8416 when submitting as veteran remove claimantFullname key

### DIFF
--- a/src/applications/medical-expense-report/config/submit-transformer.js
+++ b/src/applications/medical-expense-report/config/submit-transformer.js
@@ -22,7 +22,7 @@ function swapNames(formData) {
       parsedFormData.claimantFullName?.last;
     transformedValue.veteranFullName.suffix =
       parsedFormData.claimantFullName?.suffix;
-    transformedValue.claimantFullName = {};
+    delete transformedValue.claimantFullName;
   }
 
   // Alter fullNameRecipient to recipientName in careExpenses

--- a/src/applications/medical-expense-report/tests/unit/utils/transform.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/utils/transform.unit.spec.jsx
@@ -43,7 +43,6 @@ describe('submit transformer', () => {
     expect(parsedResult.medicalExpenseReportsClaim).to.have.property('form');
     expect(parsedForm).to.deep.equal({
       claimantNotVeteran: false,
-      claimantFullName: {},
       veteranFullName: {
         first: 'John',
         middle: 'A',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When submitting a veteran, delete the claimantFullname key instead of submitting an empty object to fix submission 422 error.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126580

## Testing done

- Manual testing, by looking at submitted object in network tab
- Updated unit tests

## Screenshots

N/A

## What areas of the site does it impact?

The submission for the 21P-8416

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
