### PR TITLE
fix: correct composite action path in slack-notify

### DIFF
--- a/.github/workflows/slack-notify/action.yml
+++ b/.github/workflows/slack-notify/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: ./../configure-aws-credentials
+      uses: ./.github/workflows/configure-aws-credentials
       with:
         aws_region: ${{ inputs.aws_region }}
         role: ${{ inputs.role }}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### TeamSites
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes the path reference in the `slack-notify` composite action to correctly reference the `configure-aws-credentials` composite action
- The path `./../configure-aws-credentials` doesn't resolve correctly because GitHub Actions interprets `uses: ./path` relative to the repository root, not the action file location
- This caused the error: `Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/vets-website/configure-aws-credentials'`
- Changed path from `uses: ./../configure-aws-credentials` to `uses: ./.github/workflows/configure-aws-credentials`

## Related issue(s)

- N/A - Bug discovered during OIDC conversion work

## Testing done

- Verified the path `./.github/workflows/configure-aws-credentials` correctly points to the existing composite action by running daily deploy worklfow from this branch
- YAML syntax validation passed

## Screenshots

<img width="759" height="154" alt="image" src="https://github.com/user-attachments/assets/12bf6e4d-3801-4fc1-abb0-505ae3696b01" />


## What areas of the site does it impact?

This impacts GitHub Actions workflows that use the `slack-notify` composite action. No site functionality is affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no docs needed)
- [x] Screenshot of the developed feature is added (N/A - no UI)
- [x] Accessibility testing has been performed (N/A - no UI)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - no UI)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - no application changes)

## Requested Feedback

This is a straightforward path fix. The key insight is that GitHub Actions `uses: ./path` is always relative to the repository root, not the file's directory location.