### PR TITLE
10-10EZR: Add validation for Spouse values

### DIFF
--- a/src/applications/ezr/definitions/spousePersonalInformation.js
+++ b/src/applications/ezr/definitions/spousePersonalInformation.js
@@ -7,6 +7,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { validateMarriageDate } from '../utils/validation';
 import content from '../locales/en/content.json';
 
 const { spouseFullName } = ezrSchema.properties;
@@ -25,9 +26,10 @@ const spousePersonalInformationPage = (options = {}) => ({
     spouseDateOfBirth: currentOrPastDateUI(
       content['household-spouse-dob-label'],
     ),
-    dateOfMarriage: currentOrPastDateUI(
-      content['household-spouse-marriage-date-label'],
-    ),
+    dateOfMarriage: {
+      ...currentOrPastDateUI(content['household-spouse-marriage-date-label']),
+      'ui:validations': [validateMarriageDate],
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/ezr/locales/en/content.json
+++ b/src/applications/ezr/locales/en/content.json
@@ -297,6 +297,7 @@
   "validation-error-message-generic":"Please provide a response",
   "validation-insurance-group-code": "Group code (either this or the policy number is required)",
   "validation-insurance-policy-number": "Policy number (either this or the group code is required)",
+  "validation-marriage-date": "Date of marriage must be after spouse’s date of birth",
   "validation-medicare-claim-number": "Please enter a valid 11-character Medicare claim number",
   "validation-required-label": "(*Required)",
   "vet-address-match-title": "Is your home address the same as your mailing address?",

--- a/src/applications/ezr/tests/e2e/fixtures/mocks/mock-prefill-with-non-prefill-data.json
+++ b/src/applications/ezr/tests/e2e/fixtures/mocks/mock-prefill-with-non-prefill-data.json
@@ -45,6 +45,7 @@
     "dateOfMarriage": "1995-02-22",
     "cohabitedLastYear": true,
     "sameAddress": true,
+    "maritalStatus": "Married",
     "nonPrefill": {
       "previousFinancialInfo": {
         "veteranFinancialInfo": {

--- a/src/applications/ezr/tests/unit/utils/helpers/spouseUtils.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/helpers/spouseUtils.unit.spec.jsx
@@ -141,71 +141,19 @@ describe('spouseUtils', () => {
         context('Required fields present but not valid', () => {
           [
             {
-              desc: 'spouseFullName.first is too long',
-              item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  first: '12345678901234567890123456',
-                },
-              }),
+              desc: 'spouseDateOfBirth is before 1900',
+              item: makeItem({ spouseDateOfBirth: '1899-01-01' }),
             },
             {
-              desc: 'spouseFullName.first fails the pattern check',
-              item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  first: ' ',
-                },
-              }),
+              desc: 'dateOfMarriage is before 1900',
+              item: makeItem({ dateOfMarriage: '1899-01-01' }),
             },
             {
-              desc: 'spouseFullName.middle is too long',
+              desc: 'dateOfMarriage is before spouseDateOfBirth',
               item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  middle: '1234567890123456789012345678901',
-                },
+                spouseDateOfBirth: '2010-06-15',
+                dateOfMarriage: '1980-01-01',
               }),
-            },
-            {
-              desc: 'spouseFullName.last is too short',
-              item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  last: '1',
-                },
-              }),
-            },
-            {
-              desc: 'spouseFullName.last is too long',
-              item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  last: '123456789012345678901234567890123456',
-                },
-              }),
-            },
-            {
-              desc: 'spouseFullName.last fails the pattern check',
-              item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  last: '  ',
-                },
-              }),
-            },
-            {
-              desc: 'spouseFullName.suffix is invalid',
-              item: makeItem({
-                spouseFullName: {
-                  ...VALID.spouseFullName,
-                  suffix: 'foo',
-                },
-              }),
-            },
-            {
-              desc: 'spouseSocialSecurityNumber is invalid',
-              item: makeItem({ spouseSocialSecurityNumber: 'foo' }),
             },
           ].forEach(({ desc, item }) => {
             it(`should return true when ${desc}`, () => {

--- a/src/applications/ezr/tests/unit/utils/helpers/spouseUtils.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/helpers/spouseUtils.unit.spec.jsx
@@ -63,6 +63,15 @@ describe('spouseUtils', () => {
                 provideSupportLastYear: undefined,
               }),
             },
+            {
+              desc: 'valid suffix value present',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  suffix: 'Jr.',
+                },
+              }),
+            },
           ].forEach(({ desc, item }) => {
             it(`should return false when ${desc}`, () => {
               expect(isItemIncomplete(item)).to.be.false;
@@ -121,6 +130,82 @@ describe('spouseUtils', () => {
                   last: undefined,
                 },
               }),
+            },
+          ].forEach(({ desc, item }) => {
+            it(`should return true when ${desc}`, () => {
+              expect(isItemIncomplete(item)).to.be.true;
+            });
+          });
+        });
+
+        context('Required fields present but not valid', () => {
+          [
+            {
+              desc: 'spouseFullName.first is too long',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  first: '12345678901234567890123456',
+                },
+              }),
+            },
+            {
+              desc: 'spouseFullName.first fails the pattern check',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  first: ' ',
+                },
+              }),
+            },
+            {
+              desc: 'spouseFullName.middle is too long',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  middle: '1234567890123456789012345678901',
+                },
+              }),
+            },
+            {
+              desc: 'spouseFullName.last is too short',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  last: '1',
+                },
+              }),
+            },
+            {
+              desc: 'spouseFullName.last is too long',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  last: '123456789012345678901234567890123456',
+                },
+              }),
+            },
+            {
+              desc: 'spouseFullName.last fails the pattern check',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  last: '  ',
+                },
+              }),
+            },
+            {
+              desc: 'spouseFullName.suffix is invalid',
+              item: makeItem({
+                spouseFullName: {
+                  ...VALID.spouseFullName,
+                  suffix: 'foo',
+                },
+              }),
+            },
+            {
+              desc: 'spouseSocialSecurityNumber is invalid',
+              item: makeItem({ spouseSocialSecurityNumber: 'foo' }),
             },
           ].forEach(({ desc, item }) => {
             it(`should return true when ${desc}`, () => {

--- a/src/applications/ezr/tests/unit/utils/validation.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/validation.unit.spec.jsx
@@ -8,6 +8,7 @@ import {
   validateAgentOrangeExposureDates,
   validateExposureDates,
   validatePolicyNumberGroupCode,
+  validateMarriageDate,
 } from '../../../utils/validation';
 
 describe('ezr validation utils', () => {
@@ -31,6 +32,32 @@ describe('ezr validation utils', () => {
         };
         validateDependentDate(errors, '2010-01-01', {
           dateOfBirth: '2011-01-01',
+        });
+        expect(errors.addError.called).to.be.true;
+      });
+    });
+  });
+
+  context('when `validateMarriageDate` executes', () => {
+    context('when form data is valid', () => {
+      it('should not set error message', () => {
+        const errors = {
+          addError: sinon.spy(),
+        };
+        validateMarriageDate(errors, '2010-01-01', {
+          spouseDateOfBirth: '2009-12-31',
+        });
+        expect(errors.addError.called).to.be.false;
+      });
+    });
+
+    context('when birth date is after marriage date', () => {
+      it('should set error message', () => {
+        const errors = {
+          addError: sinon.spy(),
+        };
+        validateMarriageDate(errors, '2010-01-01', {
+          spouseDateOfBirth: '2011-01-01',
         });
         expect(errors.addError.called).to.be.true;
       });

--- a/src/applications/ezr/utils/validation.js
+++ b/src/applications/ezr/utils/validation.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { isEqual } from 'lodash';
 import {
   convertToDateField,
@@ -23,18 +22,35 @@ export function validateCurrency(errors, fieldData) {
 }
 
 /**
- * Validate input data to ensure dependent data is on or after the dependents
+ * Validate input data to ensure dependent date is on or after the dependent's
  * date of birth
  * @param {Object} - errors - the error handling object from the forms system
  * @param {String} - fieldData - the value from the text input field
  * @param {Object} - formData - the entire form data object
  */
 export function validateDependentDate(errors, fieldData, { dateOfBirth }) {
-  const dependentDate = moment(fieldData);
-  const birthDate = moment(dateOfBirth);
+  const dependentDate = new Date(fieldData);
+  const birthDate = new Date(dateOfBirth);
 
-  if (birthDate.isAfter(dependentDate)) {
+  if (birthDate > dependentDate) {
     errors.addError(content['validation-dependent-date']);
+  }
+  validateCurrentOrPastDate(errors, fieldData);
+}
+
+/**
+ * Validate input data to ensure date of marriage is on or after the spouse's
+ * date of birth
+ * @param {Object} - errors - the error handling object from the forms system
+ * @param {String} - fieldData - the value from the text input field
+ * @param {Object} - formData - the entire form data object
+ */
+export function validateMarriageDate(errors, fieldData, { spouseDateOfBirth }) {
+  const dateOfMarriage = new Date(fieldData);
+  const birthDate = new Date(spouseDateOfBirth);
+
+  if (birthDate > dateOfMarriage) {
+    errors.addError(content['validation-marriage-date']);
   }
   validateCurrentOrPastDate(errors, fieldData);
 }


### PR DESCRIPTION
## Summary
- Tech Debt cleanup: add value validation to Spouse `isItemIncomplete` functionality
- Health Applications 10-10

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124791

## Testing done

- Confirmed locally that the form is still submittable with valid values

## What areas of the site does it impact?
- EZR form

## Acceptance criteria
- EZR form only accepts valid values

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
