### PR TITLE
Add node 22 CI debugging to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Running tests](#running-tests)
     - [Unit tests](#unit-tests)
     - [End-to-end (E2E) / Browser tests](#end-to-end-e2e--browser-tests)
+    - [Debugging Node 22 CI failures](#debugging-node-22-ci-failures)
   - [Running a mock API for local development](#running-a-mock-api-for-local-development)
   - [More commands](#more-commands)
   - [Supported Browsers](#supported-browsers)
@@ -220,6 +221,48 @@ Examples:
 Afterward, check `/mochawesome-report` contents.
 
 **For other options with `yarn cy:run`,** [the same options for `cypress run` are applicable](https://docs.cypress.io/guides/guides/command-line.html#Commands).
+
+### Debugging Node 22 CI failures
+
+If your PR passes tests locally but fails the Node 22 compatibility check in CI, you can reproduce the issue locally:
+
+```sh
+# Switch to Node 22
+nvm use 22
+# OR install if you don't have it
+nvm install 22 && nvm use 22
+
+# Create a temporary branch from the Node 22 test branch
+git checkout -b temp-test-node22 origin/node-22-bug-bash-testing
+
+# Merge your feature branch into it (this replicates what CI does)
+git merge your-feature-branch
+
+# Install dependencies
+yarn install-safe
+
+# Run the failing test
+yarn test:unit path/to/failing/test.unit.spec.jsx
+
+# Make fixes to the test file(s) until tests pass
+
+# Switch back to your feature branch
+git checkout your-feature-branch
+
+# Switch back to Node 14 for normal development
+nvm use 14
+
+# Apply the fixes (cherry-pick the commit or manually copy changes)
+git cherry-pick <commit-hash-of-fix>
+
+# Push your feature branch with the fixes
+git push origin your-feature-branch
+
+# Clean up temporary branch (optional)
+git branch -D temp-test-node22
+```
+
+**Note:** The Node 22 branch uses happy-dom instead of jsdom, which can cause different behavior in tests, particularly with sessionStorage, web components, and async operations.
 
 ## Running a mock API for local development
 


### PR DESCRIPTION
## Summary

- Add node 22 CI debugging to README

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5317

## Testing done

- Verified steps reproduce CI

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
