### PR TITLE
remove choose a facility option from facility options'

### DIFF
--- a/src/applications/facility-locator/components/search-form/facility-type/index.jsx
+++ b/src/applications/facility-locator/components/search-form/facility-type/index.jsx
@@ -22,8 +22,9 @@ const FacilityType = ({
     ? nonPPMSfacilityTypeOptions
     : facilityTypesOptions;
   const showError = !isValid && facilityTypeChanged && !facilityType;
-
-  const options = Object.keys(locationOptions).map(facility => (
+  const { ...filteredLocationOptions } = locationOptions;
+  delete filteredLocationOptions[''];
+  const options = Object.keys(filteredLocationOptions).map(facility => (
     <option key={facility} value={facility}>
       {locationOptions[facility]}
     </option>

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -257,7 +257,6 @@ export const vetCenterServices = [
 ];
 
 export const facilityTypesOptions = {
-  [LocationType.NONE]: 'Choose a facility type',
   [LocationType.HEALTH]: 'VA health',
   [LocationType.URGENT_CARE]: 'Urgent care',
   [LocationType.EMERGENCY_CARE]: 'Emergency care',
@@ -270,7 +269,6 @@ export const facilityTypesOptions = {
 };
 
 export const nonPPMSfacilityTypeOptions = {
-  [LocationType.NONE]: 'Choose a facility type',
   [LocationType.HEALTH]: 'VA health',
   [LocationType.BENEFITS]: 'VA benefits',
   [LocationType.CEMETERY]: 'VA cemeteries',

--- a/src/applications/facility-locator/tests/components/search-form/facility-type/index.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-form/facility-type/index.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('FacilityType', () => {
       const dropdown = screen.getByTestId('facility-type');
       expect(dropdown.classList.contains('facility-type-dropdown')).to.be.true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should render an error when one exists', () => {
@@ -67,7 +67,7 @@ describe('FacilityType', () => {
       const dropdown = screen.getByTestId('facility-type');
       expect(dropdown.classList.contains('facility-error')).to.be.true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should remove the pharmacy option when the PPMS service is down', () => {
@@ -85,7 +85,7 @@ describe('FacilityType', () => {
         />,
       );
 
-      expectOptions(screen, 5, true);
+      expectOptions(screen, 4, true);
     });
   });
 
@@ -109,7 +109,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-tablet')).to.be
         .true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should correctly render the facility type dropdown for mobile', () => {
@@ -131,7 +131,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-mobile')).to.be
         .true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should correctly render the facility type dropdown for desktop', () => {
@@ -153,7 +153,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-desktop')).to
         .be.true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
   });
 });

--- a/src/applications/facility-locator/tests/components/search-form/facility-type/index.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-form/facility-type/index.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('FacilityType', () => {
       const dropdown = screen.getByTestId('facility-type');
       expect(dropdown.classList.contains('facility-type-dropdown')).to.be.true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should render an error when one exists', () => {
@@ -67,7 +67,7 @@ describe('FacilityType', () => {
       const dropdown = screen.getByTestId('facility-type');
       expect(dropdown.classList.contains('facility-error')).to.be.true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should remove the pharmacy option when the PPMS service is down', () => {
@@ -109,7 +109,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-tablet')).to.be
         .true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should correctly render the facility type dropdown for mobile', () => {
@@ -131,7 +131,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-mobile')).to.be
         .true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
 
     it('should correctly render the facility type dropdown for desktop', () => {
@@ -153,7 +153,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-desktop')).to
         .be.true;
 
-      expectOptions(screen, 9);
+      expectOptions(screen, 8);
     });
   });
 });

--- a/src/applications/facility-locator/tests/components/search-form/facility-type/index.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-form/facility-type/index.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('FacilityType', () => {
       const dropdown = screen.getByTestId('facility-type');
       expect(dropdown.classList.contains('facility-type-dropdown')).to.be.true;
 
-      expectOptions(screen, 8);
+      expectOptions(screen, 9);
     });
 
     it('should render an error when one exists', () => {
@@ -67,7 +67,7 @@ describe('FacilityType', () => {
       const dropdown = screen.getByTestId('facility-type');
       expect(dropdown.classList.contains('facility-error')).to.be.true;
 
-      expectOptions(screen, 8);
+      expectOptions(screen, 9);
     });
 
     it('should remove the pharmacy option when the PPMS service is down', () => {
@@ -109,7 +109,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-tablet')).to.be
         .true;
 
-      expectOptions(screen, 8);
+      expectOptions(screen, 9);
     });
 
     it('should correctly render the facility type dropdown for mobile', () => {
@@ -131,7 +131,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-mobile')).to.be
         .true;
 
-      expectOptions(screen, 8);
+      expectOptions(screen, 9);
     });
 
     it('should correctly render the facility type dropdown for desktop', () => {
@@ -153,7 +153,7 @@ describe('FacilityType', () => {
       expect(dropdown.classList.contains('facility-type-dropdown-desktop')).to
         .be.true;
 
-      expectOptions(screen, 8);
+      expectOptions(screen, 9);
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The option "Choose a facility type" was removed from the list of options provided to the facility type selection input
- Steps to reproduce the behavior taken from [this ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22892):
  - Go to [staging facility locator prototype](https://staging.va.gov/find-locations/) or prod: https://www.va.gov/find-locations/
  - See "Choose a facility type" texts displayed as a default on the Facility type field
  - Expand facility type field
  - See "-Select-" displayed above "Choose a facility type"
- Because "-Select-" appears to be hardcoded into the VA Select Component, the option of "Choose a facility type" was removed the the options supplied to the input
- I work for Sitewide/Facilities team
- No flipper

## Related issue(s)

- [‘Facility type’ select options include both ‘- Select -’ and ‘Choose a facility type’](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22892)

## Testing done

- In the previous phenotype, both "-Select-" and "Choose a facility type" are shown
- After changes, only "-Select-" is visible
- The input was viewed in desktop and mobile and the desired result (only seeing select) was observed


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="621" height="368" alt="Screenshot 2025-12-18 at 2 02 59 PM" src="https://github.com/user-attachments/assets/7fe2f9cb-fa38-4217-b587-8c4e796c347e" /> |  <img width="402" height="374" alt="Screenshot 2025-12-18 at 2 33 48 PM" src="https://github.com/user-attachments/assets/59068d7a-72ec-4772-92c2-e5eb2fb3b1e1" /> |

## What areas of the site does it impact?

Facility Locator 

## Acceptance criteria

### Quality Assurance & Testing

- [NA] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [NA] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [NA] Events are being sent to the appropriate logging solution
- [NA] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [NA] Did you login to a local build and verify all authenticated routes work as expected with a test user


## Requested Feedback
NA