### PR TITLE
render date of marriage from arraybuilder values

### DIFF
--- a/src/applications/ezr/components/FormDescriptions/SpouseSummaryCardDescription.jsx
+++ b/src/applications/ezr/components/FormDescriptions/SpouseSummaryCardDescription.jsx
@@ -6,7 +6,7 @@ export const maritalStatusesWithDateOfMarriage = ['married', 'separated'];
 const SpouseSummaryCardDescription = () => {
   const { maritalStatus, dateOfMarriage } = useSelector(state => ({
     maritalStatus: state.form.data['view:maritalStatus'].maritalStatus,
-    dateOfMarriage: state.form.data.dateOfMarriage,
+    dateOfMarriage: state.form.data.spouseInformation[0].dateOfMarriage,
   }));
   const allDetails = [maritalStatus];
   if (

--- a/src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/components/FormDescriptions/SpouseSummaryCardDescription.unit.spec.jsx
@@ -18,6 +18,7 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
                   'view:maritalStatus': {
                     maritalStatus: status,
                   },
+                  spouseInformation: [{}],
                 },
               },
             },
@@ -46,7 +47,11 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
                   'view:maritalStatus': {
                     maritalStatus: status,
                   },
-                  dateOfMarriage: '1995-02-22',
+                  spouseInformation: [
+                    {
+                      dateOfMarriage: '1995-02-22',
+                    },
+                  ],
                 },
               },
             },
@@ -72,7 +77,11 @@ describe('ezr <SpouseSummaryCardDescription>', () => {
               'view:maritalStatus': {
                 maritalStatus: 'never married',
               },
-              dateOfMarriage: '1995-02-22',
+              spouseInformation: [
+                {
+                  dateOfMarriage: '1995-02-22',
+                },
+              ],
             },
           },
         },


### PR DESCRIPTION
## Summary

- Show the Date of Marriage entered from filling out the form, rather than only prefilled data
- Currently, the date used is from the top level of the form data, ignoring anything filled in during the session. 
- Solution: use the data from the ArrayBuilder's `spouseInformation` array instead.
- Health Applications 10-10 EZR
- This is behind the `ezr_spouse_confirmation_flow_enabled`, together with the rest of the Spouse V2 functionality

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117847
- https://github.com/department-of-veterans-affairs/vets-website/pull/40592

## Testing done

- Confirmed with local testing and mocked prefill data
- Verification process:
  - Fill out the EZR form, choosing a Marital Status of Married or Separated.
  - If there is prefilled spouse data, edit it to change the Date of Marriage.
  - On the Summary page after filling in that info, confirm that the updated Date of Marriage is displayed.
  - Also confirm that on the Review page shown before submitting.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

10-10EZR form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
