### PR TITLE
Add OH Request E2E tests

### DIFF
--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -1,5 +1,9 @@
 import { getTypeOfCareById } from '../../../../../utils/appointment';
-import { TYPE_OF_CARE_IDS } from '../../../../../utils/constants';
+import {
+  APPOINTMENT_STATUS,
+  TYPE_OF_CARE_IDS,
+} from '../../../../../utils/constants';
+import MockAppointmentResponse from '../../../../fixtures/MockAppointmentResponse';
 import MockEligibilityResponse from '../../../../fixtures/MockEligibilityResponse';
 import MockFacilityResponse from '../../../../fixtures/MockFacilityResponse';
 import MockRelationshipResponse from '../../../../fixtures/MockRelationshipResponse';
@@ -17,6 +21,8 @@ import TypeOfVisitPageObject from '../../../page-objects/TypeOfVisitPageObject';
 import UrgentCareInformationPageObject from '../../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../../page-objects/VAFacilityPageObject';
 import {
+  mockAppointmentCreateApi,
+  mockAppointmentGetApi,
   mockAppointmentsGetApi,
   mockEligibilityCCApi,
   mockEligibilityDirectApi,
@@ -36,7 +42,14 @@ const { idV2: typeOfCareId, cceType } = getTypeOfCareById(
 describe('OH request flow - Food and Nutrition', () => {
   beforeEach(() => {
     vaosSetup();
-
+    const response = new MockAppointmentResponse({
+      id: 'mock1',
+      localStartTime: new Date(),
+      status: APPOINTMENT_STATUS.proposed,
+      pending: true,
+    }).setType('REQUEST');
+    mockAppointmentGetApi({ response });
+    mockAppointmentCreateApi({ response });
     mockAppointmentsGetApi({ response: [] });
     mockFeatureToggles({
       vaOnlineSchedulingImmediateCareAlert: true,
@@ -115,7 +128,6 @@ describe('OH request flow - Food and Nutrition', () => {
             .assertHeading({
               name: /What.s the reason for this appointment/i,
             })
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })
@@ -221,7 +233,6 @@ describe('OH request flow - Food and Nutrition', () => {
               .assertHeading({
                 name: /What.s the reason for this appointment/i,
               })
-              .selectReasonForAppointment()
               .assertLabel({
                 label: /Add any details you.d like to share with your provider/,
               })
@@ -327,7 +338,6 @@ describe('OH request flow - Food and Nutrition', () => {
             .assertHeading({
               name: /What.s the reason for this appointment/i,
             })
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })
@@ -429,7 +439,6 @@ describe('OH request flow - Food and Nutrition', () => {
             .assertHeading({
               name: /What.s the reason for this appointment/i,
             })
-            .selectReasonForAppointment()
             .assertLabel({
               label: /Add any details you.d like to share with your provider/,
             })

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -1,0 +1,468 @@
+import { getTypeOfCareById } from '../../../../../utils/appointment';
+import { TYPE_OF_CARE_IDS } from '../../../../../utils/constants';
+import MockEligibilityResponse from '../../../../fixtures/MockEligibilityResponse';
+import MockFacilityResponse from '../../../../fixtures/MockFacilityResponse';
+import MockRelationshipResponse from '../../../../fixtures/MockRelationshipResponse';
+import MockUser from '../../../../fixtures/MockUser';
+import AppointmentListPageObject from '../../../page-objects/AppointmentList/AppointmentListPageObject';
+import ConfirmationPageObject from '../../../page-objects/ConfirmationPageObject';
+import ContactInfoPageObject from '../../../page-objects/ContactInfoPageObject';
+import DateTimeRequestPageObject from '../../../page-objects/DateTimeRequestPageObject';
+import ProviderPageObject from '../../../page-objects/ProviderPageObject';
+import ReasonForAppointmentPageObject from '../../../page-objects/ReasonForAppointmentPageObject';
+import ReviewPageObject from '../../../page-objects/ReviewPageObject';
+import TypeOfCarePageObject from '../../../page-objects/TypeOfCarePageObject';
+import TypeOfFacilityPageObject from '../../../page-objects/TypeOfFacilityPageObject';
+import TypeOfVisitPageObject from '../../../page-objects/TypeOfVisitPageObject';
+import UrgentCareInformationPageObject from '../../../page-objects/UrgentCareInformationPageObject';
+import VAFacilityPageObject from '../../../page-objects/VAFacilityPageObject';
+import {
+  mockAppointmentsGetApi,
+  mockEligibilityCCApi,
+  mockEligibilityDirectApi,
+  mockEligibilityRequestApi,
+  mockFacilitiesApi,
+  mockFeatureToggles,
+  mockRelationshipsApi,
+  mockSchedulingConfigurationApi,
+  mockVamcEhrApi,
+  vaosSetup,
+} from '../../../vaos-cypress-helpers';
+
+const { idV2: typeOfCareId, cceType } = getTypeOfCareById(
+  TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID,
+);
+
+describe('OH request flow - Food and Nutrition', () => {
+  beforeEach(() => {
+    vaosSetup();
+
+    mockAppointmentsGetApi({ response: [] });
+    mockFeatureToggles({
+      vaOnlineSchedulingImmediateCareAlert: true,
+    });
+    mockVamcEhrApi({ isCerner: true });
+  });
+
+  describe('When the user has more than one provider available', () => {
+    describe('And both direct scheduling and request enabled', () => {
+      describe('And request limit not reached', () => {
+        it('should submit form', () => {
+          // Arrange
+          const mockEligibilityResponse = new MockEligibilityResponse({
+            facilityId: '983',
+            typeOfCareId,
+          });
+          const mockUser = new MockUser({ addressLine1: '123 Main St.' });
+
+          mockFacilitiesApi({
+            response: MockFacilityResponse.createResponses({
+              facilityIds: ['983', '984'],
+            }),
+          });
+          mockEligibilityDirectApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityRequestApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityCCApi({ cceType, isEligible: true });
+          mockRelationshipsApi({
+            response: [
+              new MockRelationshipResponse(),
+              new MockRelationshipResponse(),
+            ],
+          });
+          mockSchedulingConfigurationApi({
+            facilityIds: ['983'],
+            typeOfCareId,
+            isDirect: true,
+            isRequest: true,
+          });
+
+          // Act
+          cy.login(mockUser);
+          AppointmentListPageObject.visit().scheduleAppointment(
+            'Schedule a new appointment',
+          );
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+          TypeOfCarePageObject.assertUrl()
+            .assertAddressAlert({ exist: false })
+            .selectTypeOfCare(/Nutrition and food/i)
+            .clickNextButton();
+          TypeOfFacilityPageObject.assertUrl()
+            .selectTypeOfFacility(/VA medical center or clinic/i)
+            .clickNextButton();
+          VAFacilityPageObject.assertUrl()
+            .selectLocation(/Facility 983/i)
+            .clickNextButton();
+          ProviderPageObject.assertUrl()
+            .assertHeading({
+              level: 1,
+              name: /Which provider do you want to schedule with/i,
+            })
+            .clickLink({
+              name: 'Request an appointment',
+              useShadowDOM: true,
+            });
+          DateTimeRequestPageObject.assertUrl()
+            .assertHeading({
+              name: /When would you like an appointment/i,
+            })
+            .selectFirstAvailableDate()
+            .clickNextButton();
+          ReasonForAppointmentPageObject.assertUrl()
+            .assertHeading({
+              name: /What.s the reason for this appointment/i,
+            })
+            .selectReasonForAppointment()
+            .assertLabel({
+              label: /Add any details you.d like to share with your provider/,
+            })
+            .typeAdditionalText({
+              content: 'This is a test',
+            })
+            .clickNextButton();
+          TypeOfVisitPageObject.assertUrl()
+            .assertHeading({
+              name: /How do you want to attend this appointment/i,
+            })
+            .selectVisitType('In person')
+            .clickNextButton();
+          ContactInfoPageObject.assertUrl()
+            .assertHeading({
+              name: /How should we contact you/i,
+            })
+            .typeEmailAddress('veteran@va.gov')
+            .typePhoneNumber('5555555555')
+            .clickNextButton();
+          ReviewPageObject.assertUrl()
+            .assertHeading({
+              name: /Review and submit your request/,
+            })
+            .clickRequestButton();
+          ConfirmationPageObject.assertUrl({
+            isDirect: false,
+          });
+
+          // Assert
+          cy.axeCheckBestPractice();
+        });
+      });
+    });
+    describe('And only request enabled', () => {
+      describe('And request enabled', () => {
+        describe('And request limit not reached', () => {
+          it('should submit form', () => {
+            // Arrange
+            const mockEligibilityResponse = new MockEligibilityResponse({
+              facilityId: '983',
+              typeOfCareId,
+            });
+            const mockUser = new MockUser({ addressLine1: '123 Main St.' });
+
+            mockFacilitiesApi({
+              response: MockFacilityResponse.createResponses({
+                facilityIds: ['983', '984'],
+              }),
+            });
+            mockEligibilityDirectApi({
+              response: mockEligibilityResponse,
+            });
+            mockEligibilityRequestApi({
+              response: mockEligibilityResponse,
+            });
+            mockEligibilityCCApi({ cceType, isEligible: true });
+            mockRelationshipsApi({
+              response: [
+                new MockRelationshipResponse(),
+                new MockRelationshipResponse(),
+              ],
+            });
+            mockSchedulingConfigurationApi({
+              facilityIds: ['983'],
+              typeOfCareId,
+              isDirect: false,
+              isRequest: true,
+            });
+
+            // Act
+            cy.login(mockUser);
+            AppointmentListPageObject.visit().scheduleAppointment(
+              'Schedule a new appointment',
+            );
+            UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+            TypeOfCarePageObject.assertUrl()
+              .assertAddressAlert({ exist: false })
+              .selectTypeOfCare(/Nutrition and food/i)
+              .clickNextButton();
+            TypeOfFacilityPageObject.assertUrl()
+              .selectTypeOfFacility(/VA medical center or clinic/i)
+              .clickNextButton();
+            VAFacilityPageObject.assertUrl()
+              .selectLocation(/Facility 983/i)
+              .clickNextButton();
+            ProviderPageObject.assertUrl()
+              .assertHeading({
+                level: 1,
+                name: /Which provider do you want to schedule with/i,
+              })
+              .clickLink({
+                name: 'Request an appointment',
+                useShadowDOM: true,
+              });
+            DateTimeRequestPageObject.assertUrl()
+              .assertHeading({
+                name: /When would you like an appointment/i,
+              })
+              .selectFirstAvailableDate()
+              .clickNextButton();
+            ReasonForAppointmentPageObject.assertUrl()
+              .assertHeading({
+                name: /What.s the reason for this appointment/i,
+              })
+              .selectReasonForAppointment()
+              .assertLabel({
+                label: /Add any details you.d like to share with your provider/,
+              })
+              .typeAdditionalText({
+                content: 'This is a test',
+              })
+              .clickNextButton();
+            TypeOfVisitPageObject.assertUrl()
+              .assertHeading({
+                name: /How do you want to attend this appointment/i,
+              })
+              .selectVisitType('In person')
+              .clickNextButton();
+            ContactInfoPageObject.assertUrl()
+              .assertHeading({
+                name: /How should we contact you/i,
+              })
+              .typeEmailAddress('veteran@va.gov')
+              .typePhoneNumber('5555555555')
+              .clickNextButton();
+            ReviewPageObject.assertUrl()
+              .assertHeading({
+                name: /Review and submit your request/,
+              })
+              .clickRequestButton();
+            ConfirmationPageObject.assertUrl({
+              isDirect: false,
+            });
+
+            // Assert
+            cy.axeCheckBestPractice();
+          });
+        });
+      });
+    });
+  });
+
+  describe('When the user has one provider available', () => {
+    describe('And both direct scheduling and request enabled', () => {
+      describe('And request limit not reached', () => {
+        it('should submit form', () => {
+          // Arrange
+          const mockEligibilityResponse = new MockEligibilityResponse({
+            facilityId: '983',
+            typeOfCareId,
+          });
+          const mockUser = new MockUser({ addressLine1: '123 Main St.' });
+
+          mockFacilitiesApi({
+            response: MockFacilityResponse.createResponses({
+              facilityIds: ['983', '984'],
+            }),
+          });
+          mockEligibilityDirectApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityRequestApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityCCApi({ cceType, isEligible: true });
+          mockRelationshipsApi({
+            response: [new MockRelationshipResponse()],
+          });
+          mockSchedulingConfigurationApi({
+            facilityIds: ['983'],
+            typeOfCareId,
+            isDirect: true,
+            isRequest: true,
+          });
+
+          // Act
+          cy.login(mockUser);
+          AppointmentListPageObject.visit().scheduleAppointment(
+            'Schedule a new appointment',
+          );
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+          TypeOfCarePageObject.assertUrl()
+            .assertAddressAlert({ exist: false })
+            .selectTypeOfCare(/Nutrition and food/i)
+            .clickNextButton();
+          TypeOfFacilityPageObject.assertUrl()
+            .selectTypeOfFacility(/VA medical center or clinic/i)
+            .clickNextButton();
+          VAFacilityPageObject.assertUrl()
+            .selectLocation(/Facility 983/i)
+            .clickNextButton();
+          ProviderPageObject.assertUrl()
+            .assertHeading({
+              level: 1,
+              name: /Your nutrition and food provider/i,
+            })
+            .clickLink({
+              name: 'Request an appointment',
+              useShadowDOM: true,
+            });
+          DateTimeRequestPageObject.assertUrl()
+            .assertHeading({
+              name: /When would you like an appointment/i,
+            })
+            .selectFirstAvailableDate()
+            .clickNextButton();
+          ReasonForAppointmentPageObject.assertUrl()
+            .assertHeading({
+              name: /What.s the reason for this appointment/i,
+            })
+            .selectReasonForAppointment()
+            .assertLabel({
+              label: /Add any details you.d like to share with your provider/,
+            })
+            .typeAdditionalText({
+              content: 'This is a test',
+            })
+            .clickNextButton();
+          TypeOfVisitPageObject.assertUrl()
+            .assertHeading({
+              name: /How do you want to attend this appointment/i,
+            })
+            .selectVisitType('In person')
+            .clickNextButton();
+          ContactInfoPageObject.assertUrl()
+            .assertHeading({
+              name: /How should we contact you/i,
+            })
+            .typeEmailAddress('veteran@va.gov')
+            .typePhoneNumber('5555555555')
+            .clickNextButton();
+          ReviewPageObject.assertUrl()
+            .assertHeading({
+              name: /Review and submit your request/,
+            })
+            .clickRequestButton();
+          ConfirmationPageObject.assertUrl({
+            isDirect: false,
+          });
+
+          // Assert
+          cy.axeCheckBestPractice();
+        });
+      });
+    });
+    describe('And only request enabled', () => {
+      describe('And request limit not reached', () => {
+        it('should submit form', () => {
+          // Arrange
+          const mockEligibilityResponse = new MockEligibilityResponse({
+            facilityId: '983',
+            typeOfCareId,
+          });
+          const mockUser = new MockUser({ addressLine1: '123 Main St.' });
+
+          mockFacilitiesApi({
+            response: MockFacilityResponse.createResponses({
+              facilityIds: ['983', '984'],
+            }),
+          });
+          mockEligibilityDirectApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityRequestApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityCCApi({ cceType, isEligible: true });
+          mockRelationshipsApi({
+            response: [new MockRelationshipResponse()],
+          });
+          mockSchedulingConfigurationApi({
+            facilityIds: ['983'],
+            typeOfCareId,
+            isDirect: false,
+            isRequest: true,
+          });
+
+          // Act
+          cy.login(mockUser);
+          AppointmentListPageObject.visit().scheduleAppointment(
+            'Schedule a new appointment',
+          );
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+          TypeOfCarePageObject.assertUrl()
+            .assertAddressAlert({ exist: false })
+            .selectTypeOfCare(/Nutrition and food/i)
+            .clickNextButton();
+          TypeOfFacilityPageObject.assertUrl()
+            .selectTypeOfFacility(/VA medical center or clinic/i)
+            .clickNextButton();
+          VAFacilityPageObject.assertUrl()
+            .selectLocation(/Facility 983/i)
+            .clickNextButton();
+          ProviderPageObject.assertUrl()
+            .assertHeading({
+              level: 1,
+              name: /Your nutrition and food provider/i,
+            })
+            .clickLink({
+              name: 'Request an appointment',
+              useShadowDOM: true,
+            });
+          DateTimeRequestPageObject.assertUrl()
+            .assertHeading({
+              name: /When would you like an appointment/i,
+            })
+            .selectFirstAvailableDate()
+            .clickNextButton();
+          ReasonForAppointmentPageObject.assertUrl()
+            .assertHeading({
+              name: /What.s the reason for this appointment/i,
+            })
+            .selectReasonForAppointment()
+            .assertLabel({
+              label: /Add any details you.d like to share with your provider/,
+            })
+            .typeAdditionalText({
+              content: 'This is a test',
+            })
+            .clickNextButton();
+          TypeOfVisitPageObject.assertUrl()
+            .assertHeading({
+              name: /How do you want to attend this appointment/i,
+            })
+            .selectVisitType('In person')
+            .clickNextButton();
+          ContactInfoPageObject.assertUrl()
+            .assertHeading({
+              name: /How should we contact you/i,
+            })
+            .typeEmailAddress('veteran@va.gov')
+            .typePhoneNumber('5555555555')
+            .clickNextButton();
+          ReviewPageObject.assertUrl()
+            .assertHeading({
+              name: /Review and submit your request/,
+            })
+            .clickRequestButton();
+          ConfirmationPageObject.assertUrl({
+            isDirect: false,
+          });
+
+          // Assert
+          cy.axeCheckBestPractice();
+        });
+      });
+    });
+  });
+});

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -163,108 +163,106 @@ describe('OH request flow - Food and Nutrition', () => {
       });
     });
     describe('And only request enabled', () => {
-      describe('And request enabled', () => {
-        describe('And request limit not reached', () => {
-          it('should submit form', () => {
-            // Arrange
-            const mockEligibilityResponse = new MockEligibilityResponse({
-              facilityId: '983',
-              typeOfCareId,
-            });
-            const mockUser = new MockUser({ addressLine1: '123 Main St.' });
-
-            mockFacilitiesApi({
-              response: MockFacilityResponse.createResponses({
-                facilityIds: ['983', '984'],
-              }),
-            });
-            mockEligibilityDirectApi({
-              response: mockEligibilityResponse,
-            });
-            mockEligibilityRequestApi({
-              response: mockEligibilityResponse,
-            });
-            mockEligibilityCCApi({ cceType, isEligible: true });
-            mockRelationshipsApi({
-              response: [
-                new MockRelationshipResponse(),
-                new MockRelationshipResponse(),
-              ],
-            });
-            mockSchedulingConfigurationApi({
-              facilityIds: ['983'],
-              typeOfCareId,
-              isDirect: false,
-              isRequest: true,
-            });
-
-            // Act
-            cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
-            UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
-            TypeOfCarePageObject.assertUrl()
-              .assertAddressAlert({ exist: false })
-              .selectTypeOfCare(/Nutrition and food/i)
-              .clickNextButton();
-            TypeOfFacilityPageObject.assertUrl()
-              .selectTypeOfFacility(/VA medical center or clinic/i)
-              .clickNextButton();
-            VAFacilityPageObject.assertUrl()
-              .selectLocation(/Facility 983/i)
-              .clickNextButton();
-            ProviderPageObject.assertUrl()
-              .assertHeading({
-                level: 1,
-                name: /Which provider do you want to schedule with/i,
-              })
-              .clickLink({
-                name: 'Request an appointment',
-                useShadowDOM: true,
-              });
-            DateTimeRequestPageObject.assertUrl()
-              .assertHeading({
-                name: /When would you like an appointment/i,
-              })
-              .selectFirstAvailableDate()
-              .clickNextButton();
-            ReasonForAppointmentPageObject.assertUrl()
-              .assertHeading({
-                name: /What.s the reason for this appointment/i,
-              })
-              .assertLabel({
-                label: /Add any details you.d like to share with your provider/,
-              })
-              .typeAdditionalText({
-                content: 'This is a test',
-              })
-              .clickNextButton();
-            TypeOfVisitPageObject.assertUrl()
-              .assertHeading({
-                name: /How do you want to attend this appointment/i,
-              })
-              .selectVisitType('In person')
-              .clickNextButton();
-            ContactInfoPageObject.assertUrl()
-              .assertHeading({
-                name: /How should we contact you/i,
-              })
-              .typeEmailAddress('veteran@va.gov')
-              .typePhoneNumber('5555555555')
-              .clickNextButton();
-            ReviewPageObject.assertUrl()
-              .assertHeading({
-                name: /Review and submit your request/,
-              })
-              .clickRequestButton();
-            ConfirmationPageObject.assertUrl({
-              isDirect: false,
-            });
-
-            // Assert
-            cy.axeCheckBestPractice();
+      describe('And request limit not reached', () => {
+        it('should submit form', () => {
+          // Arrange
+          const mockEligibilityResponse = new MockEligibilityResponse({
+            facilityId: '983',
+            typeOfCareId,
           });
+          const mockUser = new MockUser({ addressLine1: '123 Main St.' });
+
+          mockFacilitiesApi({
+            response: MockFacilityResponse.createResponses({
+              facilityIds: ['983', '984'],
+            }),
+          });
+          mockEligibilityDirectApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityRequestApi({
+            response: mockEligibilityResponse,
+          });
+          mockEligibilityCCApi({ cceType, isEligible: true });
+          mockRelationshipsApi({
+            response: [
+              new MockRelationshipResponse(),
+              new MockRelationshipResponse(),
+            ],
+          });
+          mockSchedulingConfigurationApi({
+            facilityIds: ['983'],
+            typeOfCareId,
+            isDirect: false,
+            isRequest: true,
+          });
+
+          // Act
+          cy.login(mockUser);
+          AppointmentListPageObject.visit().scheduleAppointment(
+            'Schedule a new appointment',
+          );
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+          TypeOfCarePageObject.assertUrl()
+            .assertAddressAlert({ exist: false })
+            .selectTypeOfCare(/Nutrition and food/i)
+            .clickNextButton();
+          TypeOfFacilityPageObject.assertUrl()
+            .selectTypeOfFacility(/VA medical center or clinic/i)
+            .clickNextButton();
+          VAFacilityPageObject.assertUrl()
+            .selectLocation(/Facility 983/i)
+            .clickNextButton();
+          ProviderPageObject.assertUrl()
+            .assertHeading({
+              level: 1,
+              name: /Which provider do you want to schedule with/i,
+            })
+            .clickLink({
+              name: 'Request an appointment',
+              useShadowDOM: true,
+            });
+          DateTimeRequestPageObject.assertUrl()
+            .assertHeading({
+              name: /When would you like an appointment/i,
+            })
+            .selectFirstAvailableDate()
+            .clickNextButton();
+          ReasonForAppointmentPageObject.assertUrl()
+            .assertHeading({
+              name: /What.s the reason for this appointment/i,
+            })
+            .assertLabel({
+              label: /Add any details you.d like to share with your provider/,
+            })
+            .typeAdditionalText({
+              content: 'This is a test',
+            })
+            .clickNextButton();
+          TypeOfVisitPageObject.assertUrl()
+            .assertHeading({
+              name: /How do you want to attend this appointment/i,
+            })
+            .selectVisitType('In person')
+            .clickNextButton();
+          ContactInfoPageObject.assertUrl()
+            .assertHeading({
+              name: /How should we contact you/i,
+            })
+            .typeEmailAddress('veteran@va.gov')
+            .typePhoneNumber('5555555555')
+            .clickNextButton();
+          ReviewPageObject.assertUrl()
+            .assertHeading({
+              name: /Review and submit your request/,
+            })
+            .clickRequestButton();
+          ConfirmationPageObject.assertUrl({
+            isDirect: false,
+          });
+
+          // Assert
+          cy.axeCheckBestPractice();
         });
       });
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adding E2E tests for OH Request flow. These tests cover the primary successful scenarios
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125715

## Testing done

- Ensured new tests runs successfully

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
