### PR TITLE
Updates csp content order so ID.me is shown first

### DIFF
--- a/src/applications/_mock-form-ae-design-patterns/shared/components/SaveInProgressInfo1010Ezr.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/shared/components/SaveInProgressInfo1010Ezr.jsx
@@ -75,8 +75,8 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
         </p>
 
         <p>
-          <strong>Don’t yet have a verified account?</strong> Create a{' '}
-          <strong>Login.gov</strong> or <strong>ID.me</strong> account now. Then
+          <strong>Don’t yet have a verified account?</strong> Create an{' '}
+          <strong>ID.me</strong> or <strong>Login.gov</strong> account now. Then
           come back here and sign in. We’ll help you verify your identity for
           your account.
         </p>

--- a/src/applications/accredited-representative-portal/containers/HelpPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/HelpPage.jsx
@@ -131,7 +131,7 @@ const HelpPage = title => {
               <p>
                 To submit {RepresentationLink()} on VA.gov, Veterans must sign
                 in to their {VAGovLink()} account, which requires authentication
-                with Login.gov or ID.me. By requiring sign-in with these
+                with ID.me or Login.gov. By requiring sign-in with these
                 methods, we ensure that all submitters have verified their
                 identity with the federal government.
               </p>
@@ -139,8 +139,8 @@ const HelpPage = title => {
           </va-accordion>
           <h2 id="creating-your-account">Creating your account</h2>
           <p>
-            To use the Accredited Representative Portal, you need to create a
-            Login.gov or an ID.me account and associate it with your email on
+            To use the Accredited Representative Portal, you need to create an
+            ID.me or a Login.gov account and associate it with your email on
             file with the VA’s Office of General Counsel (OGC).
           </p>
           <va-accordion>
@@ -173,15 +173,15 @@ const HelpPage = title => {
                 >
                   OGC accreditation search tool
                 </Link>
-                . If you are found in the OGC tool but not the Find a
+                . If you are found in the OGC tool but not the Find a
                 Representative tool, it likely means VA doesn’t have a valid
                 physical address on file for you.
               </p>
               <h3 className="vads-u-font-size--h4">
-                Step 2: Create a Login.gov or ID.me account
+                Step 2: Create an ID.me or Login.gov account
               </h3>
               <p>
-                Login.gov and ID.me are services that provide secure ways to
+                ID.me and Login.gov are services that provide secure ways to
                 sign in to many government websites using just one account. When
                 creating your account, it’s recommended to use a personal email
                 you’ll always have access to. Follow the service provider’s
@@ -204,7 +204,7 @@ const HelpPage = title => {
                 Step 3: Associate your OGC email with your account
               </h3>
               <p>
-                If you created your Login.gov or ID.me account using your
+                If you created your ID.me or Login.gov account using your
                 personal email, you’ll need to add the email address you have on
                 file with OGC. Follow the service provider’s instructions to add
                 an email to your account.
@@ -245,7 +245,7 @@ const HelpPage = title => {
                 className="content-link"
                 to="https://www.va.gov/resources/support-for-common-logingov-and-idme-issues/"
               >
-                Get support for common Login.gov and ID.me issues
+                Get support for common ID.me and Login.gov issues
               </Link>
               <br />
               <br />
@@ -253,12 +253,12 @@ const HelpPage = title => {
                 Or you can get more help on each account provider’s website.
               </p>
               <p>
-                <Link className="content-link" to="https://login.gov/help/">
-                  Go to the Login.gov help center
-                </Link>
-                <br />
                 <Link className="content-link" to="https://help.id.me/hc/en-us">
                   Go to the ID.me support section
+                </Link>
+                <br />
+                <Link className="content-link" to="https://login.gov/help/">
+                  Go to the Login.gov help center
                 </Link>
               </p>
             </va-accordion-item>
@@ -552,7 +552,7 @@ const HelpPage = title => {
               <p>
                 <va-telephone contact="8552250709" />
                 <br />
-                Hours: Monday through Friday, 8:00 a.m. to 9:00 p.m. ET
+                Hours: Monday through Friday, 8:00 a.m. to 9:00 p.m. ET
               </p>
               <p>
                 Call the VA accredited representative support line to get help
@@ -574,7 +574,7 @@ const HelpPage = title => {
               <p>
                 Email the Accredited Representative Portal team at{' '}
                 {EmailHelpLink()}
-                 if you’re a VSO manager or certifying official and you’d like
+                if you’re a VSO manager or certifying official and you’d like
                 access to the Representation Request feature for your
                 organization.
               </p>

--- a/src/applications/accredited-representative-portal/containers/LoginContainer.jsx
+++ b/src/applications/accredited-representative-portal/containers/LoginContainer.jsx
@@ -52,7 +52,7 @@ const LoginContainer = () => {
               </li>
               <li className="vads-u-margin--0">
                 <a href="/resources/support-for-common-logingov-and-idme-issues/">
-                  Common issues with Login.gov or ID.me
+                  Common issues with ID.me or Login.gov
                 </a>
               </li>
             </ul>

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -183,10 +183,7 @@ const ConfirmationPage = ({ form, download }) => {
       </h2>
       <va-process-list class="vads-u-margin-left--neg2 vads-u-padding-bottom--0">
         <va-process-list-item header="Sign in to VA.gov" level="3">
-          <p>
-            You can sign in with your Login.gov, ID.me, DS Logon, or My
-            HealtheVet
-          </p>
+          <p>You can sign in with your ID.me or Login.gov account.</p>
         </va-process-list-item>
         <va-process-list-item header="Submit your request" level="3">
           <p>

--- a/src/applications/medallions/containers/IntroductionPage.jsx
+++ b/src/applications/medallions/containers/IntroductionPage.jsx
@@ -163,8 +163,8 @@ export const IntroductionPage = props => {
             </ul>
 
             <p>
-              <strong>Don’t yet have a verified account?</strong> Create a{' '}
-              <strong>Login.gov</strong> or <strong>ID.me</strong> account.
+              <strong>Don’t yet have a verified account?</strong> Create an{' '}
+              <strong>ID.me</strong> or <strong>Login.gov</strong> account.
               We’ll help you verify your identity for your account now.
             </p>
 

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
@@ -43,8 +43,8 @@ const UnauthenticatedAlert = ({
             benefits.
           </p>
           <p>
-            <strong>Don’t yet have a verified account?</strong> Create a{' '}
-            <strong>Login.gov</strong> or <strong>ID.me</strong> account. We’ll
+            <strong>Don’t yet have a verified account?</strong> Create an{' '}
+            <strong>ID.me</strong> or <strong>Login.gov</strong> account. We’ll
             help you verify your identity for your account now.
           </p>
           <p>

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
@@ -99,19 +99,19 @@ const UnverifiedAlert = ({
             account.
           </p>
           <p>
-            <strong>If you already have a Login.gov or ID.me account,</strong>{' '}
+            <strong>If you already have an ID.me or Login.gov account,</strong>{' '}
             sign in with that account. If you still need to verify your identity
             for your account, we’ll help you do that now.
           </p>
           <p>
-            <strong>If you don’t have a Login.gov or ID.me account,</strong>{' '}
+            <strong>If you don’t have an ID.me or Login.gov account,</strong>{' '}
             create one now. We’ll help you verify your identity.
           </p>
           <p>
-            <VerifyButton csp={CSP_IDS.LOGIN_GOV} />
+            <VerifyButton csp={CSP_IDS.ID_ME} />
           </p>
           <p>
-            <VerifyButton csp={CSP_IDS.ID_ME} />
+            <VerifyButton csp={CSP_IDS.LOGIN_GOV} />
           </p>
           <va-link
             href="/resources/creating-an-account-for-vagov/"

--- a/src/applications/survivor-dependent-education-benefit/22-5490/components/incorrectFormModal.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/components/incorrectFormModal.jsx
@@ -53,7 +53,7 @@ const IncorrectFormModal = props => {
         <li>
           If you are a Veteran or service member applying on behalf of your
           dependent, your application will be denied. Your dependent will need
-          to complete the application from their own Login.gov or ID.me account.
+          to complete the application from their own ID.me or Login.gov account.
         </li>
         {relationshipToMember === 'child' && (
           <li>

--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -253,7 +253,7 @@ export default function TermsOfUse() {
           )}
           <p>
             To manage your benefits and care online again, you’ll need to sign
-            in with a <strong>Login.gov</strong> or <strong>ID.me</strong>{' '}
+            in with an <strong>ID.me</strong> or <strong>Login.gov</strong>{' '}
             account and accept these terms. If you don’t have one of these
             accounts, you’ll need to create one.
           </p>

--- a/src/applications/terms-of-use/touData.jsx
+++ b/src/applications/terms-of-use/touData.jsx
@@ -117,7 +117,7 @@ export default [
       <>
         <p>
           Groups of people who use VA.gov and other VA online tools and services
-          include those who sign in with an account (such as Login.gov or ID.me)
+          include those who sign in with an account (such as ID.me or Login.gov)
           and those who don’t sign in. These groups include Veterans, VA
           patients, beneficiaries, Veteran advocates, caregivers, personal legal
           representatives, and the general public.

--- a/src/applications/toe/components/NoSponsorModal.jsx
+++ b/src/applications/toe/components/NoSponsorModal.jsx
@@ -37,7 +37,7 @@ const NoSponsorModal = ({ sponsorsList }) => {
         <li>
           If you are a Veteran or service member applying on behalf of your
           dependent, your application will be denied. Your dependent must apply
-          from their own Login.gov or ID.me account.
+          from their own ID.me or Login.gov account.
         </li>
         <li>
           If you believe you’re an eligible dependent receiving benefits through{' '}

--- a/src/applications/toe/containers/IntroductionPage.jsx
+++ b/src/applications/toe/containers/IntroductionPage.jsx
@@ -36,7 +36,7 @@ export const IntroductionPage = ({
 
           <p>
             <strong>Note:</strong> If you use our online tool to apply, be sure
-            you’re signed in as a family member to your own Login.gov or ID.me
+            you’re signed in as a family member to your own ID.me or Login.gov
             account to complete this application. We can’t process your
             application if the Veteran or service member signs in to their
             account and submits the application for you.

--- a/src/applications/verify-your-enrollment/components/LoginAlert.jsx
+++ b/src/applications/verify-your-enrollment/components/LoginAlert.jsx
@@ -5,7 +5,7 @@ import { CSP_IDS } from 'platform/user/authentication/constants';
 
 const LoginAlert = () => {
   const { ID_ME, LOGIN_GOV } = CSP_IDS;
-  const heading = `Verify your identity with Login.gov or ID.me to change your direct deposit information online`;
+  const heading = `Verify your identity with ID.me or Login.gov to change your direct deposit information online`;
   return (
     <VaAlert status="continue" visible uswds>
       <h2 slot="headline">{heading}</h2>
@@ -16,7 +16,7 @@ const LoginAlert = () => {
           This helps us protect your bank account and prevent fraud.
         </p>
         <p>
-          <strong>If you have a verified Login.gov or ID.me account</strong>,
+          <strong>If you have a verified ID.me or Login.gov account</strong>,
           sign out now. Then sign back in with that account to continue.
         </p>
         <p>

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -39,7 +39,7 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
         ))}
 
         <a href="https://www.va.gov/resources/creating-an-account-for-vagov">
-          Learn about creating a Login.gov or ID.me account
+          Learn about creating an ID.me or Login.gov account
         </a>
 
         {dslogonIsDisabled && (

--- a/src/platform/user/authentication/components/LoginInfo.jsx
+++ b/src/platform/user/authentication/components/LoginInfo.jsx
@@ -13,7 +13,7 @@ export default () => {
       url: '/resources/can-i-delete-my-logingov-or-idme-account',
     },
     {
-      text: 'Common issues with Login.gov or ID.me',
+      text: 'Common issues with ID.me or Login.gov',
       url: '/resources/support-for-common-logingov-and-idme-issues/',
     },
   ];

--- a/src/platform/user/authentication/downtime.js
+++ b/src/platform/user/authentication/downtime.js
@@ -28,7 +28,7 @@ export const generateCSPBanner = ({ csp }) => {
     ? {
         headline: `You may have trouble signing in with some of your accounts`,
         status: 'warning',
-        message: `We’re sorry. We’re working to fix some problems with ID.me, but you can still sign in to VA.gov using your Login.gov account. If you’d like to sign in with your ID.me or DS Logon accounts, please check back later.`,
+        message: `We’re sorry. We’re working to fix some problems with ID.me, but you can still sign in to VA.gov using your Login.gov account. If you’d like to sign in with your ID.me account, please check back later.`,
       }
     : {
         headline: `You may have trouble signing in with ${

--- a/src/platform/user/authentication/errors.js
+++ b/src/platform/user/authentication/errors.js
@@ -49,7 +49,7 @@ export const AUTH_ERRORS = {
   },
   UUID_MISSING: {
     errorCode: '104',
-    message: `UUID Missing (Login.gov or ID.me)`,
+    message: `UUID Missing (ID.me or Login.gov)`,
   },
   MULTIPLE_CORPIDS: {
     errorCode: '106',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update all remaining content on VA.gov that references credential service providers to ensure the following:

- Only ID.me and Login.gov are referenced as available identity providers.
- ID.me is always listed before Login.gov in both content order and button order.
- There are no references suggesting that users can sign in with DS Logon as an active credential service provider (displaying the retirement notice is acceptable).
- There are no references suggesting that users can sign in with My HealtheVet as an active credential service provider (the My HealtheVet exception page is excluded from this requirement).

## Related issue(s)

[Issue #932](https://github.com/department-of-veterans-affairs/identity-documentation/issues/932)

## Testing done

- confirmed each update locally
- content updates only
- no unit tests needed to be updated

## Screenshots

<img width="1143" height="921" alt="Screenshot 2025-12-04 at 12 40 19 PM" src="https://github.com/user-attachments/assets/89c7cfaa-84a2-463a-9b8c-f5009d8d628c" />

## What areas of the site does it impact?

- [https://www.va.gov/?next=loginModal&oauth=true](https://www.va.gov/?next=loginModal&oauth=true)
- [https://www.va.gov/sign-in](https://www.va.gov/sign-in)
- [https://www.va.gov/representative/help](https://www.va.gov/representative/help)
- [https://www.va.gov/terms-of-use](https://www.va.gov/terms-of-use)

## Acceptance criteria

The following files have been updated to meet criteria in the description
- DS Logon and MHV mention removed from Form 5655 confirmation page
  - `src/applications/financial-status-report/containers/ConfirmationPage.jsx`
- DS Logon mention removed from downtime banner
  - `src/platform/user/authentication/downtime.js`
- ID.me first on the following files (content and button order)
  - `src/applications/verify-your-enrollment/components/LoginAlert.jsx`
  - `src/platform/user/authentication/components/LoginActions.jsx`
  - `src/platform/user/authentication/components/LoginInfo.jsx`
  - `src/applications/terms-of-use/containers/TermsOfUse.jsx`
  - `src/applications/terms-of-use/touData.jsx`
  - `src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx`
  - `src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx`
  - `src/applications/accredited-representative-portal/containers/LoginContainer.jsx`
  - `src/platform/user/authentication/errors.js`
  - `src/applications/_mock-form-ae-design-patterns/shared/components/SaveInProgressInfo1010Ezr.jsx`
  - `src/applications/accredited-representative-portal/containers/HelpPage.jsx`
  - `src/applications/medallions/containers/IntroductionPage.jsx`
  - `src/applications/survivor-dependent-education-benefit/22-5490/components/incorrectFormModal.jsx`
  - `src/applications/toe/components/NoSponsorModal.jsx`


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

