### PR TITLE
Refactor file card components to use DocumentCard for consistency acr…

### DIFF
--- a/src/applications/claims-status/components/DocumentCard.jsx
+++ b/src/applications/claims-status/components/DocumentCard.jsx
@@ -1,0 +1,103 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+  VaCard,
+  VaLink,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import { buildDateFormatter } from '../utils/helpers';
+
+const formatDate = buildDateFormatter();
+
+const VARIANT_CONFIG = {
+  received: {
+    datePrefix: 'Received on',
+    testIdPrefix: 'file-received-card',
+  },
+  'in-progress': {
+    datePrefix: 'Submission started on',
+    testIdPrefix: 'file-in-progress-card',
+  },
+  failed: {
+    datePrefix: 'Date failed:',
+    testIdPrefix: 'failed-file',
+  },
+};
+
+const DocumentCard = ({
+  index,
+  variant,
+  statusBadgeText,
+  headingRef,
+  fileName,
+  documentType,
+  requestTypeText,
+  date,
+  link,
+}) => {
+  const config = VARIANT_CONFIG[variant];
+  const testId = `${config.testIdPrefix}-${index}`;
+  const displayFileName = fileName || 'File name unknown';
+  const hasRealFileName = Boolean(fileName);
+
+  return (
+    <VaCard className="vads-u-margin-y--3" data-testid={testId}>
+      {statusBadgeText && (
+        <div className="file-status-badge vads-u-margin-bottom--2">
+          <span className="vads-u-visibility--screen-reader">Status</span>
+          <span className="usa-label vads-u-padding-x--1">
+            {statusBadgeText}
+          </span>
+        </div>
+      )}
+      <h4
+        className="filename-title vads-u-font-size--h4 vads-u-margin-y--0"
+        style={{ overflowWrap: 'break-word' }}
+        {...hasRealFileName && {
+          'data-dd-privacy': 'mask',
+          'data-dd-action-name': 'document filename',
+        }}
+        ref={headingRef}
+        tabIndex="-1"
+      >
+        {displayFileName}
+      </h4>
+      <div>
+        {documentType && (
+          <p className="vads-u-margin-top--0p5 vads-u-margin-bottom--0">{`Document type: ${documentType}`}</p>
+        )}
+        <p className="vads-u-margin-top--0p5 vads-u-margin-bottom--0">
+          {requestTypeText}
+        </p>
+      </div>
+      {date && (
+        <p className="document-card-date vads-u-margin-top--2 vads-u-margin-bottom--0">
+          {`${config.datePrefix} ${formatDate(date)}`}
+        </p>
+      )}
+      {link && (
+        <div className="vads-u-margin-top--0p5">
+          <VaLink active href={link.href} text={link.text} label={link.label} />
+        </div>
+      )}
+    </VaCard>
+  );
+};
+
+DocumentCard.propTypes = {
+  index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  requestTypeText: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(['received', 'in-progress', 'failed']).isRequired,
+  date: PropTypes.string,
+  documentType: PropTypes.string,
+  fileName: PropTypes.string,
+  headingRef: PropTypes.func,
+  link: PropTypes.shape({
+    href: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    label: PropTypes.string,
+  }),
+  statusBadgeText: PropTypes.string,
+};
+
+export default DocumentCard;

--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -3,18 +3,15 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom-v5-compat';
 import {
   VaLink,
-  VaCard,
   VaPagination,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import OtherWaysToSendYourDocuments from './claim-files-tab-v2/OtherWaysToSendYourDocuments';
+import DocumentCard from './DocumentCard';
 import ClaimsBreadcrumbs from './ClaimsBreadcrumbs';
 import { usePagination } from '../hooks/usePagination';
 import { fetchFailedUploads } from '../actions';
-import {
-  buildDateFormatter,
-  getTrackedItemDisplayNameFromEvidenceSubmission,
-} from '../utils/helpers';
+import { getTrackedItemDisplayNameFromEvidenceSubmission } from '../utils/helpers';
 import { setPageFocus } from '../utils/page';
 import { ITEMS_PER_PAGE } from '../constants';
 import NeedHelp from './NeedHelp';
@@ -30,8 +27,6 @@ const FilesWeCouldntReceive = () => {
   const { data: failedFiles, loading, error } = useSelector(
     state => state.disability.status.failedUploads,
   );
-
-  const formatDate = buildDateFormatter();
 
   // Sort failed files by date (most recent first)
   const sortedFailedFiles = useMemo(
@@ -155,47 +150,34 @@ const FilesWeCouldntReceive = () => {
                 role="list"
               >
                 {currentPageItems.map(file => {
-                  const requestTypeText = getTrackedItemDisplayNameFromEvidenceSubmission(
+                  const requestType = getTrackedItemDisplayNameFromEvidenceSubmission(
                     file,
                   );
 
-                  const requestText = requestTypeText
-                    ? `Submitted in response to request: ${requestTypeText}`
+                  const requestTypeText = requestType
+                    ? `Submitted in response to request: ${requestType}`
                     : 'You submitted this file as additional evidence.';
 
+                  const link = {
+                    href: `/track-claims/your-claims/${file.claimId}/status`,
+                    text: 'Go to claim this file was uploaded for',
+                    label: `Go to the claim this file was uploaded for: ${
+                      file.fileName
+                    }`,
+                  };
+
                   return (
-                    <li key={file.id}>
-                      <VaCard
-                        className="vads-u-margin-y--3"
-                        data-testid={`failed-file-${file.id}`}
-                      >
-                        <h3
-                          className="filename-title vads-u-margin-y--0 vads-u-margin-bottom--2"
-                          data-dd-privacy="mask"
-                          data-dd-action-name="document filename"
-                        >
-                          {file.fileName}
-                        </h3>
-                        <div className="vads-u-margin-bottom--2">
-                          <p className="vads-u-margin-y--0">
-                            Document type: {file.documentType}
-                          </p>
-                          <p className="vads-u-margin-y--0">{requestText}</p>
-                        </div>
-                        <p className="vads-u-margin-y--0">
-                          Date failed: {formatDate(file.failedDate)}
-                        </p>
-                        <VaLink
-                          active
-                          href={`/track-claims/your-claims/${
-                            file.claimId
-                          }/status`}
-                          text="Go to claim this file was uploaded for"
-                          label={`Go to the claim this file was uploaded for: ${
-                            file.fileName
-                          }`}
-                        />
-                      </VaCard>
+                    // ignore heading order violation (see [Design](https://www.figma.com/design/m1Xt8XjVDjZIbliCYcCKpE/Document-status?node-id=10278-153365&t=z9yq8vxF1Hj4HYmm-4))
+                    <li key={file.id} data-a11y-ignore="heading-order">
+                      <DocumentCard
+                        index={file.id}
+                        variant="failed"
+                        fileName={file.fileName}
+                        documentType={file.documentType}
+                        requestTypeText={requestTypeText}
+                        date={file.failedDate}
+                        link={link}
+                      />
                     </li>
                   );
                 })}

--- a/src/applications/claims-status/components/claim-files-tab-v2/FileSubmissionsInProgress.jsx
+++ b/src/applications/claims-status/components/claim-files-tab-v2/FileSubmissionsInProgress.jsx
@@ -1,21 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  VaCard,
   VaButton,
   VaLink,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-import {
-  buildDateFormatter,
-  getTrackedItemDisplayNameFromEvidenceSubmission,
-} from '../../utils/helpers';
+import { getTrackedItemDisplayNameFromEvidenceSubmission } from '../../utils/helpers';
+import DocumentCard from '../DocumentCard';
 import { useIncrementalReveal } from '../../hooks/useIncrementalReveal';
 import TimezoneDiscrepancyMessage from '../TimezoneDiscrepancyMessage';
 import { ANCHOR_LINKS } from '../../constants';
 import { setPageFocus } from '../../utils/page';
-
-const formatDate = buildDateFormatter();
 
 const generateInProgressDocs = evidenceSubmissions => {
   return (evidenceSubmissions || [])
@@ -116,47 +111,18 @@ const FileSubmissionsInProgress = ({ claim }) => {
 
                 return (
                   <li key={item.id || itemIndex}>
-                    <VaCard
-                      className="vads-u-margin-y--3"
-                      data-testid={`file-in-progress-card-${itemIndex}`}
-                    >
-                      {statusBadgeText && (
-                        <div className="file-status-badge vads-u-margin-bottom--2">
-                          <span className="vads-u-visibility--screen-reader">
-                            Status
-                          </span>
-                          <span className="usa-label vads-u-padding-x--1">
-                            {statusBadgeText}
-                          </span>
-                        </div>
-                      )}
-                      <h4
-                        className="filename-title vads-u-margin-top--0 vads-u-margin-bottom--2"
-                        data-dd-privacy="mask"
-                        data-dd-action-name="document filename"
-                        ref={el => {
-                          headingRefs.current[itemIndex] = el;
-                        }}
-                        tabIndex="-1"
-                      >
-                        {item.fileName || 'File name unknown'}
-                      </h4>
-                      <div className="vads-u-margin-bottom--2">
-                        {item.documentType && (
-                          <p className="vads-u-margin-y--0">
-                            {`Document type: ${item.documentType}`}
-                          </p>
-                        )}
-                        <p className="vads-u-margin-y--0">{requestTypeText}</p>
-                      </div>
-                      {item.createdAt && (
-                        <p className="file-submitted-date vads-u-margin-y--0">
-                          {`Submission started on ${formatDate(
-                            item.createdAt,
-                          )}`}
-                        </p>
-                      )}
-                    </VaCard>
+                    <DocumentCard
+                      variant="in-progress"
+                      index={itemIndex}
+                      statusBadgeText={statusBadgeText}
+                      headingRef={el => {
+                        headingRefs.current[itemIndex] = el;
+                      }}
+                      fileName={item.fileName}
+                      documentType={item.documentType}
+                      requestTypeText={requestTypeText}
+                      date={item.createdAt}
+                    />
                   </li>
                 );
               })}

--- a/src/applications/claims-status/components/claim-files-tab-v2/FilesReceived.jsx
+++ b/src/applications/claims-status/components/claim-files-tab-v2/FilesReceived.jsx
@@ -1,20 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {
-  VaCard,
-  VaButton,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-import {
-  buildDateFormatter,
-  getTrackedItemDisplayFromSupportingDocument,
-} from '../../utils/helpers';
+import { getTrackedItemDisplayFromSupportingDocument } from '../../utils/helpers';
 import { useIncrementalReveal } from '../../hooks/useIncrementalReveal';
 import { ANCHOR_LINKS } from '../../constants';
+import DocumentCard from '../DocumentCard';
 
 const NEED_ITEMS_STATUS = 'NEEDED_FROM_';
-
-const formatDate = buildDateFormatter();
 
 const getTrackedItemText = item => {
   if (item.status === 'INITIAL_REVIEW_COMPLETE' || item.status === 'ACCEPTED') {
@@ -44,7 +37,7 @@ const generateDocsFiled = docsFiled => {
       if (document.documents.length === 0) {
         return {
           requestTypeText,
-          documents: [],
+          document: null,
           text: getTrackedItemText(document),
           date: document.date,
           type: 'tracked_item',
@@ -53,7 +46,7 @@ const generateDocsFiled = docsFiled => {
       // Split tracked item into separate items for each document
       return document.documents.map(doc => ({
         requestTypeText,
-        documents: [doc],
+        document: doc,
         text: getTrackedItemText(document),
         date: doc.uploadDate || document.date,
         type: 'tracked_item',
@@ -61,13 +54,11 @@ const generateDocsFiled = docsFiled => {
     }
     return {
       requestTypeText: 'You submitted this file as additional evidence.',
-      documents: [
-        {
-          originalFileName: document.originalFileName,
-          documentTypeLabel: document.documentTypeLabel,
-          uploadDate: document.date,
-        },
-      ],
+      document: {
+        originalFileName: document.originalFileName,
+        documentTypeLabel: document.documentTypeLabel,
+        uploadDate: document.date,
+      },
       text: null,
       date: document.date,
       type: 'additional_evidence_item',
@@ -147,80 +138,25 @@ const FilesReceived = ({ claim }) => {
             >
               {currentPageItems.map((item, itemIndex) => {
                 const statusBadgeText = getStatusBadgeText(item);
+                const { document } = item;
+                const fileName = document?.originalFileName || null;
+                const documentType = document?.documentTypeLabel || null;
+                const date = document?.uploadDate || item.date;
+
                 return (
                   <li key={itemIndex}>
-                    <VaCard
-                      key={itemIndex}
-                      className="vads-u-margin-y--3"
-                      data-testid={`file-received-card-${itemIndex}`}
-                    >
-                      {statusBadgeText && (
-                        <div className="file-status-badge vads-u-margin-bottom--2">
-                          <span className="vads-u-visibility--screen-reader">
-                            Status
-                          </span>
-                          <span className="usa-label vads-u-padding-x--1">
-                            {statusBadgeText}
-                          </span>
-                        </div>
-                      )}
-                      {item.documents.length === 0 ? (
-                        <>
-                          <h4
-                            className="filename-title vads-u-margin-top--0 vads-u-margin-bottom--2"
-                            ref={el => {
-                              headingRefs.current[itemIndex] = el;
-                            }}
-                            tabIndex="-1"
-                          >
-                            File name unknown
-                          </h4>
-                          <div className="vads-u-margin-bottom--2">
-                            <p className="vads-u-margin--0">
-                              {item.requestTypeText}
-                            </p>
-                          </div>
-                          {item.date !== null && (
-                            <p className="file-received-date vads-u-margin--0">
-                              {`Received on ${formatDate(item.date)}`}
-                            </p>
-                          )}
-                        </>
-                      ) : (
-                        item.documents.map((doc, index) => (
-                          <div key={index}>
-                            <h4
-                              className="filename-title vads-u-margin-top--0 vads-u-margin-bottom--2"
-                              data-dd-privacy="mask"
-                              data-dd-action-name="document filename"
-                              ref={el => {
-                                headingRefs.current[itemIndex] = el;
-                              }}
-                              tabIndex="-1"
-                            >
-                              {doc.originalFileName
-                                ? doc.originalFileName
-                                : 'File name unknown'}
-                            </h4>
-                            <div className="vads-u-margin-bottom--2">
-                              <p className="vads-u-margin-y--0">
-                                {`Document type: ${doc.documentTypeLabel}`}
-                              </p>
-                              <p className="vads-u-margin-y--0">
-                                {item.requestTypeText}
-                              </p>
-                            </div>
-                            {(doc.uploadDate || item.date) && (
-                              <p className="file-received-date vads-u-margin-y--0">
-                                {`Received on ${formatDate(
-                                  doc.uploadDate || item.date,
-                                )}`}
-                              </p>
-                            )}
-                          </div>
-                        ))
-                      )}
-                    </VaCard>
+                    <DocumentCard
+                      index={itemIndex}
+                      variant="received"
+                      statusBadgeText={statusBadgeText}
+                      headingRef={el => {
+                        headingRefs.current[itemIndex] = el;
+                      }}
+                      fileName={fileName}
+                      documentType={documentType}
+                      requestTypeText={item.requestTypeText}
+                      date={date}
+                    />
                   </li>
                 );
               })}

--- a/src/applications/claims-status/tests/components/DocumentCard.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentCard.unit.spec.jsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import sinon from 'sinon';
+
+import DocumentCard from '../../components/DocumentCard';
+
+describe('<DocumentCard>', () => {
+  const defaultProps = {
+    index: 0,
+    variant: 'received',
+    requestTypeText: 'You submitted this file as additional evidence.',
+  };
+
+  describe('variant: received', () => {
+    it('should render with correct testId', () => {
+      const { getByTestId } = render(<DocumentCard {...defaultProps} />);
+      expect(getByTestId('file-received-card-0')).to.exist;
+    });
+
+    it('should render date with "Received on" prefix', () => {
+      const { getByText } = render(
+        <DocumentCard {...defaultProps} date="2024-01-15" />,
+      );
+      expect(getByText('Received on January 15, 2024')).to.exist;
+    });
+  });
+
+  describe('variant: in-progress', () => {
+    const inProgressProps = {
+      ...defaultProps,
+      variant: 'in-progress',
+    };
+
+    it('should render with correct testId', () => {
+      const { getByTestId } = render(<DocumentCard {...inProgressProps} />);
+      expect(getByTestId('file-in-progress-card-0')).to.exist;
+    });
+
+    it('should render date with "Submission started on" prefix', () => {
+      const { getByText } = render(
+        <DocumentCard {...inProgressProps} date="2024-01-15" />,
+      );
+      expect(getByText('Submission started on January 15, 2024')).to.exist;
+    });
+  });
+
+  describe('variant: failed', () => {
+    const failedProps = {
+      ...defaultProps,
+      variant: 'failed',
+      index: 123,
+    };
+
+    it('should render with correct testId using provided index', () => {
+      const { getByTestId } = render(<DocumentCard {...failedProps} />);
+      expect(getByTestId('failed-file-123')).to.exist;
+    });
+
+    it('should render date with "Date failed:" prefix', () => {
+      const { getByText } = render(
+        <DocumentCard {...failedProps} date="2024-01-15" />,
+      );
+      expect(getByText('Date failed: January 15, 2024')).to.exist;
+    });
+  });
+
+  describe('fileName', () => {
+    it('should display "File name unknown" when fileName is not provided', () => {
+      const { getByText } = render(<DocumentCard {...defaultProps} />);
+      expect(getByText('File name unknown')).to.exist;
+    });
+
+    it('should display the provided fileName', () => {
+      const { getByText } = render(
+        <DocumentCard {...defaultProps} fileName="test-document.pdf" />,
+      );
+      expect(getByText('test-document.pdf')).to.exist;
+    });
+
+    it('should have data-dd-privacy="mask" when fileName is provided', () => {
+      const { container } = render(
+        <DocumentCard {...defaultProps} fileName="test-document.pdf" />,
+      );
+      const heading = $('.filename-title', container);
+      expect(heading.getAttribute('data-dd-privacy')).to.equal('mask');
+      expect(heading.getAttribute('data-dd-action-name')).to.equal(
+        'document filename',
+      );
+    });
+
+    it('should not have data-dd-privacy when fileName is not provided', () => {
+      const { container } = render(<DocumentCard {...defaultProps} />);
+      const heading = $('.filename-title', container);
+      expect(heading.getAttribute('data-dd-privacy')).to.be.null;
+    });
+  });
+
+  describe('statusBadgeText', () => {
+    it('should not render status badge when statusBadgeText is not provided', () => {
+      const { container } = render(<DocumentCard {...defaultProps} />);
+      expect($('.file-status-badge', container)).to.not.exist;
+    });
+
+    it('should render status badge when statusBadgeText is provided', () => {
+      const { getByText, container } = render(
+        <DocumentCard {...defaultProps} statusBadgeText="Pending review" />,
+      );
+      expect($('.file-status-badge', container)).to.exist;
+      expect(getByText('Pending review')).to.exist;
+    });
+
+    it('should include screen reader text for status badge', () => {
+      const { container } = render(
+        <DocumentCard {...defaultProps} statusBadgeText="Pending review" />,
+      );
+      const srText = container.querySelector(
+        '.vads-u-visibility--screen-reader',
+      );
+      expect(srText.textContent).to.equal('Status');
+    });
+  });
+
+  describe('documentType', () => {
+    it('should not render document type when not provided', () => {
+      const { queryByText } = render(<DocumentCard {...defaultProps} />);
+      expect(queryByText(/Document type:/)).to.be.null;
+    });
+
+    it('should render document type when provided', () => {
+      const { getByText } = render(
+        <DocumentCard {...defaultProps} documentType="Medical records" />,
+      );
+      expect(getByText('Document type: Medical records')).to.exist;
+    });
+  });
+
+  describe('requestTypeText', () => {
+    it('should render the request type text', () => {
+      const { getByText } = render(
+        <DocumentCard
+          {...defaultProps}
+          requestTypeText="Submitted in response to request: Request 1"
+        />,
+      );
+      expect(getByText('Submitted in response to request: Request 1')).to.exist;
+    });
+  });
+
+  describe('date', () => {
+    it('should not render date when not provided', () => {
+      const { container } = render(<DocumentCard {...defaultProps} />);
+      expect($('.document-card-date', container)).to.not.exist;
+    });
+
+    it('should render date when provided', () => {
+      const { container, getByText } = render(
+        <DocumentCard {...defaultProps} date="2024-06-20" />,
+      );
+      expect($('.document-card-date', container)).to.exist;
+      expect(getByText('Received on June 20, 2024')).to.exist;
+    });
+  });
+
+  describe('link', () => {
+    const linkProps = {
+      href: '/track-claims/your-claims/123/status',
+      text: 'Go to claim this file was uploaded for',
+      label: 'Go to the claim this file was uploaded for: test.pdf',
+    };
+
+    it('should not render link when not provided', () => {
+      const { container } = render(<DocumentCard {...defaultProps} />);
+      expect($('va-link', container)).to.not.exist;
+    });
+
+    it('should render link when provided', () => {
+      const { container } = render(
+        <DocumentCard {...defaultProps} link={linkProps} />,
+      );
+      const link = $('va-link', container);
+      expect(link).to.exist;
+      expect(link.getAttribute('href')).to.equal(linkProps.href);
+      expect(link.getAttribute('text')).to.equal(linkProps.text);
+      expect(link.getAttribute('label')).to.equal(linkProps.label);
+    });
+  });
+
+  describe('headingRef', () => {
+    it('should call headingRef with the heading element', () => {
+      const headingRef = sinon.spy();
+      render(<DocumentCard {...defaultProps} headingRef={headingRef} />);
+      expect(headingRef.called).to.be.true;
+      expect(headingRef.firstCall.args[0].tagName).to.equal('H4');
+    });
+  });
+
+  describe('heading', () => {
+    it('should render h4 heading', () => {
+      const { container } = render(<DocumentCard {...defaultProps} />);
+      expect($('h4.filename-title', container)).to.exist;
+    });
+
+    it('should have tabIndex="-1" for focus management', () => {
+      const { container } = render(<DocumentCard {...defaultProps} />);
+      const heading = $('.filename-title', container);
+      expect(heading.getAttribute('tabIndex')).to.equal('-1');
+    });
+  });
+});

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -238,7 +238,7 @@ class TrackClaimsPageV2 {
               cy.get('.filename-title').should('exist');
 
               // 3. Each card should have a received date
-              cy.get('.file-received-date').should('exist');
+              cy.get('.document-card-date').should('exist');
             });
           });
         }
@@ -296,7 +296,7 @@ class TrackClaimsPageV2 {
               cy.get('.filename-title').should('exist');
 
               // 3. Each card should have a submitted date
-              cy.get('.file-submitted-date').should('exist');
+              cy.get('.document-card-date').should('exist');
             });
           });
         }

--- a/src/applications/claims-status/tests/local-dev-mock-api/common.js
+++ b/src/applications/claims-status/tests/local-dev-mock-api/common.js
@@ -1800,8 +1800,12 @@ const responses = {
     };
 
     // Configuration for testing different scenarios
-    const errorPattern = ['duplicate']; // Change this to test different scenarios
-    // const errorPattern = [null]; // for success only
+    // Appropriate values:
+    // - 'duplicate',
+    // - 'invalidClaimant',
+    // - 'unknown'
+    // - null for success only
+    const errorPattern = ['duplicate'];
 
     return (_req, res) => {
       uploadCount += 1;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
- fixes document card headings having file-names that are too long and dont wrap. 
- Creates a reusable `DocumentCard` component to standardize document card rendering across the claims-status application
- Refactors `FilesReceived`, `FileSubmissionsInProgress`, and `FilesWeCouldntReceive` components to use the new shared `DocumentCard` component
- Ensures consistent styling, structure, and behavior for all document cards matching the Figma design specifications
- Reduces code duplication by consolidating repeated card markup into a single component with variant support (`received`, `in-progress`, `failed`)
- Team: Benefits Management Tools (BMT Team 2 - Bee's Knees)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127088
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127280

## Testing done

- **Unit tests**: Added comprehensive unit tests for the new `DocumentCard` component covering all variants, props, and edge cases (211 lines of test coverage)
- **E2E tests**: Updated page object selectors from `.file-received-date` and `.file-submitted-date` to the unified `.document-card-date` class
- **Manual testing**: Verified all three card variants render correctly with proper:
  - Status badges (when applicable)
  - File names (with "File name unknown" fallback)
  - Document types
  - Request type text
  - Date prefixes per variant ("Received on", "Submission started on", "Date failed:")
  - Links (for failed variant)
- **Data privacy**: Verified `data-dd-privacy="mask"` is only applied when a real filename exists

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| File Submissions in Progress |       <img width="600" height="223" alt="Screenshot 2025-12-12 at 10 09 36 AM" src="https://github.com/user-attachments/assets/304010d6-dfe6-4425-98db-f5d7f78668d8" />  |    <img width="600" height="213" alt="Screenshot 2025-12-12 at 10 07 38 AM" src="https://github.com/user-attachments/assets/c40ba3e4-f750-46b4-b32f-d96f132e7000" />    |
| Files Received |  <img width="669" height="222" alt="Screenshot 2025-12-12 at 10 10 23 AM" src="https://github.com/user-attachments/assets/c66279ce-7cbf-4fc5-b490-a9f2c4bd593e" />  |  <img width="667" height="215" alt="Screenshot 2025-12-12 at 10 08 15 AM" src="https://github.com/user-attachments/assets/b66add0b-3d78-4cbe-bc9d-f9034e9f04d8" /> |
| Files we couldn't receive |  <img width="507" height="189" alt="Screenshot 2025-12-12 at 10 09 13 AM" src="https://github.com/user-attachments/assets/1bd0f02f-4849-441c-9a16-49aefa33710f" />  | <img width="501" height="203" alt="Screenshot 2025-12-12 at 10 08 34 AM" src="https://github.com/user-attachments/assets/0412f262-026b-4a25-a513-d56b05849244" /> |


## What areas of the site does it impact?




- Claims Status - Files tab (Files Received section)
- Claims Status - Files tab (Files In Progress section)
- Claims Status - Files We Couldn't Receive page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

- Please verify the `DocumentCard` component API is flexible enough for all current use cases
- Note: The `data-a11y-ignore="heading-order"` attribute on the failed files list items is intentional per design specifications (see Figma link in code comment)
