### PR TITLE
updates oath ff logic to remove sis ff

### DIFF
--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -17,10 +17,7 @@ export function toggleLoginModal(
   forceVerification = false,
 ) {
   return async (dispatch, getState) => {
-    const {
-      signInServiceEnabled,
-      cernerNonEligibleSisEnabled,
-    } = getState()?.featureToggles;
+    const { cernerNonEligibleSisEnabled } = getState()?.featureToggles;
 
     const nextParam = new URLSearchParams(window?.location?.search)?.get(
       'next',
@@ -28,11 +25,10 @@ export function toggleLoginModal(
     const authBrokerCookieSelector = determineAuthBroker(
       cernerNonEligibleSisEnabled,
     );
-    const sisEligible = signInServiceEnabled && authBrokerCookieSelector;
 
     const nextQuery = {
       next: nextParam ?? 'loginModal',
-      ...(sisEligible && { oauth: true }),
+      ...{ oauth: authBrokerCookieSelector },
       ...(forceVerification && { verification: 'required' }),
     };
 

--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -28,7 +28,7 @@ export function toggleLoginModal(
 
     const nextQuery = {
       next: nextParam ?? 'loginModal',
-      ...{ oauth: authBrokerCookieSelector },
+      oauth: authBrokerCookieSelector,
       ...(forceVerification && { verification: 'required' }),
     };
 

--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -1,5 +1,4 @@
 import appendQuery from 'append-query';
-import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
 import { determineAuthBroker } from 'platform/user/authentication/utilities';
 
@@ -18,19 +17,17 @@ export function toggleLoginModal(
   forceVerification = false,
 ) {
   return async (dispatch, getState) => {
-    const { cernerNonEligibleSisEnabled } = getState()?.featureToggles;
-    const { useToggleLoadingValue } = useFeatureToggle();
-    const togglesLoading = useToggleLoadingValue();
+    const { loading, cernerNonEligibleSisEnabled } = getState()?.featureToggles;
 
     const nextParam = new URLSearchParams(window?.location?.search)?.get(
       'next',
     );
     const authBrokerCookieSelector = determineAuthBroker(
       cernerNonEligibleSisEnabled,
-      togglesLoading,
+      loading,
     );
 
-    const oauth = togglesLoading ? true : authBrokerCookieSelector !== false;
+    const oauth = loading ? true : authBrokerCookieSelector !== false;
 
     const nextQuery = {
       next: nextParam ?? 'loginModal',

--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -1,4 +1,5 @@
 import appendQuery from 'append-query';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
 import { determineAuthBroker } from 'platform/user/authentication/utilities';
 
@@ -18,17 +19,22 @@ export function toggleLoginModal(
 ) {
   return async (dispatch, getState) => {
     const { cernerNonEligibleSisEnabled } = getState()?.featureToggles;
+    const { useToggleLoadingValue } = useFeatureToggle();
+    const togglesLoading = useToggleLoadingValue();
 
     const nextParam = new URLSearchParams(window?.location?.search)?.get(
       'next',
     );
     const authBrokerCookieSelector = determineAuthBroker(
       cernerNonEligibleSisEnabled,
+      togglesLoading,
     );
+
+    const oauth = togglesLoading ? true : authBrokerCookieSelector !== false;
 
     const nextQuery = {
       next: nextParam ?? 'loginModal',
-      oauth: authBrokerCookieSelector,
+      oauth,
       ...(forceVerification && { verification: 'required' }),
     };
 

--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -24,10 +24,14 @@ export function toggleLoginModal(
     );
     const authBrokerCookieSelector = determineAuthBroker(
       cernerNonEligibleSisEnabled,
-      loading,
     );
 
-    const oauth = loading ? true : authBrokerCookieSelector !== false;
+    const savedModalOpen =
+      typeof loading === 'undefined' &&
+      typeof cernerNonEligibleSisEnabled === 'undefined' &&
+      nextParam;
+
+    const oauth = savedModalOpen ? true : authBrokerCookieSelector;
 
     const nextQuery = {
       next: nextParam ?? 'loginModal',

--- a/src/platform/site-wide/user-nav/tests/actions/index.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/actions/index.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('User Nav Actions', () => {
     let store;
     const oldLocation = global.window.location;
     const featureToggleNotEnabled = {
-      featureToggles: { signInServiceEnabled: false },
+      featureToggles: { cernerNonEligibleSisEnabled: false },
     };
 
     beforeEach(() => {

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -20,22 +20,9 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
 
   useEffect(
     () => {
-      const url = new URL(window.location.href);
-      const params = url.searchParams;
-
-      const isLoginModalEntry = params.get('next') === 'loginModal';
-
-      if (isLoginModalEntry && !params.has('oauth')) {
-        setOAuth(true);
-        params.set('oauth', 'true');
-        window.history.replaceState({}, '', url.toString());
-      } else if (isLoginModalEntry && params.has('oauth')) {
-        setOAuth(OAuthEnabled && params.get('oauth') === 'true');
-      } else {
-        setOAuth(OAuthEnabled && OAuth === 'true');
-      }
+      setOAuth(OAuthEnabled && OAuth === 'true');
     },
-    [OAuthEnabled],
+    [OAuth, OAuthEnabled],
   );
 
   return (

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -26,20 +26,16 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
       const isLoginModalEntry = params.get('next') === 'loginModal';
 
       if (isLoginModalEntry && !params.has('oauth')) {
+        setOAuth(true);
         params.set('oauth', 'true');
         window.history.replaceState({}, '', url.toString());
+      } else if (isLoginModalEntry && params.has('oauth')) {
+        setOAuth(OAuthEnabled && params.get('oauth') === 'true');
+      } else {
+        setOAuth(OAuthEnabled && OAuth === 'true');
       }
-
-      setOAuth(OAuthEnabled && params.get('oauth') === 'true');
     },
     [OAuthEnabled],
-  );
-
-  useEffect(
-    () => {
-      setOAuth(OAuthEnabled && OAuth === 'true');
-    },
-    [OAuth, OAuthEnabled],
   );
 
   return (

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -18,18 +18,22 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
 
   const actionLocation = isUnifiedSignIn ? 'usip' : 'modal';
 
-  useEffect(() => {
-    const url = new URL(window.location.href);
-    const params = url.searchParams;
+  useEffect(
+    () => {
+      const url = new URL(window.location.href);
+      const params = url.searchParams;
 
-    const isLoginModalEntry = params.get('next') === 'login-modal';
-    const hasOauth = params.has('oauth');
+      const isLoginModalEntry = params.get('next') === 'loginModal';
 
-    if (isLoginModalEntry && !hasOauth) {
-      params.set('oauth', 'true');
-      window.history.replaceState({}, '', url.toString());
-    }
-  }, []);
+      if (isLoginModalEntry && !params.has('oauth')) {
+        params.set('oauth', 'true');
+        window.history.replaceState({}, '', url.toString());
+      }
+
+      setOAuth(OAuthEnabled && params.get('oauth') === 'true');
+    },
+    [OAuthEnabled],
+  );
 
   useEffect(
     () => {

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -18,6 +18,19 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
 
   const actionLocation = isUnifiedSignIn ? 'usip' : 'modal';
 
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+
+    const isLoginModalEntry = params.get('next') === 'login-modal';
+    const hasOauth = params.has('oauth');
+
+    if (isLoginModalEntry && !hasOauth) {
+      params.set('oauth', 'true');
+      window.history.replaceState({}, '', url.toString());
+    }
+  }, []);
+
   useEffect(
     () => {
       setOAuth(OAuthEnabled && OAuth === 'true');

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -457,8 +457,8 @@ export const logoutUrl = () => {
  * @param {Boolean} cernerNonEligibleSisEnabled feature toggle that controls logic
  * @returns {Boolean} Returns a boolean to determine AuthBroker
  */
-export const determineAuthBroker = featureFlagEnabled => {
-  if (!featureFlagEnabled) return true;
+export const determineAuthBroker = (featureFlagEnabled, toggleIsLoading) => {
+  if (!featureFlagEnabled && !toggleIsLoading) return false;
 
   const cookieValue = Cookies.get('CERNER_ELIGIBLE');
 
@@ -496,5 +496,5 @@ export const determineAuthBroker = featureFlagEnabled => {
    * @returns true if plain text cookie is 'false', false if 'true'
    */
   const plainTextCookie = cookieValue.trim().toLowerCase();
-  return plainTextCookie === 'false';
+  return plainTextCookie !== 'true';
 };

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -458,7 +458,7 @@ export const logoutUrl = () => {
  * @returns {Boolean} Returns a boolean to determine AuthBroker
  */
 export const determineAuthBroker = featureFlagEnabled => {
-  if (!featureFlagEnabled) return false;
+  if (!featureFlagEnabled) return true;
 
   const cookieValue = Cookies.get('CERNER_ELIGIBLE');
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.jsx
@@ -752,7 +752,7 @@ describe('Authentication Utilities', () => {
 
     it('should return false by default', () => {
       expect(authUtilities.determineAuthBroker()).to.be.false;
-      expect(authUtilities.determineAuthBroker(false)).to.be.false;
+      expect(authUtilities.determineAuthBroker(false, false)).to.be.false;
     });
 
     it('should return `true` when no cookie is found', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removes SiS feature toggle to investigate a latency bug.


## Related issue(s)

[Slack thread](https://dsva.slack.com/archives/C06JLV08D32/p1765827575630899)

## Testing done

- `cernerEligibleSiS` feature flag is enabled AND user has no cerner cookie tied to session, cookie is malformed, or cookie value is blank: query params should append `oauth=true`
- `cernerEligibleSiS` feature flag is disabled, parsed cookie `==='T'` or parsed cookie `!=='F'` query params should append `ouath=false`

## Screenshots

N/A

## What areas of the site does it impact?

- `/https://www.va.gov/?next=loginModal&oauth=true`

## Acceptance criteria

The `oauth` query param value is based on the following:
SSOe: 
- `cernerNonEligibleSiS` feature toggle is disabled
- `cernerNonEligibleSiS` feature toggle is enabled but parsed cookie returns `’T’`
- `cernerNonEligibleSiS` feature toggle is enabled but parsed cookie returns `!==‘F’`

Sign in service:
- `cernerNonEligibleSiS` feature toggle is enabled AND
- User journeys that don’t meet the criteria above. (I.e. everyone else)
  - No cerner cookie to parse
  - Cerner cookie exists but is blank
  - Cerner cookies is malformed
  - Cerner cookie exists, is successfully parsed and `=='F'`
  - Cookie parsing error handling

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
