### PR TITLE
Update AddFilesForm link to use full path on evidence request page

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -239,11 +239,10 @@ const AddFilesForm = ({ fileTab, onSubmit, uploading, progress, onCancel }) => {
 
   // Build the href for "other ways to send documents" link
   // When on the files tab, use anchor link; otherwise use full path
+  const otherWaysAnchor = `#${ANCHOR_LINKS.otherWaysToSendDocuments}`;
   const otherWaysToSendHref = fileTab
-    ? `#${ANCHOR_LINKS.otherWaysToSendDocuments}`
-    : `/track-claims/your-claims/${claimId}/files#${
-        ANCHOR_LINKS.otherWaysToSendDocuments
-      }`;
+    ? otherWaysAnchor
+    : `/track-claims/your-claims/${claimId}/files${otherWaysAnchor}`;
 
   // Track document type changes and clear errors immediately
   useEffect(

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import {
   VaFileInputMultiple,
@@ -229,11 +230,20 @@ const createSubmissionPayload = (files, docTypes, encrypted) => {
 const AddFilesForm = ({ fileTab, onSubmit, uploading, progress, onCancel }) => {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const toggleValue = useToggleValue(TOGGLE_NAMES.cstShowDocumentUploadStatus);
+  const { id: claimId } = useParams();
   const [files, setFiles] = useState([]);
   const [errors, setErrors] = useState([]);
   const [encrypted, setEncrypted] = useState([]);
   const [canShowUploadModal, setCanShowUploadModal] = useState(false);
   const fileInputRef = useRef(null);
+
+  // Build the href for "other ways to send documents" link
+  // When on the files tab, use anchor link; otherwise use full path
+  const otherWaysToSendHref = fileTab
+    ? `#${ANCHOR_LINKS.otherWaysToSendDocuments}`
+    : `/track-claims/your-claims/${claimId}/files#${
+        ANCHOR_LINKS.otherWaysToSendDocuments
+      }`;
 
   // Track document type changes and clear errors immediately
   useEffect(
@@ -389,11 +399,15 @@ const AddFilesForm = ({ fileTab, onSubmit, uploading, progress, onCancel }) => {
           <>
             <div className="vads-u-margin-top--3 vads-u-margin-bottom--5">
               <va-link
-                href={`#${ANCHOR_LINKS.otherWaysToSendDocuments}`}
+                href={otherWaysToSendHref}
                 text={SEND_YOUR_DOCUMENTS_TEXT}
                 onClick={e => {
-                  e.preventDefault();
-                  setPageFocus(e.target.href);
+                  // Only prevent default and scroll if we're on the files tab
+                  // Otherwise, let the link navigate to the files page
+                  if (fileTab) {
+                    e.preventDefault();
+                    setPageFocus(`#${ANCHOR_LINKS.otherWaysToSendDocuments}`);
+                  }
                 }}
               />
             </div>

--- a/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
@@ -8,7 +8,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import sinon from 'sinon';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Routes, Route } from 'react-router-dom-v5-compat';
+import { render } from '@testing-library/react';
 import {
   SUBMIT_TEXT,
   SEND_YOUR_DOCUMENTS_TEXT,
@@ -16,6 +18,31 @@ import {
 } from '../../../constants';
 
 import AddFilesForm from '../../../components/claim-files-tab/AddFilesForm';
+
+// Helper to render AddFilesForm with router and redux
+const renderWithRouterAndRedux = (
+  element,
+  { initialState, initialEntries },
+) => {
+  const store = {
+    getState: () => initialState,
+    subscribe: () => {},
+    dispatch: () => {},
+  };
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/track-claims/your-claims/:id/*" element={element} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+// Default initial entries for router
+const defaultInitialEntries = ['/track-claims/your-claims/123/files'];
 
 // Updated props for va-file-input-multiple implementation
 const fileFormProps = {
@@ -35,9 +62,9 @@ describe('<AddFilesForm>', () => {
       },
     };
 
-    const { container } = renderInReduxProvider(
+    const { container } = renderWithRouterAndRedux(
       <AddFilesForm {...fileFormProps} />,
-      { initialState },
+      { initialState, initialEntries: defaultInitialEntries },
     );
 
     expect($('.add-files-form', container)).to.exist;
@@ -58,17 +85,17 @@ describe('<AddFilesForm>', () => {
     };
 
     it('should render upload modal when uploading', () => {
-      const { container } = renderInReduxProvider(
+      const { container } = renderWithRouterAndRedux(
         <AddFilesForm {...fileFormProps} uploading />,
-        { initialState },
+        { initialState, initialEntries: defaultInitialEntries },
       );
       expect($('va-modal', container)).to.exist;
     });
 
     it('should include mail info additional info', () => {
-      const { container } = renderInReduxProvider(
+      const { container } = renderWithRouterAndRedux(
         <AddFilesForm {...fileFormProps} />,
-        { initialState },
+        { initialState, initialEntries: defaultInitialEntries },
       );
       // Check for the va-additional-info component
       const additionalInfo = $('va-additional-info', container);
@@ -84,9 +111,9 @@ describe('<AddFilesForm>', () => {
 
     it('should handle submit button click', () => {
       const onSubmit = sinon.spy();
-      const { container } = renderInReduxProvider(
+      const { container } = renderWithRouterAndRedux(
         <AddFilesForm {...fileFormProps} onSubmit={onSubmit} />,
-        { initialState },
+        { initialState, initialEntries: defaultInitialEntries },
       );
 
       const submitButton = $('va-button', container);
@@ -96,18 +123,18 @@ describe('<AddFilesForm>', () => {
     });
 
     it('should render updated file input section ui', () => {
-      const { getByText } = renderInReduxProvider(
+      const { getByText } = renderWithRouterAndRedux(
         <AddFilesForm {...fileFormProps} />,
-        { initialState },
+        { initialState, initialEntries: defaultInitialEntries },
       );
       getByText('Upload documents');
       getByText('If you have a document to upload, you can do that here.');
     });
 
     it('should not render heading section when it is rendered in file tab', () => {
-      const { queryByText } = renderInReduxProvider(
+      const { queryByText } = renderWithRouterAndRedux(
         <AddFilesForm {...fileFormProps} fileTab />,
-        { initialState },
+        { initialState, initialEntries: defaultInitialEntries },
       );
       expect(queryByText('Upload documents')).to.be.null;
       expect(
@@ -125,10 +152,13 @@ describe('<AddFilesForm>', () => {
       },
     };
 
-    it('should render va-link with correct href and text rather than va-additional-info', () => {
-      const { container } = renderInReduxProvider(
-        <AddFilesForm {...fileFormProps} />,
-        { initialState },
+    it('should render va-link with anchor href when on files tab', () => {
+      const { container } = renderWithRouterAndRedux(
+        <AddFilesForm {...fileFormProps} fileTab />,
+        {
+          initialState,
+          initialEntries: ['/track-claims/your-claims/123/files'],
+        },
       );
       const additionalInfo = $('va-additional-info', container);
       expect(additionalInfo).to.be.null;
@@ -136,6 +166,27 @@ describe('<AddFilesForm>', () => {
       expect(vaLink).to.exist;
       expect(vaLink.getAttribute('href')).to.equal(
         `#${ANCHOR_LINKS.otherWaysToSendDocuments}`,
+      );
+      expect(vaLink.getAttribute('text')).to.equal(SEND_YOUR_DOCUMENTS_TEXT);
+    });
+
+    it('should render va-link with full path when on evidence request page', () => {
+      const claimId = '456';
+      const { container } = renderWithRouterAndRedux(
+        <AddFilesForm {...fileFormProps} />,
+        {
+          initialState,
+          initialEntries: [
+            `/track-claims/your-claims/${claimId}/needed-from-you/789`,
+          ],
+        },
+      );
+      const vaLink = $('va-link', container);
+      expect(vaLink).to.exist;
+      expect(vaLink.getAttribute('href')).to.equal(
+        `/track-claims/your-claims/${claimId}/files#${
+          ANCHOR_LINKS.otherWaysToSendDocuments
+        }`,
       );
       expect(vaLink.getAttribute('text')).to.equal(SEND_YOUR_DOCUMENTS_TEXT);
     });


### PR DESCRIPTION
## Summary

This PR updates the **"other ways to send documents" link** in `AddFilesForm` to navigate to the full files tab URL when used on the evidence request page.

### Changes

**AddFilesForm.jsx:**
- Added `useParams` hook to get the claim ID from the URL
- Created conditional `otherWaysToSendHref` that uses:
  - Anchor link `#other-ways-to-send` when on the Files tab (`fileTab` prop is true)
  - Full path `/track-claims/your-claims/{id}/files#other-ways-to-send` when on the evidence request page
- Updated onClick handler to only prevent default navigation and scroll when on the files tab

**Tests:**
- Updated unit tests in `AddFilesForm.unit.spec.jsx` to use `renderInReduxProvider`
- Updated test assertions for va-link href and text

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#127507

## How to Test Locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```

3. **Test on Files Tab:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/8/files
   - Scroll down to the "Upload additional evidence" section
   - Click the "Send your documents another way" link
   - Verify it scrolls to "Other ways to send your documents" section on the same page

4. **Test on Evidence Request Page:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/8/needed-from-you/14268
   - Scroll down to the upload section
   - Click the "Send your documents another way" link
   - Verify it navigates to the Files tab and scrolls to "Other ways to send your documents" section

## Testing Done

- Updated unit tests for `AddFilesForm` component
- **Manual Testing:** Verified link behavior on both Files tab and evidence request page

## Screenshots

_N/A - No visual UI changes, only link behavior update._

## What areas of the site does it impact?

- Files tab on claim details page (`track-claims/your-claims/:id/files`)
- Evidence request pages (`track-claims/your-claims/:id/needed-from-you/:trackedItemId` and `track-claims/your-claims/:id/needed-from-others/:trackedItemId`)

## Acceptance Criteria

- [x] Link uses anchor href `#other-ways-to-send` when on the Files tab
- [x] Link uses full path `/track-claims/your-claims/{id}/files#other-ways-to-send` when on evidence request page
- [x] Clicking link on Files tab scrolls to the target section
- [x] Clicking link on evidence request page navigates to Files tab with anchor
- [x] Unit tests updated

## Quality Assurance & Testing

- [x] I updated unit tests for the affected component
- [x] Manual testing confirmed link navigates correctly from both pages