### PR TITLE
DMT | 127815 fix stack

### DIFF
--- a/src/applications/dependents/686c-674/components/ReviewDependents.jsx
+++ b/src/applications/dependents/686c-674/components/ReviewDependents.jsx
@@ -29,7 +29,7 @@ const ReviewDependents = ({
   contentBeforeButtons,
   contentAfterButtons,
 }) => {
-  const hasApiError = useSelector(state => state.dependents?.error || false);
+  const hasApiError = useSelector(state => !!state.dependents?.error || false);
 
   const dependents = data?.dependents?.awarded;
   const isDependentsArray = Array.isArray(dependents);
@@ -44,7 +44,11 @@ const ReviewDependents = ({
       if (showPicklist && (hasApiError || !hasDependents)) {
         // Only allow adding dependents, not removing if dependents array is
         // empty
-        setFormData({ ...data, 'view:addOrRemoveDependents': { add: true } });
+        setFormData({
+          ...data,
+          'view:addOrRemoveDependents': { add: true },
+          'view:dependentsApiError': hasApiError,
+        });
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -83,20 +87,22 @@ const ReviewDependents = ({
           <h4 slot="headline">
             We can’t access your dependent records right now
           </h4>
+          <p>We’re sorry. Something went wrong on our end.</p>
           <p>
-            We’re sorry. Something went wrong on our end. You won’t be able to
-            remove dependents at this time.
+            You can add dependents using this application, but you won’t be able
+            to remove dependents at this time.
           </p>
           <p>
-            Try again later or call us at{' '}
-            <va-telephone contact={CONTACTS.VA_BENEFITS} /> (
-            <va-telephone contact={CONTACTS['711']} />
+            If you need to remove a dependent, please try again later or call us
+            at <va-telephone contact={CONTACTS.VA_BENEFITS} /> (
+            <va-telephone contact={CONTACTS['711']} tty />
             ).
           </p>
         </va-alert>
       )}
 
-      {isDependentsArray &&
+      {!hasDependentError &&
+        isDependentsArray &&
         dependents.length === 0 && (
           <va-alert status="info">
             <div>
@@ -105,34 +111,36 @@ const ReviewDependents = ({
           </va-alert>
         )}
 
-      {hasDependents && (
-        <>
-          <p>
-            Remove a dependent from your VA benefits if these changes occurred:
-          </p>
-          <ul>
-            <li>
-              You got divorced, <strong>or</strong>
-            </li>
-            <li>
-              Your child died, <strong>or</strong>
-            </li>
-            <li>
-              Your child (either a minor or a student) got married,{' '}
-              <strong>or</strong>
-            </li>
-            <li>Your parent died</li>
-          </ul>
-          <p>
-            Not reporting changes could lead to a benefit overpayment. You’d
-            have to repay that money.
-          </p>
+      {!hasDependentError &&
+        hasDependents && (
+          <>
+            <p>
+              Remove a dependent from your VA benefits if these changes
+              occurred:
+            </p>
+            <ul>
+              <li>
+                You got divorced, <strong>or</strong>
+              </li>
+              <li>
+                Your child died, <strong>or</strong>
+              </li>
+              <li>
+                Your child (either a minor or a student) got married,{' '}
+                <strong>or</strong>
+              </li>
+              <li>Your parent died</li>
+            </ul>
+            <p>
+              Not reporting changes could lead to a benefit overpayment. You’d
+              have to repay that money.
+            </p>
 
-          {dependents.map(renderDependentCard)}
+            {dependents.map(renderDependentCard)}
 
-          <h4>Check if someone is missing on your VA benefits</h4>
-        </>
-      )}
+            <h4>Check if someone is missing on your VA benefits</h4>
+          </>
+        )}
 
       <p>Add a dependent to your VA benefits if these changes occurred:</p>
       <ul>

--- a/src/applications/dependents/686c-674/config/utilities/data.js
+++ b/src/applications/dependents/686c-674/config/utilities/data.js
@@ -336,13 +336,15 @@ export const hasAwardedDependents = (formData = {}) =>
 
 /**
  * If v3 flow is enabled, show options selection (add or remove question) if
- * there are awarded dependents; if no awarded dependents, only show the add
- * dependents flow
+ * there are awarded dependents and no dependents API error; if no awarded
+ * dependents, only show the add dependents flow
  * @param {object} formData - form data object
  * @returns {boolean} - true if options selection should be shown
  */
 export const showOptionsSelection = formData =>
-  showV3Picklist(formData) ? hasAwardedDependents(formData) : true;
+  showV3Picklist(formData)
+    ? !formData['view:dependentsApiError'] && hasAwardedDependents(formData)
+    : true;
 
 /**
  * If v3 picklist is enabled, check if remove flow is selected and if all the

--- a/src/applications/dependents/686c-674/tests/components/ReviewDependents.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/components/ReviewDependents.unit.spec.jsx
@@ -157,11 +157,13 @@ describe('ReviewDependents', () => {
     );
 
     expect(container.querySelector('va-alert[status="info"]')).to.exist;
+    expect(container.querySelector('va-alert[status="error"]')).to.not.exist;
     expect(setFormDataSpy.called).to.be.true;
     expect(setFormDataSpy.args[0][0]).to.deep.equal({
       vaDependentsV3: true,
       dependents: { awarded: [] },
       'view:addOrRemoveDependents': { add: true },
+      'view:dependentsApiError': false,
     });
   });
 
@@ -178,11 +180,13 @@ describe('ReviewDependents', () => {
     );
 
     expect(container.querySelector('va-alert[status="error"]')).to.exist;
+    expect(container.querySelector('va-alert[status="info"]')).to.not.exist;
     expect(setFormDataSpy.called).to.be.true;
     expect(setFormDataSpy.args[0][0]).to.deep.equal({
       vaDependentsV3: true,
       dependents: { awarded: [] },
       'view:addOrRemoveDependents': { add: true },
+      'view:dependentsApiError': true,
     });
   });
 

--- a/src/applications/dependents/686c-674/tests/config/utilities.data.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/utilities.data.unit.spec.jsx
@@ -514,6 +514,15 @@ describe('showOptionsSelection', () => {
       }),
     ).to.be.false;
   });
+  it('should return false if the feature flag is on and there is an API error', () => {
+    expect(
+      showOptionsSelection({
+        vaDependentsV3: true,
+        dependents: { awarded: [{}] },
+        'view:dependentsApiError': true,
+      }),
+    ).to.be.false;
+  });
 });
 
 describe('hasAwardedDependents', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > If there is a situation where the API call to fetch dependents fails, and there are no dependents in the form data (from prefill), two stacked alerts will be displayed. After discussing different scenarios with design, we decided to completely hide the dependents from the form data (if there are any), and hide the remove flow for an API failure. This ensures that the Veteran will always see the most up-to-date list of dependents. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127815

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Review dependents | <img width="612" height="606" alt="API failure error alert above an info alert stating that no dependents are on file" src="https://github.com/user-attachments/assets/8891a78e-d2c0-4c3d-a87b-0825a3e0bf58" /> | <img width="629" height="643" alt="Screenshot 2025-12-16 at 1 07 22 PM" src="https://github.com/user-attachments/assets/714cd5e1-5e56-40f8-a85d-a743f3d984ea" /> |

This update will now ensure that the remove flow is skipped when we get an API error

![api error alert showing on review dependents page, clicking continue goes straight into the add dependents flow](https://github.com/user-attachments/assets/10b883f6-9422-4e85-af13-78ee95bba376)

## What areas of the site does it impact?

Dependents Management Form (686C-674)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
