### PR TITLE
Fixes VAOS cypress e2e tests for CC requests

### DIFF
--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
@@ -133,7 +133,6 @@ describe('VAOS direct schedule flow - Optometry', () => {
             .clickNextButton();
 
           ReasonForAppointmentPageObject.assertUrl()
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })
@@ -190,7 +189,6 @@ describe('VAOS direct schedule flow - Optometry', () => {
             .clickNextButton();
 
           ReasonForAppointmentPageObject.assertUrl()
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })
@@ -289,7 +287,6 @@ describe('VAOS direct schedule flow - Optometry', () => {
             .clickNextButton();
 
           ReasonForAppointmentPageObject.assertUrl()
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })
@@ -344,7 +341,6 @@ describe('VAOS direct schedule flow - Optometry', () => {
             .clickNextButton();
 
           ReasonForAppointmentPageObject.assertUrl()
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/home-sleep-testing.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/home-sleep-testing.cypress.spec.js
@@ -140,7 +140,6 @@ describe('VAOS request schedule flow - sleep care', () => {
           .assertHeading({
             name: /What.s the reason for this appointment/i,
           })
-          .selectReasonForAppointment()
           .assertLabel({
             label: /Add any details you.d like to share with your provider/,
           })


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This fixes a few failing VAOS e2e tests that resulted from the changes in a [previously merged PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40588).

## Related issue(s)
N/A

## Testing done
- e2e tests were updated and now are passing

## Screenshots

## What areas of the site does it impact?

VAOS e2e tests for CC requests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

