### PR TITLE
Adds redirects for regional benefit offices

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -2193,5 +2193,29 @@
   "src": "/rocleveland",
   "dest": "/cleveland-va-regional-benefit-office/",
   "catchAll": true
+},
+{
+  "domain": "www.benefits.va.gov",
+  "src": "/manila",
+  "dest": "/va-regional-benefit-office-at-us-embassy-in-manila/",
+  "catchAll": true
+},
+{
+  "domain": "www.benefits.va.gov",
+  "src": "/romanila",
+  "dest": "/va-regional-benefit-office-at-us-embassy-in-manila/",
+  "catchAll": true
+},
+{
+  "domain": "www.benefits.va.gov",
+  "src": "/buffalo",
+  "dest": "/buffalo-va-regional-benefit-office/",
+  "catchAll": true
+},
+{
+  "domain": "www.benefits.va.gov",
+  "src": "/robuffalo",
+  "dest": "/buffalo-va-regional-benefit-office/",
+  "catchAll": true
 }
 ]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request adds several new cross-domain redirect rules for the `www.benefits.va.gov` domain to ensure users are directed to the correct VA regional benefit office pages.

New cross-domain redirects:

* Added redirects from `/manila` and `/romanila` to `/va-regional-benefit-office-at-us-embassy-in-manila/` for the `www.benefits.va.gov` domain.
* Added redirects from `/buffalo` and `/robuffalo` to `/buffalo-va-regional-benefit-office/` for the `www.benefits.va.gov` domain.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119879
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127642

