### PR TITLE
bugfix for 0538 verification alert

### DIFF
--- a/src/applications/dependents/686c-674/tests/mock-api-full-data.js
+++ b/src/applications/dependents/686c-674/tests/mock-api-full-data.js
@@ -196,6 +196,17 @@ const userData = () => {
   };
 };
 
+const mockRatingInfo = {
+  data: {
+    id: '',
+    type: 'lighthouse_rating_info',
+    attributes: {
+      userPercentOfDisability: 70,
+      sourceSystem: 'Lighthouse',
+    },
+  },
+};
+
 const responses = {
   'GET /v0/user': userData(),
   'GET /v0/feature_toggles': {
@@ -222,14 +233,7 @@ const responses = {
   'GET /v0/profile/valid_va_file_number': mockVaFileNumber,
   'GET /v0/in_progress_forms/686C-674-V2': mockSipGet,
   'PUT /v0/in_progress_forms/686C-674-V2': mockSipPut,
-  'GET /v0/disability_compensation_form/rating_info': {
-    // eslint-disable-next-line camelcase
-    disability_decision_type_name: 'Service Connected',
-    // eslint-disable-next-line camelcase
-    service_connected_combined_degree: 90,
-    // eslint-disable-next-line camelcase
-    user_percent_of_disability: 90,
-  },
+  'GET /v0/disability_compensation_form/rating_info': mockRatingInfo,
 
   'GET /v0/dependents_applications/show': mockDependents,
 

--- a/src/applications/dependents/view-dependents/reducers/ratingInfo.js
+++ b/src/applications/dependents/view-dependents/reducers/ratingInfo.js
@@ -12,15 +12,15 @@ const initialState = {
 const minRating = 30;
 
 /**
- *
- * @param {*} state
- * @param {*} action
- * @returns
+ * Sets hasMinimumRating state value
+ * @param {object} state
+ * @param {object} action
+ * @returns {object} state object and loading state
  */
 function ratingValue(state = initialState, action) {
   switch (action.type) {
     case FETCH_RATING_INFO_SUCCESS:
-      if (action.response.service_connected_combined_degree >= minRating) {
+      if (action.response.userPercentOfDisability >= minRating) {
         return {
           ...state,
           loading: false,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- fixes a bug that prevented users from seeing the 0538 verification alert


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

