### PR TITLE
add missing space to component and unit test

### DIFF
--- a/src/applications/dependents/686c-674/components/picklist/stepchildFinancialSupportExit.jsx
+++ b/src/applications/dependents/686c-674/components/picklist/stepchildFinancialSupportExit.jsx
@@ -42,7 +42,7 @@ const stepchildFinancialSupportExit = {
       <p>
         Because you provide at least half of
         <span className="dd-privacy-mask" data-dd-action-name="first name">
-          {makeNamePossessive(firstName)}
+          {` ${makeNamePossessive(firstName)}`}
         </span>{' '}
         financial support, {firstName} is an eligible dependent.
       </p>

--- a/src/applications/dependents/686c-674/tests/components/picklist/stepchildFinancialSupportExit.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/components/picklist/stepchildFinancialSupportExit.unit.spec.jsx
@@ -71,7 +71,7 @@ describe('stepchildFinancialSupportExit', () => {
 
     expect(paragraphs.length).to.be.at.least(2);
     expect(paragraphs[0].textContent).to.include(
-      'Because you provide at least half ofNAOMI',
+      'Because you provide at least half of NAOMI',
     );
     expect(paragraphs[0].textContent).to.include('is an eligible dependent');
     expect(paragraphs[1].textContent).to.include(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add missing space to copy on stepchild financial support exit page
- Add missing space to assoc unit test

## Related issue(s)

[686c/674 | DMT: Fix missing space on stepchild financial support exit page](https://github.com/department-of-veterans-affairs/va.gov-team/issues/127386)

## Testing done

- run tests for `dependents/686c-674`


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
