### PR TITLE
Fixed Error Page Flashing on MHV Portal Redirect

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -120,7 +120,9 @@ export default function AuthApp({ location }) {
       );
       if (!termsResponse?.provisioned) {
         handleAuthError(null, '111');
+        return false;
       }
+      return true;
     } catch (err) {
       const message = err?.error;
       if (message === 'Agreement not accepted') {
@@ -132,6 +134,7 @@ export default function AuthApp({ location }) {
       } else {
         handleAuthError(err, '110');
       }
+      return false;
     }
   }
 
@@ -155,15 +158,13 @@ export default function AuthApp({ location }) {
       requestId,
       errorCode,
     );
-    if (isMyVAHealth) {
-      await handleProvisioning();
-    }
+    const provisioned = isMyVAHealth && (await handleProvisioning());
     const { userAttributes, userProfile } = authMetrics;
     authMetrics.run();
     const { needsPortalNotice, needsMyHealth } = checkPortalRequirements({
       isPortalNoticeInterstitialEnabled,
       userAttributes,
-      isMyVAHealth,
+      provisioned,
     });
     if (
       !skipToRedirect &&

--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -117,12 +117,12 @@ export const handleTokenRequest = async ({
 export const checkPortalRequirements = ({
   isPortalNoticeInterstitialEnabled,
   userAttributes,
-  isMyVAHealth,
+  provisioned,
 }) => {
   const { vaPatient = false, facilities = [] } =
     userAttributes?.vaProfile || {};
   const redirectElligible =
-    isPortalNoticeInterstitialEnabled && isMyVAHealth && vaPatient;
+    isPortalNoticeInterstitialEnabled && provisioned && vaPatient;
 
   const activeFacilities = ['757'];
   const approvedFacilities = [

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -441,6 +441,14 @@ describe('AuthApp', () => {
           { status: 200 },
         );
       }),
+      createPutHandler(
+        'https://dev-api.va.gov/v0/terms_of_use_agreements/update_provisioning',
+        () => {
+          return jsonResponse({
+            provisioned: true,
+          });
+        },
+      ),
     );
 
     render(
@@ -501,6 +509,14 @@ describe('AuthApp', () => {
           { status: 200 },
         );
       }),
+      createPutHandler(
+        'https://dev-api.va.gov/v0/terms_of_use_agreements/update_provisioning',
+        () => {
+          return jsonResponse({
+            provisioned: true,
+          });
+        },
+      ),
     );
 
     render(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed an issue where unprovisioned users were still being redirected to the MHV Portal Interstitial and only being shown a brief glimpse of the correct error page.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/960)

## Testing done
- Updated `AuthApp.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/applications/auth/tests/AuthApp.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `AuthApp.jsx` and the related tests.

## Acceptance criteria
- [x] Fix error page flashing during MHV Portal Redirect.