### PR TITLE
Add filter exception for sr only alerts for tests

### DIFF
--- a/src/platform/forms-system/test/pageTestHelpers.spec.jsx
+++ b/src/platform/forms-system/test/pageTestHelpers.spec.jsx
@@ -87,7 +87,16 @@ export const testNumberOfErrorsOnSubmit = (
       await new Promise(resolve => setTimeout(resolve, 0));
 
       await waitFor(() => {
-        const errors = queryAllByRole('alert');
+        const alerts = queryAllByRole('alert');
+
+        // Filter out screen reader announcements (sr-only with aria-live="polite")
+        const errors = alerts.filter(
+          alert =>
+            !(
+              alert.classList.contains('sr-only') &&
+              alert.getAttribute('aria-live') === 'polite'
+            ),
+        );
         expect(errors).to.have.lengthOf(expectedNumberOfErrors);
       });
     });


### PR DESCRIPTION
## Summary

- Add filter exception for sr only alerts for tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/40398

## Testing done

- Unit tests pass

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
