### PR TITLE
OH - Reverts Temp removal of hasAvailability check on provider page to enable testing on staging #40755

### DIFF
--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
@@ -20,13 +20,7 @@ function handleClick({ history, dispatch, data, provider, pageKey }) {
 }
 
 export default function ProviderCard({ provider }) {
-  // Temporarily marking all providers as hasAvailability=true to enable a
-  // test on staging
-  const hasAvailability = true;
-  const { lastSeen, providerName } = provider;
-
-  // const { lastSeen, providerName, hasAvailability } = provider;
-
+  const { lastSeen, providerName, hasAvailability } = provider;
   const dispatch = useDispatch();
   const history = useHistory();
   const pageKey = useSelector(state => state?.newAppointment?.currentPageKey);

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.jsx
@@ -142,6 +142,7 @@ describe('VAOS Page: ProviderSelectPage', () => {
     });
   });
 
+  /* Commenting out for now to unblock OH request test in staging */
   describe('when user is over request limit', () => {
     it('should display correct call a provider text', async () => {
       const store = createTestStore({
@@ -160,8 +161,7 @@ describe('VAOS Page: ProviderSelectPage', () => {
     });
   });
 
-  // Temporarily skipping so we can verify staging behavior
-  describe.skip('when a provider has no availability', () => {
+  describe('when a provider has no availability', () => {
     const store = createTestStore({
       ...defaultState,
       newAppointment: {


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This reverts a previous [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40755) that was used for testing on staging. 

## Related issue(s)
N/A

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?
Appointments OH direct schedule flow.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
