### PR TITLE
[CDP] Overpayment empty error states language updates

### DIFF
--- a/src/applications/combined-debt-portal/combined/components/AlertCard.jsx
+++ b/src/applications/combined-debt-portal/combined/components/AlertCard.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-import { APP_TYPES } from '../utils/helpers';
+import {
+  APP_TYPES,
+  healthResourceCenterPhoneContent,
+  dmcPhoneContent,
+} from '../utils/helpers';
 
 const AlertCard = ({ appType }) => {
   return (
@@ -15,38 +18,23 @@ const AlertCard = ({ appType }) => {
       >
         <h2 slot="headline" className="vads-u-font-size--h3">
           We can’t access your{' '}
-          {`${appType === APP_TYPES.DEBT ? 'debt' : 'copay'}`} records right now
+          {`${appType === APP_TYPES.DEBT ? 'overpayment' : 'copay'}`} records
+          right now
         </h2>
-        <p>
-          We’re sorry. Information about{' '}
-          {`${appType === APP_TYPES.DEBT ? 'debts' : 'copays'}`} you might have
-          is unavailable because something went wrong on our end. Please check
-          back soon.
-        </p>
-        <h3 className="vads-u-font-size--h4">What you can do</h3>
+        <p>We’re sorry. Something went wrong on our end. Check back soon.</p>
+
         {appType === APP_TYPES.DEBT ? (
           <>
-            <p className="vads-u-margin-bottom--0">
-              If you continue having trouble viewing information about your
-              current debts, contact us online through{' '}
-              <a href="https://ask.va.gov">Ask VA</a>.
-            </p>
-            <p className="vads-u-margin-top--0">
-              If you need immediate assistance call the Debt Management Center
-              at <va-telephone contact={CONTACTS.DMC} /> (
-              <va-telephone contact={CONTACTS[711]} tty />
-              ). For international callers, use{' '}
-              <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />.
-              We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+            <p>
+              If you need help now, contact us online through{' '}
+              <a href="https://ask.va.gov">Ask VA</a> or call the Debt{' '}
+              Management Center at {dmcPhoneContent()}
             </p>
           </>
         ) : (
           <p>
-            If you continue having trouble viewing information about your
-            copays, call the VA Health Resource Center at{' '}
-            <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-            <va-telephone contact={CONTACTS[711]} tty />
-            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            If you need help now, call the VA Health Resource Center at{' '}
+            {healthResourceCenterPhoneContent()}
           </p>
         )}
       </va-alert>

--- a/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-import { ALERT_TYPES } from '../utils/helpers';
+import {
+  ALERT_TYPES,
+  healthResourceCenterPhoneContent,
+  dmcPhoneContent,
+} from '../utils/helpers';
 import ZeroDebtsCopaysSection from './ZeroDebtsCopaysSection';
 
 const ComboAlert = ({ children }) => children;
@@ -15,34 +18,24 @@ ComboAlert.Error = () => {
       data-testid="balance-card-combo-alert-error"
     >
       <h2 slot="headline">
-        We can’t access your debt and copay records right now
+        We can’t access your overpayment and copay records right now
       </h2>
       <p>
-        We’re sorry. Information about debts and copays you might have is
+        We’re sorry. Information about overpayments and copays you might have is
         unavailable because something went wrong on our end. Please check back
         soon.
       </p>
-      <h3 className="vads-u-font-size--h4">What you can do</h3>
-      <p>
-        If you continue having trouble viewing information about your current
-        debts and bills, contact us online through{' '}
-        <a href="https://ask.va.gov">Ask VA</a>.
-      </p>
-      <p>
-        If you need immediate assistance with overpayment debt, call the Debt
-        Management Center at <va-telephone contact={CONTACTS.DMC} /> (
-        <va-telephone contact={CONTACTS[711]} tty />
-        ). For international callers, use{' '}
-        <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />. We’re
-        here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-      </p>
-      <p>
-        If you need immediate assistance with copay bills, call the VA Health
-        Resource Center at{' '}
-        <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-        <va-telephone contact={CONTACTS[711]} tty />
-        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-      </p>
+      <h3 className="vads-u-font-size--h4">What to do if you need help now</h3>
+      <ul>
+        <li>
+          <strong>For benefit overpayments</strong>, call the Debt Management
+          Center at {dmcPhoneContent()}
+        </li>
+        <li>
+          <strong>For medical copay bills</strong>, call the VA Health Resource
+          Center at {healthResourceCenterPhoneContent()}
+        </li>
+      </ul>
       <p className="vads-u-margin-bottom--0">
         <va-link active text="Contact us at Ask VA" url="https://ask.va.gov" />
       </p>
@@ -57,28 +50,24 @@ ComboAlert.Zero = () => {
       status="info"
       data-testid="balance-card-combo-alert-zero"
     >
-      <h2 slot="headline" className="vads-u-font-size--h3">
-        You don’t have any current VA debt or copay bills
+      <h2 slot="headline">
+        You don’t have any outstanding overpayments or copay bills
       </h2>
       <p>
-        Our records show you don’t have any current VA benefit debt and you
-        haven’t received a copay bill in the past 6 months.
+        Our records show you don’t have any outstanding overpayments related to
+        VA benefits and you haven’t received a copay bill in the past 6 months.
       </p>
       <h3 className="vads-u-font-size--h4">
-        What to do if you think you have a VA debt or copay bill:
+        What to do if you think you have an overpayment or copay bill:
       </h3>
       <ul>
         <li>
-          <strong>For benefit debts</strong>, call the Debt Management Center
-          (DMC) at <va-telephone contact={CONTACTS.DMC} /> (
-          <va-telephone tty contact="711" />
-          ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+          <strong>For overpayments</strong>, call the Debt Management Center at{' '}
+          {dmcPhoneContent()}
         </li>
         <li>
           <strong>For medical copay bills</strong>, call the VA Health Resource
-          Center at <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} />(
-          <va-telephone tty contact="711" />
-          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          Center at {healthResourceCenterPhoneContent()}
         </li>
       </ul>
       <p className="vads-u-margin-bottom--0">

--- a/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
@@ -20,11 +20,7 @@ ComboAlert.Error = () => {
       <h2 slot="headline">
         We can’t access your overpayment and copay records right now
       </h2>
-      <p>
-        We’re sorry. Information about overpayments and copays you might have is
-        unavailable because something went wrong on our end. Please check back
-        soon.
-      </p>
+      <p>We’re sorry. Something went wrong on our end. Check back soon</p>
       <h3 className="vads-u-font-size--h4">What to do if you need help now</h3>
       <ul>
         <li>

--- a/src/applications/combined-debt-portal/combined/components/Modals.jsx
+++ b/src/applications/combined-debt-portal/combined/components/Modals.jsx
@@ -5,6 +5,10 @@ import {
 } from '@department-of-veterans-affairs/web-components/react-bindings';
 import PropTypes from 'prop-types';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import {
+  dmcPhoneContent,
+  healthResourceCenterPhoneContent,
+} from '../utils/helpers';
 
 const Modals = ({ children, title }) => {
   const [visible, setVisible] = useState(false);
@@ -92,14 +96,7 @@ Modals.Rights = () => (
           text="va.gov/contact-us/ask-va/"
         />
       </li>
-      <li>
-        Calling the Debt Management Center at{' '}
-        <va-telephone contact={CONTACTS.DMC} /> (
-        <va-telephone contact={CONTACTS[711]} tty />
-        ). For international callers, use{' '}
-        <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />. We’re
-        here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-      </li>
+      <li>Calling the Debt Management Center at {dmcPhoneContent()}</li>
     </ul>
 
     <h3>Right to request waiver of a debt</h3>
@@ -203,7 +200,7 @@ Modals.Rights = () => (
       <li>
         Calling us at <va-telephone contact={CONTACTS.HELP_DESK} /> (
         <va-telephone contact={CONTACTS[711]} tty />
-        ). For international callers, use{' '}
+        ). If you’re outside the U.S., call{' '}
         <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />. We’re
         here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
       </li>
@@ -216,10 +213,7 @@ Modals.Rights = () => (
     </p>
     <p>
       To request a hardship determination, submit a completed Financial Status
-      Report (VA Form VA5655). If you need help, call us at{' '}
-      <va-telephone contact="8008270648" />. If you’re outside the U.S., call{' '}
-      <va-telephone contact="6127136415" international />. We’re here Monday
-      through Friday, 7:30 a.m. to 7:00 p.m. ET.
+      Report (VA Form VA5655). If you need help, call us at {dmcPhoneContent()}
     </p>
     <p>
       You can fill out VA Form VA5655 online at{' '}
@@ -268,16 +262,11 @@ Modals.Rights = () => (
     </p>
     <p>
       For help with understanding your health care copay charges, contact our VA
-      Health Resource Center at 866-400-1238. We're here Monday through Friday,
-      8:00 a.m. to 8:00 p.m. ET.
+      Health Resource Center at {healthResourceCenterPhoneContent()}
     </p>
     <p>
       For help with understanding your VA benefit overpayments, contact our VA
-      Debt Management Center at <va-telephone contact={CONTACTS.DMC} /> (
-      <va-telephone contact={CONTACTS[711]} tty />
-      ). If you’re outside the U.S., call{' '}
-      <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />. We’re here
-      Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+      Debt Management Center at {dmcPhoneContent()}
     </p>
 
     <h3>VA Privacy</h3>

--- a/src/applications/combined-debt-portal/combined/components/OtherVADebts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/OtherVADebts.jsx
@@ -3,17 +3,18 @@ import PropTypes from 'prop-types';
 import { APP_TYPES } from '../utils/helpers';
 
 const OtherVADebts = ({ module, subHeading }) => {
+  const HeadingTag = subHeading ? 'h3' : 'h2';
   return (
     <>
-      <h2
-        className={subHeading ? 'vads-u-font-size--h3' : ''}
+      <HeadingTag
+        className={subHeading ? 'vads-u-font-size--h4' : 'vads-u-font-size--h2'}
         data-testid="other-va-debts-head"
         id="other-va-debts"
       >
         {`${
           module === APP_TYPES.DEBT ? `Overpayment balances` : 'VA copay bills'
         }`}
-      </h2>
+      </HeadingTag>
       <p>
         Our records show you have{' '}
         {module === APP_TYPES.DEBT && (

--- a/src/applications/combined-debt-portal/combined/components/ZeroBalanceCard.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ZeroBalanceCard.jsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-import { APP_TYPES } from '../utils/helpers';
+import { APP_TYPES, dmcPhoneContent } from '../utils/helpers';
 import { phoneContent } from '../utils/copayAlertContent';
 
 const ZeroBalanceCard = ({ appType }) => {
   const cardTitle =
     appType === APP_TYPES.DEBT
-      ? `You don't have any current VA debt`
-      : `You don't have any outstanding overpayments`;
+      ? `You don't have any outstanding overpayments`
+      : `You don't have any copay bills`;
 
   const cardContent =
     appType === APP_TYPES.DEBT ? (
       <p className="vads-u-margin-y--0">
-        If you think this is incorrect, call the Debt Management Center (DMC) at{' '}
-        <va-telephone contact={CONTACTS.DMC} /> (
-        <va-telephone tty contact="711" />
-        ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+        If you think this is incorrect, call the Debt Management Center at{' '}
+        {dmcPhoneContent()}
       </p>
     ) : (
       <>

--- a/src/applications/combined-debt-portal/combined/components/ZeroDebtsCopaysSection.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ZeroDebtsCopaysSection.jsx
@@ -1,36 +1,35 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+import {
+  dmcPhoneContent,
+  healthResourceCenterPhoneContent,
+} from '../utils/helpers';
 
 const ZeroDebtsCopaysSection = () => {
   return (
     <>
-      <h2>You don’t have any current VA debt or copay bills</h2>
+      <h2>You don’t have any outstanding overpayments or copay bills</h2>
       <p>
-        Our records show you don’t have any current VA benefit debt and you
-        haven’t received a copay bill in the past 6 months.
+        Our records show you don’t have any outstanding overpayments related to
+        VA benefits and you haven’t received a copay bill in the past 6 months.
       </p>
-      <h3>What to do if you think you have a VA debt or copay bill</h3>
-      <div>
-        <p>
-          For benefit debts, call the Debt Management Center (DMC) at{' '}
-          <va-telephone contact={CONTACTS.DMC} /> (
-          <va-telephone tty contact="711" />
-          ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-        </p>
-        <p>
-          For medical copay bills, call the VA Health Resource Center at{' '}
-          <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-          <va-telephone contact={CONTACTS[711]} tty />
-          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-        </p>{' '}
-        <va-link
-          active
-          class="vads-u-margin-top--2"
-          data-testid="return-to-va-link"
-          href="https://va.gov"
-          text="Return to VA.gov"
-        />
-      </div>
+      <h3>What to do if you think you have an overpayment or copay bill</h3>
+      <ul>
+        <li>
+          <strong>For overpayments</strong>, {dmcPhoneContent()}
+        </li>
+        <li>
+          <strong>For medical copay bills</strong>,{' '}
+          {healthResourceCenterPhoneContent()}
+        </li>
+      </ul>{' '}
+      <va-link
+        active
+        class="vads-u-margin-top--2"
+        data-testid="return-to-va-link"
+        href="https://va.gov"
+        text="Return to VA.gov"
+      />
     </>
   );
 };

--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -4,13 +4,17 @@ import {
   VaBreadcrumbs,
   VaLinkAction,
 } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { VaLoadingIndicator } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 
 import Balances from '../components/Balances';
 import ComboAlerts from '../components/ComboAlerts';
-import { ALERT_TYPES, setPageFocus } from '../utils/helpers';
+import {
+  ALERT_TYPES,
+  setPageFocus,
+  healthResourceCenterPhoneContent,
+  dmcPhoneContent,
+} from '../utils/helpers';
 import {
   calculateTotalDebts,
   calculateTotalBills,
@@ -109,21 +113,25 @@ const OverviewPage = () => {
                   <strong>Questions about overpayments</strong>
                 </p>
                 <p>
-                  Call the Debt Management Center (DMC) at{' '}
-                  <va-telephone contact={CONTACTS.DMC} /> (
-                  <va-telephone tty contact="711" />
-                  ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m.
-                  ET.
+                  Contact us online through{' '}
+                  <va-link
+                    text="AskVA"
+                    href="/contact-us/ask-va/introduction"
+                  />{' '}
+                  or call the Debt Management Center (DMC) at{' '}
+                  {dmcPhoneContent()}
                 </p>
                 <p>
                   <strong>Questions about copay bills</strong>
                 </p>
                 <p>
-                  Call the VA Health Resource Center at{' '}
-                  <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-                  <va-telephone tty contact="711" />
-                  ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.
-                  ET.
+                  Contact us online through{' '}
+                  <va-link
+                    text="AskVA"
+                    href="/contact-us/ask-va/introduction"
+                  />{' '}
+                  or call the VA Health Resource Center at{' '}
+                  {healthResourceCenterPhoneContent()}
                 </p>
               </div>
             </va-need-help>

--- a/src/applications/combined-debt-portal/combined/tests/e2e/combined-debt-portal.cypress.spec.js
+++ b/src/applications/combined-debt-portal/combined/tests/e2e/combined-debt-portal.cypress.spec.js
@@ -36,7 +36,7 @@ describe('CDP - Overpayments and copay bills (overview)', () => {
     it('should display No-copays-or-debts alert - C17928', () => {
       cy.get('h2').should(
         'contain',
-        'You don’t have any current VA debt or copay bills',
+        'You don’t have any outstanding overpayments or copay bills',
       );
 
       cy.findByTestId('balance-card-copay').should('not.exist');

--- a/src/applications/combined-debt-portal/combined/tests/unit/components.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/combined/tests/unit/components.unit.spec.jsx
@@ -162,7 +162,7 @@ describe('combined debt portal component helpers', () => {
       expect(
         wrapper.find('[data-testid="balance-card-zero-debt"] p').text(),
       ).to.include(
-        'If you think this is incorrect, call the Debt Management Center (DMC) at',
+        'If you think this is incorrect, call the Debt Management Center at',
       );
       wrapper.unmount();
     });

--- a/src/applications/combined-debt-portal/combined/tests/unit/components.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/combined/tests/unit/components.unit.spec.jsx
@@ -152,7 +152,7 @@ describe('combined debt portal component helpers', () => {
 
       // Test the card title
       expect(wrapper.find('[data-testid="card-title"]').text()).to.equal(
-        "You don't have any current VA debt",
+        "You don't have any outstanding overpayments",
       );
 
       // Test the content for VA debt

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -94,13 +94,7 @@ const alertMessage = (alertType, appType) => {
         testID: 'all-error-alert',
         header: `We can’t access your overpayment and copay records right now`,
         body: (
-          <>
-            <p>
-              We’re sorry. Information about overpayments and copays you might
-              have is unavailable because something went wrong on our end.
-              Please check back soon.
-            </p>
-          </>
+          <p>We’re sorry. Something went wrong on our end. Check back soon.</p>
         ),
         secondBody: (
           <>

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -71,7 +71,7 @@ const alertMessage = (alertType, appType) => {
         appType,
         header:
           appType === APP_TYPES.DEBT
-            ? `You don't have any oustanding overpayments`
+            ? `You don't have any outstanding overpayments`
             : `You haven't received a copay bill in the past 6 months`,
         body:
           appType === APP_TYPES.DEBT ? (

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-import { ALERT_TYPES, APP_TYPES } from './helpers';
+import {
+  ALERT_TYPES,
+  APP_TYPES,
+  dmcPhoneContent,
+  healthResourceCenterPhoneContent,
+} from './helpers';
 
 const alertMessage = (alertType, appType) => {
   switch (alertType) {
@@ -8,30 +12,26 @@ const alertMessage = (alertType, appType) => {
       return {
         alertStatus: 'info',
         testID: 'all-zero-alert',
-        header: `You don’t have any current VA debt or copay bills`,
+        header: `You don’t have any outstanding overpayments or copay bills`,
         body: (
           <>
             <p>
-              Our records show you don’t have any current VA benefit debt and
-              you haven’t received a copay bill in the past 6 months.
+              Our records show you don’t have any outstanding overpayments
+              related to VA benefits and you haven’t received a copay bill in
+              the past 6 months.
             </p>
           </>
         ),
-        secondHeader: `What to do if you think you have a VA debt or copay bill:`,
+        secondHeader: `What to do if you think you have an overpayment or copay bill:`,
         secondBody: (
           <ul>
             <li>
               <strong>For benefit debts</strong>, call the Debt Management
-              Center (DMC) at <va-telephone contact={CONTACTS.DMC} /> (
-              <va-telephone tty contact="711" />
-              ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+              Center at {dmcPhoneContent()}
             </li>
             <li>
               <strong>For medical copay bills</strong>, call the VA Health
-              Resource Center at{' '}
-              <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-              <va-telephone tty contact="711" />
-              ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              Resource Center at {healthResourceCenterPhoneContent()}
             </li>
           </ul>
         ),
@@ -42,42 +42,23 @@ const alertMessage = (alertType, appType) => {
         testID: `error-${appType === APP_TYPES.DEBT ? 'debt' : 'copay'}-alert`,
         appType,
         header: `We can’t access your ${
-          appType === APP_TYPES.DEBT ? 'debt' : 'copay'
+          appType === APP_TYPES.DEBT ? 'overpayment' : 'copay'
         } records right now`,
         body: (
-          <p>
-            We’re sorry. Information about{' '}
-            {`${appType === APP_TYPES.DEBT ? 'debts' : 'copays'}`} you might
-            have is unavailable because something went wrong on our end. Please
-            check back soon.
-          </p>
+          <p>We’re sorry. Something went wrong on our end. Check back soon.</p>
         ),
-        secondHeader: `What you can do`,
         secondBody: (
           <>
             {appType === APP_TYPES.DEBT ? (
-              <>
-                <p className="vads-u-margin-bottom--0">
-                  If you continue having trouble viewing information about your
-                  current debts, contact us online through{' '}
-                  <a href="https://ask.va.gov">Ask VA</a>.
-                </p>
-                <p className="vads-u-margin-top--0">
-                  If you need immediate assistance call the Debt Management
-                  Center at <va-telephone contact={CONTACTS.DMC} /> (
-                  <va-telephone contact={CONTACTS[711]} tty />
-                  ). For international callers, use{' '}
-                  <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />
-                  . We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-                </p>
-              </>
+              <p>
+                If you need help now, contact us online through{' '}
+                <a href="https://ask.va.gov">Ask VA</a> or call the Debt
+                Management Center at {dmcPhoneContent()}
+              </p>
             ) : (
               <p>
-                If you continue having trouble viewing information about your
-                copays, call the VA Health Resource Center at{' '}
-                <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-                <va-telephone contact={CONTACTS[711]} tty />
-                ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+                If you need help now, call the VA Health Resource Center at{' '}
+                {healthResourceCenterPhoneContent()}
               </p>
             )}
           </>
@@ -90,24 +71,19 @@ const alertMessage = (alertType, appType) => {
         appType,
         header:
           appType === APP_TYPES.DEBT
-            ? `You don't have any current VA debt`
+            ? `You don't have any oustanding overpayments`
             : `You haven't received a copay bill in the past 6 months`,
         body:
           appType === APP_TYPES.DEBT ? (
             <p>
-              Our records show you don’t have any current debt related to VA
-              benefits. If you think this is incorrect, call the Debt Management
-              Center (DMC) at <va-telephone contact={CONTACTS.DMC} /> (
-              <va-telephone tty contact="711" />
-              ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+              Our records show you don’t have any outstanding overpayments
+              related to VA benefits. If you think this is incorrect, call the
+              Debt Management Center (DMC) at {dmcPhoneContent()}
             </p>
           ) : (
             <p>
               If you think this is incorrect, contact the VA Health Resource
-              Center at{' '}
-              <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-              <va-telephone tty contact="711" />
-              ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              Center at {healthResourceCenterPhoneContent()}
             </p>
           ),
       };
@@ -116,38 +92,30 @@ const alertMessage = (alertType, appType) => {
       return {
         alertStatus: 'error',
         testID: 'all-error-alert',
-        header: `We can’t access your debt and copay records right now`,
+        header: `We can’t access your overpayment and copay records right now`,
         body: (
           <>
             <p>
-              We’re sorry. Information about debts and copays you might have is
-              unavailable because something went wrong on our end. Please check
-              back soon.
+              We’re sorry. Information about overpayments and copays you might
+              have is unavailable because something went wrong on our end.
+              Please check back soon.
             </p>
           </>
         ),
-        secondHeader: `What you can do`,
         secondBody: (
           <>
             <p>
               If you continue having trouble viewing information about your
-              current debts and bills, contact us online through{' '}
+              outstanding overpayments and copays, contact us online through{' '}
               <a href="https://ask.va.gov">Ask VA</a>.
             </p>
             <p>
               If you need immediate assistance with overpayment debt, call the
-              Debt Management Center at <va-telephone contact={CONTACTS.DMC} />{' '}
-              (<va-telephone contact={CONTACTS[711]} tty />
-              ). For international callers, use{' '}
-              <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />.
-              We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+              Debt Management Center at {dmcPhoneContent()}
             </p>
             <p>
               If you need immediate assistance with copay bills, call the VA
-              Health Resource Center at{' '}
-              <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-              <va-telephone contact={CONTACTS[711]} tty />
-              ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              Health Resource Center at {healthResourceCenterPhoneContent()}
             </p>
             <p className="vads-u-margin-bottom--0">
               <va-link

--- a/src/applications/combined-debt-portal/combined/utils/copayAlertContent.js
+++ b/src/applications/combined-debt-portal/combined/utils/copayAlertContent.js
@@ -25,7 +25,7 @@ export const getCopayAlertContent = (copay, type) => {
         showLinks: false,
         testId: 'copay-no-health-care-alert',
         bodyText: (
-          <div>
+          <>
             <p>
               You can’t check copay balances at this time because our records
               show that you’re not enrolled in VA health care.
@@ -33,7 +33,7 @@ export const getCopayAlertContent = (copay, type) => {
             <p>
               <va-link-action
                 href="https://va.gov/health-care/how-to-apply/"
-                text=" Find out how to apply for VA health care benefits"
+                text="Find out how to apply for VA health care benefits"
                 type="primary"
               />
             </p>
@@ -45,7 +45,7 @@ export const getCopayAlertContent = (copay, type) => {
               <va-icon icon="phone" size="3" />{' '}
               <va-telephone contact={CONTACTS['222_VETS']} />
             </p>
-          </div>
+          </>
         ),
       };
     case 'status':

--- a/src/applications/combined-debt-portal/combined/utils/copayAlertContent.js
+++ b/src/applications/combined-debt-portal/combined/utils/copayAlertContent.js
@@ -153,8 +153,7 @@ export const getCopayAlertContent = (copay, type) => {
         bodyText: (
           <>
             <p>
-              We’re sorry. Something went wrong on our end. You won’t be able to
-              access information about your copay balances at this time.
+              We’re sorry. Something went wrong on our end. Check back soon.
             </p>
             <h3 className="vads-u-font-size--h4">What you can do</h3>
             <p>

--- a/src/applications/combined-debt-portal/combined/utils/helpers.js
+++ b/src/applications/combined-debt-portal/combined/utils/helpers.js
@@ -6,6 +6,7 @@ import React from 'react';
 import { templates } from '@department-of-veterans-affairs/platform-pdf/exports';
 import * as Sentry from '@sentry/browser';
 import recordEvent from 'platform/monitoring/record-event';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export const APP_TYPES = Object.freeze({
   DEBT: 'DEBT',
@@ -249,4 +250,28 @@ export const handlePdfGeneration = async (environment, pdfData) => {
       `OneDebtLetter - PDF generation failed: ${err.message}`,
     );
   }
+};
+
+// Debt Management Center phone content
+export const dmcPhoneContent = () => {
+  return (
+    <>
+      <va-telephone contact={CONTACTS.DMC} /> (
+      <va-telephone contact={CONTACTS[711]} tty />
+      ). If you’re outside the U.S., call{' '}
+      <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />. We’re here
+      Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+    </>
+  );
+};
+
+// Health Resource Center phone content
+export const healthResourceCenterPhoneContent = () => {
+  return (
+    <>
+      <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
+      <va-telephone contact={CONTACTS[711]} tty />
+      ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+    </>
+  );
 };

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
@@ -9,6 +9,10 @@ const DebtCardsList = () => {
 
   return (
     <div className="vads-u-margin-top--3" data-testid="current-va-debt-list">
+      <p>
+        Please note that payments may take up to 4 business days to reflect
+        after processing.
+      </p>
       {debts.map((debt, index) => (
         <DebtSummaryCard key={`${index}-${debt.compositeDebtId}`} debt={debt} />
       ))}

--- a/src/applications/combined-debt-portal/debt-letters/components/NeedHelp.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/NeedHelp.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+import { dmcPhoneContent } from '../../combined/utils/helpers';
 
 export const NeedHelp = () => (
   <va-need-help id="needHelp" class="vads-u-margin-top--4">
     <div slot="content">
       <p>
-        If you have any questions about your benefit overpayment contact us
+        If you have any questions about your benefit overpayments contact us
         online through <va-link href="https://ask.va.gov/" text="Ask VA" /> or
-        call us at <va-telephone contact={CONTACTS.DMC} /> (
-        <va-telephone contact="711" tty="true" />
-        ). If you’re outside the U.S., call{' '}
-        <va-telephone contact={CONTACTS.DMC_OVERSEAS} international />. We’re
-        here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+        call us at {dmcPhoneContent()}
       </p>
     </div>
   </va-need-help>

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -30,11 +30,9 @@ const renderAlert = (alertType, statements) => {
       </h2>
       {alertInfo.body}
       {alertInfo.secondHeader ? (
-        <>
-          <h3 className="vads-u-font-size--h4">{alertInfo.secondHeader}</h3>
-          {alertInfo.secondBody}
-        </>
+        <h3 className="vads-u-font-size--h4">{alertInfo.secondHeader}</h3>
       ) : null}
+      {alertInfo.secondBody ? alertInfo.secondBody : null}
       {showVAReturnLink ? (
         <va-link
           active
@@ -184,10 +182,6 @@ const DebtLettersSummary = () => {
           education, disability compensation, or pension programs. Find out how
           to resolve overpayments and what to do if you need financial
           assistance.
-        </p>
-        <p>
-          Please note that payments may take up to 4 business days to reflect
-          after processing.
         </p>
         {renderContent()}
       </div>

--- a/src/applications/combined-debt-portal/medical-copays/components/NeedHelpCopay.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/NeedHelpCopay.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { healthResourceCenterPhoneContent } from '../../combined/utils/helpers';
 
 export const NeedHelpCopay = () => (
   <va-need-help data-testid="need-help" class="vads-u-margin-top--4">
     <div slot="content">
       <p>
-        You can contact us online through{' '}
-        <va-link text="Ask VA" href="https://ask.va.gov" /> or call the VA
-        Health Resource Center at{' '}
-        <va-telephone contact={CONTACTS.HEALTH_RESOURCE_CENTER} /> (
-        <va-telephone contact="711" tty="true" />
-        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+        Contact us online through{' '}
+        <va-link text="Ask VA" href="/contact-us/ask-va" /> or call the VA
+        Health Resource Center at {healthResourceCenterPhoneContent()}
       </p>
     </div>
   </va-need-help>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Refactor heading tag and classes in OtherVADebts, replaced static h2 with dynamic heading tag (h2 or h3) based on subHeading prop and updates class names for font size accordingly
- Refactor contact info to use helper functions 
- Centralizes Debt Management Center and Health Resource Center contact information into reusable helper functions. Updates all components and alert messages to use these helpers, ensuring consistent formatting and easier maintenance. Also updates terminology from 'debt' to 'overpayment' for improved clarity.
- Refactor contact info to use helper functions
- Centralizes Debt Management Center and Health Resource Center contact information into reusable helper functions. Updates all components and alert messages to use these helpers, ensuring consistent formatting and easier maintenance. Also updates terminology from 'debt' to 'overpayment' for improved clarity.
- Update unit and e2e tests for overpayments wording
- Replaces references to 'current VA debt' with 'outstanding overpayments' in both Cypress E2E and unit tests to align with updated terminology in the combined debt portal.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#127116


## Testing done

- Tested locally by manually enabling each error/empty state by setting each relevant const to true 
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Overview empty state | <img width="847" height="843" alt="Screenshot 2025-12-16 at 2 48 40 PM" src="https://github.com/user-attachments/assets/d67e6e11-1810-4262-b31e-46c037f148ba" /> | <img width="799" height="818" alt="Screenshot 2025-12-16 at 2 50 03 PM" src="https://github.com/user-attachments/assets/e219a562-8f2f-464a-9f3d-f28f58e1df3f" /> |
| Overview error state  |  <img width="799" height="928" alt="Screenshot 2025-12-16 at 2 47 05 PM" src="https://github.com/user-attachments/assets/cff704dc-2cf5-4141-905d-d2397d9f1eb7" /> |  <img width="751" height="784" alt="Screenshot 2025-12-16 at 2 11 36 PM" src="https://github.com/user-attachments/assets/cbabf156-cd31-4e05-810b-b95d790fb914" /> |
| Overview Overpayment error state | <img width="789" height="997" alt="Screenshot 2025-12-16 at 2 44 21 PM" src="https://github.com/user-attachments/assets/c1169fb3-3576-4a31-b615-d4d3dc090140" />  |<img width="748" height="759" alt="Screenshot 2025-12-12 at 2 46 33 PM" src="https://github.com/user-attachments/assets/75f9940c-54ec-4b4b-a52f-8cb994450f7a" /> |
| Overview Copay error state | <img width="770" height="931" alt="Screenshot 2025-12-16 at 2 45 09 PM" src="https://github.com/user-attachments/assets/429d6c8e-7469-4af4-909e-4a0530bb8f1b" /> | <img width="793" height="1010" alt="Screenshot 2025-12-12 at 2 47 52 PM" src="https://github.com/user-attachments/assets/890e10b6-305a-46ce-82e9-c5e3b9910503" />|
| Overview No healthcare | <img width="768" height="962" alt="Screenshot 2025-12-16 at 2 56 44 PM" src="https://github.com/user-attachments/assets/9dc99527-fc06-41fe-bfae-72ae4829518b" />  | <img width="779" height="859" alt="Screenshot 2025-12-12 at 4 52 14 PM" src="https://github.com/user-attachments/assets/0600a242-0037-42a3-a128-f3c563578dbc" /> |
| Overpayment summary page error state | <img width="745" height="727" alt="Screenshot 2025-12-16 at 3 04 52 PM" src="https://github.com/user-attachments/assets/f5369420-768e-4a41-b144-f497f0c29fa0" />  |  <img width="759" height="773" alt="Screenshot 2025-12-16 at 3 54 31 PM" src="https://github.com/user-attachments/assets/4f9ade5d-7fe0-4762-a2ff-528fa60276cd" /> |
| Overpayment summary empty state with copays | <img width="788" height="702" alt="Screenshot 2025-12-16 at 3 07 00 PM" src="https://github.com/user-attachments/assets/8b865897-8f40-479a-9d98-768a1003a86b" /> |  <img width="755" height="454" alt="Screenshot 2025-12-12 at 1 42 44 PM" src="https://github.com/user-attachments/assets/e45e6f3a-fb5b-4997-8bb2-dc491eb09982" /> |
| Overview Need Help | <img width="800" height="309" alt="Screenshot 2025-12-15 at 3 47 05 PM" src="https://github.com/user-attachments/assets/79591d1c-369c-408a-b63d-d4f03e31039b" /> | <img width="710" height="311" alt="Screenshot 2025-12-15 at 3 18 45 PM" src="https://github.com/user-attachments/assets/82535a02-e658-4fb5-8f08-0944d65e8348" /> | 

## What areas of the site does it impact?

Combined debt portal

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
