### PR TITLE
refactor(ci): complete OIDC migration for all AWS credentials and fix workflow permissions

### DIFF
--- a/.github/workflows/continuous-deploy-production.yml
+++ b/.github/workflows/continuous-deploy-production.yml
@@ -11,12 +11,18 @@ jobs:
     name: Notify of Pending Deployment
     if: ${{ github.event.client_payload.github_ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    env: 
+    permissions:
+      id-token: write
+      contents: read
+    env:
       VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+
       - name: Notify application team in Slack
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         with:
           payload: > 
             {
@@ -36,8 +42,7 @@ jobs:
               ]
             }
           channel_id: ${{ github.event.client_payload.slack_channel != '' && github.event.client_payload.slack_channel || env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
   deploy:
     name: Deploy
@@ -97,12 +102,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' && success() }}
     needs: [deploy]
+    permissions:
+      id-token: write
+      contents: read
     env:
       VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+
       - name: Notify Slack - Deployment Succeeded
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         with:
           payload: >-
             {
@@ -122,21 +133,26 @@ jobs:
               ]
             }
           channel_id: ${{ github.event.client_payload.slack_channel != '' && github.event.client_payload.slack_channel || env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
     if: ${{ always() && github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
     needs: [deploy]
+    permissions:
+      id-token: write
+      contents: read
     env:
       VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+
       - name: Slack – Deployment rejected (not approved)
         if: ${{ needs.deploy.result == 'failure' && needs.deploy.outputs.started == '' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
           payload: >-
@@ -157,12 +173,11 @@ jobs:
               ]
             }
           channel_id: ${{ github.event.client_payload.slack_channel != '' && github.event.client_payload.slack_channel || env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Slack – Deployment expired (no approval)
         if: ${{ needs.deploy.result == 'cancelled' && needs.deploy.outputs.started == '' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
           payload: >-
@@ -183,12 +198,11 @@ jobs:
               ]
             }
           channel_id: ${{ github.event.client_payload.slack_channel != '' && github.event.client_payload.slack_channel || env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Slack – Deployment cancelled during execution
         if: ${{ needs.deploy.result == 'cancelled' && needs.deploy.outputs.started == 'true' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
           payload: >-
@@ -209,12 +223,11 @@ jobs:
               ]
             }
           channel_id: ${{ github.event.client_payload.slack_channel != '' && github.event.client_payload.slack_channel || env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Slack – Deployment failed (error during run)
         if: ${{ needs.deploy.result == 'failure' && needs.deploy.outputs.started == 'true' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
           payload: >-
@@ -235,5 +248,4 @@ jobs:
               ]
             }
           channel_id: ${{ github.event.client_payload.slack_channel != '' && github.event.client_payload.slack_channel || env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1248,15 +1248,14 @@ jobs:
 
       - name: Notify Slack about Unit test failures
         if: ${{ github.ref != 'refs/heads/main' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          payload: '{"attachments": [{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]}'
           channel_id: C026PD47Z19 #gha-test-status
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       # ------------------------
       # | Upload BigQuery Data |
@@ -1561,15 +1560,14 @@ jobs:
 
       - name: Notify Slack about Cypress test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
           channel_id: C026PD47Z19 #gha-test-status
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
         # ------------------------
         # | Upload BigQuery Data |
@@ -1671,15 +1669,14 @@ jobs:
 
       - name: Notify Slack about Cypress test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
           channel_id: C026PD47Z19 #gha-test-status
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
         # ------------------------
         # | Upload BigQuery Data |
@@ -2104,6 +2101,9 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
     needs: [deploy, build]
+    permissions:
+      id-token: write
+      contents: read
     env:
       ALERT_TEAMS: true # Alerts teams for single/grouped app builds when set to true
       DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
@@ -2135,20 +2135,18 @@ jobs:
 
       - name: Notify application team in Slack
         if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${{steps.get-changed-apps.outputs.slack_groups}} CI for your application failed on the `main` branch in `vets-website`: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>\n For help troubleshooting, see the <https://depo-platform-documentation.scrollhelp.site/developer-docs/Handling-failed-single%2Fgrouped-application-pipelines.2066645150.html|documentation> on failed workflow runs."}}]}]}'
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Notify Slack
         if: steps.get-changed-apps.outputs.slack_groups == ''
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "`main` branch CI in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -354,7 +354,7 @@ jobs:
     needs: [set-env, notify-start]
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -150,6 +150,9 @@ jobs:
     name: Notify Freeze Ended
     runs-on: ubuntu-latest
     needs: [holiday-checker, main-deployment]
+    permissions:
+      id-token: write
+      contents: read
     if: ${{
       github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'false' && needs.main-deployment.outputs.reenabled == 'true'
       }}
@@ -162,8 +165,7 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
           channel_id: "C04868KS69L" # Frontend COP
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Short delay before SRE Slack (Ended)
         run: sleep 2
@@ -174,12 +176,14 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#32CD32", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "✅ *Code Freeze Ended:* Deployment workflows for `vets-website` and `content-build` have been re-enabled following the holiday period."}}]}]}'
           channel_id: "C06JM7UUHE3" # platform-sre-team
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
   notify-bypass:
     name: Notify Bypass Activation
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     if: ${{ github.event.inputs.bypass_freeze == 'true' }}
     steps:
       - name: Checkout Repository
@@ -190,8 +194,7 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#0000FF", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "ℹ️ *Deploy Freeze Bypassed:* Emergency bypass activated. Deployment workflows for `vets-website` and `content-build` have been force enabled."}}]}]}'
           channel_id: "C04868KS69L"
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Short delay before SRE Slack (Bypass)
         run: sleep 2
@@ -202,13 +205,15 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#0000FF", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "ℹ️ *Deploy Freeze Bypassed:* Emergency bypass activated. Deployment workflows for `vets-website` and `content-build` have been force enabled."}}]}]}'
           channel_id: "C06JM7UUHE3"
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
   notify-code-freeze-failure:
     name: Notify Code Freeze Failure
     runs-on: ubuntu-latest
     needs: [holiday-checker, main-deployment]
+    permissions:
+      id-token: write
+      contents: read
     if: ${{
       always() && github.event.inputs.bypass_freeze != 'true' && (
       (needs.holiday-checker.outputs.is_holiday == 'true' && cancelled()) ||
@@ -225,8 +230,7 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
           channel_id: "C04868KS69L"
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Short delay before SRE Slack (Failure)
         run: sleep 2
@@ -237,8 +241,7 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FF0000", "blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> *Code Freeze Operation Failed:* Unable to toggle deploy workflows for `vets-website` and `content-build`. Please investigate the issue immediately: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}} |View Run Details>."}}]}]}'
           channel_id: "C06JM7UUHE3"
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
   holiday-decision-gate:
     name: Holiday Decision Gate
@@ -312,6 +315,9 @@ jobs:
     name: Notify Start
     runs-on: ubuntu-latest
     needs: set-env
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -323,8 +329,7 @@ jobs:
           RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
         with:
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
           payload: |
             {
               "attachments": [
@@ -430,6 +435,9 @@ jobs:
     name: Notify Success
     runs-on: ubuntu-latest
     needs: deploy
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -441,14 +449,16 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Successfully deployed vets-website to production"}}]}]}'
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
     if: ${{ failure() || cancelled() }}
     needs: deploy
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -461,5 +471,4 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Production deploy for vets-website has failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -132,6 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: [lighthouse]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -141,5 +144,4 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "The Lighthouse scan for today just finished! <https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload-test/lighthouse/homepage.html|View the results>"}}]}]}'
           channel_id: ${{ env.CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}

--- a/.github/workflows/daily-product-scan.yml
+++ b/.github/workflows/daily-product-scan.yml
@@ -80,5 +80,4 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#03D3FC","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> AUTOMATIC UPDATE! The product-directory.json file has been updated. The updates have been merged to the main product directory."}}]}]}'
           channel_id: C026PD47Z19
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}

--- a/.github/workflows/e2e-allow-list-cleanup.yml
+++ b/.github/workflows/e2e-allow-list-cleanup.yml
@@ -95,6 +95,7 @@ jobs:
     name: Clean up E2E Test Stability Allow List
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       id-token: write
       contents: read
     needs: [fetch-allow-lists]

--- a/.github/workflows/freeze-enforcer.yml
+++ b/.github/workflows/freeze-enforcer.yml
@@ -56,6 +56,9 @@ jobs:
     name: Notify Freeze Enabled (Early)
     runs-on: ubuntu-latest
     needs: [holiday-checker, enforce-freeze]
+    permissions:
+      id-token: write
+      contents: read
     if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'true' }}
     steps:
       - name: Checkout Repository
@@ -67,8 +70,7 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FFA500", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "🚫 *Code Freeze Enabled:* Holiday freeze is active. Deployment workflows for `vets-website` and `content-build` are disabled/gated. No deployments should occur until further notice."}}]}]}'
           channel_id: ${{ env.COP_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Short delay before SRE Slack (Enabled)
         run: sleep 2
@@ -79,7 +81,6 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FFA500", "blocks": [{"type": "section","text": {"type": "mrkdwn", "text": "🚫 *Code Freeze Enabled:* Holiday freeze is active. Deployment workflows for `vets-website` and `content-build` are disabled/gated. No deployments should occur until further notice."}}]}]}'
           channel_id: ${{ env.SRE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
 

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -182,6 +182,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ failure() || cancelled() }}
     needs: deploy
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -193,5 +196,4 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "vets-website manual dev/staging deploy failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role: ${{ vars.AWS_ASSUME_ROLE }}

--- a/.github/workflows/slack-notify/action.yml
+++ b/.github/workflows/slack-notify/action.yml
@@ -8,23 +8,22 @@ inputs:
   payload:
     description: attached message
     required: true
-  aws-access-key-id:
-    description: aws-access-key-id
+  role:
+    description: AWS IAM role to assume (required for OIDC)
     required: true
-  aws-secret-access-key:
-    description: aws-secret-access-key
-    required: true
+  aws_region:
+    description: AWS region
+    required: false
+    default: 'us-gov-west-1'
 
 runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: ./../configure-aws-credentials
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: us-gov-west-1
-        mask-aws-account-id: true
+        aws_region: ${{ inputs.aws_region }}
+        role: ${{ inputs.role }}
 
     - name: Get Slack bot token
       uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR completes comprehensive OIDC cleanup for all AWS credentials in GitHub Actions workflows. All workflows now use OIDC-based authentication instead of hardcoded IAM user secrets, centralizing AWS configuration through the local slack-notify composite action.

### Changes Made

**1. Converted slack-notify composite action to OIDC** (74e6865)
- Updated `.github/workflows/slack-notify/action.yml` to use the centralized `configure-aws-credentials` composite action
- Replaced `aws-access-key-id`/`aws-secret-access-key` inputs with `role` parameter
- Added `aws_region` input with default value

**2. Updated workflows using local slack-notify action** (74e6865, 2be5bd2, 69107b4, 81d8cdd, 5a46d26)
- daily-deploy-production.yml (6 notification jobs)
- manual-deploy-dev-staging.yml
- freeze-enforcer.yml  
- daily-product-scan.yml
- daily-lighthouse-scan.yml
- Added `permissions: id-token: write, contents: read` to all jobs
- Replaced AWS secrets with `role: ${{ vars.AWS_ASSUME_ROLE }}`

**3. Converted workflows using external slack-notify action** (cd36e70, 8a0f7b7)
- continuous-deploy-production.yml (3 jobs, 6 notification calls)
- continuous-integration.yml (3 jobs, 5 notification calls)
- Migrated from `department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main` to local `./.github/workflows/slack-notify`
- Added checkout steps where needed
- Added OIDC permissions to all affected jobs

**4. Fixed daily production deploy release creation** (87c0f9f)
- Changed `create-release` job permissions from `contents: read` to `contents: write`
- Resolves 403 "resource is not accessible by integration" error

**5. Fixed E2E test stability allow list checks** (44d6035)
- Added `checks: write` permission to `clean-up-allow-list` job
- Enables checks-action operations

### Results
- ✅ Zero remaining references to `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` secrets
- ✅ All AWS credentials now use OIDC via `${{ vars.AWS_ASSUME_ROLE }}`
- ✅ Centralized AWS configuration through local composite action
- ✅ All 9 affected workflows properly configured with OIDC permissions

## Related issue(s)

- [Fix: Various CI permission issues following OIDC conversion](https://github.com/department-of-veterans-affairs/va.gov-team/issues/127500)

## Testing done

- Verified syntax of all modified YAML files
- Confirmed zero remaining AWS secret references via grep search
- Ensured all workflows reference `${{ vars.AWS_ASSUME_ROLE }}` consistently
- Validated all jobs have proper OIDC permissions (`id-token: write`)
- Confirmed all slack-notify calls use local composite action

## Screenshots

N/A - Infrastructure changes only

## What areas of the site does it impact?

GitHub Actions CI/CD workflows for:
- All deployment workflows (daily, manual, continuous)
- Slack notifications across all workflows
- Code freeze enforcement
- Product and Lighthouse scans
- Testing reports and E2E test stability tracking

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (inline YAML comments where needed)
- N/A Screenshot of the developed feature is added
- N/A [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- N/A Events are being sent to the appropriate logging solution
- N/A Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- N/A Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please review the OIDC permission configuration and verify the migration from external to local slack-notify action is appropriate for all workflows.