### PR TITLE
534WZ Add missing serial comma

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/01-veteran-information/veteranAdditional.js
+++ b/src/applications/survivors-benefits/config/chapters/01-veteran-information/veteranAdditional.js
@@ -12,7 +12,7 @@ export default {
     ...titleUI('Additional Veteran information'),
     vaClaimsHistory: yesNoUI({
       title:
-        'Has the Veteran, surviving spouse, child or parent ever filed a claim with the VA?',
+        'Has the Veteran, surviving spouse, child, or parent ever filed a claim with the VA?',
     }),
     diedOnDuty: yesNoUI({
       title: 'Did the Veteran die while on active duty?',

--- a/src/applications/survivors-benefits/tests/unit/pages/01-veteran-information/veteranAdditional.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/01-veteran-information/veteranAdditional.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('Claimant Information Page', () => {
     const vaMemorableDates = $$('va-memorable-date', formDOM);
 
     const vaEverClaim = $(
-      'va-radio[label="Has the Veteran, surviving spouse, child or parent ever filed a claim with the VA?"]',
+      'va-radio[label="Has the Veteran, surviving spouse, child, or parent ever filed a claim with the VA?"]',
       formDOM,
     );
     const vaActiveDuty = $(

--- a/src/applications/survivors-benefits/tests/utils.js
+++ b/src/applications/survivors-benefits/tests/utils.js
@@ -77,7 +77,7 @@ export const checkContentAdditionalVetsInfo = () => {
   checkVisibleElementContent('legend', 'Additional Veteran information');
   checkVisibleElementContent(
     'va-radio',
-    'Has the Veteran, surviving spouse, child or parent ever filed a claim with the VA?',
+    'Has the Veteran, surviving spouse, child, or parent ever filed a claim with the VA?',
   );
   checkVisibleElementContent(
     'va-radio',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request makes a minor wording update to the question about VA claims history in the "Additional Veteran information" section. The change adds a comma for clarity in the list of claimants. The update is applied consistently across the configuration, unit tests, and test utilities.

Most important change:

* Content update for clarity:
  * Added a comma in the question "Has the Veteran, surviving spouse, child, or parent ever filed a claim with the VA?" in `veteranAdditional.js`, unit test spec, and test utility to improve readability. [[1]](diffhunk://#diff-8e751e5043bdbb37e1f48c6f8ad4b2f0fcea614445950440630e571515c22690L15-R15) [[2]](diffhunk://#diff-423a2f47ab7732a3724ad374e8c5af09100300a9c36ef205ec536964b3d0385fL26-R26) [[3]](diffhunk://#diff-d5876227502c191d98b8b45618e3d3f004d9862560712b0b773f7cad9660b904L80-R80)
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#124506
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done
Functional and unit tests.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |
<img width="1012" height="298" alt="image" src="https://github.com/user-attachments/assets/7d83a947-a34a-4468-9f80-15c96a63eab3" />
|
<img width="502" height="545" alt="image" src="https://github.com/user-attachments/assets/380670b4-71ed-4091-83b3-a41af11ede77" />
|

## What areas of the site does it impact?
534EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
