### PR TITLE
removes dsl interstitial redirect

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -10,7 +10,6 @@ import {
   FORCE_NEEDED,
   EXTERNAL_APPS,
   EXTERNAL_REDIRECTS,
-  CSP_IDS,
 } from 'platform/user/authentication/constants';
 import { AUTH_LEVEL, getAuthError } from 'platform/user/authentication/errors';
 import { setupProfileSession } from 'platform/user/profile/utilities';
@@ -50,9 +49,6 @@ export default function AuthApp({ location }) {
   const isFeatureToggleLoading = useSelector(
     store => store?.featureToggles?.loading,
   );
-  const isInterstitialEnabled = useSelector(
-    store => store?.featureToggles?.dslogonInterstitialRedirect,
-  );
   const isEmailInterstitialEnabled = useSelector(
     store => store?.featureToggles?.confirmContactEmailInterstitialEnabled,
   );
@@ -81,11 +77,6 @@ export default function AuthApp({ location }) {
   };
 
   const redirect = () => {
-    if (isInterstitialEnabled && CSP_IDS.DS_LOGON === loginType) {
-      window.location.replace('/sign-in-changes-reminder');
-      return;
-    }
-
     // remove from session storage
     sessionStorage.removeItem(AUTHN_SETTINGS.RETURN_URL);
 

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -333,55 +333,6 @@ describe('AuthApp', () => {
     });
   });
 
-  it('should redirect to /sign-in-changes-reminder interstitial page', async () => {
-    const originalLocation = window.location;
-    if (!Location.prototype.replace) {
-      window.location = { replace: sinon.spy() };
-    } else {
-      window.location.replace = sinon.spy();
-    }
-
-    const store = {
-      dispatch: sinon.spy(),
-      subscribe: sinon.spy(),
-      getState: () => ({
-        featureToggles: {
-          dslogonInterstitialRedirect: true,
-        },
-      }),
-    };
-    sessionStorage.setItem('authReturnUrl', 'https://dev.va.gov/my-va');
-    server.use(
-      createGetHandler('https://dev-api.va.gov/v0/user', () => {
-        return jsonResponse(
-          {
-            data: {
-              attributes: {
-                profile: {
-                  signIn: { serviceName: 'dslogon', ssoe: true },
-                },
-              },
-            },
-          },
-          { status: 200 },
-        );
-      }),
-    );
-
-    render(
-      <Provider store={store}>
-        <AuthApp location={{ query: { auth: 'success', type: 'dslogon' } }} />
-      </Provider>,
-    );
-
-    await waitFor(() => expect(window.location.replace.calledOnce).to.be.true);
-    expect(window.location.replace.calledWith('/sign-in-changes-reminder')).to
-      .be.true;
-
-    window.location = originalLocation;
-    sessionStorage.clear();
-  });
-
   it('should redirect to /sign-in-confirm-contact-email interstitial page', async () => {
     const originalLocation = window.location;
     if (!Location.prototype.replace) {

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -76,7 +76,6 @@
   "disabilityCompNewConditionsWorkflow": "disability_compensation_new_conditions_workflow",
   "dischargeWizardFeatures": "discharge_wizard_features",
   "disputeDebt": "dispute_debt",
-  "dslogonInterstitialRedirect": "dslogon_interstitial_redirect",
   "dslogonButtonDisabled": "dslogon_button_disabled",
   "emptyStateBenefitLetters": "empty_state_benefit_letters",
   "enrollmentVerification": "enrollment_verification",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removes DSL CSP interstitial redirect from `AuthApp.jsx` as it is no longer needed after DS Logon credential service provider deprecation

## Related issue(s)

[Issue #152](https://github.com/department-of-veterans-affairs/identity-documentation/issues/152)

## Testing done

- Unit tests for application passing

## What areas of the site does it impact?

[va.gov/sign-in-changes-reminder](va.gov/sign-in-changes-reminder)

## Acceptance criteria

- remove interstitial redirect from `redirect` function located at `srcs/applications/auth/containers/AuthApp.jsx`
- remove `isInterstitialEnabled` declaration 
- update application unit tests where needed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
