### PR TITLE
VEBT-3848: 22-10278 - Update breadcrumbs and align with design (including title)

### DIFF
--- a/src/applications/edu-benefits/10278/components/Breadcrumbs.jsx
+++ b/src/applications/edu-benefits/10278/components/Breadcrumbs.jsx
@@ -12,18 +12,24 @@ const Breadcrumbs = () => {
       label: 'Education and training',
     },
     {
+      href: '/education/disclose-information-to-third-party',
+      label:
+        'Disclose personal information to a third party for education benefits',
+    },
+    {
       href:
-        '/education/authorize-va-to-disclose-personal-information-form-22-10278',
-      label: 'Authorize VA to disclose personal information to a third party',
+        '/education/disclose-information-to-third-party/authorize-disclosure-form-22-10278',
+      label:
+        'Authorize VA to disclose personal information to a third party for education benefits',
     },
   ];
   return (
     <div className="row">
       <div className="vads-u-margin-left--2 mobile-lg:vads-u-margin-left--1">
         <VaBreadcrumbs
-          uswds
           breadcrumbList={crumbs}
           data-testid="breadcrumbs"
+          wrapping
         />
       </div>
     </div>

--- a/src/applications/edu-benefits/10278/constants.js
+++ b/src/applications/edu-benefits/10278/constants.js
@@ -1,4 +1,4 @@
 export const TITLE =
-  'Authorize VA to disclose personal information to a third party';
+  'Authorize VA to disclose personal information to a third party for education benefits';
 export const SUBTITLE =
-  'Authorization to disclose personal information about education benefits to a third party (VA Form 22-10278)';
+  'Authorization to disclose personal information to a third party (VA Form 22-10278)';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates the breadcrumbs, title, and subtitle used across Form 22-10278
- These changes can be seen reflected on the Introduction Page

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-3848

**Given**: (The initial context or precondition of the scenario)

Form 10278 IA spec

**When**: (The action performed by the user or the system)

updating breadcrumbs per IA spec  https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/information-architecture/ia-design-docs/benefits-portfolio/education-release-info-3rd-party-22-10278.md

**Then**: (The expected outcome or result)

they will align with design (including title) 

Acceptance Criteria

- **AC1**: The breadcrumbs have been updated to align with design per IA spec.  https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/information-architecture/ia-design-docs/benefits-portfolio/education-release-info-3rd-party-22-10278.md
- **AC2**:  The form title (h1) has been updated to match the latest Figma design file.

## Testing done

- Local testing to ensure breadcrumbs text (along with their path), title, and subtitle reflect the latest design of Form 22-10278
- No unit tests were required to be updated but the `IntroductionPage` tests still have 100% code coverage

<img width="954" height="281" alt="Unit Test Coverage" src="https://github.com/user-attachments/assets/48b98c18-693c-43e5-989d-6fb0fcb2e7f9" />


## Screenshots

**Before:**

<img width="387" height="841" alt="Mobile (Before)" src="https://github.com/user-attachments/assets/e58138c9-1703-4b4f-8762-de0796c75979" />
<img width="1256" height="623" alt="Desktop (Before)" src="https://github.com/user-attachments/assets/0279258a-81a6-4cd9-8c87-fcfd9551fc77" />

**After:**

<img width="384" height="839" alt="Mobile (After)" src="https://github.com/user-attachments/assets/a6f42297-3bc4-446e-b0ea-79e77964f2e8" />
<img width="1256" height="649" alt="Desktop (After)" src="https://github.com/user-attachments/assets/3200b55f-8fdd-48cd-8c0f-75e4c61f6633" />


## What areas of the site does it impact?

- Form 22-10278 | Breadcrumbs, Title, and Subtitle

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
