### PR TITLE
[#127511] Travel Pay, isCC /file-new-claim exclusion

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -130,12 +130,15 @@ const IntroductionPage = () => {
                 />{' '}
                 to file your claim.
               </p>
-              <va-link-action
-                onClick={createClaim}
-                href="#"
-                text="Start your travel reimbursement claim"
-                type="primary"
-              />
+              {appointment &&
+                !appointment.isCC && (
+                  <va-link-action
+                    onClick={createClaim}
+                    href="#"
+                    text="Start your travel reimbursement claim"
+                    type="primary"
+                  />
+                )}
             </va-process-list-item>
           </va-process-list>
         </div>

--- a/src/applications/travel-pay/components/submit-flow/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/submit-flow/pages/IntroductionPage.jsx
@@ -56,7 +56,8 @@ const IntroductionPage = ({ onStart }) => {
             </p>
             {data &&
               !data.travelPayClaim?.claim &&
-              data.isPast && (
+              data.isPast &&
+              !data.isCC && (
                 <va-link-action
                   onClick={e => onStart(e)}
                   href="javascript0:void"

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
@@ -270,6 +270,74 @@ describe('Travel Pay – IntroductionPage', () => {
     expect(getByTestId('introduction-page')).to.exist;
   });
 
+  it('hides the start button when appointment is community care (isCC)', () => {
+    const stateWithCCAppointment = {
+      ...getData(),
+      travelPay: {
+        ...getData().travelPay,
+        appointment: {
+          ...getData().travelPay.appointment,
+          data: {
+            id: '12345',
+            facilityName: 'Test Facility',
+            isCC: true,
+          },
+        },
+      },
+    };
+
+    const { container } = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <IntroductionPage />
+      </MemoryRouter>,
+      {
+        initialState: stateWithCCAppointment,
+        reducers: reducer,
+      },
+    );
+
+    // Verify the start button does not exist
+    const startButton = $(
+      'va-link-action[text="Start your travel reimbursement claim"]',
+      container,
+    );
+    expect(startButton).to.not.exist;
+  });
+
+  it('shows the start button when appointment is not community care', () => {
+    const stateWithNonCCAppointment = {
+      ...getData(),
+      travelPay: {
+        ...getData().travelPay,
+        appointment: {
+          ...getData().travelPay.appointment,
+          data: {
+            id: '12345',
+            facilityName: 'Test Facility',
+            isCC: false,
+          },
+        },
+      },
+    };
+
+    const { container } = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <IntroductionPage />
+      </MemoryRouter>,
+      {
+        initialState: stateWithNonCCAppointment,
+        reducers: reducer,
+      },
+    );
+
+    // Verify the start button exists
+    const startButton = $(
+      'va-link-action[text="Start your travel reimbursement claim"]',
+      container,
+    );
+    expect(startButton).to.exist;
+  });
+
   it('navigates using appointment claim ID when complexClaim data is null', async () => {
     // Set up state with claim ID on appointment but null complexClaim data
     const stateWithAppointmentClaim = {

--- a/src/applications/travel-pay/tests/components/submit-flow/pages/IntroductionPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/submit-flow/pages/IntroductionPage.unit.spec.jsx
@@ -262,4 +262,35 @@ describe('Introduction page', () => {
 
     expect($('va-link-action[text="Start a mileage-only claim"]')).to.not.exist;
   });
+
+  it('should hide entry point if appointment is community care (isCC)', () => {
+    MockDate.set('2025-01-05');
+    renderWithStoreAndRouter(<IntroductionPage {...props} />, {
+      initialState: {
+        scheduledDowntime: {
+          globalDowntime: null,
+          isReady: true,
+          isPending: false,
+          serviceMap: { get() {} },
+          dismissedDowntimeWarnings: [],
+        },
+        travelPay: {
+          appointment: {
+            isLoading: true,
+            error: null,
+            data: {
+              ...mockAppt,
+              isPast: true,
+              daysSinceAppt: 6,
+              isOutOfBounds: false,
+              isCC: true,
+            },
+          },
+        },
+      },
+      reducers: reducer,
+    });
+
+    expect($('va-link-action[text="Start a mileage-only claim"]')).to.not.exist;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

# Summary

- Hide "Start a mileage-only claim" and "Start your travel reimbursement claim" buttons when appointment is community care (`isCC: true`)
- Community care appointments are not eligible for online travel pay claim filing through this application
- Travel Pay team maintains this component

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127511

## Testing done

- **Old behavior**: Both mileage-only and complex claim start buttons displayed for all eligible appointments, including community care appointments
- **New behavior**: Start buttons are hidden when `appointment.isCC` is `true`
- **Verification steps**:
  1. Load introduction page with a community care appointment (`isCC: true`)
  2. Verify "Start a mileage-only claim" button does not appear (submit flow)
  3. Verify "Start your travel reimbursement claim" button does not appear (complex claims)
  4. Load introduction page with a non-CC appointment (`isCC: false`)
  5. Verify buttons appear as expected
- **Tests completed**: 
  - Added unit test: "should hide entry point if appointment is community care (isCC)" for submit-flow
  - Added unit tests: "hides the start button when appointment is community care (isCC)" and "shows the start button when appointment is not community care" for complex-claims
  - All existing and new unit tests passing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="750" height="3692" alt="before_mobile" src="https://github.com/user-attachments/assets/dec6a474-e8c5-44ce-a2fe-0ac73e6e3d09" /> | <img width="750" height="3518" alt="after_mobile" src="https://github.com/user-attachments/assets/cfdf1403-234d-4a70-93ed-4b771f8cde32" /> |
| Desktop | <img width="2378" height="2837" alt="before_desktop" src="https://github.com/user-attachments/assets/2f96bfae-151b-4ca6-b6c6-e3bc4954a8bb" /> | <img width="2378" height="2714" alt="after_desktop" src="https://github.com/user-attachments/assets/920f26e3-242e-427a-aa80-9925916d5071" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (not necessary - internal logic change)
- [x] Screenshot of the developed feature is added (not applicable - conditional hiding only)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (not applicable - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution (not applicable)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (not applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user