### PR TITLE
fix: add checks write permission to testing report jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -948,6 +948,7 @@ jobs:
     timeout-minutes: 120
     needs: [build, tests-prep]
     permissions:
+      checks: write
       id-token: write
       contents: read
     if: |
@@ -1224,6 +1225,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [testing-reports-prep, unit-tests]
     permissions:
+      checks: write
       id-token: write
       contents: read
     if: needs.unit-tests.outputs.tests_ran == 'true'
@@ -1336,6 +1338,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [testing-reports-prep, unit-tests-stress-test]
     permissions:
+      checks: write
       id-token: write
       contents: read
     if: ${{ always() && (needs.unit-tests-stress-test.result == 'success' || needs.unit-tests-stress-test.result == 'failure')}}
@@ -1431,6 +1434,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [testing-reports-prep, unit-tests]
     permissions:
+      checks: write
       id-token: write
       contents: read
     if: needs.unit-tests.outputs.tests_ran == 'true'
@@ -1545,6 +1549,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [testing-reports-prep, tests-prep, cypress-tests]
     permissions:
+      checks: write
       id-token: write
       contents: read
     if: ${{ always() && needs.tests-prep.outputs.tests != '[]' && needs.tests-prep.outputs.cypress-tests != '' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
@@ -1654,6 +1659,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [testing-reports-prep, tests-prep, stress-test-cypress-tests]
     permissions:
+      checks: write
       id-token: write
       contents: read
     if: ${{ always() && (needs.stress-test-cypress-tests.result == 'success' || needs.stresss-test-cypress-tests.result == 'failure') }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -948,7 +948,6 @@ jobs:
     timeout-minutes: 120
     needs: [build, tests-prep]
     permissions:
-      checks: write
       id-token: write
       contents: read
     if: |


### PR DESCRIPTION
## Summary

This PR fixes the \"Resource not accessible by integration\" errors occurring in CI workflow publishing steps (Publish Cypress test results, Unit test results, etc.).

## Problem

Five jobs in the continuous-integration workflow were failing with the error:
```
Error: Resource not accessible by integration
```

These jobs use the `LouisBrunner/checks-action` to publish test results as GitHub check runs. The action requires `checks: write` permission to create check runs, but the jobs only had `id-token: write` and `contents: read` permissions configured.

### Affected Jobs:
- `testing-reports-unit-tests`
- `testing-reports-unit-tests-stress-test`
- `testing-reports-unit-tests-coverage`
- `testing-reports-cypress`
- `testing-reports-cypress-stress-test`

## Solution

Added `checks: write` permission to the permissions block for all 5 affected jobs.

**Before:**
```yaml
permissions:
  id-token: write
  contents: read
```

**After:**
```yaml
permissions:
  checks: write
  id-token: write
  contents: read
```

## Testing

CI will run on this PR and verify that the publishing steps no longer fail with permission errors.

## Impact

- Test result publishing will work correctly
- Check runs will appear in PRs showing test summaries
- No breaking changes to existing functionality