### PR TITLE
[10-10EZR] require Spouse when Married or Separated

### DIFF
--- a/src/applications/ezr/config/chapters/householdInformation/spouseInformation.js
+++ b/src/applications/ezr/config/chapters/householdInformation/spouseInformation.js
@@ -5,6 +5,7 @@ import {
   spouseAddressDoesNotMatchVeteransV2,
   spouseDidNotCohabitateWithVeteranV2,
 } from 'applications/ezr/utils/helpers/form-config';
+import { spouseInformationIntroPage } from 'applications/ezr/definitions/spouseInformationIntro';
 import spouseInformationSummaryPage from '../../../definitions/spouseInformationSummary';
 import spousePersonalInformationPage from '../../../definitions/spousePersonalInformation';
 import { spouseAdditionalInformationPage } from '../../../definitions/spouseAdditionalInformation';
@@ -20,7 +21,7 @@ const options = {
   arrayPath: 'spouseInformation',
   nounSingular: 'spouse',
   nounPlural: 'spouse',
-  required: false,
+  required: true,
   maxItems: 1,
   hideMaxItemsAlert: true,
   isItemIncomplete,
@@ -51,6 +52,13 @@ const options = {
     cancelEditTitle: () => content['household-spouse-edit-cancel-modal-title'],
   },
 };
+
+/**
+ * Schemas for spouse information intro page.
+ *
+ * @returns {PageSchema}
+ */
+const spouseInformationIntroPageSchema = spouseInformationIntroPage;
 
 /**
  * Schemas for spouse information summary page.
@@ -92,9 +100,16 @@ const spouseContactInformationPageSchema = spouseContactInformationPage;
 const spouseFinancialSupportPageSchema = spouseFinancialSupportPage;
 
 const spousalInformationPages = arrayBuilderPages(options, pageBuilder => ({
+  spouseInformationIntroPage: pageBuilder.introPage({
+    title: content['household-spouse-intro-title'],
+    path: 'household-information/spouse-information',
+    uiSchema: spouseInformationIntroPageSchema.uiSchema,
+    schema: spouseInformationIntroPageSchema.schema,
+    depends: includeSpousalInformationV2,
+  }),
   spouseInformationSummaryPage: pageBuilder.summaryPage({
     title: content['household-spouse-information-summary-title'],
-    path: 'household-information/spouse-information',
+    path: 'household-information/spouse-information-summary',
     uiSchema: spouseInformationSummaryPageSchema.uiSchema,
     schema: spouseInformationSummaryPageSchema.schema,
     depends: includeSpousalInformationV2,

--- a/src/applications/ezr/definitions/spouseInformationIntro.js
+++ b/src/applications/ezr/definitions/spouseInformationIntro.js
@@ -1,0 +1,15 @@
+import { titleUI } from '~/platform/forms-system/src/js/web-component-patterns';
+import content from '../locales/en/content.json';
+
+export const spouseInformationIntroPage = {
+  uiSchema: {
+    ...titleUI(
+      content['household-spouse-intro-title'],
+      content['household-spouse-intro-description'],
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+};

--- a/src/applications/ezr/locales/en/content.json
+++ b/src/applications/ezr/locales/en/content.json
@@ -212,6 +212,8 @@
   "household-spouse-income-net-label": "Enter your spouse\u2019s net annual income from a farm, property, or business from %s",
   "household-spouse-income-other-label": "Enter your spouse\u2019s other annual income from %s",
   "household-spouse-information-summary-hint": "If you\u2019re currently married or separated, select Yes. If you\u2019re divorced or widowed or you\u2019ve never been married, select No.",
+  "household-spouse-intro-title": "Your spouse",
+  "household-spouse-intro-description": "In the next few questions, we’ll ask you about your spouse.",
   "household-spouse-marriage-date-label": "Date of marriage",
   "household-spouse-name-prefix": "Spouse\u2019s",
   "household-spouse-phone-label": "Phone number",

--- a/src/applications/ezr/tests/e2e/ezr-spouse-information-v2.cypress.spec.js
+++ b/src/applications/ezr/tests/e2e/ezr-spouse-information-v2.cypress.spec.js
@@ -52,8 +52,6 @@ describe('EZR V2 spouse information flow', () => {
     it('should successfully fill the marital information', () => {
       cy.selectVaSelect('root_view:maritalStatus_maritalStatus', 'Married');
       goToNextPage('/household-information/spouse-information');
-
-      selectYesNoWebComponent('view:hasSpouseInformationToAdd', true);
       goToNextPage(
         'household-information/spouse-information/0/personal-information',
       );
@@ -118,6 +116,7 @@ describe('EZR V2 spouse information flow', () => {
         .find('select')
         .should('have.value', 'Married');
       goToNextPage('household-information/spouse-information');
+      goToNextPage('household-information/spouse-information-summary');
 
       cy.findAllByRole('button', {
         name: /delete/i,

--- a/src/applications/ezr/tests/e2e/fixtures/mocks/mock-prefill-with-non-prefill-data.json
+++ b/src/applications/ezr/tests/e2e/fixtures/mocks/mock-prefill-with-non-prefill-data.json
@@ -45,7 +45,7 @@
     "spouseDateOfBirth": "1971-09-11",
     "dateOfMarriage": "1995-02-22",
     "cohabitedLastYear": true,
-    "maritalStatus": "Married",
+    "sameAddress": true,
     "nonPrefill": {
       "previousFinancialInfo": {
         "veteranFinancialInfo": {


### PR DESCRIPTION
## Summary

- Bug: if a Veteran indicates they're Married or Separated but does not add information for a Spouse, the submission fails when looking for `spouseFullName['first']` 
- To reproduce in Staging, use user +228, choose marital status `Married`, then when prompted to add a Spouse choose `No` and proceed through submission. The Review page will show a prompt to "Add another Spouse", and submitting without doing so will succeed but cause an error in vets-api.
- Solution: switch to use the ArrayBuilder's `required` pageflow to ensure a Married or Separated Veteran adds Spouse information. 
- Health Applications 10-10EZR
- The feature is behind `ezr_spouse_confirmation_flow_enabled`, which was on at 25% when this was discovered. It is currently fully disabled in Production, and only enabled for specific users in Staging.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127660

## Testing done

- Before: selecting a Marital Status of Married or Separated leads to this Summary page, allowing the Veteran to not add Spouse information, which leads to the bug:
<img width="557" height="633" alt="Screenshot 2025-12-12 at 1 21 18 PM" src="https://github.com/user-attachments/assets/e9fd37f1-fe46-4a30-8bef-ce98284b3eac" />
- After: the Veteran must add Spouse information, preventing the issue. With a marital status of Married or Separated, they will see this page, followed by the data entry pages:
<img width="583" height="508" alt="Screenshot 2025-12-12 at 7 57 31 PM" src="https://github.com/user-attachments/assets/7612d914-f7b4-41e6-a526-07d50563dac6" />

_Describe the steps required to verify your changes are working as expected_
- Choose Married or Separated, see the new Intro page, and proceed to submit the form with no way to avoid providing the required Spouse information.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
