### PR TITLE
126058 add prefill message copy

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/medicationResponses/single-medication-response.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/medicationResponses/single-medication-response.json
@@ -15,7 +15,7 @@
       "orderedDate": "2024-11-07T05:00:00.000Z",
       "quantity": "4",
       "expirationDate": "2025-11-08T05:00:00.000Z",
-      "dispensedDate": null,
+      "dispensedDate": "2024-11-06T05:00:00.000Z",
       "stationNumber": "989",
       "isRefillable": false,
       "isTrackable": false,

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-meds-renewal-request.cypress.spec.js
@@ -81,6 +81,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: 0`,
         `Prescription expiration date: November 8, 2025`,
         `Reason for use: Reason for use not available`,
+        `Last filled on: November 6, 2024`,
         `Quantity: 4`,
       ].join('\n');
 
@@ -161,6 +162,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: 0`,
         `Prescription expiration date: November 8, 2025`,
         `Reason for use: Reason for use not available`,
+        `Last filled on: November 6, 2024`,
         `Quantity: 4`,
       ].join('\n');
 
@@ -224,6 +226,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: `,
         `Prescription expiration date: `,
         `Reason for use: `,
+        `Last filled on: `,
         `Quantity: `,
       ].join('\n');
 
@@ -291,6 +294,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: 0`,
         `Prescription expiration date: November 8, 2025`,
         `Reason for use: Reason for use not available`,
+        `Last filled on: November 6, 2024`,
         `Quantity: 4`,
       ].join('\n');
 
@@ -365,6 +369,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: 0`,
         `Prescription expiration date: November 8, 2025`,
         `Reason for use: Reason for use not available`,
+        `Last filled on: November 6, 2024`,
         `Quantity: 4`,
       ].join('\n');
 
@@ -425,6 +430,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: 0`,
         `Prescription expiration date: November 8, 2025`,
         `Reason for use: Reason for use not available`,
+        `Last filled on: November 6, 2024`,
         `Quantity: 4`,
       ].join('\n');
 
@@ -481,6 +487,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: `,
         `Prescription expiration date: `,
         `Reason for use: `,
+        `Last filled on: `,
         `Quantity: `,
       ].join('\n');
 
@@ -532,6 +539,7 @@ describe('SM Medications Renewal Request', () => {
         `Number of refills left: 0`,
         `Prescription expiration date: November 8, 2025`,
         `Reason for use: Reason for use not available`,
+        `Last filled on: November 6, 2024`,
         `Quantity: 4`,
       ].join('\n');
 

--- a/src/applications/mhv-secure-messaging/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/util/helpers.unit.spec.jsx
@@ -979,6 +979,7 @@ describe('MHV Secure Messaging helpers', () => {
       expirationDate: '2024-12-31',
       reason: 'Refill needed',
       quantity: '30 tablets',
+      dispensedDate: '2023-08-04',
       sig: 'Take one tablet by mouth daily',
     };
 
@@ -992,6 +993,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include('Number of refills left:');
       expect(result).to.include('Prescription expiration date:');
       expect(result).to.include('Reason for use:');
+      expect(result).to.include('Last filled on:');
       expect(result).to.include('Quantity:');
       expect(result).to.not.include('Lisinopril 10mg');
       expect(result).to.not.include('1234567890');
@@ -1001,6 +1003,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.not.include('December 31, 2024');
       expect(result).to.not.include('Refill needed');
       expect(result).to.not.include('30 tablets');
+      expect(result).to.not.include('August 4, 2023');
     });
 
     it('should format message body correctly with valid rx data when rxError is false', () => {
@@ -1018,6 +1021,7 @@ describe('MHV Secure Messaging helpers', () => {
       );
       expect(result).to.include('Reason for use: Refill needed');
       expect(result).to.include('Quantity: 30 tablets');
+      expect(result).to.include('Last filled on: August 4, 2023');
     });
 
     it('should handle missing provider names and show placeholder', () => {
@@ -1132,6 +1136,26 @@ describe('MHV Secure Messaging helpers', () => {
       );
     });
 
+    it('should handle missing dispensed date and show placeholder', () => {
+      const rxWithInvalidDate = {
+        ...mockRx,
+        dispensedDate: null,
+      };
+      const result = buildRxRenewalMessageBody(rxWithInvalidDate, false);
+
+      expect(result).to.include('Last filled on: Date not available');
+    });
+
+    it('should handle empty dispensed date and show placeholder', () => {
+      const rxWithEmptyDate = {
+        ...mockRx,
+        dispensedDate: '',
+      };
+      const result = buildRxRenewalMessageBody(rxWithEmptyDate, false);
+
+      expect(result).to.include('Last filled on: Date not available');
+    });
+
     it('should handle null rx object and show all placeholders', () => {
       const result = buildRxRenewalMessageBody(null, false);
 
@@ -1149,6 +1173,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include(
         'Prescription expiration date: Date not available',
       );
+      expect(result).to.include('Last filled on: Date not available');
       expect(result).to.include('Reason for use: Reason for use not available');
       expect(result).to.include('Quantity: Quantity not available');
     });
@@ -1170,6 +1195,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include(
         'Prescription expiration date: Date not available',
       );
+      expect(result).to.include('Last filled on: Date not available');
       expect(result).to.include('Reason for use: Reason for use not available');
       expect(result).to.include('Quantity: Quantity not available');
     });
@@ -1191,6 +1217,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include(
         'Prescription expiration date: Date not available',
       );
+      expect(result).to.include('Last filled on: Date not available');
       expect(result).to.include('Reason for use: Reason for use not available');
       expect(result).to.include('Quantity: Quantity not available');
     });

--- a/src/applications/mhv-secure-messaging/util/helpers.js
+++ b/src/applications/mhv-secure-messaging/util/helpers.js
@@ -517,10 +517,10 @@ export const buildRxRenewalMessageBody = (rx, rxError) => {
     return 'Number of refills left not available';
   };
 
-  const getExpirationDateValue = () => {
+  const getDateValue = date => {
     if (rxError) return '';
-    if (rx?.expirationDate) {
-      return dateFormat(rx.expirationDate, 'MMMM D, YYYY');
+    if (date) {
+      return dateFormat(date, 'MMMM D, YYYY');
     }
     return 'Date not available';
   };
@@ -537,10 +537,11 @@ export const buildRxRenewalMessageBody = (rx, rxError) => {
     `Instructions: ${rxError ? '' : rx?.sig || 'Instructions not available'}`,
     `Provider who prescribed it: ${getProviderNameValue()}`,
     `Number of refills left: ${getRefillRemainingValue()}`,
-    `Prescription expiration date: ${getExpirationDateValue()}`,
+    `Prescription expiration date: ${getDateValue(rx?.expirationDate)}`,
     `Reason for use: ${
       rxError ? '' : rx?.reason || 'Reason for use not available'
     }`,
+    `Last filled on: ${getDateValue(rx?.dispensedDate)}`,
     `Quantity: ${rxError ? '' : rx?.quantity || 'Quantity not available'}`,
   ].join('\n');
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Add 'Last filled on: ' copy to the rx renewal messaging flow
## Related issue(s)
[126058](https://github.com/department-of-veterans-affairs/va.gov-team/issues/126058)

## Testing done
Tested locally
Specs added

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="746" height="785" alt="Screenshot 2025-12-09 at 2 02 17 PM" src="https://github.com/user-attachments/assets/b7a0efed-c584-4c0f-a450-964f48e5c0ee" /> | <img width="747" height="802" alt="Screenshot 2025-12-09 at 1 53 50 PM" src="https://github.com/user-attachments/assets/72bf038d-e327-46bb-9c09-b0d40f48f1e9" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
A 'Last filled on:' line item is added to the RX renewal message body

### Quality Assurance & Testing
Follow the RX renewal flow for a prescription that has a dispensedDate value

