### PR TITLE
Improve labs and tests error handling with Datadog RUM logging

### DIFF
--- a/src/applications/mhv-medical-records/actions/labsAndTests.js
+++ b/src/applications/mhv-medical-records/actions/labsAndTests.js
@@ -85,6 +85,10 @@ export const getLabsAndTestsList = (
     }
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    dispatch({
+      type: Actions.LabsAndTests.UPDATE_LIST_STATE,
+      payload: Constants.loadStates.FETCHED,
+    });
     sendDatadogError(error, 'actions_labsAndTests_getLabsAndTestsList');
   }
 };

--- a/src/applications/mhv-medical-records/actions/labsAndTests.js
+++ b/src/applications/mhv-medical-records/actions/labsAndTests.js
@@ -10,7 +10,11 @@ import {
 import * as Constants from '../util/constants';
 import { addAlert } from './alerts';
 import { getListWithRetry } from './common';
-import { dispatchDetails, isRadiologyId } from '../util/helpers';
+import {
+  dispatchDetails,
+  isRadiologyId,
+  sendDatadogError,
+} from '../util/helpers';
 import { radiologyRecordHash } from '../util/radiologyUtil';
 
 export const getLabsAndTestsList = (
@@ -81,7 +85,7 @@ export const getLabsAndTestsList = (
     }
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_labsAndTests_getLabsAndTestsList');
   }
 };
 
@@ -118,7 +122,7 @@ export const getLabsAndTestsDetails = (
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_labsAndTests_getLabsAndTestsDetails');
   }
 };
 

--- a/src/applications/mhv-medical-records/actions/labsAndTests.js
+++ b/src/applications/mhv-medical-records/actions/labsAndTests.js
@@ -85,10 +85,6 @@ export const getLabsAndTestsList = (
     }
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    dispatch({
-      type: Actions.LabsAndTests.UPDATE_LIST_STATE,
-      payload: Constants.loadStates.FETCHED,
-    });
     sendDatadogError(error, 'actions_labsAndTests_getLabsAndTestsList');
   }
 };

--- a/src/applications/mhv-medical-records/tests/actions/labsAndTests.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/labsAndTests.unit.spec.jsx
@@ -4,12 +4,46 @@ import sinon from 'sinon';
 import { Actions } from '../../util/actionTypes';
 import labsAndTests from '../fixtures/labsAndTests.json';
 import pathology from '../fixtures/pathology.json';
+import error404 from '../fixtures/404.json';
 import {
   clearLabsAndTestDetails,
   getLabsAndTestsList,
   getLabsAndTestsDetails,
   updateLabsAndTestDateRange,
 } from '../../actions/labsAndTests';
+
+describe('getLabsAndTestsList error handling', () => {
+  it('should dispatch an add alert action on error and not throw', async () => {
+    mockApiRequest(error404, false);
+    const dispatch = sinon.spy();
+    // This should NOT throw - error should be handled internally
+    await getLabsAndTestsList()(dispatch);
+    // Verify alert was dispatched (second call after UPDATE_LIST_STATE)
+    expect(typeof dispatch.secondCall.args[0]).to.equal('function');
+  });
+
+  it('should not dispatch GET_LIST when there is an error', async () => {
+    mockApiRequest(error404, false);
+    const dispatch = sinon.spy();
+    await getLabsAndTestsList()(dispatch);
+    const dispatchCalls = dispatch.getCalls();
+    const getListCall = dispatchCalls.find(
+      call => call.args[0].type === Actions.LabsAndTests.GET_LIST,
+    );
+    expect(getListCall).to.not.exist;
+  });
+});
+
+describe('getLabsAndTestsDetails error handling', () => {
+  it('should dispatch an add alert action on error and not throw', async () => {
+    mockApiRequest(error404, false);
+    const dispatch = sinon.spy();
+    // This should NOT throw - error should be handled internally
+    await getLabsAndTestsDetails('invalid-id', [])(dispatch);
+    // Verify alert was dispatched
+    expect(typeof dispatch.firstCall.args[0]).to.equal('function');
+  });
+});
 
 describe('getLabsAndTestsList', () => {
   it('should dispatch a get list action', () => {

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
@@ -1,0 +1,21 @@
+import MedicalRecordsSite from './mr_site/MedicalRecordsSite';
+
+describe('Medical Records View Labs and Tests', () => {
+  const site = new MedicalRecordsSite();
+
+  beforeEach(() => {
+    site.login();
+  });
+
+  it('Visits Medical Records, Views Network Error On Labs and Tests List', () => {
+    cy.intercept('GET', '/my_health/v1/medical_records/labs_and_tests', {
+      statusCode: 404,
+    });
+    cy.visit('my-health/medical-records');
+    cy.intercept('POST', '/my_health/v1/medical_records/session').as('session');
+    cy.wait('@session');
+
+    cy.visit('my-health/medical-records/labs-and-tests');
+    cy.get('[data-testid="expired-alert-message"]').should('be.visible');
+  });
+});

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
@@ -8,7 +8,13 @@ describe('Medical Records View Labs and Tests', () => {
   });
 
   it('Visits Medical Records, Views Network Error On Labs and Tests List', () => {
-    cy.intercept('GET', '/my_health/v1/medical_records/labs_and_tests', {
+    cy.intercept('GET', '/my_health/v1/medical_records/labs_and_tests*', {
+      statusCode: 404,
+    });
+    cy.intercept('GET', '/my_health/v1/medical_records/radiology*', {
+      statusCode: 404,
+    });
+    cy.intercept('GET', '/my_health/v1/medical_records/imaging*', {
       statusCode: 404,
     });
     cy.visit('my-health/medical-records');

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
@@ -17,5 +17,9 @@ describe('Medical Records View Labs and Tests', () => {
 
     cy.visit('my-health/medical-records/labs-and-tests');
     cy.get('[data-testid="expired-alert-message"]').should('be.visible');
+
+    // Axe check
+    cy.injectAxe();
+    cy.axeCheck('main');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- Improved error handling in the Labs and Tests domain by replacing `throw error` with `sendDatadogError()` in the action creators.

- **Before**: When API errors occurred in `getLabsAndTestsList` and `getLabsAndTestsDetails`, the errors were being re-thrown after dispatching an alert. This caused "Uncaught (in promise)" errors in Datadog, which are generic and lack context, making debugging difficult.

- **After**: Replace `throw error` with `sendDatadogError(error, 'feature_name')` which logs errors to Datadog RUM with proper context (app name: "Medical Records", feature name: specific action). This allows the team to filter and identify issues by domain/feature in Datadog.

- **Team**: MHV Medical Records team

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#126564
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126570

## Testing done

- New code is covered by unit tests

## Screenshots

N/A - No UI changes. This is a backend error handling improvement that affects logging only.

## What areas of the site does it impact?

This change impacts the Labs and Tests domain within MHV Medical Records:
- `/my-health/medical-records/labs-and-tests` (list page)
- `/my-health/medical-records/labs-and-tests/:labId` (details page)

The user-facing behavior remains unchanged (error alerts still display). Only the error logging to Datadog is improved.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation changes needed)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - error handling change only, no route changes)