### PR TITLE
Only show CH35 sponsor info page for CH35 benefits

### DIFF
--- a/src/applications/edu-benefits/1995/config/chapters.js
+++ b/src/applications/edu-benefits/1995/config/chapters.js
@@ -217,10 +217,15 @@ export const chapters = {
   sponsorInformation: {
     title: sponsorInformationTitle(),
     pages: {
-      sponsorInformation: {
-        ...sponsorInfo(fullSchema1995),
-        depends: isLegacyFlow,
-      },
+      sponsorInformation: (() => {
+        const page = sponsorInfo(fullSchema1995);
+        const originalDepends = page.depends;
+        return {
+          ...page,
+          depends: formData =>
+            isLegacyFlow(formData) && originalDepends(formData),
+        };
+      })(),
     },
   },
   militaryService,

--- a/src/applications/edu-benefits/1995/tests/config/sponsorInformation.depends.unit.spec.jsx
+++ b/src/applications/edu-benefits/1995/tests/config/sponsorInformation.depends.unit.spec.jsx
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+
+describe('Edu 1995 sponsorInformation depends logic', () => {
+  const sponsorInfoPage =
+    formConfig.chapters.sponsorInformation.pages.sponsorInformation;
+
+  it('should NOT show sponsor information page for chapter1606 benefit', () => {
+    const formData = {
+      benefitUpdate: 'chapter1606',
+      isMeb1995Reroute: false,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.false;
+  });
+
+  it('should NOT show sponsor information page for chapter30 benefit', () => {
+    const formData = {
+      benefitUpdate: 'chapter30',
+      isMeb1995Reroute: false,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.false;
+  });
+
+  it('should NOT show sponsor information page for chapter33 benefit', () => {
+    const formData = {
+      benefitUpdate: 'chapter33',
+      isMeb1995Reroute: false,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.false;
+  });
+
+  it('should show sponsor information page for chapter35 benefit (benefitUpdate)', () => {
+    const formData = {
+      benefitUpdate: 'chapter35',
+      isMeb1995Reroute: false,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.true;
+  });
+
+  it('should show sponsor information page for chapter35 benefit (benefitAppliedFor)', () => {
+    const formData = {
+      benefitAppliedFor: 'chapter35',
+      isMeb1995Reroute: false,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.true;
+  });
+
+  it('should NOT show sponsor information page when in MEB reroute flow', () => {
+    const formData = {
+      benefitUpdate: 'chapter35',
+      isMeb1995Reroute: true,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.false;
+  });
+
+  it('should NOT show sponsor information page when benefit is not chapter35', () => {
+    const formData = {
+      benefitUpdate: 'fryScholarship',
+      isMeb1995Reroute: false,
+    };
+    expect(sponsorInfoPage.depends(formData)).to.be.false;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Veterans completing Form 22-1995 for non-Chapter 35 benefits (like CH1606, CH30, CH33) are being shown the "DEA, Chapter 35 sponsor information" page and cannot proceed without filling it out. This is incorrect behavior as the sponsor information should only be required for Chapter 35 (DEA) beneficiaries.

## Related issue(s)
<img width="433" height="351" alt="Screenshot 2025-12-17 at 10 02 21 AM" src="https://github.com/user-attachments/assets/a1f2f891-ec7c-4070-bdc4-3448ac97f686" />


## Testing done


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user