### PR TITLE
Increase past appointment fetch range to include the current day

### DIFF
--- a/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -1,7 +1,7 @@
 import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { waitFor } from '@testing-library/dom';
 import { expect } from 'chai';
-import { addDays, addMinutes, startOfDay, subDays, subMonths } from 'date-fns';
+import { addDays, startOfDay, subDays, subMonths } from 'date-fns';
 import MockDate from 'mockdate';
 import React from 'react';
 import { AppointmentList } from '..';
@@ -105,10 +105,11 @@ describe('VAOS Backend Service Alert', () => {
   it('should not display BackendAppointmentServiceAlert if there is no failure returned on the past appointments list', async () => {
     // Arrange
     const start = subMonths(now, 3);
-    const end = addMinutes(now.setMinutes(0), 30);
+    const end = addDays(now.setMinutes(0), 1);
     const appointment = new MockAppointmentResponse({
       localStartTime: yesterday,
       status: APPOINTMENT_STATUS.booked,
+      past: true,
     }).setLocation(new MockFacilityResponse());
 
     mockAppointmentsApi({
@@ -138,10 +139,11 @@ describe('VAOS Backend Service Alert', () => {
   it('should not display BackendAppointmentServiceAlert if there is no failure returned on the past appointments list', async () => {
     // Arrange
     const start = subMonths(now, 3);
-    const end = addMinutes(now.setMinutes(0), 30);
+    const end = addDays(now.setMinutes(0), 1);
     const appointment = new MockAppointmentResponse({
       localStartTime: yesterday,
       status: APPOINTMENT_STATUS.booked,
+      past: true,
     }).setLocation(new MockFacilityResponse());
 
     mockAppointmentsApi({

--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import classNames from 'classnames';
-import { format, parseISO, subMonths } from 'date-fns';
+import { addDays, format, parseISO, subMonths } from 'date-fns';
 import { useHistory } from 'react-router-dom';
 import InfoAlert from '../../../components/InfoAlert';
 import { groupAppointmentByDay } from '../../../services/appointment';
@@ -19,7 +19,7 @@ import PastAppointmentsDateDropdown from './PastAppointmentsDateDropdown';
 
 export function getMaximumPastAppointmentDateRange() {
   const now = new Date();
-  const today = format(now, 'yyyy-MM-dd');
+  const tomorrow = format(addDays(now, 1), 'yyyy-MM-dd');
 
   const dateRanges = [3, 6, 12, 24];
   return dateRanges.map((range, index) => {
@@ -29,7 +29,7 @@ export function getMaximumPastAppointmentDateRange() {
       label: `Past ${range} months`,
       startDateRaw: start,
       startDate: format(start, 'yyyy-MM-dd'),
-      endDate: today,
+      endDate: tomorrow,
     };
   });
 }

--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
@@ -2,9 +2,9 @@ import { mockFetch } from '@department-of-veterans-affairs/platform-testing/help
 import { within } from '@testing-library/dom';
 import { expect } from 'chai';
 import {
-  addMinutes,
   format,
   startOfDay,
+  addDays,
   subDays,
   subMonths,
   subYears,
@@ -30,7 +30,7 @@ const initialState = {
 };
 const now = startOfDay(mockToday, 'day');
 const start = subMonths(now, 3);
-const end = addMinutes(new Date(now).setMinutes(0), 30);
+const end = addDays(new Date(now).setMinutes(0), 1);
 
 describe('VAOS Page: PastAppointmentsList api', () => {
   beforeEach(() => {
@@ -92,6 +92,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     const pastDate = subMonths(mockToday, 4);
     const response = new MockAppointmentResponse({
       localStartTime: pastDate,
+      past: true,
     }).setTypeOfCare(null);
 
     mockAppointmentsApi({
@@ -104,7 +105,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
     mockAppointmentsApi({
       start: subMonths(now, 6),
-      end: now,
+      end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
       response: [response],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
@@ -187,6 +188,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     const pastDate = subDays(mockToday, 3);
     const response = new MockAppointmentResponse({
       localStartTime: pastDate,
+      past: true,
     }).setLocation(new MockFacilityResponse());
 
     mockAppointmentsApi({
@@ -245,7 +247,9 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       start,
       end,
       includes: ['facilities', 'clinics', 'avs', 'travel_pay_claims'],
-      response: [new MockAppointmentResponse({ localStartTime: pastDate })],
+      response: [
+        new MockAppointmentResponse({ localStartTime: pastDate, past: true }),
+      ],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled', 'checked-in'],
     });
 
@@ -332,6 +336,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     const facility = new MockFacilityResponse();
     const response = new MockAppointmentResponse({
       localStartTime: yesterday,
+      past: true,
     });
     response.setLocation(facility);
 

--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -118,6 +118,7 @@ export default function appointmentsReducer(state = initialState, action) {
         ?.filter(appt => {
           const apptDateTime = new Date(appt.start);
           return (
+            appt.vaos.isPastAppointment &&
             isValid(apptDateTime) &&
             isWithinInterval(apptDateTime, { start: startDate, end: endDate })
           );

--- a/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/past-appointments.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/past-appointments.cypress.spec.js
@@ -33,6 +33,7 @@ describe('VAOS past appointment flow', () => {
         cancellable: false,
         localStartTime: yesterday,
         status: APPOINTMENT_STATUS.booked,
+        past: true,
       });
 
       mockAppointmentsGetApi({ response: [response] });
@@ -89,6 +90,7 @@ describe('VAOS past appointment flow', () => {
           cancellable: false,
           localStartTime: subMonths(new Date(), i),
           status: APPOINTMENT_STATUS.booked,
+          past: true,
         });
       });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We noticed that some of the upcoming appointments were not showing up in the past appointment list 1 hour after start time. 
  - One possible cause is that we pass the end date for past appointments as today in `yyyy-mm-dd` in the URL which is being interpreted as the beginning of today.
  - This means we are missing today's past appointments
  - I'm updating the logic to fetch all appointments up to tomorrow as the end date and then relying on the `past` field set by vets-api as the source of truth to filter out non-past appointments.
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126122

## Testing done

- Tested locally, and updated unit/e2e tests.

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
