### PR TITLE
Updated care expense summary and test

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -125,8 +125,8 @@ export const options = {
   text: {
     getItemName: item => item?.provider || 'Provider',
     cardDescription: item => {
-      const fromDate = transformDate(item?.careDateRange?.from);
-      const toDate = transformDate(item?.careDateRange?.to);
+      const fromDate = transformDate(item?.careDate?.from);
+      const toDate = transformDate(item?.careDate?.to);
       if (fromDate && toDate) {
         return `${fromDate} - ${toDate}`;
       }

--- a/src/applications/medical-expense-report/tests/unit/pages/02-expense/careExpensesPage.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/pages/02-expense/careExpensesPage.unit.spec.jsx
@@ -252,7 +252,7 @@ describe('Care Expenses Pages', () => {
   it('should return the correct card description when only from date is provided', () => {
     const item = {
       provider: 'John Doe Provider',
-      careDateRange: {
+      careDate: {
         from: '2004-04-04',
       },
       typeOfCare: 'RESIDENTIAL',
@@ -267,7 +267,7 @@ describe('Care Expenses Pages', () => {
   it('should return the correct card description when from and to date is provided', () => {
     const item = {
       provider: 'John Doe Provider',
-      careDateRange: {
+      careDate: {
         from: '2004-04-04',
         to: '2005-05-05',
       },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request updates the way care expense dates are handled in the medical expense report application. The main change is renaming the property used for care dates from `careDateRange` to `careDate` for both the implementation and related unit tests, ensuring consistency and correctness in how dates are referenced.

**Refactor to use `careDate` instead of `careDateRange`:**

* Updated the `cardDescription` logic in `careExpensesPages.js` to reference `item.careDate` instead of `item.careDateRange` for both `from` and `to` dates.

**Test updates for consistency:**

* Modified unit tests in `careExpensesPage.unit.spec.jsx` to use `careDate` as the property for expense items, replacing previous references to `careDateRange`. [[1]](diffhunk://#diff-8db3854b00d0ceb666499ef296290e481297171199f322c9033b5a00863bcfe1L255-R255) [[2]](diffhunk://#diff-8db3854b00d0ceb666499ef296290e481297171199f322c9033b5a00863bcfe1L270-R270)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/123051
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done
Unit Test

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |
<img width="402" height="288" alt="image" src="https://github.com/user-attachments/assets/d12ece06-271e-4d69-b964-03007c0d3328" />
|
<img width="502" height="706" alt="Screenshot 2025-12-11 at 1 40 57 PM" src="https://github.com/user-attachments/assets/5ddfde53-62f6-40f7-90a5-06673a862e08" />
|

## What areas of the site does it impact?
8416

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
