### PR TITLE
Document Status qa fixes

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -112,7 +112,7 @@ const FilesWeCouldntReceive = () => {
         <VaLink
           className="vads-u-display--block"
           href="#other-ways-to-send-documents"
-          text="Learn about other ways to send your documents."
+          text="Learn about other ways to send your documents"
           onClick={e => {
             e.preventDefault();
             setPageFocus('#other-ways-to-send');

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -25,7 +25,6 @@ import {
   PASSWORD_ERROR,
   DOC_TYPE_ERROR,
   SUBMIT_TEXT,
-  SUBMIT_FILES_FOR_REVIEW_TEXT,
   SEND_YOUR_DOCUMENTS_TEXT,
   ANCHOR_LINKS,
 } from '../../constants';
@@ -375,7 +374,7 @@ const AddFilesForm = ({ fileTab, onSubmit, uploading, progress, onCancel }) => {
         </VaFileInputMultiple>
         <VaButton
           class="vads-u-margin-top--3"
-          text={toggleValue ? SUBMIT_FILES_FOR_REVIEW_TEXT : SUBMIT_TEXT}
+          text={SUBMIT_TEXT}
           onClick={handleSubmit}
         />
         {!toggleValue && (

--- a/src/applications/claims-status/constants.js
+++ b/src/applications/claims-status/constants.js
@@ -213,7 +213,6 @@ export const VALIDATION_ERROR = 'Please select a file first';
 export const PASSWORD_ERROR = 'Please provide a password to decrypt this file';
 export const DOC_TYPE_ERROR = 'Please provide a document type';
 export const SUBMIT_TEXT = 'Submit documents for review';
-export const SUBMIT_FILES_FOR_REVIEW_TEXT = 'Submit files for review';
 export const SEND_YOUR_DOCUMENTS_TEXT = 'Send your documents another way';
 
 // Contact and submission information constants

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -72,7 +72,7 @@ describe('<FilesWeCouldntReceive>', () => {
       ).to.exist;
       expect(
         document.querySelector(
-          'va-link[text="Learn about other ways to send your documents."]',
+          'va-link[text="Learn about other ways to send your documents"]',
         ),
       ).to.exist;
       expect(getByRole('heading', { name: 'Files not received' })).to.exist;

--- a/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
@@ -11,7 +11,6 @@ import sinon from 'sinon';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import {
   SUBMIT_TEXT,
-  SUBMIT_FILES_FOR_REVIEW_TEXT,
   SEND_YOUR_DOCUMENTS_TEXT,
   ANCHOR_LINKS,
 } from '../../../constants';
@@ -43,6 +42,10 @@ describe('<AddFilesForm>', () => {
 
     expect($('.add-files-form', container)).to.exist;
     expect($('va-file-input-multiple', container)).to.exist;
+
+    const submitButton = $('va-button', container);
+    expect(submitButton).to.exist;
+    expect(submitButton.getAttribute('text')).to.equal(SUBMIT_TEXT);
   });
 
   describe('cstShowDocumentUploadStatus is false', () => {
@@ -53,16 +56,6 @@ describe('<AddFilesForm>', () => {
         loading: false,
       },
     };
-
-    it('should render submit button', () => {
-      const { container } = renderInReduxProvider(
-        <AddFilesForm {...fileFormProps} />,
-        { initialState },
-      );
-      const submitButton = $('va-button', container);
-      expect(submitButton).to.exist;
-      expect(submitButton.getAttribute('text')).to.equal(SUBMIT_TEXT);
-    });
 
     it('should render upload modal when uploading', () => {
       const { container } = renderInReduxProvider(
@@ -131,18 +124,6 @@ describe('<AddFilesForm>', () => {
         loading: false,
       },
     };
-
-    it('should render submit button', () => {
-      const { container } = renderInReduxProvider(
-        <AddFilesForm {...fileFormProps} />,
-        { initialState },
-      );
-      const submitButton = $('va-button', container);
-      expect(submitButton).to.exist;
-      expect(submitButton.getAttribute('text')).to.equal(
-        SUBMIT_FILES_FOR_REVIEW_TEXT,
-      );
-    });
 
     it('should render va-link with correct href and text rather than va-additional-info', () => {
       const { container } = renderInReduxProvider(

--- a/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
@@ -10,7 +10,7 @@ import featureToggleDisabled from './fixtures/mocks/lighthouse/feature-toggle-di
 import claimDetailsOpenManySupportingDocs from './fixtures/mocks/lighthouse/claim-detail-open-many-supporting-docs.json';
 import claimDetailsOpenManyEvidenceSubmissions from './fixtures/mocks/lighthouse/claim-detail-open-many-evidence-submissions.json';
 import claimDetailsOpenWithFailedSubmissions from './fixtures/mocks/lighthouse/claim-detail-open-with-failed-submissions.json';
-import { SUBMIT_FILES_FOR_REVIEW_TEXT, SUBMIT_TEXT } from '../../constants';
+import { SUBMIT_TEXT } from '../../constants';
 import {
   getFileInputElement,
   uploadFile,
@@ -693,7 +693,7 @@ describe('Type 1 Unknown Upload Errors', () => {
       .find('va-select')
       .should('be.visible');
     selectDocumentType(0, 'L034');
-    clickSubmitButton(SUBMIT_FILES_FOR_REVIEW_TEXT);
+    clickSubmitButton(SUBMIT_TEXT);
     cy.wait('@uploadRequest');
   };
 
@@ -735,7 +735,7 @@ describe('Type 1 Unknown Upload Errors', () => {
       .should('be.visible');
     selectDocumentType(0, 'L034');
 
-    clickSubmitButton(SUBMIT_FILES_FOR_REVIEW_TEXT);
+    clickSubmitButton(SUBMIT_TEXT);
     cy.wait('@uploadRequest');
 
     cy.get('.claims-alert').should(

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -9,11 +9,7 @@ import {
   setupUnknownErrorMock,
   setupDuplicateErrorMock,
 } from './file-upload-helpers';
-import {
-  SUBMIT_TEXT,
-  SUBMIT_FILES_FOR_REVIEW_TEXT,
-  ANCHOR_LINKS,
-} from '../../constants';
+import { SUBMIT_TEXT, ANCHOR_LINKS } from '../../constants';
 
 const setDocumentUploadStatusToggle = enabled => ({
   data: {
@@ -61,11 +57,8 @@ const uploadFileWithDocType = (fileName, fileIndex = 0, docType = 'L034') => {
 };
 
 // Helper function to click submit button
-const clickSubmitFilesButton = featureToggleEnabled => {
-  const buttonText = featureToggleEnabled
-    ? SUBMIT_FILES_FOR_REVIEW_TEXT
-    : SUBMIT_TEXT;
-  cy.get(`.add-files-form va-button[text="${buttonText}"]`)
+const clickSubmitFilesButton = () => {
+  cy.get(`.add-files-form va-button[text="${SUBMIT_TEXT}"]`)
     .shadow()
     .find('button')
     .click();
@@ -165,7 +158,7 @@ describe('Document upload', () => {
         setupPageAndIntercepts(false);
         setupUnknownErrorMock();
         uploadFileWithDocType('test-document.txt');
-        clickSubmitFilesButton(false);
+        clickSubmitFilesButton();
 
         cy.wait('@uploadRequest');
         // Verify new Type 1 unknown error alert is not present
@@ -183,7 +176,7 @@ describe('Document upload', () => {
         setupPageAndIntercepts(false);
         setupDuplicateErrorMock();
         uploadFileWithDocType('test-document.txt');
-        clickSubmitFilesButton(false);
+        clickSubmitFilesButton();
 
         cy.wait('@uploadRequest');
         // Verify duplicate error alert is present
@@ -211,7 +204,7 @@ describe('Document upload', () => {
         setupPageAndIntercepts(true);
         setupUnknownErrorMock();
         uploadFileWithDocType('test-document.txt');
-        clickSubmitFilesButton(true);
+        clickSubmitFilesButton();
 
         cy.wait('@uploadRequest');
         cy.get('#default-page .claims-alert')
@@ -269,7 +262,7 @@ describe('Document upload', () => {
 
         uploadFileWithDocType('test-document-duplicate.txt', 0);
         uploadFileWithDocType('test-document-unknown.txt', 1);
-        clickSubmitFilesButton(true);
+        clickSubmitFilesButton();
 
         cy.wait('@uploadRequests');
         cy.wait('@uploadRequests');
@@ -291,7 +284,7 @@ describe('Document upload', () => {
         setupPageAndIntercepts(true);
         setupDuplicateErrorMock();
         uploadFileWithDocType('test-document.txt');
-        clickSubmitFilesButton(true);
+        clickSubmitFilesButton();
 
         cy.wait('@uploadRequest');
         // Verify duplicate error alert is present
@@ -336,7 +329,7 @@ describe('Document upload', () => {
           }).as('uploadRequest');
           // Upload a file
           uploadFileWithDocType('test-document.txt');
-          clickSubmitFilesButton(true);
+          clickSubmitFilesButton();
           // Wait for upload to complete
           cy.wait('@uploadRequest');
           // Verify the user is redirected to the status tab after successful upload

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -4,6 +4,7 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 import featureToggleClaimDetailV2Enabled from '../fixtures/mocks/lighthouse/feature-toggle-claim-detail-v2-enabled.json';
 import featureToggleClaimPhasesEnabled from '../fixtures/mocks/lighthouse/feature-toggle-claim-phases-enabled.json';
 // END lighthouse_migration
+import { SUBMIT_TEXT } from '../../../constants';
 
 /* eslint-disable class-methods-use-this */
 class TrackClaimsPageV2 {
@@ -440,11 +441,8 @@ class TrackClaimsPageV2 {
         /\/(document-request|needed-from-you|needed-from-others)\/(\d+)/,
       );
 
-      // Click submit button - use different text based on feature toggle
-      const buttonText = showDocumentUploadStatus
-        ? 'Submit files for review'
-        : 'Submit documents for review';
-      cy.get(`.add-files-form va-button[text="${buttonText}"]`)
+      // Click submit button
+      cy.get(`.add-files-form va-button[text="${SUBMIT_TEXT}"]`)
         .shadow()
         .find('button')
         .click();
@@ -477,12 +475,9 @@ class TrackClaimsPageV2 {
     cy.get('va-alert h2').should('contain', alertHeading);
   }
 
-  submitFilesShowsError(showDocumentUploadStatus = false) {
+  submitFilesShowsError() {
     // Click submit without selecting any files to trigger validation error
-    const buttonText = showDocumentUploadStatus
-      ? 'Submit files for review'
-      : 'Submit documents for review';
-    cy.get(`va-button[text="${buttonText}"]`)
+    cy.get(`va-button[text="${SUBMIT_TEXT}"]`)
       .shadow()
       .find('button')
       .click();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Standardizes submit button text to "Submit documents for review" across all document upload flows, removing the toggle-dependent `SUBMIT_FILES_FOR_REVIEW_TEXT` constant
- Removes trailing period from "Learn about other ways to send your documents" link text in FilesWeCouldntReceive component
- Updates unit and e2e tests to reflect these text changes
- Benefits Management Tools Team (BMT Team 2)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127196
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127462

## Testing done

- **Old behavior**: Submit button text varied based on feature toggle - showed "Submit files for review" when `cstShowDocumentUploadStatus` was enabled, "Submit documents for review" when disabled
- **New behavior**: Submit button consistently shows "Submit documents for review" regardless of toggle state
- Verified unit tests pass for AddFilesForm and FilesWeCouldntReceive components
- Verified e2e tests pass for claim files and document request flows

## Screenshots

_N/A - Text-only changes, no visual layout changes_

## What areas of the site does it impact?

- Claims Status Tool - Files tab document upload
- Claims Status Tool - Document request pages
- Claims Status Tool - Failed submissions page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
