### PR TITLE
Improve Allergies error handling with Datadog RUM logging

### DIFF
--- a/src/applications/mhv-medical-records/actions/allergies.js
+++ b/src/applications/mhv-medical-records/actions/allergies.js
@@ -85,7 +85,7 @@ export const getAllergyDetails = (
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_allergies_getAllergyDetails');
   }
 };
 

--- a/src/applications/mhv-medical-records/tests/actions/allergies.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/allergies.unit.spec.jsx
@@ -200,6 +200,13 @@ describe('Get allergies action with parameter-based logic', () => {
 
       expect(unifiedItemCall).to.exist;
     });
+
+    it('should dispatch an add alert action on error and not throw', async () => {
+      mockApiRequest(allergy, false);
+      const dispatch = sinon.spy();
+      await getAllergyDetails('123', [], false, false)(dispatch);
+      expect(typeof dispatch.firstCall.args[0]).to.equal('function');
+    });
   });
 
   describe('clearAllergyDetails', () => {

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-allergies.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-allergies.cypress.spec.js
@@ -8,7 +8,10 @@ describe('Medical Records View Allergies', () => {
   });
 
   it('Visits Medical Records, Views Network Error On Allergies List', () => {
-    cy.intercept('GET', '/my_health/v1/medical_records/allergies', {
+    cy.intercept('GET', '/my_health/v1/medical_records/allergies*', {
+      statusCode: 404,
+    });
+    cy.intercept('GET', '/my_health/v2/medical_records/allergies*', {
       statusCode: 404,
     });
     cy.visit('my-health/medical-records');
@@ -17,5 +20,9 @@ describe('Medical Records View Allergies', () => {
 
     cy.visit('my-health/medical-records/allergies');
     cy.get('[data-testid="expired-alert-message"]').should('be.visible');
+
+    // Axe check
+    cy.injectAxe();
+    cy.axeCheck('main');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- Improved error handling in the Allergies domain by replacing `throw error` with `sendDatadogError()` in the `getAllergyDetails` action creator. Note: `getAllergiesList` already had `sendDatadogError()` implemented.

- Team: MHV Medical Records 

- No feature flag required.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126567
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126574

## Testing done

- **Before**: When an API error occurred in `getAllergyDetails`, the error was thrown which could cause uncaught promise rejections and didn't provide useful context for debugging.

- **After**: Errors are now logged to Datadog with a descriptive feature name (`actions_allergies_getAllergyDetails`), and the user sees a friendly error message.

- **Steps to verify**:
  1. Modify the mock server to return a 404 for `/my_health/v2/medical_records/allergies`
  2. Navigate to the Allergies page
  3. Verify the error alert "We can't access your allergy records right now" is displayed
  4. Verify no infinite fetch loop occurs (check Network tab and console)
  5. Restore mock and verify normal functionality works

- **Tests completed**:
  - New code is covered by unit and e2e tests.

## Screenshots

N/A - No UI changes. This is an internal error handling improvement. The user-facing error message behavior remains the same.

## What areas of the site does it impact?

MHV Medical Records - Allergies domain only (`/my-health/medical-records/allergies`)

## Acceptance criteria

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, no documentation changes needed
- [ ] Screenshot of the developed feature is added - N/A, no UI changes
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - E2E test includes axeCheck

### Error Handling
- [x] Browser console contains no warnings or errors.
### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user