### PR TITLE
[ARC/126379] - qa feedback on submissions page

### DIFF
--- a/src/applications/accredited-representative-portal/containers/SubmissionsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/SubmissionsPage.jsx
@@ -93,7 +93,7 @@ const SubmissionsPage = title => {
       ) ? (
         <div className="submissions__form-start">
           <h2 className="submissions__form-name vads-u-font-size--h3 vads-u-font-family--serif submissions__margin-top">
-            VA ßßForm 21-0966
+            VA Form 21-0966
           </h2>
           <p className="submissions__form-description vads-u-font-size--h4">
             Intent to File a Claim for Compensation and/or Pension, or Survivors

--- a/src/applications/accredited-representative-portal/containers/SubmissionsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/SubmissionsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   useLoaderData,
   useSearchParams,
@@ -8,7 +8,6 @@ import {
 import {
   VaLoadingIndicator,
   VaBreadcrumbs,
-  VaAlert,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from 'platform/utilities/ui';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
@@ -27,7 +26,6 @@ import SubmissionsPageResults from '../components/SubmissionsPageResults';
 
 const SubmissionsPage = title => {
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
-  const [visibleAlert, setVisibleAlert] = useState(true);
   useEffect(
     () => {
       focusElement('h1.submissions__search-header');
@@ -46,22 +44,6 @@ const SubmissionsPage = title => {
         label={SUBMISSIONS_BC_LABEL}
         homeVeteransAffairs={false}
       />
-      <VaAlert
-        close-btn-aria-label="Close notification"
-        status="info"
-        closeable
-        uswds
-        onCloseEvent={() => setVisibleAlert(false)}
-        visible={visibleAlert}
-      >
-        <h2 id="track-your-status-on-mobile" slot="headline">
-          We are working to improve this tool.
-        </h2>
-        <p className="vads-u-margin-y--0">
-          This early version of the Accredited Representative Portal has limited
-          functionality.
-        </p>
-      </VaAlert>
       <h1
         data-testid="submissions-header"
         className="submissions__search-header"
@@ -74,7 +56,7 @@ const SubmissionsPage = title => {
 
       <div className="submissions__form-start">
         <h2 className="submissions__form-name vads-u-font-size--h3 vads-u-font-family--serif">
-          Form 21-686c
+          VA Form 21-686c
         </h2>
         <p className="submissions__form-description vads-u-font-size--h4">
           Application Request to Add and/or Remove Dependents
@@ -91,7 +73,7 @@ const SubmissionsPage = title => {
 
       <div className="submissions__form-start">
         <h2 className="submissions__form-name vads-u-font-size--h3 vads-u-font-family--serif submissions__margin-top">
-          Form 21-526EZ
+          VA Form 21-526EZ
         </h2>
         <p className="submissions__form-description vads-u-font-size--h4">
           Application for Disability Compensation and Related Compensation
@@ -111,7 +93,7 @@ const SubmissionsPage = title => {
       ) ? (
         <div className="submissions__form-start">
           <h2 className="submissions__form-name vads-u-font-size--h3 vads-u-font-family--serif submissions__margin-top">
-            Form 21-0966
+            VA ßßForm 21-0966
           </h2>
           <p className="submissions__form-description vads-u-font-size--h4">
             Intent to File a Claim for Compensation and/or Pension, or Survivors

--- a/src/applications/accredited-representative-portal/sass/SubmissionsPage.scss
+++ b/src/applications/accredited-representative-portal/sass/SubmissionsPage.scss
@@ -8,7 +8,7 @@
     margin: 32px 0;
   }
   &__search-header {
-    margin: 24px 0 0;
+    margin: 0;
   }
 
   [visible="false"] {


### PR DESCRIPTION
Removing alert from Submissions page only and adding 'VA' in front of form, see ticket feedback:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/126379#issuecomment-3643752554

<img width="376" height="605" alt="Screenshot 2025-12-11 at 4 06 06 PM" src="https://github.com/user-attachments/assets/aa7236af-36df-4266-9a72-32f29604b160" />
<img width="855" height="748" alt="Screenshot 2025-12-11 at 4 05 56 PM" src="https://github.com/user-attachments/assets/82b8ee5d-060f-4035-a9cc-0b9c3f8dbe35" />
