### PR TITLE
Fix bug where empty middle name caused blank page

### DIFF
--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -122,6 +122,7 @@ const responses = {
             veteranStatusCardUseLighthouse: true,
             veteranStatusCardUseLighthouseFrontend: true,
             vreCutoverNotice: true,
+            vrePrefillName: true,
             mhvEmailConfirmation: true,
           }),
         ),

--- a/src/applications/vre/28-1900/containers/App.jsx
+++ b/src/applications/vre/28-1900/containers/App.jsx
@@ -1,13 +1,42 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import {
   DowntimeNotification,
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
+import { setData } from 'platform/forms-system/src/js/actions';
 import formConfig from '../config/form';
 
-export default function App({ location, children }) {
+function App({ location, children, formData, setFormData }) {
+  // Setup feature flags
+  const TOGGLE_KEY = 'vrePrefillName';
+  const {
+    TOGGLE_NAMES,
+    useToggleValue,
+    useToggleLoadingValue,
+  } = useFeatureToggle();
+  const vrePrefillNameEnabled = useToggleValue(TOGGLE_NAMES[TOGGLE_KEY]);
+  const isLoadingFeatureFlags = useToggleLoadingValue();
+
+  useEffect(
+    () => {
+      if (
+        !isLoadingFeatureFlags &&
+        formData[TOGGLE_KEY] !== vrePrefillNameEnabled
+      ) {
+        setFormData({
+          ...formData,
+          [`view:${TOGGLE_KEY}`]: vrePrefillNameEnabled,
+        });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isLoadingFeatureFlags, vrePrefillNameEnabled, formData[TOGGLE_KEY]],
+  );
+
   return (
     <>
       {/* <Breadcrumbs /> */}
@@ -23,7 +52,24 @@ export default function App({ location, children }) {
   );
 }
 
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+const mapStateToProps = state => ({
+  formData: state.form?.data || {},
+});
+
 App.propTypes = {
   children: PropTypes.node,
+  formData: PropTypes.object,
   location: PropTypes.object,
+  setFormData: PropTypes.func.isRequired,
 };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(App);
+
+export { App };

--- a/src/applications/vre/28-1900/tests/unit/utils/prefill-transformer.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/unit/utils/prefill-transformer.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('getSafeUserFullName', () => {
     });
   });
 
-  it('should return empty strings for missing fields', () => {
+  it('should return empty strings for missing fields and not include suffix', () => {
     const userFullName = {
       first: 'John',
       last: 'Doe',
@@ -32,7 +32,6 @@ describe('getSafeUserFullName', () => {
       first: 'John',
       middle: '',
       last: 'Doe',
-      suffix: '',
     });
   });
 
@@ -43,7 +42,6 @@ describe('getSafeUserFullName', () => {
       first: '',
       middle: '',
       last: '',
-      suffix: '',
     });
   });
 
@@ -54,7 +52,6 @@ describe('getSafeUserFullName', () => {
       first: '',
       middle: '',
       last: '',
-      suffix: '',
     });
   });
 
@@ -65,7 +62,6 @@ describe('getSafeUserFullName', () => {
       first: '',
       middle: '',
       last: '',
-      suffix: '',
     });
   });
 });

--- a/src/applications/vre/28-1900/tests/unit/utils/prefill-transformer.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/unit/utils/prefill-transformer.unit.spec.jsx
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
-import { getSafeUserFullName } from '../../../utils/prefill-transformer';
+import * as prefillModule from '../../../utils/prefill-transformer';
+
+const { getSafeUserFullName } = prefillModule;
 
 describe('getSafeUserFullName', () => {
   it('should return a complete name object when all fields are provided', () => {
@@ -63,5 +65,61 @@ describe('getSafeUserFullName', () => {
       middle: '',
       last: '',
     });
+  });
+});
+
+describe('prefillTransformer', () => {
+  const mockState = {
+    user: {
+      profile: {
+        dob: '1980-01-01',
+        userFullName: {
+          first: 'John',
+          middle: 'A',
+          last: 'Doe',
+          suffix: 'Jr.',
+        },
+        vapContactInfo: {
+          mailingAddress: {
+            countryCodeIso3: 'USA',
+            addressLine1: '123 Main St',
+            addressLine2: 'Apt 4',
+            addressLine3: '',
+            city: 'Springfield',
+            stateCode: 'IL',
+            zipCode: '62701',
+          },
+        },
+      },
+    },
+  };
+
+  it('should use getSafeUserFullName when view:vrePrefillName is true', () => {
+    const pages = [];
+    const formData = { 'view:vrePrefillName': true };
+    const metadata = {};
+
+    prefillModule.prefillTransformer(pages, formData, metadata, mockState);
+  });
+
+  it('should not use getSafeUserFullName when view:vrePrefillName is false', () => {
+    const pages = [];
+    const existingFullName = { first: 'Jane', middle: 'B', last: 'Smith' };
+    const formData = {
+      'view:vrePrefillName': false,
+      fullName: existingFullName,
+    };
+    const metadata = {};
+
+    prefillModule.prefillTransformer(pages, formData, metadata, mockState);
+  });
+
+  it('should not use getSafeUserFullName when view:vrePrefillName is undefined', () => {
+    const pages = [];
+    const existingFullName = { first: 'Jane', middle: 'B', last: 'Smith' };
+    const formData = { fullName: existingFullName };
+    const metadata = {};
+
+    prefillModule.prefillTransformer(pages, formData, metadata, mockState);
   });
 });

--- a/src/applications/vre/28-1900/tests/unit/utils/prefill-transformer.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/unit/utils/prefill-transformer.unit.spec.jsx
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { getSafeUserFullName } from '../../../utils/prefill-transformer';
+
+describe('getSafeUserFullName', () => {
+  it('should return a complete name object when all fields are provided', () => {
+    const userFullName = {
+      first: 'John',
+      middle: 'A',
+      last: 'Doe',
+      suffix: 'Jr.',
+    };
+
+    const result = getSafeUserFullName(userFullName);
+
+    expect(result).to.deep.equal({
+      first: 'John',
+      middle: 'A',
+      last: 'Doe',
+      suffix: 'Jr.',
+    });
+  });
+
+  it('should return empty strings for missing fields', () => {
+    const userFullName = {
+      first: 'John',
+      last: 'Doe',
+    };
+
+    const result = getSafeUserFullName(userFullName);
+
+    expect(result).to.deep.equal({
+      first: 'John',
+      middle: '',
+      last: 'Doe',
+      suffix: '',
+    });
+  });
+
+  it('should return all empty strings when userFullName is null', () => {
+    const result = getSafeUserFullName(null);
+
+    expect(result).to.deep.equal({
+      first: '',
+      middle: '',
+      last: '',
+      suffix: '',
+    });
+  });
+
+  it('should return all empty strings when userFullName is undefined', () => {
+    const result = getSafeUserFullName(undefined);
+
+    expect(result).to.deep.equal({
+      first: '',
+      middle: '',
+      last: '',
+      suffix: '',
+    });
+  });
+
+  it('should return all empty strings when userFullName is an empty object', () => {
+    const result = getSafeUserFullName({});
+
+    expect(result).to.deep.equal({
+      first: '',
+      middle: '',
+      last: '',
+      suffix: '',
+    });
+  });
+});

--- a/src/applications/vre/28-1900/utils/prefill-transformer.js
+++ b/src/applications/vre/28-1900/utils/prefill-transformer.js
@@ -18,10 +18,17 @@ export function prefillTransformer(pages, formData, metadata, state) {
     zipCode,
   } = vapContactInfo.mailingAddress || {};
 
+  const safeUserFullName = {
+    first: userFullName?.first ?? '',
+    middle: userFullName?.middle ?? '',
+    last: userFullName?.last ?? '',
+    suffix: userFullName?.suffix ?? '',
+  };
+
   const newData = {
     ...formData,
     dob,
-    fullName: userFullName,
+    fullName: safeUserFullName,
     veteranAddress: {
       country: countryCodeIso3,
       street: addressLine1,

--- a/src/applications/vre/28-1900/utils/prefill-transformer.js
+++ b/src/applications/vre/28-1900/utils/prefill-transformer.js
@@ -3,7 +3,7 @@ export function getSafeUserFullName(userFullName) {
     first: userFullName?.first ?? '',
     middle: userFullName?.middle ?? '',
     last: userFullName?.last ?? '',
-    suffix: userFullName?.suffix ?? '',
+    ...(userFullName?.suffix && { suffix: userFullName.suffix }), // this key shouldn't be included unless it has a value
   };
 }
 

--- a/src/applications/vre/28-1900/utils/prefill-transformer.js
+++ b/src/applications/vre/28-1900/utils/prefill-transformer.js
@@ -30,7 +30,9 @@ export function prefillTransformer(pages, formData, metadata, state) {
   const newData = {
     ...formData,
     dob,
-    fullName: getSafeUserFullName(userFullName),
+    fullName: formData['view:vrePrefillName']
+      ? getSafeUserFullName(userFullName)
+      : userFullName,
     veteranAddress: {
       country: countryCodeIso3,
       street: addressLine1,

--- a/src/applications/vre/28-1900/utils/prefill-transformer.js
+++ b/src/applications/vre/28-1900/utils/prefill-transformer.js
@@ -1,3 +1,12 @@
+export function getSafeUserFullName(userFullName) {
+  return {
+    first: userFullName?.first ?? '',
+    middle: userFullName?.middle ?? '',
+    last: userFullName?.last ?? '',
+    suffix: userFullName?.suffix ?? '',
+  };
+}
+
 /**
  * Map necessary data from prefill to populate initial form data
  * @param {Array} pages - an array of form pages
@@ -18,17 +27,10 @@ export function prefillTransformer(pages, formData, metadata, state) {
     zipCode,
   } = vapContactInfo.mailingAddress || {};
 
-  const safeUserFullName = {
-    first: userFullName?.first ?? '',
-    middle: userFullName?.middle ?? '',
-    last: userFullName?.last ?? '',
-    suffix: userFullName?.suffix ?? '',
-  };
-
   const newData = {
     ...formData,
     dob,
-    fullName: safeUserFullName,
+    fullName: getSafeUserFullName(userFullName),
     veteranAddress: {
       country: countryCodeIso3,
       street: addressLine1,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -350,6 +350,7 @@
   "virtualAgentUseStsAuthentication": "virtual_agent_use_sts_authentication",
   "virtualAgentChatbotSessionPersistenceEnabled": "virtual_agent_chatbot_session_persistence_enabled",
   "vreModularApi": "vre_modular_api",
+  "vrePrefillName": "vre_prefill_name",
   "vreCutoverNotice": "vre_cutover_notice",
   "vyeLoginWidget": "vye_login_widget",
   "yellowRibbonAutomatedDateOnSchoolSearch": "yellow_ribbon_automated_date_on_school_search",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds safety to the prefill transformer by only including values for the userFullName object if they exist
- This may fix a bug where users see a blank page after the introduction
- Solution avoids an issue where setting the suffix field to an empty string causes the field to act as though it is required
- I work for CVE and we own this form
- Puts the solution behind a feature flag whose lifespan should only last a couple weeks

## Related issue(s)

- [CVE issue 2259](https://github.com/department-of-veterans-affairs/va-iir/issues/2259)

## Testing done

- Added a unit test assuring that the prefill transformer is properly transforming user full name data objects.
- This solution handles the suffix field in a special way since it is a select. To see what the problem would be with setting `suffix` to `''`, use Redux Dev Tools to dispatch that change using the following action.
```
{
  type: 'SET_DATA',
  data: {
    fullName: {
      first: 'first',
      suffix: ''
    },
    checkBoxGroup: {},
    veteranAddress: {
      'view:militaryBaseDescription': {}
    },
    newAddress: {
      'view:militaryBaseDescription': {}
    },
    internationalPhone: {}
  }
}
```
The suffix field will now display as though it is required. Now remove the suffix field entirely, as our code solution does, and dispatch again. You should see that the field no longer acts up.
```
{
  type: 'SET_DATA',
  data: {
    fullName: {
      first: 'first',
    },
    checkBoxGroup: {},
    veteranAddress: {
      'view:militaryBaseDescription': {}
    },
    newAddress: {
      'view:militaryBaseDescription': {}
    },
    internationalPhone: {}
  }
}
```

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
