### PR TITLE
21P-8416 look for pdf url in response attributes

### DIFF
--- a/src/applications/medical-expense-report/containers/ConfirmationPage.jsx
+++ b/src/applications/medical-expense-report/containers/ConfirmationPage.jsx
@@ -7,14 +7,14 @@ export const ConfirmationPage = props => {
   const form = useSelector(state => state.form || {});
   const submission = form?.submission || {};
   const submitDate = submission?.timestamp || '';
-  const confirmationNumber = submission?.response?.confirmationNumber || '';
-
+  const attributes = submission?.response?.attributes || {};
+  const confirmationNumber = attributes?.confirmationNumber || '';
   return (
     <ConfirmationView
       formConfig={props.route?.formConfig}
       submitDate={submitDate}
       confirmationNumber={confirmationNumber}
-      pdfUrl={submission.response?.pdfUrl}
+      pdfUrl={attributes?.pdfUrl}
       devOnly={{
         showButtons: true,
       }}

--- a/src/applications/medical-expense-report/tests/fixtures/mocks/completed.json
+++ b/src/applications/medical-expense-report/tests/fixtures/mocks/completed.json
@@ -13,7 +13,7 @@
             "confirmationNumber": "1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2",
             "guid": "1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2",
             "form": "21P-8416",
-            "pdfUrl": "https://dsva-vagov-staging-medical-expense-reports.s3.us-gov-west-1.amazonaws.com/12.12.25-Form21P-8416/21P-8416_1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2.pdf?response-content-disposition=attachment%3B%20filename%3D%2221P-8416_1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2.pdf%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQD72FDTF67E676RP%2F20251212%2Fus-gov-west-1%2Fs3%2Faws4_request&X-Amz-Date=20251212T173349Z&X-Amz-Expires=1800&X-Amz-Security-Token=FwoDYXdzEEgaDB%2FMb0zRfVsqHBwFxCK8BBIiVeixut012JNd4xNsQ79DiSXERdgA7GVcJl25HMoV2s9fM5l00RwT6RYhWlP66Od%2BU1kcQvwGerAid3mpgbg8N43MENv55QnB4SPmJhnTnj0NquqAAlL4DmS8g1foqFR2d4qwqwIU1ABQ2FnSsnvFLZiindQyDZTvCMFMFAJ32Cm0u35ErRha4uFKf73rWGkobv2HnxmIuopoTM41Vmv%2BWcIV3s6Fz05ZcmbLCAerImewPQvUg41Htf8EMVSwzWLBtXXpMrySn0F0QFYBwmIkvqB%2FS11Ipw6uFxOcowOwtjoSVbSEpWlsr2bVtTKXvTthYf5kKZXVgaIQ%2FcDvwsbDSEiuwlsGhl7xwY5i5MLcn30NH%2BwQMgAbf6rVK%2FevCI7OrvCHEu10C3okXAeoqEeNktluqaWWMrxjbToHg%2Ffc8uFYPcZ1rj7%2F%2BpuKetIjjRjQFX13vLLRFhV6weFy4DWldYkhkSmJP966lSacbXqNFOSg%2FRVl2F3RYknN1PSy%2BnvVw9vYIMbPMPqTa4PG1M5r4MpdBE1A8k99rlrSH%2FJhSmiB%2FzMsdr%2Boi3Pkmh%2B6jDXuZV6j0ILjpyk4EgPVGui6Ob4dHufK5gXbmBvbmU2EAVNbUXma5doKXvLao%2F13CGdIZhTYBDUt%2B7Zoe3j%2FxMplizcQkjUdJTDpY5fa1rhZzfCSJPyQCWk34ZxCiWMSrGG4tT7hOea0B30WyqeebRex5v8k7UFf7xFI8jyDJXE%2F8dmA147NmhZhQrYKKP2j8ckGMihE57KZ3p1lKYP4suAVrbYNpVGHHKIARnXIE4f5%2Fwzm43KCeN8EKsC4&X-Amz-SignedHeaders=host&X-Amz-Signature=2b2dd16d6f2690ca5c1c13a9f913eea590ae98e88cb7617dd2d1ceb7285a0fe6"
+            "pdfUrl": "/supporting-forms-for-claims/"
         }
     }
 }

--- a/src/applications/medical-expense-report/tests/fixtures/mocks/completed.json
+++ b/src/applications/medical-expense-report/tests/fixtures/mocks/completed.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "id": "80209",
+        "type": "archived_claim",
+        "attributes": {
+            "submittedAt": "2025-12-12T17:33:47.249Z",
+            "regionalOffice": [
+                "Department of Veteran Affairs",
+                "Pension Intake Center",
+                "P.O. Box 5365",
+                "Janesville, Wisconsin 53547-5365"
+            ],
+            "confirmationNumber": "1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2",
+            "guid": "1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2",
+            "form": "21P-8416",
+            "pdfUrl": "https://dsva-vagov-staging-medical-expense-reports.s3.us-gov-west-1.amazonaws.com/12.12.25-Form21P-8416/21P-8416_1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2.pdf?response-content-disposition=attachment%3B%20filename%3D%2221P-8416_1f6a6e08-f9eb-4a8c-abd4-773026ef5fa2.pdf%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQD72FDTF67E676RP%2F20251212%2Fus-gov-west-1%2Fs3%2Faws4_request&X-Amz-Date=20251212T173349Z&X-Amz-Expires=1800&X-Amz-Security-Token=FwoDYXdzEEgaDB%2FMb0zRfVsqHBwFxCK8BBIiVeixut012JNd4xNsQ79DiSXERdgA7GVcJl25HMoV2s9fM5l00RwT6RYhWlP66Od%2BU1kcQvwGerAid3mpgbg8N43MENv55QnB4SPmJhnTnj0NquqAAlL4DmS8g1foqFR2d4qwqwIU1ABQ2FnSsnvFLZiindQyDZTvCMFMFAJ32Cm0u35ErRha4uFKf73rWGkobv2HnxmIuopoTM41Vmv%2BWcIV3s6Fz05ZcmbLCAerImewPQvUg41Htf8EMVSwzWLBtXXpMrySn0F0QFYBwmIkvqB%2FS11Ipw6uFxOcowOwtjoSVbSEpWlsr2bVtTKXvTthYf5kKZXVgaIQ%2FcDvwsbDSEiuwlsGhl7xwY5i5MLcn30NH%2BwQMgAbf6rVK%2FevCI7OrvCHEu10C3okXAeoqEeNktluqaWWMrxjbToHg%2Ffc8uFYPcZ1rj7%2F%2BpuKetIjjRjQFX13vLLRFhV6weFy4DWldYkhkSmJP966lSacbXqNFOSg%2FRVl2F3RYknN1PSy%2BnvVw9vYIMbPMPqTa4PG1M5r4MpdBE1A8k99rlrSH%2FJhSmiB%2FzMsdr%2Boi3Pkmh%2B6jDXuZV6j0ILjpyk4EgPVGui6Ob4dHufK5gXbmBvbmU2EAVNbUXma5doKXvLao%2F13CGdIZhTYBDUt%2B7Zoe3j%2FxMplizcQkjUdJTDpY5fa1rhZzfCSJPyQCWk34ZxCiWMSrGG4tT7hOea0B30WyqeebRex5v8k7UFf7xFI8jyDJXE%2F8dmA147NmhZhQrYKKP2j8ckGMihE57KZ3p1lKYP4suAVrbYNpVGHHKIARnXIE4f5%2Fwzm43KCeN8EKsC4&X-Amz-SignedHeaders=host&X-Amz-Signature=2b2dd16d6f2690ca5c1c13a9f913eea590ae98e88cb7617dd2d1ceb7285a0fe6"
+        }
+    }
+}

--- a/src/applications/medical-expense-report/tests/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/medical-expense-report/tests/fixtures/mocks/local-mock-responses.js
@@ -1,6 +1,7 @@
 // yarn mock-api --responses ./src/applications/{application}/tests/e2e/fixtures/mocks/local-mock-responses.js
 const mockUser = require('./user.json');
 const features = require('./feature-flags');
+const submit = require('./completed.json');
 
 const completedForm = require('./completed-form.json');
 
@@ -61,16 +62,7 @@ const responses = {
       },
     });
   },
-  'POST /medical_expense_reports/v0/form8416': (req, res) => {
-    return res.json({
-      formSubmissionId: '123fake-submission-id-567',
-      confirmationNumber: '123fake-submission-id-567',
-      timestamp: '2020-11-12',
-      attributes: {
-        guid: '123fake-submission-id-567',
-      },
-    });
-  },
+  'POST /medical_expense_reports/v0/form8416': submit,
 };
 
 module.exports = responses;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates the confirmation page to look for data in attributes property

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122758

## Testing done

- Run manually through the form and at the end check for pdf url on confirmation page
- To test locally, requires localhost and mocks running

## Screenshots

N/A

## What areas of the site does it impact?

Just 8416 confirmation page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
