### PR TITLE
fix: restore RUN_FULL_SUITE parameter functionality for E2E test selection

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Select E2E Tests
         run: node script/github-actions/select-e2e-tests.js
         env:
-          RUN_FULL_SUITE: false
+          RUN_FULL_SUITE: true
           CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Select E2E Tests
         run: node script/github-actions/select-e2e-tests.js
         env:
-          RUN_FULL_SUITE: true
+          RUN_FULL_SUITE: false
           CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed the `RUN_FULL_SUITE` parameter functionality in E2E test selection that had been lost over time
- **Issue**: When `RUN_FULL_SUITE=true` was passed to the Cypress test job, it would only run tests if there were changed files, defeating the purpose of running the full suite
- **Root cause**: The `RUN_FULL_SUITE` check was nested inside a `if (filteredChangedFiles.length > 0)` condition, preventing all tests from being selected when no files changed
- **Solution**: Moved the `RUN_FULL_SUITE` check to the beginning of the `selectTests()` function to immediately return all tests when enabled, bypassing file change analysis
- **Result**: When `RUN_FULL_SUITE=true`, all Cypress tests run except those strictly disallowed in the allow list (quarantined tests)
- This maintains the existing behavior where teams are blocked from merging if their quarantined tests fail, while allowing full suite runs for testing purposes

## Related issue(s)

N/A - Internal infrastructure fix

## Testing done

- **Old behavior**: When `RUN_FULL_SUITE=true` was set, tests would not run if there were no relevant file changes
- **Verification steps**:
  1. Verified syntax of modified JavaScript file passes Node.js check
  2. Reviewed code logic to ensure all tests are selected when `RUN_FULL_SUITE=true`
  3. Confirmed disallowed tests are still filtered out in the `main()` function
- **Tests completed**: Code review and syntax validation

## Screenshots

N/A - No UI changes

## What areas of the site does it impact?

This impacts the CI/CD pipeline test selection logic for E2E/Cypress tests. No end-user facing changes.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable) - N/A, this is a test infrastructure script
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, no documentation updates needed for internal script fix
- [ ] Screenshot of the developed feature is added - N/A, no UI changes
- [ ] Accessibility testing has been performed - N/A, no UI changes

### Error Handling

- [ ] Browser console contains no warnings or errors - N/A, this is a Node.js script, not browser code
- [ ] Events are being sent to the appropriate logging solution - N/A, existing logging unchanged
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A, test selection script

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A, no route changes

## Requested Feedback

This restores functionality that previously existed. The change allows the `RUN_FULL_SUITE` environment variable to work as intended for running all E2E tests except quarantined ones, regardless of which files changed in the branch.