### PR TITLE
Required explanation for veteran marriage ending

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -214,7 +214,14 @@ const endedPage = {
       title: 'Tell us how the marriage ended',
       expandUnder: 'marriageEndedBy',
       expandUnderCondition: field => field === 'OTHER',
-      required: formData => formData?.marriageEndedBy === 'OTHER',
+      required: (formData, index) => {
+        const item = formData?.veteranMarriages?.[index];
+        const currentPageData = formData;
+        return (
+          item?.marriageEndedBy === 'OTHER' ||
+          currentPageData?.marriageEndedBy === 'OTHER'
+        );
+      },
       errorMessages: { required: 'Please tell us how the marriage ended' },
     }),
   },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -44,8 +44,8 @@ function introDescription() {
 /** @type {ArrayBuilderOptions} */
 const options = {
   arrayPath: 'veteranMarriages',
-  nounSingular: 'veteran marriage',
-  nounPlural: 'veteran marriages',
+  nounSingular: 'previous marriage',
+  nounPlural: 'previous marriages',
   required: false,
   maxItems: 2,
   isItemIncomplete: item =>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request updates the logic for determining whether the "Tell us how the marriage ended" field is required in the `veteranMarriagesPages.js` configuration. The change ensures that the required validation accounts for both the specific marriage entry and the overall form data, improving accuracy for cases with multiple marriages.

Validation logic improvements:

* Updated the `required` function in the `endedPage` configuration to check both the current marriage item's `marriageEndedBy` property and the overall form data's `marriageEndedBy` property, ensuring the field is required when either is set to `'OTHER'`.
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#126713
department-of-veterans-affairs/va.gov-team#126715
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done
Unit and manual testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |
<img width="1164" height="832" alt="image" src="https://github.com/user-attachments/assets/92783540-6423-467e-876d-68983a1288cd" />
|
<img width="398" height="430" alt="Screenshot 2025-12-09 at 1 03 55 PM" src="https://github.com/user-attachments/assets/6cc85e77-3a88-48fb-9192-68c7360ab867" />
|

## What areas of the site does it impact?
534EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
