### PR TITLE
Fix cutoff date for same-day contestable issue error

### DIFF
--- a/src/applications/appeals/shared/validations/date.js
+++ b/src/applications/appeals/shared/validations/date.js
@@ -79,13 +79,27 @@ export const createDateObject = rawDateString => {
 };
 
 /**
- * Create dynamic error message for additional issues with decision dates that are today or in the future
- * Always uses current date as the cutoff for day of and in the future, formatted using VA.gov style
+ * Create dynamic error message for decision dates that are blocked
+ * Always show "The date must be before [UTC today expressed as calendar date]"
+ * This tells users the earliest acceptable date that will pass validation globally
  * @param {Object} errorMessages - Error messages object containing decisions.pastDate function
- * @returns {string} Formatted error message (e.g., "Enter a date before Dec. 10, 2025." using today's date)
+ * @returns {string} Formatted error message showing UTC today as calendar date
  */
 export const createDecisionDateErrorMsg = errorMessages => {
-  const cutoffDate = formatDateToReadableString(new Date());
+  const now = new Date();
+
+  const utcTodayAsLocalDate = new Date(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    0,
+    0,
+    0,
+    0,
+  );
+
+  const cutoffDate = formatDateToReadableString(utcTodayAsLocalDate);
+
   return errorMessages.decisions.pastDate(cutoffDate);
 };
 
@@ -105,7 +119,6 @@ export const addDateErrorMessages = (errors, errorMessages, date) => {
   if (date.isTodayOrInFuture) {
     // Lighthouse won't accept same day (as submission) decision date
     // Using UTC-based validation to match backend behavior
-
     const decisionDateErrorMessage = createDecisionDateErrorMsg(errorMessages);
 
     errors.addError(decisionDateErrorMessage);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

 Fixed a timezone inconsistency in the decision date error message for the appeals form (10182).

## Related issue(s)

[Issue Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1434/views/3?filterQuery=label%3A%22team-DRAGONS%22+jerry&pane=issue&itemId=145143430&issue=department-of-veterans-affairs%7Cva.gov-team%7C127754)

## Testing done

Tested cross-timezone behavior using Chrome DevTools sensor emulation (Tokyo, Los Angeles, etc.). No new unit tests are required; the existing validation test suite already covers the date validation logic.

## Videos/ Screenshots
<img width="1773" height="315" alt="Screenshot 2025-12-16 at 7 51 49 AM" src="https://github.com/user-attachments/assets/8abf79e0-4308-4e36-9590-4aff8242c1b3" />

### TOKYO Timezone
<img width="614" height="58" alt="Screenshot 2025-12-16 at 7 52 53 AM" src="https://github.com/user-attachments/assets/84c10292-5b4d-4364-847d-e5ba2f427fbf" />

[Manually Add Contestable Issue | Tokyo Timezone - Watch Video](https://www.loom.com/share/a02b7e638b9742689d0f170a980be0d7)

<img width="350" height="322" alt="Screenshot 2025-12-16 at 8 15 19 AM" src="https://github.com/user-attachments/assets/6b83dd05-9aef-4037-98c4-a94fb7dd8a71" /><br/>

<img width="350" height="310" alt="Screenshot 2025-12-16 at 8 14 11 AM" src="https://github.com/user-attachments/assets/16f74a1e-072c-464c-a727-6d10ec86020e" /><br/>
 
<img width="350" height="310" alt="Screenshot 2025-12-16 at 8 14 51 AM" src="https://github.com/user-attachments/assets/7f2d03b0-8c86-4776-8247-fe634cac3562" />


### US Timezone
<img width="614" height="58" alt="Screenshot 2025-12-16 at 7 53 41 AM" src="https://github.com/user-attachments/assets/d450ac5b-65d0-42d8-b87d-ac8574103b6a" />

[Manually Add Contestable Issue | US Timezone - Watch Video](https://www.loom.com/share/ce43e39cc5d04f009b925e5ce55152da)

<img width="350" height="322" alt="Screenshot 2025-12-16 at 8 31 49 AM" src="https://github.com/user-attachments/assets/21102d02-0f14-494f-87bd-fa7880ac4380" /><br/>

<img width="348" height="357" alt="Screenshot 2025-12-16 at 8 31 59 AM" src="https://github.com/user-attachments/assets/3b882848-3cef-4fa2-9047-d8e4bfbd12c8" /><<br/>

<img width="348" height="357" alt="Screenshot 2025-12-16 at 8 32 10 AM" src="https://github.com/user-attachments/assets/c7bca633-61b7-4b38-8ab3-c01ac7f33688" />


## What areas of the site does it impact?

Decision Reviews SC, HLR, NOD

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed