### PR TITLE
116517 net worth cypress testing

### DIFF
--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
@@ -33,7 +33,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.wait('@mockVaFileNumber');
           cy.injectAxeThenAxeCheck();
-          cy.clickStartForm();
+          cy.get('va-button[data-testid="continue-your-application"]').click();
         });
       },
 
@@ -43,6 +43,7 @@ const testConfig = createTestConfig(
             if (data?.veteranInformation?.isInReceiptOfPension === -1) {
               selectRadioWebComponentAlt('view:checkVeteranPension', 'Y');
             }
+            cy.injectAxeThenAxeCheck();
             cy.clickFormContinue();
           });
         });

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
@@ -23,7 +23,7 @@ const testConfig = createTestConfig(
     dataPrefix: 'data',
     dataSets: ['maximal'],
     fixtures: { data: path.join(__dirname, 'fixtures') },
-    ssetupPerTest: () => {
+    setupPerTest: () => {
       // Pass form start page path
       setupCypress('/add-remove-form-21-686c-674/veteran-information');
     },

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
@@ -4,8 +4,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
-import mockVaFileNumber from './fixtures/va-file-number.json';
-import user from './user.json';
 import {
   fillDateWebComponentPattern,
   fillStandardTextInput,
@@ -14,6 +12,7 @@ import {
   selectRadioWebComponent,
   signAndSubmit,
   selectRadioWebComponentAlt,
+  setupCypress,
 } from './cypress.helpers';
 
 Cypress.config('waitForAnimations', true);
@@ -26,35 +25,7 @@ const testConfig = createTestConfig(
     fixtures: { data: path.join(__dirname, 'fixtures') },
     setupPerTest: () => {
       // Pass form start page path
-      cy.login(user);
-      cy.intercept('GET', '/v0/feature_toggles?*', {
-        data: {
-          type: 'feature_toggles',
-          features: [
-            { name: 'vaDependentsV2', value: true },
-            { name: 'vaDependentsNetWorthAndPension', value: false },
-          ],
-        },
-      });
-      cy.intercept('POST', '/v0/claim_attachments', {
-        data: {
-          attributes: { confirmationCode: '5' },
-        },
-      });
-      cy.intercept(
-        'GET',
-        '/v0/profile/valid_va_file_number',
-        mockVaFileNumber,
-      ).as('mockVaFileNumber');
-      cy.get('@testData').then(testData => {
-        cy.intercept('GET', '/v0/in_progress_forms/686C-674-V2', testData);
-        cy.intercept('PUT', 'v0/in_progress_forms/686C-674-V2', testData);
-      });
-      cy.intercept('POST', '/v0/dependents_applications', {
-        formSubmissionId: '123fake-submission-id-max',
-        timestamp: '2025-01-01',
-        attributes: { guid: '123fake-submission-id-max' },
-      }).as('submitApplication');
+      setupCypress('/add-remove-form-21-686c-674/veteran-information');
     },
 
     pageHooks: {
@@ -62,7 +33,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.wait('@mockVaFileNumber');
           cy.injectAxeThenAxeCheck();
-          cy.clickStartForm();
+          cy.get('va-button[data-testid="continue-your-application"]').click();
         });
       },
 

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
@@ -4,8 +4,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
-import mockVaFileNumber from './fixtures/va-file-number.json';
-import user from './user.json';
 import {
   fillDateWebComponentPattern,
   fillStandardTextInput,
@@ -14,6 +12,7 @@ import {
   selectRadioWebComponent,
   signAndSubmit,
   selectRadioWebComponentAlt,
+  setupCypress,
 } from './cypress.helpers';
 
 Cypress.config('waitForAnimations', true);
@@ -24,36 +23,9 @@ const testConfig = createTestConfig(
     dataPrefix: 'data',
     dataSets: ['maximal'],
     fixtures: { data: path.join(__dirname, 'fixtures') },
-    setupPerTest: () => {
-      cy.login(user);
-      cy.intercept('GET', '/v0/feature_toggles?*', {
-        data: {
-          type: 'feature_toggles',
-          features: [
-            { name: 'vaDependentsV2', value: true },
-            { name: 'vaDependentsNetWorthAndPension', value: false },
-          ],
-        },
-      });
-      cy.intercept('POST', '/v0/claim_attachments', {
-        data: {
-          attributes: { confirmationCode: '5' },
-        },
-      });
-      cy.intercept(
-        'GET',
-        '/v0/profile/valid_va_file_number',
-        mockVaFileNumber,
-      ).as('mockVaFileNumber');
-      cy.get('@testData').then(testData => {
-        cy.intercept('GET', '/v0/in_progress_forms/686C-674-V2', testData);
-        cy.intercept('PUT', 'v0/in_progress_forms/686C-674-V2', testData);
-      });
-      cy.intercept('POST', '/v0/dependents_applications', {
-        formSubmissionId: '123fake-submission-id-max',
-        timestamp: '2025-01-01',
-        attributes: { guid: '123fake-submission-id-max' },
-      }).as('submitApplication');
+    ssetupPerTest: () => {
+      // Pass form start page path
+      setupCypress('/add-remove-form-21-686c-674/veteran-information');
     },
 
     pageHooks: {
@@ -62,6 +34,17 @@ const testConfig = createTestConfig(
           cy.wait('@mockVaFileNumber');
           cy.injectAxeThenAxeCheck();
           cy.clickStartForm();
+        });
+      },
+
+      'check-veteran-pension': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            if (data?.veteranInformation?.isInReceiptOfPension === -1) {
+              selectRadioWebComponentAlt('view:checkVeteranPension', 'Y');
+            }
+            cy.clickFormContinue();
+          });
         });
       },
 

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
@@ -397,7 +397,6 @@
       "birthDate": "1991-01-19"
     }
   ],
-  "statementOfTruthSignature": "Pauline E Foster",
   "statementOfTruthCertified": true,
   "vaDependentsDuplicateModals": true,
   "vaDependentsV3": true

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
@@ -1,5 +1,5 @@
 {
-  "vaDependentsNetWorthAndPension": false,
+  "vaDependentsNetWorthAndPension": true,
   "view:additionalEvidenceDescription": {},
   "spouseSupportingDocuments": [
     {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- 686c-674 maximal cypress test was updated to include net-worth/pension questions

## Related issue(s)

[#118517]https://github.com/department-of-veterans-affairs/va.gov-team/issues/118517

## Testing done

- run `686C-674-maximal.cypress.spec.js` e2e test

## Acceptance criteria

- test passes

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

