### PR TITLE
534 ez copy updates

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/incomeAndAssets/incomeAndAssets.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/incomeAndAssets/incomeAndAssets.js
@@ -106,7 +106,7 @@ const uiSchema = {
   ...titleUI('Income and assets', Description),
   'ui:description': WhatWeConsiderAsset,
   hasAssetsOverThreshold: yesNoUI({
-    title: 'Do you and your dependents have over $75,000 in assets?',
+    title: 'Do you and your dependents have over $25,000 in assets?',
   }),
 };
 

--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/medicalExpenses/medicalExpensesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/medicalExpenses/medicalExpensesPages.js
@@ -182,6 +182,7 @@ const recipientPage = {
     }),
     paymentRecipient: textUI({
       title: 'Who receives the payment?',
+      hint: 'For example: provider’s name or insurance company',
       'ui:required': true,
     }),
   },
@@ -201,6 +202,7 @@ const purposeDatePage = {
     ...arrayBuilderItemSubsequentPageTitleUI('Expense purpose and date'),
     purpose: textUI({
       title: 'What’s the payment for?',
+      hint: 'For example: insurance premium or medical supplies',
     }),
     paymentDate: currentOrPastDateUI({
       title: 'What’s the date of the payment?',

--- a/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/incomeAndAssets.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/incomeAndAssets.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('Income and assets page', () => {
     const vaRadioOptions = $$('va-radio-option', formDOM);
     const vaAccordions = $$('va-accordion', formDOM);
     const vaAssetsThresholdRadio = $(
-      'va-radio[label*="Do you and your dependents have over $75,000 in assets?"]',
+      'va-radio[label*="Do you and your dependents have over $25,000 in assets?"]',
       formDOM,
     );
 

--- a/src/applications/survivors-benefits/tests/utils.js
+++ b/src/applications/survivors-benefits/tests/utils.js
@@ -425,7 +425,7 @@ export const checkContentIncomeAssettsInto = () => {
   );
   checkVisibleElementContent(
     'va-radio',
-    'Do you and your dependents have over $75,000 in assets?',
+    'Do you and your dependents have over $25,000 in assets?',
   );
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request updates the asset threshold question in the survivors benefits application and improves the clarity of medical expenses form fields by adding helpful hints. The most important changes are grouped below:

**Asset threshold adjustment:**

* Changed the asset threshold in the income and assets question from $75,000 to $25,000 in the UI schema (`incomeAndAssets.js`), corresponding unit test (`incomeAndAssets.unit.spec.jsx`), and utility check (`utils.js`). [[1]](diffhunk://#diff-af3aa121856a9c7ca8f301fe4a6378bd72b1b1bc884de60b70f21e51c33cfd69L109-R109) [[2]](diffhunk://#diff-0e85bd351219d33243f158d6af920afeeb470a373364fa40c6873fd6d16072d4L23-R23) [[3]](diffhunk://#diff-d5876227502c191d98b8b45618e3d3f004d9862560712b0b773f7cad9660b904L428-R428)

**Medical expenses form improvements:**

* Added a hint to the "Who receives the payment?" field to clarify expected input (e.g., provider’s name or insurance company) (`medicalExpensesPages.js`).
* Added a hint to the "What’s the payment for?" field to clarify expected input (e.g., insurance premium or medical supplies) (`medicalExpensesPages.js`).

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/127452
https://github.com/department-of-veterans-affairs/va.gov-team/issues/127459
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done
Unit tests, e2e tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |
<img width="499" height="623" alt="Screenshot 2025-12-16 at 3 27 37 PM" src="https://github.com/user-attachments/assets/e83a9267-6f87-41b1-bb55-b6a46d1b5259" />
<img width="499" height="542" alt="Screenshot 2025-12-16 at 3 28 11 PM" src="https://github.com/user-attachments/assets/0a5973d4-85e4-4418-8d61-669d616e35b1" />
<img width="499" height="580" alt="Screenshot 2025-12-16 at 3 28 24 PM" src="https://github.com/user-attachments/assets/e2e588a4-8518-46b1-a7b2-df4fdace87c0" />

|
<img width="499" height="616" alt="Screenshot 2025-12-16 at 3 25 25 PM" src="https://github.com/user-attachments/assets/18cb18da-0d3b-4f3a-88a8-facb295a4b51" />
<img width="500" height="563" alt="Screenshot 2025-12-16 at 3 24 19 PM" src="https://github.com/user-attachments/assets/4f3f0093-810b-4626-abf3-adca529a0d9c" />
<img width="500" height="563" alt="Screenshot 2025-12-16 at 3 24 27 PM" src="https://github.com/user-attachments/assets/e858a490-d07c-4495-b729-9aefd0bc7354" />

|

## What areas of the site does it impact?
534EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
