### PR TITLE
Add error message for no active item pages in array builder

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/containers/App.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/containers/App.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -473,11 +473,15 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
     });
 
     if (activePages.length === 0 && !environment.isProduction()) {
+      const contextInfo = context
+        ? ` Context: ${JSON.stringify(context)}.`
+        : '';
       throw new Error(
-        `Array Builder Error: All item pages were filtered out for arrayPath "${arrayPath}" at index ${index}. ` +
-          `Make sure at least one of your itemPage depends functions returns true for index ${index +
-            1} (next item). ` +
-          `Check your depends conditions to ensure at least one item page is always available.`,
+        `Array Builder Error: All item pages were filtered out for arrayPath "${arrayPath}" at index ${index}.${contextInfo} ` +
+          `This means all of your itemPage depends functions returned false for this item. ` +
+          `At least one itemPage must be available for every item in the array. ` +
+          `Check your depends conditions to ensure at least one itemPage depends always returns true, ` +
+          `or remove the depends condition from at least one itemPage to make it always available.`,
       );
     }
 

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getNextPagePath } from 'platform/forms-system/src/js/routing';
+import environment from 'platform/utilities/environment';
 import {
   createArrayBuilderItemAddPath,
   onNavForwardKeepUrlParams,
@@ -460,7 +461,7 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
     typeof userRequired === 'function' ? userRequired : () => userRequired;
 
   const getActiveItemPages = (formData, index, context = null) => {
-    return itemPages.filter(page => {
+    const activePages = itemPages.filter(page => {
       try {
         if (page.depends) {
           return safeDependsItem(page.depends)(formData, index, context);
@@ -470,6 +471,17 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
         return false;
       }
     });
+
+    if (activePages.length === 0 && !environment.isProduction()) {
+      throw new Error(
+        `Array Builder Error: All item pages were filtered out for arrayPath "${arrayPath}" at index ${index}. ` +
+          `Make sure at least one of your itemPage depends functions returns true for index ${index +
+            1} (next item). ` +
+          `Check your depends conditions to ensure at least one item page is always available.`,
+      );
+    }
+
+    return activePages;
   };
 
   const getFirstItemPagePath = (formData, index, context = null) => {


### PR DESCRIPTION
## Summary

Add helpful error message if all item pages are filtered

Before:
<img width="932" height="528" alt="image" src="https://github.com/user-attachments/assets/d866cf72-da93-403a-9d83-cffaca2b2c1d" />

After:
<img width="927" height="565" alt="image" src="https://github.com/user-attachments/assets/5ac4af3b-7abd-42f8-9673-8fd38d5c883e" />


## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5281

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
