### PR TITLE
Removed DS Logon from AuthMetrics

### DIFF
--- a/src/applications/auth/containers/AuthMetrics.jsx
+++ b/src/applications/auth/containers/AuthMetrics.jsx
@@ -39,7 +39,6 @@ export default class AuthMetrics {
       case POLICY_TYPES.CUSTOM: /* type=custom is used for SSOe auto login */
       case POLICY_TYPES.MHV_VERIFIED: /* type=mhv_verified */
       case CSP_IDS.MHV:
-      case CSP_IDS.DS_LOGON:
       case CSP_IDS.ID_ME:
       case CSP_IDS.LOGIN_GOV:
       case CSP_IDS.VAMOCK:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed references to DS Logon from `AuthMetrics.jsx`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/729)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/applications/auth/tests/AuthMetrics.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `AuthMetrics.jsx`.

## Acceptance criteria
- [x] Remove references to DS Logon from AuthMetrics