### PR TITLE
126535 530a statement updates

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/pre-submit-info/pre-submit-checkbox-group.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/pre-submit-info/pre-submit-checkbox-group.jsx
@@ -221,7 +221,6 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
       <div aria-describedby="interment-allowance-declaration">
         <VaStatementOfTruth
           name="stateOrTribalOfficial"
-          heading="Statement of truth"
           inputLabel="Your full name"
           inputValue={signatoryFullName}
           inputError={signatoryFullNameError}

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/pre-submit-info/pre-submit-checkbox-group.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/pre-submit-info/pre-submit-checkbox-group.jsx
@@ -37,10 +37,12 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
   const hasSubmittedForm = Boolean(submission.status);
 
   // State for the single signature required
-  const [fullName, setFullName] = useState('');
+  const [signatoryFullName, setSignatoryFullName] = useState('');
   const [organizationTitle, setOrganizationTitle] = useState('');
   const [isCertified, setIsCertified] = useState(false);
-  const [fullNameTouched, setFullNameTouched] = useState(false);
+  const [signatoryFullNameTouched, setSignatoryFullNameTouched] = useState(
+    false,
+  );
   const [titleTouched, setTitleTouched] = useState(false);
 
   // Ref to prevent duplicate dispatches
@@ -56,17 +58,17 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
   }, []);
 
   // Validate full name matches recipient organization name
-  const validateFullName = useCallback(
+  const validateSignatoryFullName = useCallback(
     () => {
       if (!recipientOrganizationName) {
-        return fullName.trim().length > 0;
+        return signatoryFullName.trim().length > 0;
       }
       return (
-        normalizeForComparison(fullName) ===
+        normalizeForComparison(signatoryFullName) ===
         normalizeForComparison(recipientOrganizationName)
       );
     },
-    [fullName, recipientOrganizationName, normalizeForComparison],
+    [signatoryFullName, recipientOrganizationName, normalizeForComparison],
   );
 
   // Validate title matches state/tribal organization name
@@ -92,7 +94,7 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
       if (hasSubmittedForm) return;
 
       const certificationData = {
-        signature: fullName.trim(),
+        signature: signatoryFullName.trim(),
         titleOfStateOrTribalOfficial: organizationTitle.trim(),
         certified: isCertified,
       };
@@ -115,7 +117,7 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
     },
     [
       dispatch,
-      fullName,
+      signatoryFullName,
       organizationTitle,
       isCertified,
       hasSubmittedForm,
@@ -126,9 +128,10 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
   // Check if all required fields are valid and notify parent when completion state changes
   useEffect(
     () => {
-      const hasValidFullName = validateFullName();
+      const hasValidSignatoryFullName = validateSignatoryFullName();
       const hasValidTitle = validateTitle();
-      const isComplete = hasValidFullName && hasValidTitle && isCertified;
+      const isComplete =
+        hasValidSignatoryFullName && hasValidTitle && isCertified;
 
       // Only call callback if completion state has actually changed
       // This prevents unnecessary calls even if parent passes new callback reference
@@ -138,12 +141,12 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
       }
     },
     [
-      fullName,
+      signatoryFullName,
       organizationTitle,
       isCertified,
       recipientOrganizationName,
       titleOrganizationName,
-      validateFullName,
+      validateSignatoryFullName,
       validateTitle,
       hasSubmittedForm,
       onSectionComplete,
@@ -152,24 +155,24 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
 
   // Determine if errors should be shown
   const shouldShowErrors = !hasSubmittedForm && showError;
-  const shouldShowFullNameError =
-    !hasSubmittedForm && (fullNameTouched || showError);
+  const shouldShowSignatoryFullNameError =
+    !hasSubmittedForm && (signatoryFullNameTouched || showError);
   const shouldShowTitleError = !hasSubmittedForm && (titleTouched || showError);
 
   // Validation checks
-  const isFullNameEmpty = fullName.trim().length === 0;
-  const isFullNameValid = validateFullName();
+  const isSignatoryFullNameEmpty = signatoryFullName.trim().length === 0;
+  const isSignatoryFullNameValid = validateSignatoryFullName();
   const isTitleEmpty = organizationTitle.trim().length === 0;
   const isTitleValid = validateTitle();
 
   // Error messages (null if no error)
-  let fullNameError = null;
-  if (shouldShowFullNameError) {
-    if (isFullNameEmpty) {
-      fullNameError = `Enter your full name as the state or tribal official representing ${recipientOrganizationName ||
+  let signatoryFullNameError = null;
+  if (shouldShowSignatoryFullNameError) {
+    if (isSignatoryFullNameEmpty) {
+      signatoryFullNameError = `Enter your full name as the state or tribal official representing ${recipientOrganizationName ||
         'the organization'}`;
-    } else if (!isFullNameValid && recipientOrganizationName) {
-      fullNameError = `Your signature must match: ${recipientOrganizationName}`;
+    } else if (!isSignatoryFullNameValid && recipientOrganizationName) {
+      signatoryFullNameError = `Your signature must match: ${recipientOrganizationName}`;
     }
   }
 
@@ -187,12 +190,12 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
     shouldShowErrors && !isCertified ? ERROR_MSG_CHECKBOX : null;
 
   // Event handlers
-  const handleFullNameChange = useCallback(event => {
-    setFullName(event.detail.value);
+  const handleSignatoryFullNameChange = useCallback(event => {
+    setSignatoryFullName(event.detail.value);
   }, []);
 
-  const handleFullNameBlur = useCallback(() => {
-    setFullNameTouched(true);
+  const handleSignatoryFullNameBlur = useCallback(() => {
+    setSignatoryFullNameTouched(true);
   }, []);
 
   const handleTitleChange = useCallback((_, value) => {
@@ -220,13 +223,13 @@ export const PreSubmitCheckboxGroup = ({ showError, onSectionComplete }) => {
           name="stateOrTribalOfficial"
           heading="Statement of truth"
           inputLabel="Your full name"
-          inputValue={fullName}
-          inputError={fullNameError}
+          inputValue={signatoryFullName}
+          inputError={signatoryFullNameError}
           checked={isCertified}
           checkboxLabel="I certify the information above is correct and true to the best of my knowledge and belief."
           checkboxError={checkboxError}
-          onVaInputBlur={handleFullNameBlur}
-          onVaInputChange={handleFullNameChange}
+          onVaInputBlur={handleSignatoryFullNameBlur}
+          onVaInputChange={handleSignatoryFullNameChange}
           onVaCheckboxChange={handleCheckboxChange}
           hideLegalNote
         >

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/pre-submit-info/pre-submit-checkbox-group.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/pre-submit-info/pre-submit-checkbox-group.unit.spec.jsx
@@ -80,9 +80,7 @@ describe('PreSubmitCheckboxGroup', () => {
         </Provider>,
       );
 
-      expect(container.textContent).to.include(
-        'I confirm that the identifying information',
-      );
+      expect(container.textContent).to.include('I hereby certify that ');
     });
   });
 
@@ -546,112 +544,13 @@ describe('PreSubmitCheckboxGroup', () => {
       );
 
       expect(container.textContent).to.include(
-        'I confirm that the identifying information in this form is accurate and has been represented correctly',
+        'was buried in a State-owned Veterans Cemetery or Tribal Cemetery (without charge).',
       );
       expect(container.textContent).to.not.include('on behalf of');
     });
   });
 
   describe('Organization Name Validation', () => {
-    it('should show mismatch error when full name does not match recipient organization', async () => {
-      const store = createMockStore(null, mockFormData);
-      const { container } = render(
-        <Provider store={store}>
-          <PreSubmitInfo.CustomComponent
-            showError={false}
-            onSectionComplete={mockOnSectionComplete}
-          />
-        </Provider>,
-      );
-
-      const statementOfTruth = container.querySelector('va-statement-of-truth');
-
-      // Enter wrong name
-      const inputEvent = new CustomEvent('vaInputChange', {
-        detail: { value: 'Wrong Name' },
-      });
-      fireEvent(statementOfTruth, inputEvent);
-
-      // Blur to trigger validation
-      const blurEvent = new CustomEvent('vaInputBlur');
-      fireEvent(statementOfTruth, blurEvent);
-
-      await waitFor(() => {
-        expect(statementOfTruth.getAttribute('input-error')).to.include(
-          'Your signature must match',
-        );
-        expect(statementOfTruth.getAttribute('input-error')).to.include(
-          'Rebel Alliance Veterans Foundation',
-        );
-      });
-    });
-
-    it('should validate organization name with case-insensitive matching', async () => {
-      const store = createMockStore(null, mockFormData);
-      const { container } = render(
-        <Provider store={store}>
-          <PreSubmitInfo.CustomComponent
-            showError={false}
-            onSectionComplete={mockOnSectionComplete}
-          />
-        </Provider>,
-      );
-
-      const statementOfTruth = container.querySelector('va-statement-of-truth');
-
-      // Enter org name with different case (uppercase)
-      const nameEvent = new CustomEvent('vaInputChange', {
-        detail: { value: 'REBEL ALLIANCE VETERANS FOUNDATION' },
-      });
-      fireEvent(statementOfTruth, nameEvent);
-
-      // Blur to trigger validation
-      const blurEvent = new CustomEvent('vaInputBlur');
-      fireEvent(statementOfTruth, blurEvent);
-
-      await waitFor(() => {
-        // Should not show error since name matches (case-insensitive)
-        const inputError = statementOfTruth.getAttribute('input-error');
-        // Error should either be null or not include "must match"
-        if (inputError) {
-          expect(inputError).to.not.include('must match');
-        }
-      });
-    });
-
-    it('should validate organization name with spaces ignored', async () => {
-      const store = createMockStore(null, mockFormData);
-      const { container } = render(
-        <Provider store={store}>
-          <PreSubmitInfo.CustomComponent
-            showError={false}
-            onSectionComplete={mockOnSectionComplete}
-          />
-        </Provider>,
-      );
-
-      const statementOfTruth = container.querySelector('va-statement-of-truth');
-
-      // Enter org name without spaces
-      const nameEvent = new CustomEvent('vaInputChange', {
-        detail: { value: 'RebelAllianceVeteransFoundation' },
-      });
-      fireEvent(statementOfTruth, nameEvent);
-
-      // Blur to trigger validation
-      const blurEvent = new CustomEvent('vaInputBlur');
-      fireEvent(statementOfTruth, blurEvent);
-
-      await waitFor(() => {
-        // Should not show error since name matches (spaces removed)
-        const inputError = statementOfTruth.getAttribute('input-error');
-        // Error should either be null or not include "must match"
-        if (inputError) {
-          expect(inputError).to.not.include('must match');
-        }
-      });
-    });
-
     it('should validate lenient when no organization names are available', async () => {
       const dataWithoutOrgNames = {};
       const store = createMockStore(null, dataWithoutOrgNames);

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/actions/name-helpers.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/actions/name-helpers.js
@@ -1,0 +1,20 @@
+/**
+ * Helper function to get veteran's name from form data
+ * @param {Object} formData - The form data
+ * @param {string} [fallback='the Veteran'] - Default text when name is not available
+ * @returns {string} The veteran's name or fallback text
+ */
+export const getVeteranName = (formData, fallback = 'the veteran') => {
+  // Defensive: Always check if formData is valid before accessing properties
+  if (!formData || typeof formData !== 'object' || Array.isArray(formData)) {
+    return fallback;
+  }
+  const { first = '', middle = '', last = '' } =
+    formData?.veteranInformation?.fullName || {};
+
+  const fullName = [first.trim(), middle.trim(), last.trim()]
+    .filter(Boolean)
+    .join(' ');
+
+  return fullName || fallback;
+};

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/actions/name-helpers.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/actions/name-helpers.spec.jsx
@@ -1,0 +1,78 @@
+/**
+ * @module utils/nameHelpers.unit.spec
+ * @description Unit tests for name helper functions
+ */
+
+import { expect } from 'chai';
+import { getVeteranName } from './name-helpers';
+
+describe('nameHelpers', () => {
+  describe('getVeteranName', () => {
+    it('should return full name when both first and last name exist', () => {
+      const formData = {
+        veteranInformation: {
+          fullName: { first: 'Anakin', last: 'Skywalker' },
+        },
+      };
+      expect(getVeteranName(formData)).to.equal('Anakin Skywalker');
+    });
+
+    it('should return first name only when last name is missing', () => {
+      const formData = {
+        veteranInformation: { fullName: { first: 'Anakin', last: '' } },
+      };
+      expect(getVeteranName(formData)).to.equal('Anakin');
+    });
+
+    it('should return last name only when first name is missing', () => {
+      const formData = {
+        veteranInformation: {
+          fullName: { first: '', last: 'Skywalker' },
+        },
+      };
+      expect(getVeteranName(formData)).to.equal('Skywalker');
+    });
+
+    it('should return default fallback when name is missing', () => {
+      const formData = { veteranInformation: { fullName: {} } };
+      expect(getVeteranName(formData)).to.equal('the veteran');
+    });
+
+    it('should return custom fallback when provided', () => {
+      const formData = { veteranInformation: { fullName: {} } };
+      expect(getVeteranName(formData, 'custom fallback')).to.equal(
+        'custom fallback',
+      );
+    });
+
+    it('should return fallback when veteranInformation is missing', () => {
+      const formData = {};
+      expect(getVeteranName(formData)).to.equal('the veteran');
+    });
+
+    it('should return fallback when formData is null', () => {
+      expect(getVeteranName(null)).to.equal('the veteran');
+    });
+
+    it('should return fallback when formData is undefined', () => {
+      expect(getVeteranName(undefined)).to.equal('the veteran');
+    });
+
+    it('should return fallback when formData is an array', () => {
+      expect(getVeteranName([])).to.equal('the veteran');
+    });
+
+    it('should return fallback when formData is a string', () => {
+      expect(getVeteranName('invalid')).to.equal('the veteran');
+    });
+
+    it('should handle names with surrounding whitespace', () => {
+      const formData = {
+        veteranInformation: {
+          fullName: { first: '  Anakin  ', last: '  Skywalker  ' },
+        },
+      };
+      expect(getVeteranName(formData)).to.equal('Anakin Skywalker');
+    });
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Content & validation changes to the   21p-530a form statment of truth component
## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/126535

## Testing done

- updated & deleted unit tests 
- tested manually 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |    |
| Desktop |        |    <img width="680" height="553" alt="image" src="https://github.com/user-attachments/assets/9500caba-8d9c-4197-9932-bfe555910297" />|

## What areas of the site does it impact?

21p-530a form statment of truth component
## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- n/a Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
