### PR TITLE
10-7959c | Populate OHI ArrayBuilder pages

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsurance/index.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsurance/index.js
@@ -29,7 +29,7 @@ export const healthInsuranceRev2025Pages = arrayBuilderPages(
     }),
     medigapType: pageBuilder.itemPage({
       path: 'health-insurance-medigap-information/:index',
-      title: 'Plan type',
+      title: 'Medigap information',
       depends: (formData, index) =>
         formData[TOGGLE_KEY] &&
         formData.healthInsurance?.[index].insuranceType === 'medigap',
@@ -37,13 +37,13 @@ export const healthInsuranceRev2025Pages = arrayBuilderPages(
     }),
     provider: pageBuilder.itemPage({
       path: 'health-insurance-provider-information/:index',
-      title: 'Health insurance information',
+      title: 'Plan information',
       depends: formData => formData[TOGGLE_KEY],
       ...provider,
     }),
     throughEmployer: pageBuilder.itemPage({
       path: 'health-insurance-employer-sponsorship/:index',
-      title: 'Type of insurance - through employer',
+      title: 'Employer sponsorship',
       depends: formData => formData[TOGGLE_KEY],
       ...employer,
     }),

--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsurance/index.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsurance/index.js
@@ -1,0 +1,70 @@
+import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
+import FileFieldCustom from '../../../shared/components/fileUploads/FileUpload';
+import { FEATURE_TOGGLES } from '../../hooks/useDefaultFormData';
+import additionalComments from './addtlComments';
+import cardUpload from './cardUpload';
+import employer from './employer';
+import medigap from './medigap';
+import planTypes from './planTypes';
+import prescriptionCoverage from './prescriptions';
+import provider from './provider';
+import summary, { ohiArrayOptions } from './summary';
+
+const TOGGLE_KEY = `view:${FEATURE_TOGGLES[0]}`;
+
+export const healthInsuranceRev2025Pages = arrayBuilderPages(
+  ohiArrayOptions,
+  pageBuilder => ({
+    healthInsuranceSummary: pageBuilder.summaryPage({
+      path: 'other-health-insurance-plans',
+      title: 'Other health insurance plans',
+      depends: formData => formData[TOGGLE_KEY],
+      ...summary,
+    }),
+    healthInsuranceType: pageBuilder.itemPage({
+      path: 'health-insurance-plan-type/:index',
+      title: 'Plan type',
+      depends: formData => formData[TOGGLE_KEY],
+      ...planTypes,
+    }),
+    medigapType: pageBuilder.itemPage({
+      path: 'health-insurance-medigap-information/:index',
+      title: 'Plan type',
+      depends: (formData, index) =>
+        formData[TOGGLE_KEY] &&
+        formData.healthInsurance?.[index].insuranceType === 'medigap',
+      ...medigap,
+    }),
+    provider: pageBuilder.itemPage({
+      path: 'health-insurance-provider-information/:index',
+      title: 'Health insurance information',
+      depends: formData => formData[TOGGLE_KEY],
+      ...provider,
+    }),
+    throughEmployer: pageBuilder.itemPage({
+      path: 'health-insurance-employer-sponsorship/:index',
+      title: 'Type of insurance - through employer',
+      depends: formData => formData[TOGGLE_KEY],
+      ...employer,
+    }),
+    prescriptionCoverage: pageBuilder.itemPage({
+      path: 'health-insurance-prescription-coverage/:index',
+      title: 'Prescription coverage',
+      depends: formData => formData[TOGGLE_KEY],
+      ...prescriptionCoverage,
+    }),
+    comments: pageBuilder.itemPage({
+      path: 'health-insurance-additional-comments/:index',
+      title: 'Additional comments',
+      depends: formData => formData[TOGGLE_KEY],
+      ...additionalComments,
+    }),
+    insuranceCard: pageBuilder.itemPage({
+      path: 'health-insurance-card/:index',
+      title: 'Health insurance card',
+      depends: formData => formData[TOGGLE_KEY],
+      CustomPage: FileFieldCustom,
+      ...cardUpload,
+    }),
+  }),
+);

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partDEffectiveDate.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partDEffectiveDate.js
@@ -8,8 +8,9 @@ import {
 import { nameWording, privWrapper } from '../../../shared/utilities';
 import { validFieldCharsOnly } from '../../../shared/validations';
 import { validateDateRange } from '../../utils/validation';
+import { FEATURE_TOGGLES } from '../../hooks/useDefaultFormData';
 
-const TOGGLE_KEY = 'view:champvaForm107959cRev2025';
+const TOGGLE_KEY = `view:${FEATURE_TOGGLES[0]}`;
 
 const pageTitle = () =>
   titleUI(({ formData }) => {

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -43,6 +43,7 @@ import {
   applicantInsuranceCommentsSchema,
   applicantInsuranceCardSchema,
 } from '../chapters/healthInsuranceInformation';
+import { healthInsuranceRev2025Pages } from '../chapters/healthInsurance';
 
 import benefitStatus from '../chapters/signerInformation/benefitStatus';
 import certifierEmail from '../chapters/signerInformation/certifierEmail';
@@ -53,6 +54,7 @@ import { hasReq } from '../../shared/components/fileUploads/MissingFileOverview'
 import SupportingDocumentsPage from '../components/SupportingDocumentsPage';
 import { MissingFileConsentPage } from '../components/MissingFileConsentPage';
 import NotEnrolledPage from '../components/FormPages/NotEnrolledPage';
+import { FEATURE_TOGGLES } from '../hooks/useDefaultFormData';
 
 // import mockdata from '../tests/e2e/fixtures/data/test-data.json';
 
@@ -71,6 +73,8 @@ function showFileOverviewPage(formData) {
 function fnp(formData) {
   return nameWording(formData, undefined, undefined, true);
 }
+
+const REV2025_TOGGLE_KEY = `view:${FEATURE_TOGGLES[0]}`;
 
 /** @type {PageSchema} */
 const formConfig = {
@@ -308,15 +312,19 @@ const formConfig = {
     healthcareInformation: {
       title: 'Health insurance information',
       pages: {
+        ...healthInsuranceRev2025Pages,
         hasPrimaryHealthInsurance: {
           path: 'insurance-status',
+          depends: formData => !formData[REV2025_TOGGLE_KEY],
           title: formData => privWrapper(`${fnp(formData)} health insurance`),
           ...applicantHasInsuranceSchema(true),
           scrollAndFocusTarget,
         },
         primaryType: {
           path: 'insurance-plan',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(
               `${fnp(formData)} ${
@@ -329,6 +337,7 @@ const formConfig = {
         primaryMedigap: {
           path: 'insurance-medigap',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantPrimaryInsuranceType', formData) === 'medigap',
           title: formData =>
@@ -342,7 +351,9 @@ const formConfig = {
         },
         primaryProvider: {
           path: 'insurance-info',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(`${fnp(formData)} health insurance information`),
           ...applicantProviderSchema(true),
@@ -350,7 +361,9 @@ const formConfig = {
         },
         primaryThroughEmployer: {
           path: 'insurance-type',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(
               `${fnp(formData)} type of insurance for ${
@@ -362,7 +375,9 @@ const formConfig = {
         },
         primaryPrescription: {
           path: 'insurance-prescription',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(
               `${fnp(formData)} ${
@@ -375,7 +390,7 @@ const formConfig = {
         primaryEob: {
           path: 'insurance-eob',
           depends: formData =>
-            !formData['view:champvaForm107959cRev2025'] &&
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantPrimaryHasPrescription', formData),
           title: formData =>
@@ -390,7 +405,7 @@ const formConfig = {
         primaryScheduleOfBenefits: {
           path: 'insurance-sob',
           depends: formData =>
-            !formData['view:champvaForm107959cRev2025'] &&
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantPrimaryHasPrescription', formData) &&
             !get('applicantPrimaryEob', formData),
@@ -407,7 +422,9 @@ const formConfig = {
         },
         primaryCard: {
           path: 'insurance-upload',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(`${fnp(formData)} health insurance card`),
           CustomPage: FileFieldWrapped,
@@ -417,7 +434,9 @@ const formConfig = {
         },
         primaryComments: {
           path: 'insurance-comments',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(
               `${fnp(formData)} ${
@@ -429,7 +448,9 @@ const formConfig = {
         },
         hasSecondaryHealthInsurance: {
           path: 'secondary-insurance',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantHasPrimary', formData),
           title: formData =>
             privWrapper(`${fnp(formData)} additional health insurance`),
           ...applicantHasInsuranceSchema(false),
@@ -438,6 +459,7 @@ const formConfig = {
         secondaryType: {
           path: 'secondary-insurance-plan',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData),
           title: formData =>
@@ -452,6 +474,7 @@ const formConfig = {
         secondaryMedigap: {
           path: 'secondary-insurance-medigap',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData) &&
             get('applicantSecondaryInsuranceType', formData) === 'medigap',
@@ -467,6 +490,7 @@ const formConfig = {
         secondaryProvider: {
           path: 'secondary-insurance-info',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData),
           title: formData =>
@@ -477,6 +501,7 @@ const formConfig = {
         secondaryThroughEmployer: {
           path: 'secondary-insurance-type',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData),
           title: formData =>
@@ -491,6 +516,7 @@ const formConfig = {
         secondaryPrescription: {
           path: 'secondary-insurance-prescription',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData),
           title: formData =>
@@ -505,7 +531,7 @@ const formConfig = {
         secondaryEob: {
           path: 'secondary-insurance-eob',
           depends: formData =>
-            !formData['view:champvaForm107959cRev2025'] &&
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData) &&
             get('applicantSecondaryHasPrescription', formData),
@@ -521,7 +547,7 @@ const formConfig = {
         secondaryScheduleOfBenefits: {
           path: 'secondary-insurance-sob',
           depends: formData =>
-            !formData['view:champvaForm107959cRev2025'] &&
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData) &&
             get('applicantSecondaryHasPrescription', formData) &&
@@ -540,6 +566,7 @@ const formConfig = {
         secondaryCard: {
           path: 'secondary-insurance-card-upload',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData),
           title: formData =>
@@ -552,6 +579,7 @@ const formConfig = {
         secondaryComments: {
           path: 'secondary-insurance-comments',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantHasPrimary', formData) &&
             get('applicantHasSecondary', formData),
           title: formData =>
@@ -571,7 +599,8 @@ const formConfig = {
         supportingFilesReview: {
           path: 'supporting-files',
           title: 'Upload your supporting files',
-          depends: formData => showFileOverviewPage(formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] && showFileOverviewPage(formData),
           CustomPage: SupportingDocumentsPage,
           CustomPageReview: null,
           uiSchema: {
@@ -585,7 +614,8 @@ const formConfig = {
         missingFileConsent: {
           path: 'consent-mail',
           title: 'Upload your supporting files',
-          depends: formData => showFileOverviewPage(formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] && showFileOverviewPage(formData),
           CustomPage: MissingFileConsentPage,
           CustomPageReview: null,
           uiSchema: {

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -5,6 +5,7 @@ import { DowntimeNotification } from 'platform/monitoring/DowntimeNotification';
 import environment from 'platform/utilities/environment';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog';
+import { useDefaultFormData } from '../hooks/useDefaultFormData';
 import formConfig from '../config/form';
 
 const App = ({ location, children }) => {
@@ -12,6 +13,7 @@ const App = ({ location, children }) => {
     state => state.featureToggles?.loading || state.user?.profile?.loading,
   );
 
+  useDefaultFormData();
   useBrowserMonitoring({
     loggedIn: undefined,
     toggleName: 'form107959cBrowserMonitoringEnabled',

--- a/src/applications/ivc-champva/10-7959C/hooks/useDefaultFormData.jsx
+++ b/src/applications/ivc-champva/10-7959C/hooks/useDefaultFormData.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useMemo } from 'react';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { setData } from 'platform/forms-system/src/js/actions';
+
+// declare list of feature toggles for this app
+export const FEATURE_TOGGLES = ['champvaForm107959cRev2025'];
+
+export const useDefaultFormData = () => {
+  const dispatch = useDispatch();
+
+  const toggles = useSelector(state => state.featureToggles, shallowEqual);
+  const formData = useSelector(state => state.form.data, shallowEqual);
+  const loading = !!toggles?.loading;
+
+  const toggleViewFields = useMemo(
+    () => {
+      if (loading) return {};
+      return Object.fromEntries(
+        FEATURE_TOGGLES.map(key => [`view:${key}`, !!toggles[key]]),
+      );
+    },
+    [loading, toggles],
+  );
+
+  const toggleValues = useMemo(
+    () => {
+      if (loading) return {};
+      return Object.fromEntries(
+        Object.entries(toggleViewFields).filter(([k, v]) => formData[k] !== v),
+      );
+    },
+    [formData, loading, toggleViewFields],
+  );
+
+  useEffect(
+    () => {
+      if (loading) return;
+      if (Object.keys(toggleValues).length > 0) {
+        dispatch(setData({ ...formData, ...toggleValues }));
+      }
+    },
+    [dispatch, formData, loading, toggleValues],
+  );
+};

--- a/src/applications/ivc-champva/10-7959C/tests/components/MissingFileOverview.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/components/MissingFileOverview.unit.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { expect } from 'chai';
 import { testComponentRender } from 'applications/ivc-champva/shared/tests/pages/pageTests.spec';
 import { MissingFileConsentPage } from '../../components/MissingFileConsentPage';
 import SupportingDocumentsPage from '../../components/SupportingDocumentsPage';
@@ -37,13 +36,3 @@ testComponentRender(
     nonListNameKey="applicantName"
   />,
 );
-
-describe('Missing file consent page depends function', () => {
-  it('should return false if receives bad data', () => {
-    expect(
-      formConfig.chapters.fileUpload.pages.missingFileConsent.depends(
-        undefined,
-      ),
-    ).to.be.false;
-  });
-});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR conditionally adds the ArrayBuilder version of the Other Health Insurance (OHI) pages to the form config. This also wires the current pages to the feature toggle to allow for future control when that is fully implemented.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#126793

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- All pages are ready for feature toggle control

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
