### PR TITLE
Add cypress install to postinstall

### DIFF
--- a/script/run-postinstall.sh
+++ b/script/run-postinstall.sh
@@ -21,4 +21,9 @@ cd node_modules/abort-controller-es5 && yarn run postinstall && cd ../..
 echo "→ Running postinstall for markdown-it-attrs-es5..."
 cd node_modules/markdown-it-attrs-es5 && yarn run postinstall && cd ../..
 
+if ! npx cypress verify &>/dev/null; then
+  echo "→ Installing Cypress binary..."
+  npx cypress install
+fi
+
 echo "✓ Postinstall scripts completed successfully"


### PR DESCRIPTION
## Summary

- Add cypress to postinstall as I believe this was done automatically by cypress before we disabled scripts

[Current cypress version in package.json](https://github.com/department-of-veterans-affairs/vets-website/blob/045fda53a112a15463b693ee4903960a9edd71fc/package.json#L177)
<img width="421" height="154" alt="image" src="https://github.com/user-attachments/assets/06b74575-a491-4aba-a055-35f85836d408" />

This previously happened automatically on `yarn install` due to cypress's built-in postinstall hook [package.json](https://www.npmjs.com/package/cypress/v/13.15.0?activeTab=code)
<img width="678" height="517" alt="image" src="https://github.com/user-attachments/assets/065c5831-94f6-4acc-85d2-d24c03d4d271" />


## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5311

## Testing done

- Test `yarn install-safe`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
