### PR TITLE
RES-18737 Added help section to VRE pages

### DIFF
--- a/src/applications/vre/ch31-eligibility-entitlement/components/NeedHelp.jsx
+++ b/src/applications/vre/ch31-eligibility-entitlement/components/NeedHelp.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 const NeedHelp = () => (
-  <va-need-help class="vads-u-margin-top--8">
+  <va-need-help class="vads-u-margin-y--4">
     <div slot="content">
       <p>
         Call us at the VA benefits hotline{' '}

--- a/src/applications/vre/ch31-eligibility-entitlement/containers/CareerExplorationAndPlanning.jsx
+++ b/src/applications/vre/ch31-eligibility-entitlement/containers/CareerExplorationAndPlanning.jsx
@@ -3,6 +3,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import AssessYourInterestsSection from '../components/AssessYourInterestsSection';
 import FindAPathSection from '../components/FindAPathSection';
 import FindAJobSection from '../components/FindAJobSection';
+import NeedHelp from '../components/NeedHelp';
 
 export default function CareerExplorationAndPlanning() {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
@@ -39,34 +40,7 @@ export default function CareerExplorationAndPlanning() {
           <FindAJobSection />
         </va-card>
 
-        <va-need-help class="vads-u-margin-top--4">
-          <div slot="content">
-            <p>
-              Do you have more questions or need more information? Reach out to
-              your VR&E RO Counselor or Officer:
-            </p>
-            <p className="va-address-block vads-u-margin-left--0">
-              U.S. Department of Veterans Affairs
-              <br />
-              Medical Office
-              <br />
-              PO Box 11930
-              <br />
-              St. Paul, MN 55111
-              <br />
-              United States of America
-              <br />
-            </p>
-            <p>
-              Phone number title:&nbsp;
-              <va-telephone contact="8773459876" />
-            </p>
-            <p>
-              Monday through Friday, 8:00 a.m to 9:00 p.m ET. If you have
-              hearing loss, call <va-telephone contact="711" tty />.
-            </p>
-          </div>
-        </va-need-help>
+        <NeedHelp />
 
         <va-back-to-top />
       </article>

--- a/src/applications/vre/ch31-eligibility-entitlement/containers/MyCaseManagementHub.jsx
+++ b/src/applications/vre/ch31-eligibility-entitlement/containers/MyCaseManagementHub.jsx
@@ -4,6 +4,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { fetchCh31CaseStatusDetails } from '../actions/ch31-my-eligibility-and-benefits';
 import HubCardList from '../components/HubCardList';
 import ApplicationDiscontinuedAlert from '../components/ApplicationDiscontinuedAlert';
+import NeedHelp from '../components/NeedHelp';
 
 const stepLabels = [
   'Application Received',
@@ -187,6 +188,10 @@ const MyCaseManagementHub = () => {
         </div>
 
         <HubCardList step={current} />
+
+        <div className="usa-width-two-thirds">
+          <NeedHelp />
+        </div>
       </div>
     </div>
   );

--- a/src/applications/vre/ch31-eligibility-entitlement/containers/OrientationToolsAndResources.jsx
+++ b/src/applications/vre/ch31-eligibility-entitlement/containers/OrientationToolsAndResources.jsx
@@ -3,6 +3,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import WatchVideoView from '../components/WatchVideoView';
 import SelectPreferenceView from '../components/SelectPreferenceView';
 import ScheduleMeetingView from '../components/ScheduleMeetingView';
+import NeedHelp from '../components/NeedHelp';
 
 const ORIENTATION_TYPE = {
   SCHEDULE_MEETING: 'Schedule a meeting with my local RO',
@@ -122,7 +123,9 @@ export default function OrientationToolsAndResources() {
           )}
         </va-card>
 
-        <div className="vads-u-margin-top--4 medium-screen:vads-u-display--inline-block vads-u-display--none">
+        <NeedHelp />
+
+        <div className="medium-screen:vads-u-display--inline-block vads-u-display--none">
           <va-button back onClick={() => {}} text="Back to Case Tracker" />
         </div>
       </article>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Added the 'Need Help' section to the bottom of the various VRE pages

## Related issue(s)

https://jira.devops.va.gov/browse/RES-18737

## Testing done

Visit the various VRE pages and make sure that the 'Need Help' section is visible at the bottom of each

## Screenshots

<img width="1110" height="663" alt="pr-1" src="https://github.com/user-attachments/assets/b26b3d68-7aa8-44eb-b557-c9f7c15a1604" />
<img width="1086" height="781" alt="pr-2" src="https://github.com/user-attachments/assets/d66afdf9-845a-433f-84de-061b668198c7" />


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

VR&E Eligibility Application

## Acceptance criteria

Need Help section is visible at the bottom of the various VRE pages

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
