### PR TITLE
Improve Vaccines error handling with Datadog RUM logging

### DIFF
--- a/src/applications/mhv-medical-records/actions/vaccines.js
+++ b/src/applications/mhv-medical-records/actions/vaccines.js
@@ -7,7 +7,7 @@ import {
 } from '../api/MrApi';
 import * as Constants from '../util/constants';
 import { addAlert } from './alerts';
-import { dispatchDetails } from '../util/helpers';
+import { dispatchDetails, sendDatadogError } from '../util/helpers';
 import { getListWithRetry } from './common';
 
 export const getVaccinesList = (
@@ -36,7 +36,7 @@ export const getVaccinesList = (
     });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_vaccines_getVaccinesList');
   }
 };
 
@@ -48,7 +48,7 @@ export const checkForVaccineUpdates = () => async dispatch => {
     dispatch({ type: Actions.Vaccines.CHECK_FOR_UPDATE, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_vaccines_checkForVaccineUpdates');
   }
 };
 
@@ -71,7 +71,7 @@ export const getVaccineDetails = (
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_vaccines_getVaccineDetails');
   }
 };
 

--- a/src/applications/mhv-medical-records/tests/actions/vaccines.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/vaccines.unit.spec.jsx
@@ -27,6 +27,13 @@ describe('Get vaccines action', () => {
       );
     });
   });
+
+  it('should dispatch an add alert action on error and not throw', async () => {
+    mockApiRequest(vaccines, false);
+    const dispatch = sinon.spy();
+    await getVaccinesList()(dispatch);
+    expect(typeof dispatch.secondCall.args[0]).to.equal('function');
+  });
 });
 
 describe('Get vaccine action', () => {
@@ -37,6 +44,13 @@ describe('Get vaccine action', () => {
     return getVaccineDetails('3106', undefined)(dispatch).then(() => {
       expect(dispatch.firstCall.args[0].type).to.equal(Actions.Vaccines.GET);
     });
+  });
+
+  it('should dispatch an add alert action on error and not throw', async () => {
+    mockApiRequest(vaccine, false);
+    const dispatch = sinon.spy();
+    await getVaccineDetails('3106', undefined)(dispatch);
+    expect(typeof dispatch.firstCall.args[0]).to.equal('function');
   });
 });
 

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-vaccines.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-vaccines.cypress.spec.js
@@ -8,29 +8,20 @@ describe('Medical Records View Vaccines', () => {
   });
 
   it('Visits Medical Records, Views Network Error On Vaccines List', () => {
-    // const site = new MedicalRecordsSite();
-    // site.login();
-
-    cy.intercept('GET', '/my_health/v1/medical_records/vaccines', {
-      statusCode: 400,
-      body: {
-        alertType: 'error',
-        header: 'err.title',
-        content: 'err.detail',
-        response: {
-          header: 'err.title',
-          content: 'err.detail',
-        },
-      },
-    }).as('folder');
-
+    cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', {
+      statusCode: 404,
+    });
+    cy.intercept('GET', '/my_health/v2/medical_records/immunizations*', {
+      statusCode: 404,
+    });
     cy.visit('my-health/medical-records');
     cy.intercept('POST', '/my_health/v1/medical_records/session').as('session');
     cy.wait('@session');
 
-    cy.get('[href="/my-health/medical-records/vaccines"]').should('be.visible');
     cy.visit('my-health/medical-records/vaccines');
     cy.get('[data-testid="expired-alert-message"]').should('be.visible');
+
+    // Axe check
     cy.injectAxe();
     cy.axeCheck('main');
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- Improved error handling in the Vaccines domain by replacing `throw error` statements with `sendDatadogError()` calls in the action creators.
- Team: MHV Medical Records 

- No feature flag required.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126566
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126573

## Testing done

- **Before**: When an API error occurred in `getVaccinesList`, `checkForVaccineUpdates`, or `getVaccineDetails`, the error was thrown which could cause uncaught promise rejections and didn't provide useful context for debugging.

- **After**: Errors are now logged to Datadog with descriptive feature names (`actions_vaccines_getVaccinesList`, `actions_vaccines_checkForVaccineUpdates`, `actions_vaccines_getVaccineDetails`), and the user sees a friendly error message.

- **Steps to verify**:
  1. Modify the mock server to return a 404 for `/my_health/v2/medical_records/immunizations`
  2. Navigate to the Vaccines page
  3. Verify the error alert "We can't access your vaccines records right now" is displayed
  4. Verify no infinite fetch loop occurs (check Network tab and console)
  5. Restore mock and verify normal functionality works

- **Tests completed**:
  - New code is covered by unit and e2e tests.

## Screenshots

N/A - No UI changes. This is an internal error handling improvement. The user-facing error message behavior remains the same.

## What areas of the site does it impact?

MHV Medical Records - Vaccines domain only (`/my-health/medical-records/vaccines`)

## Acceptance criteria

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, no documentation changes needed
- [ ] Screenshot of the developed feature is added - N/A, no UI changes
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - E2E test includes axeCheck

### Error Handling
- [x] Browser console contains no warnings or errors.
### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user