### PR TITLE
correctly associate lengend with radio buttons

### DIFF
--- a/src/applications/simple-forms/21P-601/pages/hasAlreadyFiled.js
+++ b/src/applications/simple-forms/21P-601/pages/hasAlreadyFiled.js
@@ -7,27 +7,27 @@ import {
 
 export default {
   uiSchema: {
-    ...titleUI('Survivors benefits applications'),
-    'ui:description': (
-      <>
-        <p>
-          If you've filled out either of these applications, you don't need to
-          fill out this form:
-        </p>
-        <ul>
-          <li>
-            Application for DIC, Survivors Pension, and/or Accrued Benefits (VA
-            Form 534EZ)
-          </li>
-          <li>
-            Application for Dependency and Indemnity Compensation by Parent(s)
-            (VA Form 21P-535)
-          </li>
-        </ul>
-      </>
-    ),
+    ...titleUI('Previous applications'),
     hasAlreadyFiled: yesNoUI({
       title: 'Have you filled out either of these applications?',
+      description: (
+        <>
+          <p>
+            If you've filled out either of these applications, you don't need to
+            fill out this form:
+          </p>
+          <ul>
+            <li>
+              Application for DIC, Survivors Pension, and/or Accrued Benefits
+              (VA Form 534EZ)
+            </li>
+            <li>
+              Application for Dependency and Indemnity Compensation by Parent(s)
+              (VA Form 21P-535)
+            </li>
+          </ul>
+        </>
+      ),
     }),
   },
   schema: {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Radio Button Label Fix: Proper Association of Question and Description for Screen Readers**

Moved the description text from page-level `ui:description` into the `yesNoUI` object's `description` property to ensure proper association with the radio buttons via `aria-describedby`. Previously, when screen readers focused on the Yes/No radio buttons, they would only announce "Yes, radio button not checked, Survivors benefits application" without the actual question "Have you filled out either of these applications?" being announced. The description text explaining which forms were relevant was also not associated with the form controls.

**Changes Made:**
- Moved description from page-level `ui:description` to `yesNoUI` object's `description` property in `hasAlreadyFiled.js`
- Fixed `titleUI` text from "Survivors benefits applications" to "Previous applications" to match form config

## How to Reproduce (Bug)

1. Turn on a screen reader (JAWS on Windows or VoiceOver on iOS)
2. Navigate to the "Check your eligibility" step, page 1 ("Survivor benefits application")
3. Tab (or swipe on mobile) until focus is on the "Yes" radio button input
4. Observe that the screen reader announces: "Yes, radio button not checked, Survivors benefits application"
5. Notice that the question "Have you filled out either of these applications?" is NOT announced
6. Notice that the description text explaining which forms are relevant is NOT announced

**Affected Pages:**
- `/already-filed` (Previous applications / Survivor benefits application)

**Issue Severity:**
- Expected WCAG failure: 1.3.1 Info and Relationships and/or 3.3.2 Labels or Instructions
- Expected 508 audit severity: Critical
- Expected CC severity level: a11y-defect-2 (Labels or calls to action must be descriptive to assistive devices)
- Expected experience standard: User can complete necessary flows

## Solution and Why

**Solution:** Moved the description content from page-level `ui:description` into the `yesNoUI` object's `description` property, ensuring the question and explanatory text are properly associated with the radio buttons via `aria-describedby`.

**Why This Solution:**
1. **Proper ARIA Association:** The `description` property in `yesNoUI` creates proper `aria-describedby` relationships, ensuring screen readers announce both the question and the description when focusing on the form controls
2. **WCAG Compliance:** Addresses WCAG 1.3.1 (Info and Relationships) by ensuring form controls have associated labels and descriptions
3. **WCAG 3.3.2 Compliance:** Addresses Labels or Instructions by ensuring users receive clear instructions about what information is needed
4. **Screen Reader Experience:** Users now hear the complete context: the question, the description, and the form options, making it clear what they're being asked
5. **Follows VADS Pattern:** Aligns with the recommended VADS radio button component pattern using description message with `message-aria-describedby` slot

**Technical Approach:**
- Removed page-level `ui:description` which was not associated with form controls
- Added `description` property to `yesNoUI` object, which properly associates the text with the radio buttons
- The `yesNoUI` helper function handles the `aria-describedby` association automatically when `description` is provided
- Fixed `titleUI` text to match the form configuration for consistency

