### PR TITLE
Standardize file card text labels and structure across claim files components

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -159,6 +159,10 @@ const FilesWeCouldntReceive = () => {
                     file,
                   );
 
+                  const requestText = requestTypeText
+                    ? `Submitted in response to request: ${requestTypeText}`
+                    : 'You submitted this file as additional evidence.';
+
                   return (
                     <li key={file.id}>
                       <VaCard
@@ -170,14 +174,17 @@ const FilesWeCouldntReceive = () => {
                           data-dd-privacy="mask"
                           data-dd-action-name="document filename"
                         >
-                          File name:
                           {file.fileName}
                         </h3>
-                        {requestTypeText && (
-                          <div>Request type: {requestTypeText}</div>
-                        )}
-                        <div>Date failed: {formatDate(file.failedDate)}</div>
-                        <div>File type: {file.documentType}</div>
+                        <div className="vads-u-margin-bottom--2">
+                          <p className="vads-u-margin-y--0">
+                            Document type: {file.documentType}
+                          </p>
+                          <p className="vads-u-margin-y--0">{requestText}</p>
+                        </div>
+                        <p className="vads-u-margin-y--0">
+                          Date failed: {formatDate(file.failedDate)}
+                        </p>
                         <VaLink
                           active
                           href={`/track-claims/your-claims/${

--- a/src/applications/claims-status/components/claim-files-tab-v2/FileSubmissionsInProgress.jsx
+++ b/src/applications/claims-status/components/claim-files-tab-v2/FileSubmissionsInProgress.jsx
@@ -111,7 +111,7 @@ const FileSubmissionsInProgress = ({ claim }) => {
                   item,
                 );
                 const requestTypeText = requestType
-                  ? `Request type: ${requestType}`
+                  ? `Submitted in response to request: ${requestType}`
                   : 'You submitted this file as additional evidence.';
 
                 return (
@@ -151,7 +151,9 @@ const FileSubmissionsInProgress = ({ claim }) => {
                       </div>
                       {item.createdAt && (
                         <p className="file-submitted-date vads-u-margin-y--0">
-                          {`Submitted on ${formatDate(item.createdAt)}`}
+                          {`Submission started on ${formatDate(
+                            item.createdAt,
+                          )}`}
                         </p>
                       )}
                     </VaCard>

--- a/src/applications/claims-status/components/claim-files-tab-v2/FilesReceived.jsx
+++ b/src/applications/claims-status/components/claim-files-tab-v2/FilesReceived.jsx
@@ -18,7 +18,7 @@ const formatDate = buildDateFormatter();
 
 const getTrackedItemText = item => {
   if (item.status === 'INITIAL_REVIEW_COMPLETE' || item.status === 'ACCEPTED') {
-    return `Reviewed by VA on ${formatDate(item.receivedDate)}`;
+    return 'Reviewed by VA';
   }
   if (item.status === 'NO_LONGER_REQUIRED' && item.closedDate !== null) {
     return 'No longer needed';
@@ -37,8 +37,8 @@ const generateDocsFiled = docsFiled => {
       );
       const requestTypeText =
         document.status === 'NO_LONGER_REQUIRED'
-          ? `We received this file for a closed evidence request (${requestTypeDisplayName}).`
-          : `Request type: ${requestTypeDisplayName}`;
+          ? `We received this file for a closed evidence request: ${requestTypeDisplayName}`
+          : `Submitted in response to request: ${requestTypeDisplayName}`;
 
       // If tracked item has no documents, return single item
       if (document.documents.length === 0) {
@@ -220,10 +220,6 @@ const FilesReceived = ({ claim }) => {
                           </div>
                         ))
                       )}
-                      {item.text &&
-                        item.text.includes('Reviewed') && (
-                          <p className="vads-u-margin-y--0">{item.text}</p>
-                        )}
                     </VaCard>
                   </li>
                 );

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -275,6 +275,76 @@ describe('<FilesWeCouldntReceive>', () => {
         expect(link).to.have.attribute('label', expectedLabel);
       });
     });
+
+    it('should render card with document type and request type for tracked items', () => {
+      const mockFailedFileWithTrackedItem = [
+        {
+          id: 1,
+          fileName: 'medical-records.pdf',
+          trackedItemId: 1,
+          trackedItemDisplayName: 'Medical records',
+          failedDate: '2025-01-15T10:35:00.000Z',
+          documentType: 'VA Form 21-4142',
+          claimId: '123',
+        },
+      ];
+      const store = createMockStore(mockFailedFileWithTrackedItem);
+      const { getByText, getByTestId } = renderWithCustomStore(
+        <FilesWeCouldntReceive />,
+        store,
+      );
+
+      const card = getByTestId('failed-file-1');
+      expect(card).to.exist;
+
+      // Check file name is displayed as heading (without "File name:" prefix)
+      expect(getByText('medical-records.pdf')).to.exist;
+
+      // Check document type label
+      expect(getByText('Document type: VA Form 21-4142')).to.exist;
+
+      // Check request type text for tracked item
+      expect(getByText('Submitted in response to request: Medical records')).to
+        .exist;
+
+      // Check date failed
+      expect(getByText('Date failed: January 15, 2025')).to.exist;
+    });
+
+    it('should render card with additional evidence text when no trackedItemId', () => {
+      const mockFailedFileWithoutTrackedItem = [
+        {
+          id: 1,
+          fileName: 'additional-evidence.pdf',
+          trackedItemId: null,
+          trackedItemDisplayName: null,
+          failedDate: '2025-01-20T10:35:00.000Z',
+          documentType: 'Other Correspondence',
+          claimId: '456',
+        },
+      ];
+      const store = createMockStore(mockFailedFileWithoutTrackedItem);
+      const { getByText, getByTestId } = renderWithCustomStore(
+        <FilesWeCouldntReceive />,
+        store,
+      );
+
+      const card = getByTestId('failed-file-1');
+      expect(card).to.exist;
+
+      // Check file name is displayed as heading
+      expect(getByText('additional-evidence.pdf')).to.exist;
+
+      // Check document type label
+      expect(getByText('Document type: Other Correspondence')).to.exist;
+
+      // Check additional evidence text (when no trackedItemId)
+      expect(getByText('You submitted this file as additional evidence.')).to
+        .exist;
+
+      // Check date failed
+      expect(getByText('Date failed: January 20, 2025')).to.exist;
+    });
   });
 
   describe('Error State - API Failure', () => {

--- a/src/applications/claims-status/tests/components/claim-files-tab-v2/FileSubmissionsInProgress.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab-v2/FileSubmissionsInProgress.unit.spec.jsx
@@ -139,8 +139,8 @@ describe('<FileSubmissionsInProgress>', () => {
       expect(getAllByText('SUBMISSION IN PROGRESS')).to.have.lengthOf(2);
 
       // Check dates
-      expect(getByText('Submitted on January 15, 2024')).to.exist;
-      expect(getByText('Submitted on January 10, 2024')).to.exist;
+      expect(getByText('Submission started on January 15, 2024')).to.exist;
+      expect(getByText('Submission started on January 10, 2024')).to.exist;
     });
   });
 

--- a/src/applications/claims-status/tests/components/claim-files-tab-v2/FilesReceived.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab-v2/FilesReceived.unit.spec.jsx
@@ -70,7 +70,8 @@ describe('<FilesReceived>', () => {
         expect($('.files-received-container', container)).to.exist;
         expect(getByText('Pending review')).to.exist;
         expect(getByText('File name unknown')).to.exist;
-        expect(getByText('Request type: Request 1')).to.exist;
+        expect(getByText('Submitted in response to request: Request 1')).to
+          .exist;
         expect(getByText('Received on January 1, 2024')).to.exist;
       });
     },
@@ -113,7 +114,8 @@ describe('<FilesReceived>', () => {
         expect(getByText('file.pdf')).to.exist;
         expectMaskedFilenames(container);
         expect(getByText('Document type: Correspondence')).to.exist;
-        expect(getByText('Request type: Request 1')).to.exist;
+        expect(getByText('Submitted in response to request: Request 1')).to
+          .exist;
         expect(getByText('Received on January 1, 2024')).to.exist;
       });
     },
@@ -156,7 +158,8 @@ describe('<FilesReceived>', () => {
         expect(getByText('file.pdf')).to.exist;
         expectMaskedFilenames(container);
         expect(getByText('Document type: Correspondence')).to.exist;
-        expect(getByText('Request type: Request 1')).to.exist;
+        expect(getByText('Submitted in response to request: Request 1')).to
+          .exist;
         expect(getByText('Received on January 2, 2024')).to.exist;
       });
     },
@@ -190,7 +193,7 @@ describe('<FilesReceived>', () => {
         },
       };
 
-      it('should render card with reviewed by VA status and show both dates', () => {
+      it('should render card with reviewed by VA status', () => {
         const { container, getByText } = render(
           <FilesReceived claim={claim} />,
         );
@@ -200,9 +203,9 @@ describe('<FilesReceived>', () => {
         expect(getByText('file.pdf')).to.exist;
         expectMaskedFilenames(container);
         expect(getByText('Document type: Correspondence')).to.exist;
-        expect(getByText('Request type: Request 1')).to.exist;
+        expect(getByText('Submitted in response to request: Request 1')).to
+          .exist;
         expect(getByText('Received on January 2, 2024')).to.exist;
-        expect(getByText('Reviewed by VA on January 3, 2024')).to.exist;
       });
     },
   );
@@ -235,7 +238,7 @@ describe('<FilesReceived>', () => {
         },
       };
 
-      it('should render card with reviewed by VA status and show both dates', () => {
+      it('should render card with reviewed by VA status', () => {
         const { container, getByText } = render(
           <FilesReceived claim={claim} />,
         );
@@ -245,9 +248,9 @@ describe('<FilesReceived>', () => {
         expect(getByText('file.pdf')).to.exist;
         expectMaskedFilenames(container);
         expect(getByText('Document type: Correspondence')).to.exist;
-        expect(getByText('Request type: Request 1')).to.exist;
+        expect(getByText('Submitted in response to request: Request 1')).to
+          .exist;
         expect(getByText('Received on January 2, 2024')).to.exist;
-        expect(getByText('Reviewed by VA on January 3, 2024')).to.exist;
       });
     },
   );
@@ -292,7 +295,7 @@ describe('<FilesReceived>', () => {
         expect(getByText('Document type: Correspondence')).to.exist;
         expect(
           getByText(
-            'We received this file for a closed evidence request (Request 1).',
+            'We received this file for a closed evidence request: Request 1',
           ),
         ).to.exist;
         expect(getByText('Received on January 2, 2024')).to.exist;
@@ -337,7 +340,8 @@ describe('<FilesReceived>', () => {
         expect(getByText('file.pdf')).to.exist;
         expectMaskedFilenames(container);
         expect(getByText('Document type: Correspondence')).to.exist;
-        expect(getByText('Request type: Request 1')).to.exist;
+        expect(getByText('Submitted in response to request: Request 1')).to
+          .exist;
         expect(queryByText(/Received on/)).to.not.exist;
       });
     },
@@ -389,7 +393,9 @@ describe('<FilesReceived>', () => {
         expect(getByText('file2.pdf')).to.exist;
         expectMaskedFilenames(container, 2);
         expect(getAllByText('Pending review')).to.have.lengthOf(2);
-        expect(getAllByText('Request type: Request 1')).to.have.lengthOf(2);
+        expect(
+          getAllByText('Submitted in response to request: Request 1'),
+        ).to.have.lengthOf(2);
       });
     },
   );

--- a/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
@@ -601,11 +601,11 @@ describe('Failed Submissions in Progress Empty State', () => {
         {
           id: 2,
           fileName: 'test-document-2.pdf',
-          trackedItemDisplayName: 'Additional Evidence',
+          trackedItemDisplayName: null,
           failedDate: '2025-01-20T14:20:00.000Z',
-          documentType: 'Other',
+          documentType: 'Other Correspondence',
           claimId: '123',
-          trackedItemId: 2,
+          trackedItemId: null,
         },
       ];
 
@@ -647,17 +647,24 @@ describe('Failed Submissions in Progress Empty State', () => {
       // Verify failed files list exists
       cy.get('[data-testid="failed-files-list"]').should('exist');
 
-      // Verify both files are displayed
+      // Verify card for tracked item (with trackedItemId)
       cy.get('[data-testid="failed-file-1"]').within(() => {
         cy.contains('test-document-1.pdf').should('exist');
-        cy.contains('21-4142').should('exist');
-        cy.contains('VA Form 21-4142').should('exist');
+        cy.contains('Document type: VA Form 21-4142').should('exist');
+        cy.contains('Submitted in response to request: 21-4142').should(
+          'exist',
+        );
+        cy.contains('Date failed:').should('exist');
       });
 
+      // Verify card for additional evidence (without trackedItemId)
       cy.get('[data-testid="failed-file-2"]').within(() => {
         cy.contains('test-document-2.pdf').should('exist');
-        cy.contains('Additional Evidence').should('exist');
-        cy.contains('Other').should('exist');
+        cy.contains('Document type: Other Correspondence').should('exist');
+        cy.contains('You submitted this file as additional evidence.').should(
+          'exist',
+        );
+        cy.contains('Date failed:').should('exist');
       });
 
       cy.injectAxeThenAxeCheck();


### PR DESCRIPTION
## Summary

This PR standardizes the **file card text labels and structure** across the claim files components (`FilesReceived`, `FileSubmissionsInProgress`, and `FilesWeCouldntReceive`) to match the Figma design specifications.

### Changes

**FilesWeCouldntReceive.jsx:**
- Removed "File name:" prefix from heading - now displays filename directly
- Changed "File type:" label to "Document type:"
- Added "You submitted this file as additional evidence." text for files without `trackedItemId`
- Updated request type format to "Submitted in response to request: [name]"

**FileSubmissionsInProgress.jsx:**
- Changed date label from "Submitted on" to "Submission started on"
- Updated request type format to "Submitted in response to request: [name]"

**FilesReceived.jsx:**
- Updated request type format for consistency
- Updated closed evidence request text format

**Tests:**
- Updated unit tests in `FileSubmissionsInProgress.unit.spec.jsx` for new date label
- Updated unit tests in `FilesReceived.unit.spec.jsx` for new text formats
- Added new unit tests in `FilesWeCouldntReceive.unit.spec.jsx` for card content (document type, request type, additional evidence case)
- Updated e2e tests in `02.claim-files.v2.cypress.spec.js` for explicit text label assertions

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#127088

## How to Test Locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```
   
3. **Test FileSubmissionsInProgress:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/10/files
   - Verify cards show "Submission started on [date]"
   - Verify request type text format

4. **Test FilesReceived:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/9/files
   - Verify cards show correct badge, document type, and request type format

5. **Test FilesWeCouldntReceive:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/files-we-couldnt-receive
   - Verify cards show "Document type:" label (not "File type:")
   - Verify filename is displayed without "File name:" prefix
   - Verify both tracked item and additional evidence text variants

## Testing Done

- Updated unit tests for all three components
- Added new unit tests for card content in `FilesWeCouldntReceive.unit.spec.jsx`
- Updated e2e tests with explicit assertions for new text labels
- **Manual Testing:** Verified all three pages display correct card structure per Figma

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### FileSubmissionsInProgress

| Before | After |
| ------ | ----- |
| <img width="519" height="345" alt="Screenshot 2025-12-11 at 10 23 01 AM" src="https://github.com/user-attachments/assets/80a55b0b-b64a-4120-bcc6-f29414e49ea6" /> | <img width="519" height="347" alt="Screenshot 2025-12-11 at 10 23 22 AM" src="https://github.com/user-attachments/assets/5f082fca-0222-489d-9923-8d7a3884cdaa" /> |


### FilesReceived



| Before | After |
| ------ | ----- |
| <img width="518" height="366" alt="Screenshot 2025-12-11 at 10 21 43 AM" src="https://github.com/user-attachments/assets/40c85044-561e-49b8-abca-0323939fdca6" /> | <img width="518" height="346" alt="Screenshot 2025-12-11 at 10 20 31 AM" src="https://github.com/user-attachments/assets/1c6c12b1-5e3d-4364-9ca4-c86f53c40ff2" /> |
| <img width="519" height="162" alt="Screenshot 2025-12-11 at 10 21 53 AM" src="https://github.com/user-attachments/assets/348f64aa-6573-4c45-9083-1f125f14c49d" />  | <img width="519" height="162" alt="Screenshot 2025-12-11 at 10 19 46 AM" src="https://github.com/user-attachments/assets/a69dbe02-76a4-47a7-891c-de6436276c0a" /> |



### FilesWeCouldntReceive

| Before | After |
| ------ | ----- |
| <img width="449" height="276" alt="Screenshot 2025-12-11 at 10 24 46 AM" src="https://github.com/user-attachments/assets/08bb832c-2025-4ccd-b41e-090d2a79bfd6" /> | <img width="450" height="329" alt="Screenshot 2025-12-11 at 10 24 20 AM" src="https://github.com/user-attachments/assets/921c5983-ae42-4a34-9259-073475d1b3d9" /> |


## What areas of the site does it impact?

- Files tab on claim details page (`track-claims/your-claims/:id/files`)
- Files We Couldn't Receive page (`track-claims/your-claims/files-we-couldnt-receive`)

## Acceptance Criteria

- [x] FileSubmissionsInProgress shows "Submission started on [date]"
- [x] FilesWeCouldntReceive shows "Document type:" instead of "File type:"
- [x] FilesWeCouldntReceive shows filename without "File name:" prefix
- [x] FilesWeCouldntReceive shows "You submitted this file as additional evidence." for non-tracked items
- [x] Card structure is consistent across all three components
- [x] Unit tests updated for new text labels
- [x] E2e tests updated with explicit assertions

## Quality Assurance & Testing

- [x] I updated unit tests for all affected components
- [x] I added new unit tests for previously untested card content
- [x] I updated e2e tests with explicit text label assertions
- [x] Manual testing confirmed cards match Figma design