### PR TITLE
Improve Vitals detail error handling with Datadog RUM logging

### DIFF
--- a/src/applications/mhv-medical-records/actions/vitals.js
+++ b/src/applications/mhv-medical-records/actions/vitals.js
@@ -55,7 +55,7 @@ export const getVitalDetails = (vitalType, vitalList) => async dispatch => {
     dispatch({ type: Actions.Vitals.GET, vitalType });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    sendDatadogError(error, 'actions_vitals_getVitalDetails');
   }
 };
 

--- a/src/applications/mhv-medical-records/tests/actions/vitals.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/vitals.unit.spec.jsx
@@ -101,6 +101,13 @@ describe('Get vital details action', () => {
       expect(typeof dispatch.firstCall.args[0]).to.equal('function');
     });
   });
+
+  it('should dispatch an add alert action on error and not throw', async () => {
+    mockApiRequest(error404, false);
+    const dispatch = sinon.spy();
+    await getVitalDetails('vitalType', [])(dispatch);
+    expect(typeof dispatch.firstCall.args[0]).to.equal('function');
+  });
 });
 
 describe('set vitals list action', () => {

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-vitals.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-vitals.cypress.spec.js
@@ -8,42 +8,21 @@ describe('Medical Records View Vitals', () => {
   });
 
   it('Visits Medical Records, Views Network Error On Vitals List', () => {
-    // const site = new MedicalRecordsSite();
-    // site.login();
-
-    cy.intercept('GET', '/my_health/v1/medical_records/vitals', {
-      statusCode: 400,
-      body: {
-        alertType: 'error',
-        header: 'err.title',
-        content: 'err.detail',
-        response: {
-          header: 'err.title',
-          content: 'err.detail',
-        },
-      },
-    }).as('folder');
-
-    cy.visit('my-health/medical-records');
-    cy.intercept('POST', '/my_health/v1/medical_records/session').as('session');
-    cy.wait('@session');
-
-    cy.get('[href="/my-health/medical-records/vaccines"]').should('be.visible');
-    cy.visit('my-health/medical-records/vitals');
-    cy.get('[data-testid="expired-alert-message"]').should('be.visible');
-    cy.injectAxe();
-    cy.axeCheck('main');
-  });
-  it('Visits Medical Records, Views Error Messages From Vitals Server Endpoint', () => {
-    cy.intercept('GET', '/my_health/v1/medical_records/vitals', {
+    cy.intercept('GET', '/my_health/v1/medical_records/vitals*', {
+      statusCode: 404,
+    });
+    cy.intercept('GET', '/my_health/v2/medical_records/vitals*', {
       statusCode: 404,
     });
     cy.visit('my-health/medical-records');
     cy.intercept('POST', '/my_health/v1/medical_records/session').as('session');
     cy.wait('@session');
 
-    cy.get('[href="/my-health/medical-records/vaccines"]').should('be.visible');
     cy.visit('my-health/medical-records/vitals');
-    cy.get('[data-testid="expired-alert-message"]').should('not.be.visible');
+    cy.get('[data-testid="expired-alert-message"]').should('be.visible');
+
+    // Axe check
+    cy.injectAxe();
+    cy.axeCheck('main');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- Improved error handling in the Vitals domain by replacing `throw error` with `sendDatadogError()` in the `getVitalDetails` action creator. Note: `getVitals` (list) already had `sendDatadogError()` implemented.

- Team: MHV Medical Records 

- No feature flag required.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126569

## Testing done

- **Before**: When an API error occurred in `getVitalDetails`, the error was thrown which could cause uncaught promise rejections and didn't provide useful context for debugging.

- **After**: Errors are now logged to Datadog with a descriptive feature name (`actions_vitals_getVitalDetails`), and the user sees a friendly error message.

- **Steps to verify**:
  1. Modify the mock server to return a 404 for `/my_health/v2/medical_records/vitals`
  2. Navigate to the Vitals page
  3. Verify the error alert is displayed
  4. Verify no infinite fetch loop occurs (check Network tab and console)
  5. Restore mock and verify normal functionality works

- **Tests completed**:
  - New code is covered by unit and e2e tests.

## Screenshots

N/A - No UI changes. This is an internal error handling improvement. The user-facing error message behavior remains the same.

## What areas of the site does it impact?

MHV Medical Records - Vitals domain only (`/my-health/medical-records/vitals`)

## Acceptance criteria

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary) - N/A, no documentation changes needed
- [ ] Screenshot of the developed feature is added - N/A, no UI changes
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - E2E test includes axeCheck

### Error Handling
- [x] Browser console contains no warnings or errors.
### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user