### PR TITLE
686c conditionally add prefill based on returnUrl

### DIFF
--- a/src/applications/dependents/686c-674/config/prefill-transformer.js
+++ b/src/applications/dependents/686c-674/config/prefill-transformer.js
@@ -11,6 +11,11 @@ export default function prefillTransformer(pages, formData, metadata) {
   } = formData?.nonPrefill || {};
   const contact = formData?.veteranContactInformation || {};
   const address = contact.veteranAddress || {};
+
+  // Check if this is saved in-progress data (has returnUrl) vs fresh prefill data
+  // If user has saved their progress, we should preserve their edits to the address
+  const isSavedInProgressData = !!metadata?.returnUrl;
+
   const isMilitary =
     ['APO', 'FPO', 'DPO'].includes((address?.city || '').toUpperCase()) ||
     false;
@@ -19,6 +24,29 @@ export default function prefillTransformer(pages, formData, metadata) {
     dependents,
     isPrefill: true,
   });
+
+  // Build the veteran address - preserve user edits if this is saved data
+  let veteranAddress;
+  if (isSavedInProgressData && address.country) {
+    // This is saved in-progress data with an existing address
+    // Preserve the user's edits by keeping the existing address structure
+    veteranAddress = {
+      isMilitary,
+      ...address,
+    };
+  } else {
+    // This is fresh prefill data - transform VA Profile format to form format
+    veteranAddress = {
+      isMilitary,
+      country: address.country || address.countryName || 'USA',
+      street: address.street || address.addressLine1 || '',
+      street2: address.street2 || address.addressLine2 || '',
+      street3: address.street3 || address.addressLine3 || '',
+      city: address.city || '',
+      state: address.state || address.stateCode || '',
+      postalCode: address.postalCode || address.zipCode || '',
+    };
+  }
 
   return {
     pages,
@@ -30,16 +58,7 @@ export default function prefillTransformer(pages, formData, metadata) {
         isInReceiptOfPension,
       },
       veteranContactInformation: {
-        veteranAddress: {
-          isMilitary,
-          country: address.country || address.countryName || 'USA',
-          street: address.street || address.addressLine1 || '',
-          street2: address.street2 || address.addressLine2 || '',
-          street3: address.street3 || address.addressLine3 || '',
-          city: address.city || '',
-          state: address.state || address.stateCode || '',
-          postalCode: address.postalCode || address.zipCode || '',
-        },
+        veteranAddress,
         phoneNumber: contact.phoneNumber || null,
         emailAddress: contact.emailAddress || null,
       },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Only uses prefill data in 686c if there is no returnUrl present. Presence of this field indicates the form data has already been saved by the Veteran. In turn, we should not be replacing form data with prefill data.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127290

## Testing done

- Unit tests added
- manual verification

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
