### PR TITLE
Ask-VA - Eliminated Unauthenticated Education Inquiries

### DIFF
--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -82,6 +82,10 @@ export default function submitTransformer(formData, uploadFiles) {
     schoolCode = formData?.schoolInfo?.schoolFacilityCode || null;
   }
 
+  const requireSignIn = formData?.requireSignInLogic
+    ? Object.values(formData?.requireSignInLogic).some(value => value === true)
+    : false;
+
   return {
     ...formData,
     ...transformAddress(formData),
@@ -94,5 +98,6 @@ export default function submitTransformer(formData, uploadFiles) {
         formData.stateOfTheFacility ||
         formData.stateOrResidency.schoolState,
     },
+    requireSignIn,
   };
 }

--- a/src/applications/ask-va/containers/CategorySelectPage.jsx
+++ b/src/applications/ask-va/containers/CategorySelectPage.jsx
@@ -49,6 +49,10 @@ const CategorySelectPage = props => {
         selectCategory: '',
         allowAttachments: false,
         categoryRequiresSignIn: false,
+        requireSignInLogic: {
+          ...formData.requireSignInLogic,
+          category: false,
+        },
         contactPreferences: null,
       });
       return;
@@ -99,6 +103,16 @@ const CategorySelectPage = props => {
       contactPreferences: selected.attributes.contactPreferences,
       categoryRequiresSignIn:
         selected.attributes.requiresAuthentication && !isLOA3,
+      requireSignInLogic: formData.requireSignInLogic
+        ? {
+            ...formData.requireSignInLogic,
+            category: selected.attributes.requiresAuthentication,
+          }
+        : {
+            category: selected.attributes.requiresAuthentication,
+            topic: false,
+            personQuestionIsAbout: false,
+          },
     });
   };
 

--- a/src/applications/ask-va/containers/TopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/TopicSelectPage.jsx
@@ -49,6 +49,10 @@ const TopicSelectPage = props => {
         selectTopic: '',
         topicId: null,
         topicRequiresSignIn: false,
+        requireSignInLogic: {
+          ...formData.requireSignInLogic,
+          topic: false,
+        },
       });
       return;
     }
@@ -68,6 +72,16 @@ const TopicSelectPage = props => {
       topicId: selected.id,
       topicRequiresSignIn:
         selected.attributes.requiresAuthentication && !isLOA3,
+      requireSignInLogic: formData.requireSignInLogic
+        ? {
+            ...formData.requireSignInLogic,
+            topic: selected.attributes.requiresAuthentication,
+          }
+        : {
+            category: false,
+            topic: selected.attributes.requiresAuthentication,
+            personQuestionIsAbout: false,
+          },
     });
   };
 

--- a/src/applications/ask-va/containers/WhoIsYourQuestionAboutCustomPage.jsx
+++ b/src/applications/ask-va/containers/WhoIsYourQuestionAboutCustomPage.jsx
@@ -39,6 +39,20 @@ const WhoIsYourQuestionAboutCustomPage = props => {
         (selectedValue === whoIsYourQuestionAboutLabels.MYSELF ||
           selectedValue === whoIsYourQuestionAboutLabels.SOMEONE_ELSE) &&
         !isLOA3,
+      requireSignInLogic: formData.requireSignInLogic
+        ? {
+            ...formData.requireSignInLogic,
+            personQuestionIsAbout:
+              selectedValue === whoIsYourQuestionAboutLabels.MYSELF ||
+              selectedValue === whoIsYourQuestionAboutLabels.SOMEONE_ELSE,
+          }
+        : {
+            category: false,
+            topic: false,
+            personQuestionIsAbout:
+              selectedValue === whoIsYourQuestionAboutLabels.MYSELF ||
+              selectedValue === whoIsYourQuestionAboutLabels.SOMEONE_ELSE,
+          },
     });
   };
 
@@ -79,6 +93,7 @@ const WhoIsYourQuestionAboutCustomPage = props => {
 WhoIsYourQuestionAboutCustomPage.propTypes = {
   formData: PropTypes.shape({
     whoIsYourQuestionAbout: PropTypes.string,
+    requireSignInLogic: PropTypes.object,
   }),
   goBack: PropTypes.func,
   goForward: PropTypes.func,

--- a/src/applications/ask-va/tests/config/submit-transformer.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/submit-transformer.unit.spec.jsx
@@ -50,6 +50,7 @@ describe('Ask VA submit transformer', () => {
         SchoolFacilityCode: '333',
         StateAbbreviation: 'AL',
       },
+      requireSignIn: false,
     });
   });
 
@@ -79,6 +80,7 @@ describe('Ask VA submit transformer', () => {
         SchoolFacilityCode: '777',
         StateAbbreviation: 'MI',
       },
+      requireSignIn: false,
     });
   });
 
@@ -108,6 +110,7 @@ describe('Ask VA submit transformer', () => {
         SchoolFacilityCode: null,
         StateAbbreviation: 'NY',
       },
+      requireSignIn: false,
     });
   });
 

--- a/src/applications/ask-va/utils/reviewPageUtils.js
+++ b/src/applications/ask-va/utils/reviewPageUtils.js
@@ -192,7 +192,9 @@ export const handleFormSubmission = async ({
     const transformedData = submitTransformer(formData, files);
 
     const url = `${envUrl}${
-      isLoggedIn && isUserLOA3 ? URL.AUTH_INQUIRIES : URL.INQUIRIES
+      (isLoggedIn && isUserLOA3) || transformedData.requireSignIn
+        ? URL.AUTH_INQUIRIES
+        : URL.INQUIRIES
     }`;
 
     return await submitFormData({


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Eliminate Unauthenticated Education inquiries by tracking if sign in is required throughout the form and enforcing it
- [Replication Steps](https://github.com/department-of-veterans-affairs/ask-va/issues/1872#issuecomment-3494278014)
- The occurence is less than 1% - we need a small piece of logic to direct the app to the authenticated route when we know that its an authenticated request
- AskVA
- No flipper

## Related issue(s)

- _[2034 - Eliminate Unauthenticated Education Inquiry ](https://github.com/department-of-veterans-affairs/ask-va/issues/2034)
- [1872 - Prevent unauth submissions for Education category](https://github.com/department-of-veterans-affairs/ask-va/issues/1872)


## Testing done

- Old behavior - if you are logged in, send to /auth, otherwise send to /
- Implement the ability to track user selections that indicate the need to sign in - tested by iterating through and watching state values change
- Updated unit tests that we failing
- Test three scenarios:  

1. Authenticated inquiry, logged in goes to /auth
2. Unauthenticated inquiry goes to /
3. Authenticated inquiry, not logged in goes to /auth



## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

* Ask VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ x Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_


Copy of pull request https://github.com/department-of-veterans-affairs/vets-website/pull/40461