### PR TITLE
Medications Page UI Changes for OH Data

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import {
   validateField,
   dateFormat,
   displayProviderName,
 } from '../../util/helpers';
+import { selectCernerPilotFlag } from '../../util/selectors';
 import ExtraDetails from '../shared/ExtraDetails';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 import { ACTIVE_NON_VA } from '../../util/constants';
 
 const NonVaPrescription = prescription => {
+  const isCernerPilot = useSelector(selectCernerPilotFlag);
+
   const content = () => {
     return (
       <div className="medication-details-div vads-u-margin-bottom--3">
@@ -73,14 +77,16 @@ const NonVaPrescription = prescription => {
             {prescription.sig || 'Instructions not available'}
           </p>
         </section>
-        <section>
-          <h3 className="vads-u-font-size--source-sans-normalized vads-u-font-family--sans">
-            Reason for use
-          </h3>
-          <p data-testid="rx-reason-for-use">
-            {prescription.indicationForUse || 'Reason for use not available'}
-          </p>
-        </section>
+        {!isCernerPilot && (
+          <section>
+            <h3 className="vads-u-font-size--source-sans-normalized vads-u-font-family--sans">
+              Reason for use
+            </h3>
+            <p data-testid="rx-reason-for-use">
+              {prescription.indicationForUse || 'Reason for use not available'}
+            </p>
+          </section>
+        )}
         <section>
           <h3 className="vads-u-font-size--source-sans-normalized vads-u-font-family--sans">
             When you started taking this medication

--- a/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
@@ -21,10 +21,14 @@ import {
   prescriptionMedAndRenewalStatus,
 } from '../../util/helpers';
 import MedicationDescription from '../shared/MedicationDescription';
-import { selectPendingMedsFlag } from '../../util/selectors';
+import {
+  selectCernerPilotFlag,
+  selectPendingMedsFlag,
+} from '../../util/selectors';
 
 const PrescriptionPrintOnly = props => {
   const { rx, refillHistory, isDetailsRx } = props;
+  const isCernerPilot = useSelector(selectCernerPilotFlag);
   const showRefillHistory = getShowRefillHistory(refillHistory);
   const pharmacyPhone = pharmacyPhoneNumber(rx);
   const latestTrackingStatus = rx?.trackingList?.[0];
@@ -44,10 +48,12 @@ const PrescriptionPrintOnly = props => {
         <strong>Instructions:</strong>
         {pres.sig || 'Instructions not available'}
       </p>
-      <p>
-        <strong>Reason for use:</strong>
-        {pres.indicationForUse || 'Reason for use not available'}
-      </p>
+      {!isCernerPilot && (
+        <p>
+          <strong>Reason for use:</strong>
+          {pres.indicationForUse || 'Reason for use not available'}
+        </p>
+      )}
       <p className="no-break">
         <strong>Status:</strong> {rxStatus}
       </p>
@@ -184,24 +190,33 @@ const PrescriptionPrintOnly = props => {
               <strong>Facility:</strong>{' '}
               {rx.facilityName || 'VA facility name not available'}
             </p>
-            <p>
-              <strong>Pharmacy phone number:</strong>{' '}
-              {pharmacyPhone ? (
-                <>
-                  <va-telephone contact={pharmacyPhone} not-clickable /> (
-                  <va-telephone tty contact="711" not-clickable />)
-                </>
-              ) : (
-                FIELD_NONE_NOTED
-              )}
-            </p>
+            {isCernerPilot ? (
+              <p>
+                <strong>Pharmacy contact information:</strong> Check your
+                prescription label or contact your VA facility.
+              </p>
+            ) : (
+              <p>
+                <strong>Pharmacy phone number:</strong>{' '}
+                {pharmacyPhone ? (
+                  <>
+                    <va-telephone contact={pharmacyPhone} not-clickable /> (
+                    <va-telephone tty contact="711" not-clickable />)
+                  </>
+                ) : (
+                  FIELD_NONE_NOTED
+                )}
+              </p>
+            )}
             <p>
               <strong>Instructions:</strong> {validateField(rx.sig)}
             </p>
-            <p>
-              <strong>Reason for use:</strong>{' '}
-              {validateField(rx.indicationForUse)}
-            </p>
+            {!isCernerPilot && (
+              <p>
+                <strong>Reason for use:</strong>{' '}
+                {validateField(rx.indicationForUse)}
+              </p>
+            )}
             <p>
               <strong>Quantity:</strong> {validateField(rx.quantity)}
             </p>
@@ -227,65 +242,68 @@ const PrescriptionPrintOnly = props => {
                 </p>
               )}
           </div>
-          {showRefillHistory && (
-            <div className="print-only-refill-container vads-u-margin-left--2">
-              <h4>Refill history</h4>
-              <p className="vads-u-margin-y--1p5">
-                {`Showing ${refillHistory.length} fill${
-                  refillHistory.length > 1 ? 's, from newest to oldest' : ''
-                }`}
-              </p>
-              <div className="print-only-rx-details-container">
-                {refillHistory.map((entry, i) => {
-                  const index = refillHistory.length - i - 1;
-                  const { shape, color, backImprint, frontImprint } = entry;
-                  const isPartialFill =
-                    entry.prescriptionSource === RX_SOURCE.PARTIAL_FILL;
-                  const refillLabel = determineRefillLabel(
-                    isPartialFill,
-                    refillHistory,
-                    i,
-                  );
-                  return (
-                    <div key={index} className="vads-u-margin-bottom--2">
-                      <h5 className="vads-u-margin-top--1">
-                        {`${refillLabel}: ${dateFormat(entry.dispensedDate)}`}
-                      </h5>
-                      {isPartialFill && (
-                        <>
-                          <p>This fill has a smaller quantity on purpose.</p>
-                          <p>
-                            <strong>Quantity:</strong> {entry.quantity}
-                          </p>
-                        </>
-                      )}
-                      {i === 0 &&
-                        !isPartialFill && (
-                          <p>
-                            <strong>Shipped on:</strong>{' '}
-                            {dateFormat(latestTrackingStatus?.completeDateTime)}
-                          </p>
+          {showRefillHistory &&
+            !isCernerPilot && (
+              <div className="print-only-refill-container vads-u-margin-left--2">
+                <h4>Refill history</h4>
+                <p className="vads-u-margin-y--1p5">
+                  {`Showing ${refillHistory.length} fill${
+                    refillHistory.length > 1 ? 's, from newest to oldest' : ''
+                  }`}
+                </p>
+                <div className="print-only-rx-details-container">
+                  {refillHistory.map((entry, i) => {
+                    const index = refillHistory.length - i - 1;
+                    const { shape, color, backImprint, frontImprint } = entry;
+                    const isPartialFill =
+                      entry.prescriptionSource === RX_SOURCE.PARTIAL_FILL;
+                    const refillLabel = determineRefillLabel(
+                      isPartialFill,
+                      refillHistory,
+                      i,
+                    );
+                    return (
+                      <div key={index} className="vads-u-margin-bottom--2">
+                        <h5 className="vads-u-margin-top--1">
+                          {`${refillLabel}: ${dateFormat(entry.dispensedDate)}`}
+                        </h5>
+                        {isPartialFill && (
+                          <>
+                            <p>This fill has a smaller quantity on purpose.</p>
+                            <p>
+                              <strong>Quantity:</strong> {entry.quantity}
+                            </p>
+                          </>
                         )}
-                      {!isPartialFill && (
-                        <>
-                          <p className="vads-u-margin--0">
-                            <strong>Medication description: </strong>
-                          </p>
-                          <MedicationDescription
-                            shape={shape}
-                            color={color}
-                            frontImprint={frontImprint}
-                            backImprint={backImprint}
-                            pharmacyPhone={pharmacyPhone}
-                          />
-                        </>
-                      )}
-                    </div>
-                  );
-                })}
+                        {i === 0 &&
+                          !isPartialFill && (
+                            <p>
+                              <strong>Shipped on:</strong>{' '}
+                              {dateFormat(
+                                latestTrackingStatus?.completeDateTime,
+                              )}
+                            </p>
+                          )}
+                        {!isPartialFill && (
+                          <>
+                            <p className="vads-u-margin--0">
+                              <strong>Medication description: </strong>
+                            </p>
+                            <MedicationDescription
+                              shape={shape}
+                              color={color}
+                              frontImprint={frontImprint}
+                              backImprint={backImprint}
+                              pharmacyPhone={pharmacyPhone}
+                            />
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          )}
+            )}
           {isDetailsRx &&
             rx.groupedMedications?.length > 0 && (
               <>

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -57,6 +57,7 @@ import {
   selectFilterOption,
   selectPageNumber,
 } from '../selectors/selectPreferences';
+import { selectCernerPilotFlag } from '../util/selectors';
 
 const PrescriptionDetails = () => {
   const { prescriptionId } = useParams();
@@ -65,6 +66,8 @@ const PrescriptionDetails = () => {
   const selectedSortOption = useSelector(selectSortOption);
   const selectedFilterOption = useSelector(selectFilterOption);
   const currentPage = useSelector(selectPageNumber);
+  // OH feature flag
+  const isCernerPilot = useSelector(selectCernerPilotFlag);
   // Consolidate query parameters into a single state object to avoid multiple re-renders
   const [queryParams] = useState({
     page: currentPage || 1,
@@ -226,12 +229,12 @@ const PrescriptionDetails = () => {
           DATETIME_FORMATS.longMonthDate,
         )}\n\n${
           nonVaPrescription
-            ? buildNonVAPrescriptionTXT(prescription)
-            : buildVAPrescriptionTXT(prescription)
+            ? buildNonVAPrescriptionTXT(prescription, {}, isCernerPilot)
+            : buildVAPrescriptionTXT(prescription, isCernerPilot)
         }${allergiesList ?? ''}`
       );
     },
-    [userName, dob, prescription, nonVaPrescription],
+    [userName, dob, prescription, nonVaPrescription, isCernerPilot],
   );
 
   const handleFileDownload = async format => {
@@ -303,11 +306,11 @@ const PrescriptionDetails = () => {
       if (!prescription) return;
       setPrescriptionPdfList(
         nonVaPrescription
-          ? buildNonVAPrescriptionPDFList(prescription)
-          : buildVAPrescriptionPDFList(prescription),
+          ? buildNonVAPrescriptionPDFList(prescription, isCernerPilot)
+          : buildVAPrescriptionPDFList(prescription, isCernerPilot),
       );
     },
-    [nonVaPrescription, prescription],
+    [nonVaPrescription, prescription, isCernerPilot],
   );
 
   const filledEnteredDate = () => {

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -80,10 +80,12 @@ import FilterAriaRegion from '../components/MedicationsList/FilterAriaRegion';
 import RxRenewalDeleteDraftSuccessAlert from '../components/shared/RxRenewalDeleteDraftSuccessAlert';
 import { useURLPagination } from '../hooks/useURLPagination';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { selectCernerPilotFlag } from '../util/selectors';
 
 const Prescriptions = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const isCernerPilot = useSelector(selectCernerPilotFlag);
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const userName = useSelector(selectUserFullName);
   const dob = useSelector(selectUserDob);
@@ -356,12 +358,12 @@ const Prescriptions = () => {
 
       if (format === DOWNLOAD_FORMAT.PDF) {
         generatePDF(
-          buildPrescriptionsPDFList(prescriptionsExportList),
+          buildPrescriptionsPDFList(prescriptionsExportList, isCernerPilot),
           buildAllergiesPDFList(allergies),
         );
       } else if (format === DOWNLOAD_FORMAT.TXT) {
         generateTXT(
-          buildPrescriptionsTXT(prescriptionsExportList),
+          buildPrescriptionsTXT(prescriptionsExportList, isCernerPilot),
           buildAllergiesTXT(allergies),
         );
       } else if (format === PRINT_FORMAT.PRINT) {
@@ -380,6 +382,7 @@ const Prescriptions = () => {
       pdfTxtGenerateStatus,
       generatePDF,
       generateTXT,
+      isCernerPilot,
     ],
   );
 

--- a/src/applications/mhv-medications/tests/components/PrescriptionDetails/NonVaPrescription.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionDetails/NonVaPrescription.unit.spec.jsx
@@ -6,9 +6,14 @@ import NonVaPrescription from '../../../components/PrescriptionDetails/NonVaPres
 
 describe('nonVaPrescription details container', () => {
   const prescription = nonVaRxDetailsResponse.data.attributes;
-  const setup = (rx = prescription) => {
+  const setup = (rx = prescription, { isCernerPilot = false } = {}) => {
     return renderWithStoreAndRouterV6(<NonVaPrescription {...rx} />, {
-      initialState: {},
+      initialState: {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          mhv_medications_cerner_pilot: isCernerPilot,
+        },
+      },
       reducers: {},
       initialEntries: ['/prescriptions/1234567891'],
     });
@@ -87,5 +92,11 @@ describe('nonVaPrescription details container', () => {
     expect(getByTestId('rx-documented-by')).to.have.text('Provider name not available');
     expect(getByTestId('rx-documented-at')).to.have.text('VA facility name not available');
     /* eslint-enable prettier/prettier */
+  });
+
+  it('hides reason for use section when Cerner pilot is enabled', () => {
+    const screen = setup(prescription, { isCernerPilot: true });
+
+    expect(screen.queryByTestId('rx-reason-for-use')).to.be.null;
   });
 });

--- a/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
@@ -5,15 +5,26 @@ import rxDetailsResponse from '../../fixtures/prescriptionDetails.json';
 import PrescriptionPrintOnly from '../../../components/PrescriptionDetails/PrescriptionPrintOnly';
 
 describe('Prescription print only container', () => {
-  const setup = (params = { va: true, isDetailsRx: false }) => {
+  const setup = (
+    params = { va: true, isDetailsRx: false, isCernerPilot: false },
+  ) => {
     const rx = {
       ...rxDetailsResponse.data.attributes,
       ...(!params.va && { prescriptionSource: 'NV' }),
     };
+
+    const initialState = {
+      featureToggles: {
+        /* eslint-disable camelcase */
+        mhv_medications_cerner_pilot: params.isCernerPilot,
+        /* eslint-enable camelcase */
+      },
+    };
+
     return renderWithStoreAndRouterV6(
       <PrescriptionPrintOnly rx={rx} isDetailsRx={params.isDetailsRx} />,
       {
-        initialState: {},
+        initialState,
         reducers: {},
         initialEntries: ['/prescriptions/1234567891'],
       },
@@ -44,7 +55,11 @@ describe('Prescription print only container', () => {
     expect(screen.findByText('Quantity:')).to.exist;
   });
   it('should render Non-VA rx details', () => {
-    const screen = setup({ va: false });
+    const screen = setup({
+      va: false,
+      isDetailsRx: false,
+      isCernerPilot: false,
+    });
     expect(screen.findByText('Instructions:')).to.exist;
     expect(screen.findByText('Reason for use')).to.exist;
     expect(screen.findByText('Status:')).to.exist;
@@ -58,15 +73,50 @@ describe('Prescription print only container', () => {
     ).to.exist;
   });
   it('should render h2 tag', () => {
-    const screen = setup({ isDetailsRx: true, va: true });
+    const screen = setup({ isDetailsRx: true, va: true, isCernerPilot: false });
     const nameElement = screen.getByText('ONDANSETRON 8 MG TAB');
     const detailsHeaderElement = screen.getByText('Most recent prescription');
     expect(nameElement.tagName).to.equal('H2');
     expect(detailsHeaderElement.tagName).to.equal('H3');
   });
   it('should render h3 tag', () => {
-    const screen = setup({ isDetailsRx: false });
+    const screen = setup({ isDetailsRx: false, isCernerPilot: false });
     const nameElement = screen.getByText('ONDANSETRON 8 MG TAB');
     expect(nameElement.tagName).to.equal('H3');
+  });
+
+  it('should hide reason for use when Cerner pilot is enabled', () => {
+    const screen = setup({
+      va: true,
+      isDetailsRx: false,
+      isCernerPilot: true,
+    });
+
+    expect(screen.queryByText('Reason for use')).to.not.exist;
+  });
+
+  it('should hide pharmacy phone and displays a link when Cerner pilot is enabled', () => {
+    const screen = setup({
+      va: true,
+      isDetailsRx: false,
+      isCernerPilot: true,
+    });
+
+    expect(screen.queryByText('Pharmacy phone number:')).to.not.exist;
+    expect(
+      screen.getByText(
+        'Check your prescription label or contact your VA facility.',
+      ),
+    ).to.exist;
+  });
+
+  it('should hide refill history when Cerner pilot is enabled', () => {
+    const screen = setup({
+      va: true,
+      isDetailsRx: false,
+      isCernerPilot: true,
+    });
+
+    expect(screen.queryByText('Refill history')).to.not.exist;
   });
 });

--- a/src/applications/mhv-medications/tests/components/PrescriptionDetails/VaPrescription.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionDetails/VaPrescription.unit.spec.jsx
@@ -12,12 +12,18 @@ import { RX_SOURCE } from '../../../util/constants';
 describe('vaPrescription details container', () => {
   const prescription = rxDetailsResponse.data.attributes;
   const newRx = { ...prescription, phoneNumber: '1234567891' };
-  const setup = (rx = newRx, ffEnabled = true) => {
+  const setup = (
+    rx = newRx,
+    ffEnabled = true,
+    { isCernerPilot = false } = {},
+  ) => {
     return renderWithStoreAndRouterV6(<VaPrescription {...rx} />, {
       initialState: {
         featureToggles: {
           // eslint-disable-next-line camelcase
           mhv_medications_display_documentation_content: ffEnabled,
+          // eslint-disable-next-line camelcase
+          mhv_medications_cerner_pilot: isCernerPilot,
         },
       },
       reducers: {},
@@ -398,5 +404,32 @@ describe('vaPrescription details container', () => {
     const quantityValue = quantityHeading.nextElementSibling;
     expect(quantityValue).to.exist;
     expect(quantityValue.textContent).to.equal('0');
+  });
+
+  it('hides reason for use when Cerner pilot is enabled', () => {
+    const screen = setup(newRx, true, { isCernerPilot: true });
+
+    expect(screen.queryByText('Reason for use')).to.not.exist;
+  });
+
+  it('hides pharmacy phone and displays a link when Cerner pilot is enabled', () => {
+    const screen = setup(newRx, true, { isCernerPilot: true });
+    const pharmacyPhone = screen.queryByTestId('phone-number');
+    const findFacilityLink = screen.getByTestId('find-facility-link');
+
+    expect(pharmacyPhone).to.not.exist;
+    expect(findFacilityLink).to.exist;
+    expect(
+      screen.getByText(
+        'Check your prescription label or contact your VA facility.',
+      ),
+    ).to.exist;
+    expect(screen.getByText('Find your VA facility')).to.exist;
+  });
+
+  it('hides refill history when Cerner pilot is enabled', () => {
+    const screen = setup(newRx, true, { isCernerPilot: true });
+
+    expect(screen.queryByText('Refill history')).to.not.exist;
   });
 });

--- a/src/applications/mhv-medications/tests/util/pdfConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/pdfConfigs.unit.spec.jsx
@@ -23,11 +23,6 @@ describe('Prescriptions List Config', () => {
     expect(pdfList.length).to.equal(prescriptions.length);
   });
 
-  it('should contain 13 values', () => {
-    const pdfList = buildPrescriptionsPDFList(prescriptions);
-    expect(pdfList[0].sections[0].items.length).to.equal(13);
-  });
-
   it('should contain a header with prescription name', () => {
     const pdfList = buildPrescriptionsPDFList(prescriptions);
     expect(pdfList[0].header).to.equal(prescriptions[0].prescriptionName);
@@ -213,5 +208,37 @@ describe('Medication Information Config', () => {
     ]);
     expect(pdfData.sections[1].header).to.equal('Test 2');
     expect(pdfData.sections[1].items[0].value).to.equal('Paragraph');
+  });
+
+  describe('Cerner pilot feature flag', () => {
+    describe('VA Prescription config', () => {
+      const rxDetails = { ...prescriptionDetails.data.attributes };
+      const pdfGen = buildVAPrescriptionPDFList(rxDetails, true);
+      const items = pdfGen[0].sections[0].items.map(item => item.title);
+
+      it('should NOT show "Reason for Use" field', () => {
+        expect(items).to.not.include('Reason for use:');
+      });
+      it('should show "Pharmacy contact information" field', () => {
+        const status = pdfGen[0].sections[0].items.find(
+          item => item.title === 'Pharmacy contact information',
+        );
+        expect(status.value).to.match(
+          /Check your prescription label or contact your VA facility./,
+        );
+      });
+      it('should NOT create "Refill history" section', () => {
+        expect(pdfGen[1]).to.not.exist;
+      });
+    });
+
+    describe('Non-VA Prescription config', () => {
+      const pdfGen = buildNonVAPrescriptionPDFList(nonVAPrescription, true);
+      const items = pdfGen[0].sections[0].items.map(item => item.title);
+
+      it('should NOT show "Reason for Use" field', () => {
+        expect(items).to.not.include('Reason for use:');
+      });
+    });
   });
 });

--- a/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
@@ -277,4 +277,35 @@ describe('Medication Information Config', () => {
     const txt = await convertHtmlForDownload(htmlContent, DOWNLOAD_FORMAT.PDF);
     expect(txt).to.be.a('array');
   });
+
+  describe('Cerner pilot feature flag', () => {
+    describe('VA Prescription config', () => {
+      const rxDetails = { ...prescriptionDetails.data.attributes };
+      const txt = buildVAPrescriptionTXT(rxDetails, true);
+
+      it('should NOT show "Reason for Use" field', () => {
+        expect(txt).to.not.include('Reason for use:');
+      });
+      it('should show "Pharmacy contact information" field', () => {
+        expect(txt).to.include(
+          'Pharmacy contact information: Check your prescription label or contact your VA facility.',
+        );
+      });
+      it('should NOT create "Refill history" section', () => {
+        expect(txt).to.not.include('Refill history\n');
+      });
+    });
+
+    describe('Non-VA Prescription config', () => {
+      const txt = buildNonVAPrescriptionTXT(
+        nonVAPrescription.data.attributes,
+        { includeSeparators: true },
+        true,
+      );
+
+      it('should NOT show "Reason for Use" field', () => {
+        expect(txt).to.not.include('Reason for use:');
+      });
+    });
+  });
 });

--- a/src/applications/mhv-medications/util/pdfConfigs.js
+++ b/src/applications/mhv-medications/util/pdfConfigs.js
@@ -60,7 +60,10 @@ import {
  *
  * @returns {Array<PdfConfigItem>}
  */
-export const buildNonVAPrescriptionPDFList = prescription => {
+export const buildNonVAPrescriptionPDFList = (
+  prescription,
+  isCernerPilot = false,
+) => {
   return [
     {
       sections: [
@@ -71,7 +74,7 @@ export const buildNonVAPrescriptionPDFList = prescription => {
               value: prescription.sig || 'Instructions not available',
               inline: true,
             },
-            {
+            !isCernerPilot && {
               title: 'Reason for use',
               value:
                 prescription.indicationForUse || 'Reason for use not available',
@@ -121,11 +124,14 @@ export const buildNonVAPrescriptionPDFList = prescription => {
  *
  * @returns {Array<PdfConfigItem>}
  */
-export const buildPrescriptionsPDFList = prescriptions => {
+export const buildPrescriptionsPDFList = (
+  prescriptions,
+  isCernerPilot = false,
+) => {
   return prescriptions?.map(rx => {
     if (rx?.prescriptionSource === RX_SOURCE.NON_VA) {
       return {
-        ...buildNonVAPrescriptionPDFList(rx)[0],
+        ...buildNonVAPrescriptionPDFList(rx, isCernerPilot)[0],
         header: rx?.prescriptionName || rx?.orderableItem,
       };
     }
@@ -216,7 +222,12 @@ export const buildPrescriptionsPDFList = prescriptions => {
               value: validateIfAvailable('Facility', rx.facilityName),
               inline: true,
             },
-            {
+            (isCernerPilot && {
+              title: 'Pharmacy contact information',
+              value:
+                'Check your prescription label or contact your VA facility.',
+              inline: true,
+            }) || {
               title: 'Pharmacy phone number',
               value: validateIfAvailable(
                 'Pharmacy phone number',
@@ -229,7 +240,7 @@ export const buildPrescriptionsPDFList = prescriptions => {
               value: validateIfAvailable('Instructions', rx.sig),
               inline: true,
             },
-            {
+            !isCernerPilot && {
               title: 'Reason for use',
               value: validateIfAvailable('Reason for use', rx.indicationForUse),
               inline: true,
@@ -355,7 +366,10 @@ export const buildAllergiesPDFList = allergies => {
  *
  * @returns {Array<PdfConfigItem>}
  */
-export const buildVAPrescriptionPDFList = prescription => {
+export const buildVAPrescriptionPDFList = (
+  prescription,
+  isCernerPilot = false,
+) => {
   const refillHistory = getRefillHistory(prescription);
   const showRefillHistory = getShowRefillHistory(refillHistory);
   const pendingMed =
@@ -431,7 +445,12 @@ export const buildVAPrescriptionPDFList = prescription => {
               value: validateIfAvailable('Facility', prescription.facilityName),
               inline: true,
             },
-            {
+            (isCernerPilot && {
+              title: 'Pharmacy contact information',
+              value:
+                'Check your prescription label or contact your VA facility.',
+              inline: true,
+            }) || {
               title: 'Pharmacy phone number',
               value: validateIfAvailable(
                 'Pharmacy phone number',
@@ -444,7 +463,7 @@ export const buildVAPrescriptionPDFList = prescription => {
               value: validateIfAvailable('Instructions', prescription.sig),
               inline: true,
             },
-            {
+            !isCernerPilot && {
               title: 'Reason for use',
               value: validateIfAvailable(
                 'Reason for use',
@@ -478,7 +497,7 @@ export const buildVAPrescriptionPDFList = prescription => {
         },
       ],
     },
-    ...(showRefillHistory
+    ...(showRefillHistory && !isCernerPilot
       ? [
           {
             header: 'Refill history',
@@ -559,7 +578,7 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}`
                             },
                           ]
                         : []),
-                      ...(!isPartialFill
+                      ...(!isPartialFill && !isCernerPilot
                         ? [
                             {
                               title: 'Medication description',
@@ -568,7 +587,7 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}`
                             },
                           ]
                         : []),
-                      ...(hasValidDesc && !isPartialFill
+                      ...(hasValidDesc && !isPartialFill && !isCernerPilot
                         ? [
                             {
                               title: 'Note',
@@ -580,7 +599,7 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}`
                             },
                           ]
                         : []),
-                      ...(!isPartialFill
+                      ...(!isPartialFill && !isCernerPilot
                         ? [
                             {
                               value: description,

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -51,7 +51,7 @@ const getLastFilledAndRxNumberBlock = rx => {
         `Prescription number: ${rx.prescriptionNumber}`,
       );
 };
-const getAttributes = rx =>
+const getAttributes = (rx, isCernerPilot) =>
   joinLines(
     `Status: ${prescriptionMedAndRenewalStatus(rx, medStatusDisplayTypes.TXT)}`,
     fieldLine('Refills left', rx.refillRemaining),
@@ -61,9 +61,14 @@ const getAttributes = rx =>
       'Date not available',
     )}`,
     fieldLine('Facility', rx.facilityName),
-    fieldLine('Pharmacy phone number', rx.phoneNumber),
+    isCernerPilot
+      ? fieldLine(
+          'Pharmacy contact information',
+          'Check your prescription label or contact your VA facility.',
+        )
+      : fieldLine('Pharmacy phone number', rx.phoneNumber),
     fieldLine('Instructions', rx.sig),
-    fieldLine('Reason for use', rx.indicationForUse),
+    !isCernerPilot && fieldLine('Reason for use', rx.indicationForUse),
     `Prescribed on: ${dateFormat(
       rx.orderedDate,
       DATETIME_FORMATS.longMonthDate,
@@ -78,7 +83,11 @@ const getAttributes = rx =>
 /**
  * Return Non-VA prescription TXT
  */
-export const buildNonVAPrescriptionTXT = (prescription, options) => {
+export const buildNonVAPrescriptionTXT = (
+  prescription,
+  options = {},
+  isCernerPilot = false,
+) => {
   const { includeSeparators = true } = options ?? {};
   const header = includeSeparators
     ? `${newLine()}${SEPARATOR}${newLine(3)}`
@@ -88,7 +97,8 @@ export const buildNonVAPrescriptionTXT = (prescription, options) => {
     prescription?.prescriptionName || prescription?.orderableItem,
     joinLines(
       fieldLine('Instructions', prescription.sig),
-      fieldLine('Reason for use', prescription.indicationForUse),
+      !isCernerPilot &&
+        fieldLine('Reason for use', prescription.indicationForUse),
       `Status: ${validateField(
         prescription.dispStatus?.toString(),
       )}${newLine()}A VA provider added this medication record in your VA medical records. But this isn’t a prescription you filled through a VA pharmacy. This could be sample medications, over-the-counter medications, supplements or herbal remedies. You can’t request refills or manage this medication through this online tool. If you aren't taking this medication, ask your provider to remove it at your next appointment.`,
@@ -116,7 +126,7 @@ export const buildNonVAPrescriptionTXT = (prescription, options) => {
 /**
  * Return prescriptions list TXT
  */
-export const buildPrescriptionsTXT = prescriptions => {
+export const buildPrescriptionsTXT = (prescriptions, isCernerPilot = false) => {
   const mostRecentRxRefillLine = rx => {
     const newest = getMostRecentRxRefill(rx);
 
@@ -136,9 +146,13 @@ export const buildPrescriptionsTXT = prescriptions => {
 
   const body = (prescriptions || []).map(rx => {
     if (rx?.prescriptionSource === RX_SOURCE.NON_VA) {
-      return buildNonVAPrescriptionTXT(rx, {
-        includeSeparators: false,
-      }).trimEnd();
+      return buildNonVAPrescriptionTXT(
+        rx,
+        {
+          includeSeparators: false,
+        },
+        isCernerPilot,
+      ).trimEnd();
     }
 
     const title = rx.prescriptionName;
@@ -147,7 +161,7 @@ export const buildPrescriptionsTXT = prescriptions => {
     return joinBlocks(
       title,
       getLastFilledAndRxNumberBlock(rx),
-      getAttributes(rx),
+      getAttributes(rx, isCernerPilot),
       mostRecent,
     ).trimEnd();
   });
@@ -205,7 +219,7 @@ export const buildAllergiesTXT = allergies => {
 /**
  * Return VA prescription TXT
  */
-export const buildVAPrescriptionTXT = prescription => {
+export const buildVAPrescriptionTXT = (prescription, isCernerPilot = false) => {
   const header = `${newLine()}${SEPARATOR}${newLine(3)}`;
   const rxTitle = prescription?.prescriptionName || prescription?.orderableItem;
   const subTitle = `Most recent prescription`;
@@ -214,13 +228,13 @@ export const buildVAPrescriptionTXT = prescription => {
     `${rxTitle}${newLine()}`,
     `${subTitle}${newLine()}`,
     getLastFilledAndRxNumberBlock(prescription),
-    getAttributes(prescription),
+    getAttributes(prescription, isCernerPilot),
   ).trimEnd();
 
   let refillHistorySection = '';
   const refillHistory = getRefillHistory(prescription);
   const showRefillHistory = getShowRefillHistory(refillHistory);
-  if (showRefillHistory) {
+  if (showRefillHistory && !isCernerPilot) {
     const refillHistoryHeader = joinLines(
       'Refill history',
       `Showing ${refillHistory.length} fill${
@@ -270,7 +284,9 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}${newLine()}`
                 'Date not available',
               )}`
             : '',
-          !isPartialFill ? `Medication description: ${description}` : '',
+          !isPartialFill && !isCernerPilot
+            ? `Medication description: ${description}`
+            : '',
         );
       })
       .join(newLine(2));


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
This pull request introduces conditional UI changes throughout the MHV Medications application based on the new Cerner Pilot feature flag. The main updates ensure that certain fields and sections—such as "Reason for use," pharmacy contact information, and refill history—are hidden or modified for users in the Cerner Pilot group. Additionally, the Cerner Pilot flag is now passed through to export and print utilities, and relevant tests have been updated to support the new flag.

**NOTE: THIS DOES NOT INCLUDE ANY CHANGES TO MEDICATION STATUSES**

**Feature flag integration and conditional rendering:**

* Added use of `selectCernerPilotFlag` selector and `isCernerPilot` variable in multiple components (`NonVaPrescription.jsx`, `PrescriptionPrintOnly.jsx`, `VaPrescription.jsx`, `PrescriptionDetails.jsx`, `Prescriptions.jsx`) to control visibility of fields and sections for Cerner Pilot users. [[1]](diffhunk://#diff-e5e410b22e7a9e0db55e7de32b225c855f93028d14ed5e498a3cb575f53f0331R3-R16) [[2]](diffhunk://#diff-dc092dfd7ad14a2a3b6a4c1a8a148e80490cdab4a2a2a4816a61ba44077f47ddL24-R31) [[3]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8L34-R37) [[4]](diffhunk://#diff-082cf44604c58777182d9f17f925c064a37acbae43fd2debbca2d16cece92da8R60) [[5]](diffhunk://#diff-e4c26bbc12972783856a48f3a72b40dc932b9968ed6d0ac898c3f07606aabfe8R83-R88)

* Updated UI to hide "Reason for use" and refill history sections, and to display alternative pharmacy contact information for Cerner Pilot users in prescription detail and print views. [[1]](diffhunk://#diff-e5e410b22e7a9e0db55e7de32b225c855f93028d14ed5e498a3cb575f53f0331R80) [[2]](diffhunk://#diff-e5e410b22e7a9e0db55e7de32b225c855f93028d14ed5e498a3cb575f53f0331R89) [[3]](diffhunk://#diff-dc092dfd7ad14a2a3b6a4c1a8a148e80490cdab4a2a2a4816a61ba44077f47ddR51-R56) [[4]](diffhunk://#diff-dc092dfd7ad14a2a3b6a4c1a8a148e80490cdab4a2a2a4816a61ba44077f47ddR193-R198) [[5]](diffhunk://#diff-dc092dfd7ad14a2a3b6a4c1a8a148e80490cdab4a2a2a4816a61ba44077f47ddR210-R219) [[6]](diffhunk://#diff-dc092dfd7ad14a2a3b6a4c1a8a148e80490cdab4a2a2a4816a61ba44077f47ddL230-R246) [[7]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8R147-R189) [[8]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8L278-R334) [[9]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8R344-R345) [[10]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8L358-R394) [[11]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8L483-R521)

**Export and print utilities:**

* Passed the `isCernerPilot` flag to prescription export and print functions (`buildVAPrescriptionTXT`, `buildNonVAPrescriptionTXT`, `buildVAPrescriptionPDFList`, `buildNonVAPrescriptionPDFList`, `buildPrescriptionsPDFList`, `buildPrescriptionsTXT`) to ensure output matches the conditional UI. [[1]](diffhunk://#diff-082cf44604c58777182d9f17f925c064a37acbae43fd2debbca2d16cece92da8L229-R237) [[2]](diffhunk://#diff-082cf44604c58777182d9f17f925c064a37acbae43fd2debbca2d16cece92da8L306-R313) [[3]](diffhunk://#diff-e4c26bbc12972783856a48f3a72b40dc932b9968ed6d0ac898c3f07606aabfe8L359-R370)

**Test updates:**

* Updated the Non-VA Prescription unit test setup to support the Cerner Pilot flag in the Redux store’s initial state.

**General refactoring and cleanup:**

* Minor formatting and code style improvements, such as consistent destructuring and formatting of JSX and function calls. [[1]](diffhunk://#diff-dc092dfd7ad14a2a3b6a4c1a8a148e80490cdab4a2a2a4816a61ba44077f47ddL266-R284) [[2]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8L411-R448) [[3]](diffhunk://#diff-ddc3cf2294f3243b5e7565472475f21acc0fb3b73fe63994d33cb1f1fdb159b8L494-R544)


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/126121

## Testing done

- Added unit tests for each VA & Non-VA medications displayed on the medications page
- Added unit tests for each VA & Non-VA medications for export & print
- Manually tested the different prescription types for medication page, PDF, TXT, and print and ensured UI is consistent across all three

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
**Note: VA.gov only, not mobile**
With Cerner Pilot feature flag on (examples):
<img width="510" height="650" alt="Screenshot 2025-12-04 at 2 06 06 PM" src="https://github.com/user-attachments/assets/b1174add-d07c-4ba5-837c-6a432f7b38cd" />
<img width="905" height="698" alt="Screenshot 2025-12-04 at 2 08 27 PM" src="https://github.com/user-attachments/assets/327805d8-a8be-49e8-90d9-8122f18c7a88" />
<img width="820" height="645" alt="Screenshot 2025-12-04 at 2 21 03 PM" src="https://github.com/user-attachments/assets/326ff172-fb4f-4f54-90af-df9733c71add" />



**Testing enhancements:**
* Updated the `NonVaPrescription` unit test setup to allow testing with the Cerner Pilot flag enabled or disabled.

These changes ensure that users in the Cerner Pilot experience the correct UI and exports tailored to their needs, with content and fields appropriately shown or hidden.

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
