### PR TITLE
remove requirement for certain form fields

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js
@@ -78,9 +78,7 @@ export const benefitsDetailsUiSchema = {
     stopReceivingDate: currentOrPastDateUI({
       title: 'Stop receiving date', // Default title, will be updated by updateUiSchema
       hint: 'Enter an approximate date if the exact date is unknown',
-      errorMessages: {
-        required: 'Stop receiving date is required',
-      },
+      required: false,
     }),
   },
   'ui:options': {
@@ -128,7 +126,6 @@ export const benefitsDetailsSchema = {
         'grossMonthlyAmount',
         'startReceivingDate',
         'firstPaymentDate',
-        'stopReceivingDate',
       ],
       properties: {
         benefitType: {

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.js
@@ -22,16 +22,14 @@ export const employmentTerminationUiSchema = {
       hint:
         'If they retired on disability, please specify the disability(ies).',
       charcount: true,
+      required: false,
       errorMessages: {
-        required: 'Reason for termination is required',
         maxLength: 'Termination reason must be less than 1000 characters',
       },
     }),
     dateLastWorked: MemorableDateUI({
       title: 'Date last worked',
-      errorMessages: {
-        required: 'Date last worked is required',
-      },
+      required: false,
     }),
   },
 };
@@ -46,7 +44,6 @@ export const employmentTerminationSchema = {
   properties: {
     employmentTermination: {
       type: 'object',
-      required: ['terminationReason', 'dateLastWorked'],
       properties: {
         terminationReason: {
           type: 'string',

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/tests/fixtures/data/minimal.json
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/tests/fixtures/data/minimal.json
@@ -47,8 +47,7 @@
       "benefitType": "Resistance network medical coverage and equipment allowance for field operatives with hazardous duty classification",
       "grossMonthlyAmount": 2500,
       "startReceivingDate": "2020-02-01",
-      "firstPaymentDate": "2020-02-15",
-      "stopReceivingDate": "2024-12-31"
+      "firstPaymentDate": "2020-02-15"
     },
     "remarks": {
       "remarks": "Currently employed veteran with ongoing service to intelligence operations. Has middle name. Demonstrates currently employed scenario where no employment ending date is provided. Receives current ongoing benefits with no stop date. Not in Reserve/Guard status. Tests signature validation disabled with different name."


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updated VA Form 21-4192 (Request for Employment Information in Connection with Claim for Disability Benefits) to make certain fields optional per stakeholder requirements
- **Changes made:**
  - **Step 3 of 7 (Employment Information)**: Made "Reason for termination of employment" and "Date last worked" optional
  - **Step 5 of 7 (Benefit entitlement and/or payments)**: Made "When will [veteran] no longer receive this benefit (if known)?" optional
- **Solution**: Removed fields from required arrays in JSON schemas and removed `required: true` flags and required error messages from UI schemas in [employment-termination.js](vets-website/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.js) and [benefits-details.js](vets-website/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js)
- **Why this solution**: Stakeholders updated their requirements after initial implementation in a previous ticket. These fields are already optional in the backend vets-api OpenAPI schema, so this change aligns the frontend validation with the backend
- **Team**: Benefits Optimization Aquia team owns maintenance of this form
- **Background**: This partially reverts work done in ticket #127125 based on updated stakeholder requirements

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127853
## Testing done

**Old behavior:**
- "Reason for termination of employment" field displayed (*Required) indicator and blocked form submission if empty
- "Date last worked" field displayed (*Required) indicator and blocked form submission if empty  
- "When will [veteran] no longer receive this benefit" field displayed (*Required) indicator and blocked form submission if empty

**New behavior:**
- All three fields no longer display (*Required) indicator
- Form can be submitted successfully with these fields left empty
- Fields still accept input when provided and validate format (e.g., dates, character limits)

**Testing completed:**
- Verified backend schema in vets-api already treats these fields as optional (no changes needed in backend)
- Confirmed no dedicated schema exists in vets-json-schema for this form
- Ran all 312 unit tests for the 21-4192 application - all passing
- Verified no linting or compile errors in modified files
- Confirmed existing test suites for benefits-details and employment-last-payment pages still pass

**Manual testing needed:**
- [ ] Load form in browser and navigate to Step 3 (Employment Termination page)
- [ ] Verify "Reason for termination of employment" no longer shows (*Required)
- [ ] Verify "Date last worked" no longer shows (*Required)
- [ ] Attempt to continue without filling these fields - should succeed
- [ ] Navigate to Step 5 (Benefits Details page)
- [ ] Verify "When will [veteran] no longer receive this benefit" no longer shows (*Required)
- [ ] Attempt to continue without filling this field - should succeed
- [ ] Complete and submit the entire form with these fields empty - should succeed
- [ ] Verify form submission creates a valid saved claim and processes correctly

## Screenshots

_Screenshots to be added showing before/after of the form fields without the (*Required) indicator_

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="624" height="616" alt="image" src="https://github.com/user-attachments/assets/ce3be913-0df3-4365-a8b8-fbe89b846e65" /> <img width="733" height="699" alt="image" src="https://github.com/user-attachments/assets/56b5fe79-59b2-4130-8a2b-e594871d1b68" /> <img width="819" height="951" alt="image" src="https://github.com/user-attachments/assets/df3b8cf2-8255-4887-8440-90528051a82d" /> | <img width="645" height="657" alt="image" src="https://github.com/user-attachments/assets/42cac116-4657-4aff-b6a2-a876312b6a2f" />  <img width="697" height="727" alt="image" src="https://github.com/user-attachments/assets/f33a5261-3e32-49e3-96f5-c6519b9daa6e" /> <img width="645" height="987" alt="image" src="https://github.com/user-attachments/assets/1adad621-c239-489f-a36a-0443fd4a4110" /> |

## What areas of the site does it impact?

This change only impacts VA Form 21-4192 (Employment Information form) at the route:
- `/disability/eligibility/special-claims/unemployability/submit-employment-information-form-21-4192`

No other areas of the site are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). _(No new tests required - all 312 existing unit tests pass)_
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated _(No documentation updates needed - form behavior change only)_
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution _(No changes to logging - existing form submission tracking remains)_
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) _(Form already has monitoring via existing StatsD metrics)_

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user _(Form does not require authentication - it's completed by employers)_

## Requested Feedback

Please verify in your review that:
1. The fields are appropriately removed from required arrays in both uiSchema and schema
2. Error messages for required validation are removed
3. Other validation (e.g., maxLength for terminationReason, date format) remains intact
4. No other fields were inadvertently affected
