### PR TITLE
 Community provider > Service type input is not updating aria-expanded correctly 

### DIFF
--- a/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
@@ -226,6 +226,7 @@ class CCServiceTypeAhead extends Component {
             )}
             <span id="service-typeahead">
               <input
+                role="combobox"
                 {...getInputProps({
                   placeholder: this.props.useProgressiveDisclosure
                     ? undefined
@@ -239,6 +240,8 @@ class CCServiceTypeAhead extends Component {
                 }}
                 id="service-type-ahead-input"
                 aria-describedby="could-not-find-service-prompt error-message"
+                aria-expanded={isOpen ? 'true' : 'false'}
+                aria-controls="downshift-110-menu"
               />
 
               {this.renderSearchForAvailableServicePrompt(inputValue)}

--- a/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
@@ -196,67 +196,72 @@ class CCServiceTypeAhead extends Component {
           getInputProps,
           getItemProps,
           getLabelProps,
+          getMenuProps,
           isOpen,
           inputValue,
           highlightedIndex,
-        }) => (
-          <div
-            id="service-error"
-            className={classNames('vads-u-margin--0', {
-              'usa-input-error': showError,
-            })}
-          >
-            <label {...getLabelProps()} htmlFor="service-type-ahead-input">
-              Service type{' '}
-              <span className="form-required-span">(*Required)</span>
-            </label>
-            {this.props.useProgressiveDisclosure && (
-              <p className="service-hint-text">
-                Start typing to search for a service, like Chiropractor or
-                Optometrist.
-              </p>
-            )}
-            {showError && (
-              <span className="usa-input-error-message" role="alert">
-                <span id="error-message">
-                  <span className="sr-only">Error</span>
-                  Start typing and select a service type
+        }) => {
+          const { id } = getMenuProps();
+          return (
+            <div
+              id="service-error"
+              className={classNames('vads-u-margin--0', {
+                'usa-input-error': showError,
+              })}
+            >
+              <label {...getLabelProps()} htmlFor="service-type-ahead-input">
+                Service type{' '}
+                <span className="form-required-span">(*Required)</span>
+              </label>
+              {this.props.useProgressiveDisclosure && (
+                <p className="service-hint-text">
+                  Start typing to search for a service, like Chiropractor or
+                  Optometrist.
+                </p>
+              )}
+              {showError && (
+                <span className="usa-input-error-message" role="alert">
+                  <span id="error-message">
+                    <span className="sr-only">Error</span>
+                    Start typing and select a service type
+                  </span>
                 </span>
+              )}
+              <span id="service-typeahead">
+                <input
+                  role="combobox"
+                  {...getInputProps({
+                    placeholder: this.props.useProgressiveDisclosure
+                      ? undefined
+                      : 'like Chiropractor or Optometrist',
+
+                    onFocus: () => this.setState({ isFocused: true }),
+                    disabled: currentQuery?.fetchSvcsInProgress,
+                  })}
+                  onBlur={() => {
+                    this.setState({ isFocused: false });
+                  }}
+                  id="service-type-ahead-input"
+                  aria-describedby="could-not-find-service-prompt error-message"
+                  aria-expanded={isOpen ? 'true' : 'false'}
+                  aria-controls={id}
+                />
+
+                {this.renderSearchForAvailableServicePrompt(inputValue)}
+                {isOpen &&
+                  inputValue &&
+                  inputValue.length >= MIN_SEARCH_CHARS &&
+                  this.renderServiceTypeDropdownOptions(
+                    getItemProps,
+                    highlightedIndex,
+                    inputValue,
+                    id,
+                  )}
+                {this.renderTryAnotherServicePrompt(inputValue)}
               </span>
-            )}
-            <span id="service-typeahead">
-              <input
-                role="combobox"
-                {...getInputProps({
-                  placeholder: this.props.useProgressiveDisclosure
-                    ? undefined
-                    : 'like Chiropractor or Optometrist',
-
-                  onFocus: () => this.setState({ isFocused: true }),
-                  disabled: currentQuery?.fetchSvcsInProgress,
-                })}
-                onBlur={() => {
-                  this.setState({ isFocused: false });
-                }}
-                id="service-type-ahead-input"
-                aria-describedby="could-not-find-service-prompt error-message"
-                aria-expanded={isOpen ? 'true' : 'false'}
-                aria-controls="downshift-110-menu"
-              />
-
-              {this.renderSearchForAvailableServicePrompt(inputValue)}
-              {isOpen &&
-                inputValue &&
-                inputValue.length >= MIN_SEARCH_CHARS &&
-                this.renderServiceTypeDropdownOptions(
-                  getItemProps,
-                  highlightedIndex,
-                  inputValue,
-                )}
-              {this.renderTryAnotherServicePrompt(inputValue)}
-            </span>
-          </div>
-        )}
+            </div>
+          );
+        }}
       </Downshift>
     );
   }

--- a/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
@@ -196,12 +196,10 @@ class CCServiceTypeAhead extends Component {
           getInputProps,
           getItemProps,
           getLabelProps,
-          getMenuProps,
           isOpen,
           inputValue,
           highlightedIndex,
         }) => {
-          const { id } = getMenuProps();
           return (
             <div
               id="service-error"
@@ -244,7 +242,7 @@ class CCServiceTypeAhead extends Component {
                   id="service-type-ahead-input"
                   aria-describedby="could-not-find-service-prompt error-message"
                   aria-expanded={isOpen ? 'true' : 'false'}
-                  aria-controls={id}
+                  aria-controls="service-typeahead"
                 />
 
                 {this.renderSearchForAvailableServicePrompt(inputValue)}
@@ -255,7 +253,6 @@ class CCServiceTypeAhead extends Component {
                     getItemProps,
                     highlightedIndex,
                     inputValue,
-                    id,
                   )}
                 {this.renderTryAnotherServicePrompt(inputValue)}
               </span>

--- a/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
@@ -126,6 +126,7 @@ class CCServiceTypeAhead extends Component {
   ) => {
     return (
       <div
+        id="service-typeahead-listbox"
         className={`dropdown${
           this.props.useProgressiveDisclosure && this.props.isSmallDesktop
             ? ' drowpdown-fl-sm-desktop'
@@ -242,7 +243,7 @@ class CCServiceTypeAhead extends Component {
                   id="service-type-ahead-input"
                   aria-describedby="could-not-find-service-prompt error-message"
                   aria-expanded={isOpen}
-                  aria-controls="service-typeahead"
+                  aria-controls="service-typeahead-listbox"
                 />
 
                 {this.renderSearchForAvailableServicePrompt(inputValue)}

--- a/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
@@ -241,7 +241,7 @@ class CCServiceTypeAhead extends Component {
                   }}
                   id="service-type-ahead-input"
                   aria-describedby="could-not-find-service-prompt error-message"
-                  aria-expanded={isOpen ? 'true' : 'false'}
+                  aria-expanded={isOpen}
                   aria-controls="service-typeahead"
                 />
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request fixes an accessibility issue in the Community Provider service type input where the aria-expanded attribute was not updating correctly to reflect the open/closed state of the dropdown.

Changes:

- Converted an arrow function to a function with explicit return statement in the Downshift render prop
- Added `role="combobox"` to the input element
- Added `aria-expanded` attribute dynamically bound to the isOpen state
- Added `aria-controls` attribute linking to the dropdown container

## Related issue(s)

- Fixes department-of-veterans-affairs/va.gov-cms#22926

## Testing done

Reproduce Bug:

1. Go to Facility Locator - Community Provider Facility Type
2. Open devtools.
3. Tab or click into the field.
4. Type a character and note that the dropdown is closed, but aria-expanded=true
5. Type a second character. Note the dropdown opens, aria-expanded=true (so now it's correct).
6. Delete a character. Note that the dropdown closes, but aria-expanded=true. Wrong again.
7. Also try a screenreader while opening and closing the dropdown.

Confirm Changes:

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | <img width="994" height="197" alt="image" src="https://github.com/user-attachments/assets/5c84e117-18a0-4fc1-ad0d-9b0ba57e4a04" />| <img width="1287" height="393" alt="Screenshot 2026-01-15 at 1 55 01 PM" src="https://github.com/user-attachments/assets/fe5afbe9-bbd5-40e1-9f86-853009598232" /> <img width="1271" height="417" alt="Screenshot 2026-01-15 at 1 55 09 PM" src="https://github.com/user-attachments/assets/44d954ce-30dc-419d-af59-346a61d719e4" /> <img width="1286" height="430" alt="Screenshot 2026-01-15 at 1 55 17 PM" src="https://github.com/user-attachments/assets/e14c27a5-3eac-45ee-b873-45443451888d" />|

## What areas of the site does it impact?

Facility locator form

## Acceptance criteria

### Quality Assurance & Testing

- [NA] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [NA] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [NA] Events are being sent to the appropriate logging solution
- [NA] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [NA] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
