### PR TITLE
MHV SM - Correct "move thread" API request #127284

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
+++ b/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams, useHistory } from 'react-router-dom';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui/index';
@@ -23,7 +23,7 @@ const ThreadDetails = props => {
     customFoldersRedesignEnabled,
     largeAttachmentsEnabled,
   } = useFeatureToggles();
-  const { threadId } = useParams();
+  const { threadId: messageId } = useParams();
   const { testing } = props;
   const dispatch = useDispatch();
   const location = useLocation();
@@ -37,6 +37,7 @@ const ThreadDetails = props => {
   const { folder } = useSelector(state => state.sm.folders);
 
   const message = messages?.length && messages[0];
+  const threadId = message?.threadId;
   const [isCreateNewModalVisible, setIsCreateNewModalVisible] = useState(false);
   const [isLoaded, setIsLoaded] = useState(testing);
   const [isEditing, setIsEditing] = useState(false);
@@ -70,22 +71,29 @@ const ThreadDetails = props => {
     [drafts, dispatch, folder, threadFolderId],
   );
 
+  const handleRedirectToFolder = useCallback(
+    () => {
+      navigateToFolderByFolderId(folder?.folderId || 0, history);
+    },
+    [folder, history],
+  );
+
   useEffect(
     () => {
-      if (threadId) {
-        dispatch(retrieveMessageThread(threadId))
+      if (messageId) {
+        dispatch(retrieveMessageThread(messageId))
           .then(() => {
             setIsLoaded(true);
           })
           .catch(() => {
-            navigateToFolderByFolderId(folder?.folderId || 0, history);
+            handleRedirectToFolder();
           });
       }
       return () => {
         dispatch(closeAlert());
       };
     },
-    [dispatch, threadId, location.pathname],
+    [dispatch, messageId, location.pathname, handleRedirectToFolder],
   );
 
   useEffect(

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
@@ -52,7 +52,7 @@ describe('SM THREAD SINGLE MESSAGE DETAILED VIEW', () => {
     ]);
 
     it('moves folders with ease', () => {
-      cy.intercept('**/v1/messaging/threads/2666253/move?folder_id=*', {
+      cy.intercept('**/v1/messaging/threads/7176615/move?folder_id=*', {
         statusCode: 200,
       }).as('mockMoveThread');
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request corrects how thread IDs are handled in the `ThreadDetails` component and improves code maintainability by introducing a dedicated redirect handler. Additionally, it updates a test to use a new thread ID. The most important changes are grouped below by theme:

**Refactoring and Code Maintainability:**

* Renamed the variable from `threadId` to `messageId` when extracting from `useParams`, and now derives the actual `threadId` from the first message in the thread for improved clarity and separation of concerns. (`src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx`) [[1]](diffhunk://#diff-eedb5e84f8932086accd89dd50a7ae3e42f5e6be939985aec5c4aa8fb6ab9f20L26-R26) [[2]](diffhunk://#diff-eedb5e84f8932086accd89dd50a7ae3e42f5e6be939985aec5c4aa8fb6ab9f20R40)
* Added a `handleRedirectToFolder` callback to encapsulate folder redirection logic, replacing inline calls for better readability and reusability. (`src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx`)
* Updated the main `useEffect` to use `messageId` for thread retrieval and utilize the new redirect handler on error, ensuring consistent navigation flow. (`src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx`)

**Testing Updates:**

* Changed the intercepted thread ID in the Cypress test from `2666253` to `7176615` to match the new thread ID logic and keep tests in sync with code changes. (`src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js`)

**General Improvements:**

* Added `useCallback` to the imports in `ThreadDetails.jsx` to support the new callback logic. (`src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127284
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118116

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
