### PR TITLE
[#127959] Travel Pay, base64 expense encoding

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -40,7 +40,11 @@ const toBase64 = file =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.readAsDataURL(file);
-    reader.onload = () => resolve(reader.result);
+    reader.onload = () => {
+      // Strip the data URL prefix to get just the base64 data
+      const base64Data = reader.result?.split(',')[1] ?? '';
+      resolve(base64Data);
+    };
     reader.onerror = reject;
   });
 

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -36,7 +36,7 @@ import ExpenseLodgingFields from './ExpenseLodgingFields';
 import ExpenseCommonCarrierFields from './ExpenseCommonCarrierFields';
 import CancelExpenseModal from './CancelExpenseModal';
 
-const toBase64 = file =>
+export const toBase64 = file =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.readAsDataURL(file);

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -11,7 +11,9 @@ import {
 import * as api from '@department-of-veterans-affairs/platform-utilities/api';
 import sinon from 'sinon';
 
-import ExpensePage from '../../../../components/complex-claims/pages/ExpensePage';
+import ExpensePage, {
+  toBase64,
+} from '../../../../components/complex-claims/pages/ExpensePage';
 import ChooseExpenseType from '../../../../components/complex-claims/pages/ChooseExpenseType';
 import reducer from '../../../../redux/reducer';
 import {
@@ -578,7 +580,7 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
               {
                 filename: 'saved.pdf',
                 mimetype: 'application/pdf',
-                fileData: 'data:application/pdf;base64,AA==',
+                fileData: 'AA==',
                 documentId: TEST_DOCUMENT_ID,
                 createdon: '2025-11-17',
               },
@@ -891,5 +893,76 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
       },
       { timeout: 3000 },
     );
+  });
+});
+
+describe('toBase64 helper function', () => {
+  let originalFileReader;
+
+  beforeEach(() => {
+    originalFileReader = global.FileReader;
+  });
+
+  afterEach(() => {
+    global.FileReader = originalFileReader;
+  });
+
+  it('should strip data URL prefix and return only base64 data', async () => {
+    const mockBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAUA';
+    const mockDataUrl = `data:image/png;base64,${mockBase64}`;
+
+    global.FileReader = class {
+      readAsDataURL() {
+        this.result = mockDataUrl;
+        this.onload();
+      }
+    };
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    const result = await toBase64(file);
+    expect(result).to.equal(mockBase64);
+  });
+
+  it('should return empty string if result is malformed', async () => {
+    global.FileReader = class {
+      readAsDataURL() {
+        this.result = 'malformed-no-comma';
+        this.onload();
+      }
+    };
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    const result = await toBase64(file);
+    expect(result).to.equal('');
+  });
+
+  it('should return empty string if result is null', async () => {
+    global.FileReader = class {
+      readAsDataURL() {
+        this.result = null;
+        this.onload();
+      }
+    };
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    const result = await toBase64(file);
+    expect(result).to.equal('');
+  });
+
+  it('should handle FileReader errors', async () => {
+    global.FileReader = class {
+      readAsDataURL() {
+        this.onerror(new Error('Read failed'));
+      }
+    };
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+    try {
+      await toBase64(file);
+      expect.fail('Should have thrown error');
+    } catch (error) {
+      expect(error.message).to.equal('Read failed');
+    }
   });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -914,7 +914,7 @@ describe('toBase64 helper function', () => {
     global.FileReader = class {
       readAsDataURL() {
         this.result = mockDataUrl;
-        this.onload();
+        setTimeout(() => this.onload(), 0);
       }
     };
 
@@ -927,7 +927,7 @@ describe('toBase64 helper function', () => {
     global.FileReader = class {
       readAsDataURL() {
         this.result = 'malformed-no-comma';
-        this.onload();
+        setTimeout(() => this.onload(), 0);
       }
     };
 
@@ -940,7 +940,7 @@ describe('toBase64 helper function', () => {
     global.FileReader = class {
       readAsDataURL() {
         this.result = null;
-        this.onload();
+        setTimeout(() => this.onload(), 0);
       }
     };
 
@@ -952,7 +952,7 @@ describe('toBase64 helper function', () => {
   it('should handle FileReader errors', async () => {
     global.FileReader = class {
       readAsDataURL() {
-        this.onerror(new Error('Read failed'));
+        setTimeout(() => this.onerror(new Error('Read failed')), 0);
       }
     };
 

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -911,11 +911,11 @@ describe('toBase64 helper function', () => {
     const mockBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAUA';
     const mockDataUrl = `data:image/png;base64,${mockBase64}`;
 
-    global.FileReader = class {
-      readAsDataURL() {
+    global.FileReader = function MockFileReader() {
+      this.readAsDataURL = function readAsDataURL() {
         this.result = mockDataUrl;
         setTimeout(() => this.onload(), 0);
-      }
+      };
     };
 
     const file = new File(['test'], 'test.png', { type: 'image/png' });
@@ -924,11 +924,11 @@ describe('toBase64 helper function', () => {
   });
 
   it('should return empty string if result is malformed', async () => {
-    global.FileReader = class {
-      readAsDataURL() {
+    global.FileReader = function MockFileReader() {
+      this.readAsDataURL = function readAsDataURL() {
         this.result = 'malformed-no-comma';
         setTimeout(() => this.onload(), 0);
-      }
+      };
     };
 
     const file = new File(['test'], 'test.png', { type: 'image/png' });
@@ -937,11 +937,11 @@ describe('toBase64 helper function', () => {
   });
 
   it('should return empty string if result is null', async () => {
-    global.FileReader = class {
-      readAsDataURL() {
+    global.FileReader = function MockFileReader() {
+      this.readAsDataURL = function readAsDataURL() {
         this.result = null;
         setTimeout(() => this.onload(), 0);
-      }
+      };
     };
 
     const file = new File(['test'], 'test.png', { type: 'image/png' });
@@ -950,10 +950,10 @@ describe('toBase64 helper function', () => {
   });
 
   it('should handle FileReader errors', async () => {
-    global.FileReader = class {
-      readAsDataURL() {
+    global.FileReader = function MockFileReader() {
+      this.readAsDataURL = function readAsDataURL() {
         setTimeout(() => this.onerror(new Error('Read failed')), 0);
-      }
+      };
     };
 
     const file = new File(['test'], 'test.png', { type: 'image/png' });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Strip data URL prefix from base64-encoded file data to return only the base64 string, since the TP API cites the current format as invalid.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127959

## Testing done

Tested the document upload with files locally to ensure the correct format was passed to the API

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user