### PR TITLE
Hide 'Not filled yet' text when Cerner pilot flag is enabled

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
@@ -118,17 +118,19 @@ const PrescriptionPrintOnly = props => {
               : 'About your prescription'}
           </DetailsHeaderElement>
           <div className="print-only-rx-details-container">
-            {!pendingMed && !pendingRenewal ? (
-              <p>
-                <strong>Last filled on:</strong>{' '}
-                {rx?.sortedDispensedDate
-                  ? dateFormat(
-                      rx.sortedDispensedDate,
-                      DATETIME_FORMATS.longMonthDate,
-                    )
-                  : 'Not filled yet'}
-              </p>
-            ) : null}
+            {!pendingMed &&
+              !pendingRenewal &&
+              (rx?.sortedDispensedDate || !isCernerPilot) && (
+                <p>
+                  <strong>Last filled on:</strong>{' '}
+                  {rx?.sortedDispensedDate
+                    ? dateFormat(
+                        rx.sortedDispensedDate,
+                        DATETIME_FORMATS.longMonthDate,
+                      )
+                    : 'Not filled yet'}
+                </p>
+              )}
             {!pendingMed &&
               !pendingRenewal && (
                 <>
@@ -326,15 +328,17 @@ const PrescriptionPrintOnly = props => {
                           <h4>
                             {`Prescription number: ${entry.prescriptionNumber}`}
                           </h4>
-                          <p>
-                            <strong>Last filled:</strong>{' '}
-                            {entry.sortedDispensedDate
-                              ? dateFormat(
-                                  entry.sortedDispensedDate,
-                                  DATETIME_FORMATS.longMonthDate,
-                                )
-                              : 'Not filled yet'}
-                          </p>
+                          {(entry.sortedDispensedDate || !isCernerPilot) && (
+                            <p>
+                              <strong>Last filled:</strong>{' '}
+                              {entry.sortedDispensedDate
+                                ? dateFormat(
+                                    entry.sortedDispensedDate,
+                                    DATETIME_FORMATS.longMonthDate,
+                                  )
+                                : 'Not filled yet'}
+                            </p>
+                          )}
                           <p>
                             <strong>Quantity:</strong>{' '}
                             {validateField(entry.quantity)}

--- a/src/applications/mhv-medications/components/shared/LastFilledInfo.jsx
+++ b/src/applications/mhv-medications/components/shared/LastFilledInfo.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { dateFormat, rxSourceIsNonVA } from '../../util/helpers';
 import { DATETIME_FORMATS } from '../../util/constants';
+import { selectCernerPilotFlag } from '../../util/selectors';
 
 const LastFilledInfo = rx => {
   const { orderedDate, sortedDispensedDate } = rx;
+  const isCernerPilot = useSelector(selectCernerPilotFlag);
 
   const nonVA = rxSourceIsNonVA(rx);
   const showLastFilledDate = !nonVA && !!sortedDispensedDate;
@@ -32,7 +35,8 @@ const LastFilledInfo = rx => {
         </p>
       )}
       {!nonVA &&
-        !showLastFilledDate && (
+        !showLastFilledDate &&
+        !isCernerPilot && (
           <p data-testid="active-not-filled-rx" data-dd-privacy="mask">
             Not filled yet
           </p>

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -356,22 +356,26 @@ const PrescriptionDetails = () => {
         </>
       );
     }
-    return (
-      <>
-        {prescription?.sortedDispensedDate ? (
-          <span>
-            Last filled on{' '}
-            {dateFormat(
-              prescription.sortedDispensedDate,
-              DATETIME_FORMATS.longMonthDate,
-            )}
-          </span>
-        ) : (
-          <span>Not filled yet</span>
-        )}
-      </>
-    );
+    if (prescription?.sortedDispensedDate) {
+      return (
+        <span>
+          Last filled on{' '}
+          {dateFormat(
+            prescription.sortedDispensedDate,
+            DATETIME_FORMATS.longMonthDate,
+          )}
+        </span>
+      );
+    }
+    if (!isCernerPilot) {
+      return <span>Not filled yet</span>;
+    }
+    return null;
   };
+
+  // Determine if we should show the last filled paragraph
+  const showLastFilledParagraph =
+    nonVaPrescription || prescription?.sortedDispensedDate || !isCernerPilot;
 
   const [isErrorNotificationVisible, setIsErrorNotificationVisible] = useState(
     false,
@@ -478,15 +482,17 @@ const PrescriptionDetails = () => {
               <ApiErrorNotification errorType="access" content="medications" />
             ) : (
               <>
-                <p
-                  id="last-filled"
-                  className={`title-last-filled-on vads-u-font-family--sans vads-u-margin-top--2 medium-screen: vads-u-margin-bottom--2 ${
-                    nonVaPrescription ? 'vads-u-margin-bottom--2' : ''
-                  }`}
-                  data-testid="rx-last-filled-date"
-                >
-                  {filledEnteredDate()}
-                </p>
+                {showLastFilledParagraph && (
+                  <p
+                    id="last-filled"
+                    className={`title-last-filled-on vads-u-font-family--sans vads-u-margin-top--2 medium-screen: vads-u-margin-bottom--2 ${
+                      nonVaPrescription ? 'vads-u-margin-bottom--2' : ''
+                    }`}
+                    data-testid="rx-last-filled-date"
+                  >
+                    {filledEnteredDate()}
+                  </p>
+                )}
                 {prescription.prescriptionSource ===
                   RX_SOURCE.PENDING_DISPENSE && pendingMedAlert()}
                 {isErrorNotificationVisible && (

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -345,7 +345,9 @@ const RefillPrescriptions = () => {
                             lastFilledText = 'Not filled yet';
                           }
                           const descriptionLines = [
-                            `Prescription number: ${prescription.prescriptionNumber}`,
+                            `Prescription number: ${
+                              prescription.prescriptionNumber
+                            }`,
                           ];
                           if (lastFilledText) {
                             descriptionLines.push(lastFilledText);

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -344,11 +344,16 @@ const RefillPrescriptions = () => {
                           } else if (!isOracleHealthPilot) {
                             lastFilledText = 'Not filled yet';
                           }
-                          return `Prescription number: ${
-                            prescription.prescriptionNumber
+                          const descriptionLines = [
+                            `Prescription number: ${prescription.prescriptionNumber}`,
+                          ];
+                          if (lastFilledText) {
+                            descriptionLines.push(lastFilledText);
                           }
-                        ${lastFilledText}
-                        ${prescription.refillRemaining} refills left`;
+                          descriptionLines.push(
+                            `${prescription.refillRemaining} refills left`,
+                          );
+                          return descriptionLines.join('\n');
                         })()}
                       />
                     </div>

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -228,6 +228,26 @@ const RefillPrescriptions = () => {
   const baseTitle = 'Medications | Veterans Affairs';
   usePrintTitle(baseTitle, userName, dob, updatePageTitle);
 
+  const getCheckboxDescription = prescription => {
+    let lastFilledText = '';
+    if (prescription.sortedDispensedDate || prescription.dispensedDate) {
+      lastFilledText = `Last filled on ${dateFormat(
+        prescription.sortedDispensedDate || prescription.dispensedDate,
+        DATETIME_FORMATS.longMonthDate,
+      )}`;
+    } else if (!isCernerPilot) {
+      lastFilledText = 'Not filled yet';
+    }
+    const descriptionLines = [
+      `Prescription number: ${prescription.prescriptionNumber}`,
+    ];
+    if (lastFilledText) {
+      descriptionLines.push(lastFilledText);
+    }
+    descriptionLines.push(`${prescription.refillRemaining} refills left`);
+    return descriptionLines.join('\n');
+  };
+
   const content = () => {
     if (isLoading || isRefilling) {
       return (
@@ -330,33 +350,9 @@ const RefillPrescriptions = () => {
                         }
                         onVaChange={() => onSelectPrescription(prescription)}
                         uswds
-                        checkbox-description={(() => {
-                          let lastFilledText = '';
-                          if (
-                            prescription.sortedDispensedDate ||
-                            prescription.dispensedDate
-                          ) {
-                            lastFilledText = `Last filled on ${dateFormat(
-                              prescription.sortedDispensedDate ||
-                                prescription.dispensedDate,
-                              DATETIME_FORMATS.longMonthDate,
-                            )}`;
-                          } else if (!isCernerPilot) {
-                            lastFilledText = 'Not filled yet';
-                          }
-                          const descriptionLines = [
-                            `Prescription number: ${
-                              prescription.prescriptionNumber
-                            }`,
-                          ];
-                          if (lastFilledText) {
-                            descriptionLines.push(lastFilledText);
-                          }
-                          descriptionLines.push(
-                            `${prescription.refillRemaining} refills left`,
-                          );
-                          return descriptionLines.join('\n');
-                        })()}
+                        checkbox-description={getCheckboxDescription(
+                          prescription,
+                        )}
                       />
                     </div>
                   ))}

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -330,20 +330,26 @@ const RefillPrescriptions = () => {
                         }
                         onVaChange={() => onSelectPrescription(prescription)}
                         uswds
-                        checkbox-description={`Prescription number: ${
-                          prescription.prescriptionNumber
-                        }
-                        ${
-                          prescription.sortedDispensedDate ||
-                          prescription.dispensedDate
-                            ? `Last filled on ${dateFormat(
-                                prescription.sortedDispensedDate ||
-                                  prescription.dispensedDate,
-                                DATETIME_FORMATS.longMonthDate,
-                              )}`
-                            : 'Not filled yet'
-                        }
-                        ${prescription.refillRemaining} refills left`}
+                        checkbox-description={(() => {
+                          let lastFilledText = '';
+                          if (
+                            prescription.sortedDispensedDate ||
+                            prescription.dispensedDate
+                          ) {
+                            lastFilledText = `Last filled on ${dateFormat(
+                              prescription.sortedDispensedDate ||
+                                prescription.dispensedDate,
+                              DATETIME_FORMATS.longMonthDate,
+                            )}`;
+                          } else if (!isOracleHealthPilot) {
+                            lastFilledText = 'Not filled yet';
+                          }
+                          return `Prescription number: ${
+                            prescription.prescriptionNumber
+                          }
+                        ${lastFilledText}
+                        ${prescription.refillRemaining} refills left`;
+                        })()}
                       />
                     </div>
                   ))}

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -46,7 +46,7 @@ const RefillPrescriptions = () => {
     error: refillableError,
   } = useGetRefillablePrescriptionsQuery();
 
-  const isOracleHealthPilot = useSelector(selectCernerPilotFlag);
+  const isCernerPilot = useSelector(selectCernerPilotFlag);
 
   const [
     bulkRefillPrescriptions,
@@ -146,7 +146,7 @@ const RefillPrescriptions = () => {
 
       // Get just the prescription IDs for the bulk refill
       const prescriptionIds = selectedRefillList.map(rx => {
-        if (isOracleHealthPilot) {
+        if (isCernerPilot) {
           return { id: rx.prescriptionId, stationNumber: rx.stationNumber };
         }
         return rx.prescriptionId;
@@ -341,7 +341,7 @@ const RefillPrescriptions = () => {
                                 prescription.dispensedDate,
                               DATETIME_FORMATS.longMonthDate,
                             )}`;
-                          } else if (!isOracleHealthPilot) {
+                          } else if (!isCernerPilot) {
                             lastFilledText = 'Not filled yet';
                           }
                           const descriptionLines = [

--- a/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
@@ -119,4 +119,58 @@ describe('Prescription print only container', () => {
 
     expect(screen.queryByText('Refill history')).to.not.exist;
   });
+
+  it('should hide "Not filled yet" when Cerner pilot is enabled and no dispense date', () => {
+    const rx = {
+      ...rxDetailsResponse.data.attributes,
+      sortedDispensedDate: null,
+      dispensedDate: null,
+    };
+
+    const initialState = {
+      featureToggles: {
+        /* eslint-disable camelcase */
+        mhv_medications_cerner_pilot: true,
+        /* eslint-enable camelcase */
+      },
+    };
+
+    const screen = renderWithStoreAndRouterV6(
+      <PrescriptionPrintOnly rx={rx} isDetailsRx={false} />,
+      {
+        initialState,
+        reducers: {},
+        initialEntries: ['/prescriptions/1234567891'],
+      },
+    );
+
+    expect(screen.queryByText('Not filled yet')).to.not.exist;
+  });
+
+  it('should show "Not filled yet" when Cerner pilot is disabled and no dispense date', () => {
+    const rx = {
+      ...rxDetailsResponse.data.attributes,
+      sortedDispensedDate: null,
+      dispensedDate: null,
+    };
+
+    const initialState = {
+      featureToggles: {
+        /* eslint-disable camelcase */
+        mhv_medications_cerner_pilot: false,
+        /* eslint-enable camelcase */
+      },
+    };
+
+    const screen = renderWithStoreAndRouterV6(
+      <PrescriptionPrintOnly rx={rx} isDetailsRx={false} />,
+      {
+        initialState,
+        reducers: {},
+        initialEntries: ['/prescriptions/1234567891'],
+      },
+    );
+
+    expect(screen.getByText('Not filled yet')).to.exist;
+  });
 });

--- a/src/applications/mhv-medications/tests/components/shared/LastFilledInfo.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/LastFilledInfo.unit.spec.jsx
@@ -70,4 +70,25 @@ describe('Medications Medications List Card Last Filled Info', () => {
       ),
     ).to.not.exist;
   });
+
+  describe('Cerner pilot enabled', () => {
+    const setupWithCernerPilot = (rx = prescriptionsListItem) => {
+      return renderWithStoreAndRouterV6(<LastFilledInfo {...rx} />, {
+        initialState: {
+          featureToggles: {
+            // eslint-disable-next-line camelcase
+            mhv_medications_cerner_pilot: true,
+          },
+        },
+        reducers,
+      });
+    };
+
+    it('does not render "Not filled yet" when Cerner pilot is enabled and no dispense date', () => {
+      const rx = { ...prescriptionsListItem, sortedDispensedDate: null };
+      const screen = setupWithCernerPilot(rx);
+      expect(screen.queryByTestId('active-not-filled-rx')).to.not.exist;
+      expect(screen.queryByText('Not filled yet')).to.not.exist;
+    });
+  });
 });

--- a/src/applications/mhv-medications/tests/containers/PrescriptionDetails.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/PrescriptionDetails.unit.spec.jsx
@@ -178,6 +178,26 @@ describe('Prescription details container', () => {
     });
   });
 
+  it('does not display "Not filled yet" when Cerner pilot is enabled and no dispense date', async () => {
+    sandbox.restore();
+    stubAllergiesApi({ sandbox });
+    stubPrescriptionsApiCache({ sandbox, data: false });
+    const data = JSON.parse(JSON.stringify(singlePrescription));
+    data.dispensedDate = null;
+    data.sortedDispensedDate = null;
+    stubPrescriptionIdApi({ sandbox, data });
+    stubUsePrefetch({ sandbox });
+    const screen = setup({
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medications_cerner_pilot: true,
+      },
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('rx-last-filled-date')).to.not.exist;
+    });
+  });
+
   it('displays "Documented on" instead of "filled by" date, when med is non VA', async () => {
     sandbox.restore();
     stubAllergiesApi({ sandbox });

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -191,6 +191,34 @@ describe('Refill Prescriptions Component', () => {
       );
   });
 
+  it('does not show "Not filled yet" when Cerner pilot is enabled', async () => {
+    sandbox.restore();
+    // Create a prescription with no dispense date
+    const rxWithNoDispenseDate = {
+      ...refillablePrescriptions[0],
+      dispensedDate: null,
+      sortedDispensedDate: null,
+    };
+    initMockApis({
+      sinonSandbox: sandbox,
+      prescriptions: [rxWithNoDispenseDate],
+    });
+    const screen = setup({
+      ...initialState,
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medications_cerner_pilot: true,
+      },
+    });
+    const lastFilledEl = await screen.findByTestId(
+      'refill-prescription-checkbox-0',
+    );
+    expect(lastFilledEl).to.exist;
+    expect(lastFilledEl)
+      .to.have.property('checkbox-description')
+      .that.does.not.include('Not filled yet');
+  });
+
   it('Checks the checkbox for first prescription', async () => {
     const screen = setup();
     const checkbox = await screen.findByTestId(

--- a/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
@@ -4,11 +4,14 @@ import pendingRxDetails from './fixtures/pending-prescriptions-details.json';
 import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsListPage from './pages/MedicationsListPage';
 import mockToggles from './fixtures/toggles-response.json';
+import allergies from './fixtures/allergies.json';
+import { medicationsUrls } from '../../util/constants';
 
 describe('Medications Details Page - Cerner Pilot Enabled - Not Filled Yet Hidden', () => {
   const site = new MedicationsSite();
   const detailsPage = new MedicationsDetailsPage();
   const listPage = new MedicationsListPage();
+  const updatedOrderDate = listPage.updatedOrderDates(pendingPrescriptions);
 
   // Create mock toggles with Cerner pilot enabled
   const baseFeatures = mockToggles.data.features.filter(
@@ -32,8 +35,38 @@ describe('Medications Details Page - Cerner Pilot Enabled - Not Filled Yet Hidde
   });
 
   it('does not display "Not filled yet" text when Cerner pilot is enabled', () => {
-    listPage.visitMedicationsListPageURL(pendingPrescriptions);
-    detailsPage.clickMedicationDetailsLink(pendingRxDetails, 1);
+    // When Cerner pilot is enabled, the app uses v2 endpoints
+    cy.intercept(
+      'GET',
+      '/my_health/v2/prescriptions?page=1&per_page=10&sort=alphabetical-status',
+      updatedOrderDate,
+    ).as('v2Prescriptions');
+    cy.intercept(
+      'GET',
+      '/my_health/v1/medical_records/allergies',
+      allergies,
+    ).as('allergies');
+    // Intercept v2 prescription details endpoint
+    cy.intercept(
+      'GET',
+      `/my_health/v2/prescriptions/${
+        pendingRxDetails.data.attributes.prescriptionId
+      }`,
+      pendingRxDetails,
+    ).as('v2PrescriptionDetails');
+    cy.visit(medicationsUrls.MEDICATIONS_URL);
+    cy.wait('@v2Prescriptions');
+
+    // Click on medication details link (card number 1)
+    cy.get(
+      '[data-testid="medication-list"] > :nth-child(1) [data-testid="medications-history-details-link"]',
+    ).should('be.visible');
+    cy.get(
+      '[data-testid="medication-list"] > :nth-child(1) [data-testid="medications-history-details-link"]',
+    )
+      .first()
+      .click({ waitForAnimations: true });
+
     detailsPage.verifyHeaderTextOnDetailsPage('About this prescription');
 
     // Verify "Last filled on" section is NOT displayed when Cerner pilot is enabled

--- a/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
@@ -36,8 +36,9 @@ describe('Medications Details Page - Cerner Pilot Enabled - Not Filled Yet Hidde
     detailsPage.clickMedicationDetailsLink(pendingRxDetails, 1);
     detailsPage.verifyHeaderTextOnDetailsPage('About this prescription');
 
-    // Verify "Not filled yet" text is NOT displayed when Cerner pilot is enabled
-    detailsPage.verifyLastFilledDateNotDisplayedOnDetailsPage('Not filled yet');
+    // Verify "Last filled on" section is NOT displayed when Cerner pilot is enabled
+    // and there is no dispense date
+    detailsPage.verifyLastFilledDateNotDisplayedOnDetailsPage();
 
     cy.injectAxe();
     cy.axeCheck('main');

--- a/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js
@@ -1,0 +1,45 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import pendingPrescriptions from './fixtures/pending-prescriptions-med-list.json';
+import pendingRxDetails from './fixtures/pending-prescriptions-details.json';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+import mockToggles from './fixtures/toggles-response.json';
+
+describe('Medications Details Page - Cerner Pilot Enabled - Not Filled Yet Hidden', () => {
+  const site = new MedicationsSite();
+  const detailsPage = new MedicationsDetailsPage();
+  const listPage = new MedicationsListPage();
+
+  // Create mock toggles with Cerner pilot enabled
+  const baseFeatures = mockToggles.data.features.filter(
+    f => f.name !== 'mhv_medications_cerner_pilot',
+  );
+  const mockTogglesWithCernerPilot = {
+    data: {
+      type: 'feature_toggles',
+      features: [
+        ...baseFeatures,
+        { name: 'mhv_medications_cerner_pilot', value: true },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    site.login();
+    cy.intercept('GET', '/v0/feature_toggles?*', mockTogglesWithCernerPilot).as(
+      'featureToggles',
+    );
+  });
+
+  it('does not display "Not filled yet" text when Cerner pilot is enabled', () => {
+    listPage.visitMedicationsListPageURL(pendingPrescriptions);
+    detailsPage.clickMedicationDetailsLink(pendingRxDetails, 1);
+    detailsPage.verifyHeaderTextOnDetailsPage('About this prescription');
+
+    // Verify "Not filled yet" text is NOT displayed when Cerner pilot is enabled
+    detailsPage.verifyLastFilledDateNotDisplayedOnDetailsPage('Not filled yet');
+
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -565,6 +565,10 @@ class MedicationsDetailsPage {
     cy.get('[data-testid="rx-last-filled-date"]').should('contain', text);
   };
 
+  verifyLastFilledDateNotDisplayedOnDetailsPage = text => {
+    cy.get('[data-testid="rx-last-filled-date"]').should('not.contain', text);
+  };
+
   verifyRefillLinkTextOnDetailsPage = text => {
     cy.get('[data-testid="refill-nav-link"]').should('have.text', text);
   };

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -565,8 +565,8 @@ class MedicationsDetailsPage {
     cy.get('[data-testid="rx-last-filled-date"]').should('contain', text);
   };
 
-  verifyLastFilledDateNotDisplayedOnDetailsPage = text => {
-    cy.get('[data-testid="rx-last-filled-date"]').should('not.contain', text);
+  verifyLastFilledDateNotDisplayedOnDetailsPage = () => {
+    cy.get('[data-testid="rx-last-filled-date"]').should('not.exist');
   };
 
   verifyRefillLinkTextOnDetailsPage = text => {


### PR DESCRIPTION
## Description

This PR hides the "Not filled yet" text throughout the Medications application when the Cerner pilot feature flag (`mhv_medications_cerner_pilot`) is enabled.

## Changes

### Source Files
- **`LastFilledInfo.jsx`** - Added check for `isCernerPilot` flag to conditionally hide "Not filled yet" on medication cards
- **`PrescriptionDetails.jsx`** - Updated `filledEnteredDate()` to return `null` when Cerner pilot is enabled with no dispense date, preventing empty paragraph rendering
- **`RefillPrescriptions.jsx`** - Refactored checkbox description logic to hide "Not filled yet" for Cerner pilot users
- **`PrescriptionPrintOnly.jsx`** - Updated two occurrences to hide the entire "Last filled on" paragraph when no fill date exists and Cerner pilot is enabled

### Test Files
- Added unit tests for Cerner pilot scenarios to all affected component test files
- Created new Cypress e2e test (`medications-cerner-pilot-not-filled-yet-hidden.cypress.spec.js`) to verify the behavior
- Added helper method to `MedicationsDetailsPage.js` page object

## Testing

- All existing unit tests pass
- New unit tests added for Cerner pilot enabled scenarios
- New Cypress test verifies "Not filled yet" is hidden on details page when flag is enabled

## Acceptance Criteria

- [x] "Not filled yet" text is hidden on medication cards when Cerner pilot flag is enabled
- [x] "Not filled yet" text is hidden on prescription details page when Cerner pilot flag is enabled
- [x] "Not filled yet" text is hidden on refill prescriptions page when Cerner pilot flag is enabled
- [x] "Not filled yet" text is hidden on print view when Cerner pilot flag is enabled
- [x] No empty paragraphs or labels rendered when text is hidden
- [x] Existing functionality unchanged when Cerner pilot flag is disabled