### PR TITLE
Fix keyboard accessibility for document status alerts and anchor links

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab-v2/FilesWeCouldntReceiveEntryPoint.jsx
+++ b/src/applications/claims-status/components/claim-files-tab-v2/FilesWeCouldntReceiveEntryPoint.jsx
@@ -16,11 +16,13 @@ const FilesWeCouldntReceiveEntryPoint = ({ evidenceSubmissions }) => {
 
   return (
     <div
-      id={ANCHOR_LINKS.filesWeCouldntReceive}
       className="files-we-couldnt-receive-entry-point"
       data-testid="files-we-couldnt-receive-entry-point"
     >
-      <h3 className="vads-u-margin-top--0 vads-u-margin-bottom--3">
+      <h3
+        className="vads-u-margin-top--0 vads-u-margin-bottom--3"
+        id={ANCHOR_LINKS.filesWeCouldntReceive}
+      >
         Files we couldn’t receive
       </h3>
       <p>

--- a/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
@@ -188,10 +188,11 @@ describe('<ClaimDetailLayout>', () => {
       </Provider>,
     );
 
-    const selector = container.querySelector('va-alert');
-    expect(selector).to.exist;
+    const alert = container.querySelector('va-alert');
+    expect(alert).to.exist;
+    const headline = alert.querySelector('h2');
     await waitFor(() => {
-      expect(document.activeElement).to.equal(selector);
+      expect(document.activeElement).to.equal(headline);
     });
   });
 

--- a/src/applications/claims-status/tests/components/FilesPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesPage.unit.spec.jsx
@@ -194,10 +194,11 @@ describe('<FilesPage>', () => {
         </Provider>,
       );
 
-      const selector = container.querySelector('va-alert');
-      expect(selector).to.exist;
+      const alert = container.querySelector('va-alert');
+      expect(alert).to.exist;
+      const headline = alert.querySelector('h2');
       await waitFor(() => {
-        expect(document.activeElement).to.equal(selector);
+        expect(document.activeElement).to.equal(headline);
       });
     });
   });

--- a/src/applications/claims-status/tests/utils/page.unit.spec.jsx
+++ b/src/applications/claims-status/tests/utils/page.unit.spec.jsx
@@ -40,46 +40,36 @@ describe('Page utils:', () => {
 
   describe('focusNotificationAlert', () => {
     let alertElement;
+    let headlineElement;
 
-    beforeEach(() => {
+    afterEach(() => {
+      if (alertElement && alertElement.parentNode) {
+        document.body.removeChild(alertElement);
+      }
+    });
+
+    it('should focus headline inside alert when present', () => {
+      alertElement = document.createElement('div');
+      alertElement.className = 'claims-alert';
+      headlineElement = document.createElement('h2');
+      alertElement.appendChild(headlineElement);
+      document.body.appendChild(alertElement);
+
+      focusNotificationAlert();
+
+      expect(document.activeElement).to.equal(headlineElement);
+      expect(headlineElement.getAttribute('tabindex')).to.equal('-1');
+    });
+
+    it('should focus alert container when no headline present', () => {
       alertElement = document.createElement('div');
       alertElement.className = 'claims-alert';
       document.body.appendChild(alertElement);
-    });
 
-    afterEach(() => {
-      document.body.removeChild(alertElement);
-    });
-
-    it('should focus immediately if element is present and focusable', () => {
       focusNotificationAlert();
 
       expect(document.activeElement).to.equal(alertElement);
       expect(alertElement.getAttribute('tabindex')).to.equal('-1');
-    });
-
-    it('should retry focus if focus does not succeed initially', done => {
-      const originalFocus = alertElement.focus;
-
-      let calledOnce = false;
-
-      alertElement.focus = () => {
-        if (!calledOnce) {
-          calledOnce = true;
-        } else {
-          alertElement.focus = originalFocus;
-          alertElement.focus();
-        }
-      };
-
-      focusNotificationAlert();
-
-      setTimeout(() => {
-        setTimeout(() => {
-          expect(document.activeElement).to.equal(alertElement);
-          done();
-        }, 160);
-      }, 0);
     });
   });
 });

--- a/src/applications/claims-status/utils/page.js
+++ b/src/applications/claims-status/utils/page.js
@@ -40,13 +40,12 @@ export function isTab(url) {
 export const focusNotificationAlert = () => {
   const alert = document.querySelector('.claims-alert');
   if (alert) {
-    setFocus(alert);
-    setTimeout(() => {
-      if (document.activeElement !== alert) {
-        setTimeout(() => {
-          setFocus(alert);
-        }, 150);
-      }
-    }, 0);
+    // Focus headline to preserve SHIFT+TAB navigation to alert's interactive elements
+    const headline = alert.querySelector('h2');
+    if (headline) {
+      setFocus(headline);
+    } else {
+      setFocus(alert);
+    }
   }
 };


### PR DESCRIPTION
## Summary

Fixes keyboard accessibility issue where users couldn't SHIFT+TAB back to interactive elements (links, close button) within document status alerts after tabbing out.

## What Changed

1. **`focusNotificationAlert()` in `page.js`:** Updated to focus on the alert's headline (`h2`) instead of the alert container. This prevents `tabindex="-1"` from being set on the `va-alert` host element, which was interfering with keyboard navigation.

2. **`FilesWeCouldntReceiveEntryPoint.jsx`:** Moved the anchor `id` from the container `div` to the `h3` heading so that clicking the "Files we couldn't receive section" link focuses on the heading instead of the entire container.

## Note on Problem 1 (Focus Order)

The focus order within the alert (Link then X button instead of X button then Link) is a structural limitation of the va-alert web component's shadow DOM. This can't be fixed at the application level since the close button is rendered after the slotted content in the shadow DOM. The ticket noted Problem 1 as "annoying" while Problem 2 (SHIFT+TAB navigation) was the potential launch blocker, which this PR resolves.

## Related issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#127648

## How to Test Locally

1. **Set up for success alert:**
   - In `src/applications/claims-status/tests/local-dev-mock-api/common.js`, set `errorPattern` to `null`

2. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

3. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```

4. **Test keyboard navigation:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/8/files
   - Upload a file and submit
   - After the green success alert appears, use TAB to navigate through the alert elements (link → X button)
   - TAB out of the alert to the next focusable element
   - Use SHIFT+TAB to navigate back
   - Verify you can reach both the X button and the link within the alert

5. **Test "Files we couldn't receive" anchor link:**
  - Navigate to: http://localhost:3001/track-claims/your-claims/3/files
  - In the "File submissions in progress" section, click the "Files we couldn't receive section" link
  - Verify it scrolls to the "Files we couldn't receive" section and focuses on the h3 heading
   
## Testing done

- [x] Manual keyboard navigation testing (see video below)
- [x] Verified TAB navigates through alert elements
- [x] Verified SHIFT+TAB returns to alert elements
- [x] Updated unit tests for `focusNotificationAlert()` to match new headline focus behavior
- [x] Updated FilesPage.unit.spec.jsx and ClaimDetailLayout.unit.spec.jsx to expect focus on alert headline 
- [x] Verified "Files we couldn't receive section" link focuses on the h3 heading

## Screenshots / Video


https://github.com/user-attachments/assets/26e1e097-fd5d-4934-8bc6-a4536cae7080
