### PR TITLE
Fix "No records" message flashing before records load

### DIFF
--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -253,7 +253,7 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="allergies-page-spinner"
-              message="We're loading your records."
+              message="We’re loading your records."
               setFocus
               data-testid="loading-indicator"
             />

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -249,40 +249,43 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
               }}
             />
           )}
-        {isLoadingAcceleratedData || isLoading ? (
+        {(isLoadingAcceleratedData || isLoading) && (
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="allergies-page-spinner"
-              message="We’re loading your records."
+              message="We're loading your records."
               setFocus
               data-testid="loading-indicator"
             />
           </div>
-        ) : (
-          <>
-            {allergies?.length ? (
-              <>
-                <RecordList
-                  records={allergies?.map(allergy => ({
-                    ...allergy,
-                    isOracleHealthData: isCerner,
-                  }))}
-                  type={recordType.ALLERGIES}
-                />
-                <DownloadingRecordsInfo description="Allergies" />
-                <PrintDownload
-                  description="Allergies - List"
-                  list
-                  downloadPdf={generateAllergiesPdf}
-                  downloadTxt={generateAllergiesTxt}
-                />
-                <div className="vads-u-margin-y--5 vads-u-border-top--1px vads-u-border-color--white" />
-              </>
-            ) : (
-              <NoRecordsMessage type={recordType.ALLERGIES} />
-            )}
-          </>
         )}
+        {!isLoadingAcceleratedData &&
+          !isLoading &&
+          allergies !== undefined && (
+            <>
+              {allergies?.length ? (
+                <>
+                  <RecordList
+                    records={allergies?.map(allergy => ({
+                      ...allergy,
+                      isOracleHealthData: isCerner,
+                    }))}
+                    type={recordType.ALLERGIES}
+                  />
+                  <DownloadingRecordsInfo description="Allergies" />
+                  <PrintDownload
+                    description="Allergies - List"
+                    list
+                    downloadPdf={generateAllergiesPdf}
+                    downloadTxt={generateAllergiesTxt}
+                  />
+                  <div className="vads-u-margin-y--5 vads-u-border-top--1px vads-u-border-color--white" />
+                </>
+              ) : (
+                <NoRecordsMessage type={recordType.ALLERGIES} />
+              )}
+            </>
+          )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -183,7 +183,7 @@ const CareSummariesAndNotes = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="notes-page-spinner"
-              message="We're loading your records."
+              message="We’re loading your records."
               setFocus
               data-testid="loading-indicator"
             />

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -183,33 +183,39 @@ const CareSummariesAndNotes = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="notes-page-spinner"
-              message="We’re loading your records."
+              message="We're loading your records."
               setFocus
               data-testid="loading-indicator"
             />
           </div>
         )}
         {!isLoadingAcceleratedData &&
-        !isLoading &&
-        careSummariesAndNotes?.length ? (
-          <RecordList
-            records={careSummariesAndNotes}
-            domainOptions={{
-              isAccelerating: isAcceleratingCareNotes,
-              timeFrame: getTimeFrame(dateRange),
-              displayTimeFrame: getDisplayTimeFrame(dateRange),
-            }}
-            type="care summaries and notes"
-            hideRecordsLabel
-          />
-        ) : (
-          <NoRecordsMessage
-            type={recordType.CARE_SUMMARIES_AND_NOTES}
-            timeFrame={
-              isAcceleratingCareNotes ? getDisplayTimeFrame(dateRange) : ''
-            }
-          />
-        )}
+          !isLoading &&
+          careSummariesAndNotes !== undefined && (
+            <>
+              {careSummariesAndNotes?.length ? (
+                <RecordList
+                  records={careSummariesAndNotes}
+                  domainOptions={{
+                    isAccelerating: isAcceleratingCareNotes,
+                    timeFrame: getTimeFrame(dateRange),
+                    displayTimeFrame: getDisplayTimeFrame(dateRange),
+                  }}
+                  type="care summaries and notes"
+                  hideRecordsLabel
+                />
+              ) : (
+                <NoRecordsMessage
+                  type={recordType.CARE_SUMMARIES_AND_NOTES}
+                  timeFrame={
+                    isAcceleratingCareNotes
+                      ? getDisplayTimeFrame(dateRange)
+                      : ''
+                  }
+                />
+              )}
+            </>
+          )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -132,20 +132,26 @@ const HealthConditions = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="conditions-page-spinner"
-              message="We’re loading your records."
+              message="We're loading your records."
               setFocus
               data-testid="accelerated-loading-indicator"
             />
           </div>
         )}
-        {!isLoadingAcceleratedData && !isLoading && conditions?.length ? (
-          <RecordList
-            records={conditions}
-            type={recordType.HEALTH_CONDITIONS}
-          />
-        ) : (
-          <NoRecordsMessage type={recordType.HEALTH_CONDITIONS} />
-        )}
+        {!isLoadingAcceleratedData &&
+          !isLoading &&
+          conditions !== undefined && (
+            <>
+              {conditions?.length ? (
+                <RecordList
+                  records={conditions}
+                  type={recordType.HEALTH_CONDITIONS}
+                />
+              ) : (
+                <NoRecordsMessage type={recordType.HEALTH_CONDITIONS} />
+              )}
+            </>
+          )}
       </RecordListSection>
     </>
   );

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -132,7 +132,7 @@ const HealthConditions = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="conditions-page-spinner"
-              message="We're loading your records."
+              message="We’re loading your records."
               setFocus
               data-testid="accelerated-loading-indicator"
             />

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -215,7 +215,7 @@ const LabsAndTests = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="labs-and-tests-page-spinner"
-              message="We're loading your records."
+              message="We’re loading your records."
               setFocus
               data-testid="loading-indicator"
             />

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -94,6 +94,9 @@ const LabsAndTests = () => {
 
   const { isLoading, isAcceleratingLabsAndTests } = useAcceleratedData();
 
+  const isLoadingAcceleratedData =
+    isAcceleratingLabsAndTests && listState === loadStates.FETCHING;
+
   const dispatchAction = useMemo(
     () => {
       return isCurrent => {
@@ -127,9 +130,6 @@ const LabsAndTests = () => {
     updateListActionType: Actions.LabsAndTests.UPDATE_LIST_STATE,
     reloadRecordsAction: reloadRecords,
   });
-
-  const isLoadingAcceleratedData =
-    isAcceleratingLabsAndTests && listState === loadStates.FETCHING;
 
   useEffect(
     () => {
@@ -215,14 +215,15 @@ const LabsAndTests = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="labs-and-tests-page-spinner"
-              message="We’re loading your records."
+              message="We're loading your records."
               setFocus
               data-testid="loading-indicator"
             />
           </div>
         )}
         {!isLoadingAcceleratedData &&
-          !isLoading && (
+          !isLoading &&
+          labsAndTests !== undefined && (
             <>
               {labsAndTests?.length ? (
                 <>

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -291,7 +291,7 @@ const Vaccines = props => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="vaccines-page-spinner"
-              message="We're loading your records."
+              message="We’re loading your records."
               setFocus
               data-testid="loading-indicator"
             />

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -38,6 +38,7 @@ import {
   accessAlertTypes,
   refreshExtractTypes,
   statsdFrontEndActions,
+  loadStates,
 } from '../util/constants';
 import PrintDownload from '../components/shared/PrintDownload';
 import DownloadingRecordsInfo from '../components/shared/DownloadingRecordsInfo';
@@ -58,6 +59,7 @@ import {
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import TrackedSpinner from '../components/shared/TrackedSpinner';
 import { useTrackAction } from '../hooks/useTrackAction';
 import { Actions } from '../util/actionTypes';
 
@@ -93,7 +95,10 @@ const Vaccines = props => {
   const history = useHistory();
   const paramPage = getParamValue(location.search, 'page');
 
-  const { isAcceleratingVaccines } = useAcceleratedData();
+  const { isLoading, isAcceleratingVaccines } = useAcceleratedData();
+
+  const isLoadingAcceleratedData =
+    isAcceleratingVaccines && listState === loadStates.FETCHING;
 
   const dispatchAction = isCurrent => {
     return getVaccinesList(
@@ -282,39 +287,55 @@ const Vaccines = props => {
           />
         )}
 
-        {vaccines?.length ? (
-          <>
-            {useBackendPagination && vaccines ? (
-              <RecordListNew
-                records={vaccines?.map(vaccine => ({
-                  ...vaccine,
-                  isOracleHealthData: isAcceleratingVaccines,
-                }))}
-                type={recordType.VACCINES}
-                metadata={metadata}
-              />
-            ) : (
-              <RecordList
-                records={vaccines?.map(vaccine => ({
-                  ...vaccine,
-                  isOracleHealthData: isAcceleratingVaccines,
-                }))}
-                type={recordType.VACCINES}
-              />
-            )}
-
-            <DownloadingRecordsInfo description="Vaccines" />
-            <PrintDownload
-              description="Vaccines - List"
-              list
-              downloadPdf={generateVaccinesPdf}
-              downloadTxt={generateVaccinesTxt}
+        {(isLoadingAcceleratedData || isLoading) && (
+          <div className="vads-u-margin-y--8">
+            <TrackedSpinner
+              id="vaccines-page-spinner"
+              message="We're loading your records."
+              setFocus
+              data-testid="loading-indicator"
             />
-            <div className="vads-u-margin-y--5 vads-u-border-top--1px vads-u-border-color--white" />
-          </>
-        ) : (
-          <NoRecordsMessage type={recordType.VACCINES} />
+          </div>
         )}
+        {!isLoadingAcceleratedData &&
+          !isLoading &&
+          vaccines !== undefined && (
+            <>
+              {vaccines?.length ? (
+                <>
+                  {useBackendPagination && vaccines ? (
+                    <RecordListNew
+                      records={vaccines?.map(vaccine => ({
+                        ...vaccine,
+                        isOracleHealthData: isAcceleratingVaccines,
+                      }))}
+                      type={recordType.VACCINES}
+                      metadata={metadata}
+                    />
+                  ) : (
+                    <RecordList
+                      records={vaccines?.map(vaccine => ({
+                        ...vaccine,
+                        isOracleHealthData: isAcceleratingVaccines,
+                      }))}
+                      type={recordType.VACCINES}
+                    />
+                  )}
+
+                  <DownloadingRecordsInfo description="Vaccines" />
+                  <PrintDownload
+                    description="Vaccines - List"
+                    list
+                    downloadPdf={generateVaccinesPdf}
+                    downloadTxt={generateVaccinesTxt}
+                  />
+                  <div className="vads-u-margin-y--5 vads-u-border-top--1px vads-u-border-color--white" />
+                </>
+              ) : (
+                <NoRecordsMessage type={recordType.VACCINES} />
+              )}
+            </>
+          )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -148,32 +148,35 @@ const Vitals = () => {
               }}
             />
           )}
-        {isLoadingAcceleratedData || isLoading ? (
+        {(isLoadingAcceleratedData || isLoading) && (
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="vitals-page-spinner"
-              message="We’re loading your vitals."
+              message="We're loading your vitals."
               setFocus
               data-testid="loading-indicator"
             />
           </div>
-        ) : (
-          <>
-            {cards?.length ? (
-              <RecordList
-                records={cards}
-                type={recordType.VITALS}
-                perPage={PER_PAGE}
-                hidePagination
-                domainOptions={{
-                  isAccelerating: isCerner,
-                }}
-              />
-            ) : (
-              <NoRecordsMessage type={recordType.VITALS} />
-            )}
-          </>
         )}
+        {!isLoadingAcceleratedData &&
+          !isLoading &&
+          cards !== undefined && (
+            <>
+              {cards?.length ? (
+                <RecordList
+                  records={cards}
+                  type={recordType.VITALS}
+                  perPage={PER_PAGE}
+                  hidePagination
+                  domainOptions={{
+                    isAccelerating: isCerner,
+                  }}
+                />
+              ) : (
+                <NoRecordsMessage type={recordType.VITALS} />
+              )}
+            </>
+          )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -152,7 +152,7 @@ const Vitals = () => {
           <div className="vads-u-margin-y--8">
             <TrackedSpinner
               id="vitals-page-spinner"
-              message="We're loading your vitals."
+              message="We’re loading your vitals."
               setFocus
               data-testid="loading-indicator"
             />

--- a/src/applications/mhv-medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -205,6 +205,34 @@ describe('Allergies list container with no allergies', () => {
   });
 });
 
+describe('Allergies does not flash NoRecordsMessage before data loads', () => {
+  it('does not show NoRecordsMessage when allergiesList is undefined', () => {
+    const initialState = {
+      user,
+      mr: {
+        allergies: {
+          allergiesList: undefined, // Data not yet fetched
+        },
+        alerts: { alertList: [] },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(<Allergies runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/allergies',
+    });
+
+    // Should NOT show the no records message when data is undefined
+    expect(
+      screen.queryByText(
+        'There are no allergies or reactions in your VA medical records.',
+        { exact: true },
+      ),
+    ).to.not.exist;
+  });
+});
+
 describe('Allergies list container with errors', () => {
   it('displays an error', async () => {
     const initialState = {

--- a/src/applications/mhv-medical-records/tests/containers/CareSummariesAndNotes.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/CareSummariesAndNotes.unit.spec.jsx
@@ -152,6 +152,39 @@ describe('CareSummariesAndNotes list container with errors', () => {
   });
 });
 
+describe('CareSummariesAndNotes does not flash NoRecordsMessage before data loads', () => {
+  it('does not show NoRecordsMessage when careSummariesAndNotesList is undefined', () => {
+    const initialState = {
+      user,
+      mr: {
+        careSummariesAndNotes: {
+          careSummariesAndNotesList: undefined, // Data not yet fetched
+          dateRange: {
+            option: '3',
+            fromDate: '2025-08-13',
+            toDate: '2025-11-13',
+          },
+        },
+        alerts: { alertList: [] },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(<CareSummariesAndNotes />, {
+      initialState,
+      reducers: reducer,
+      path: '/summaries-and-notes',
+    });
+
+    // Should NOT show the no records message when data is undefined
+    expect(
+      screen.queryByText(
+        'There are no care summaries and notes in your VA medical records',
+        { exact: false },
+      ),
+    ).to.not.exist;
+  });
+});
+
 describe('CareSummariesAndNotes global isLoading states', () => {
   const baseState = {
     user,

--- a/src/applications/mhv-medical-records/tests/containers/HealthConditions.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/HealthConditions.unit.spec.jsx
@@ -120,6 +120,34 @@ describe('Health conditions list container with no health conditions', () => {
   });
 });
 
+describe('HealthConditions does not flash NoRecordsMessage before data loads', () => {
+  it('does not show NoRecordsMessage when conditionsList is undefined', () => {
+    const initialState = {
+      user,
+      mr: {
+        conditions: {
+          conditionsList: undefined, // Data not yet fetched
+        },
+        alerts: { alertList: [] },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(<HealthConditions />, {
+      initialState,
+      reducers: reducer,
+      path: '/conditions',
+    });
+
+    // Should NOT show the no records message when data is undefined
+    expect(
+      screen.queryByText(
+        'There are no health conditions in your VA medical records.',
+        { exact: false },
+      ),
+    ).to.not.exist;
+  });
+});
+
 describe('Health conditions container with errors', () => {
   it('displays an error', async () => {
     const initialState = {

--- a/src/applications/mhv-medical-records/tests/containers/LabsAndTests.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LabsAndTests.unit.spec.jsx
@@ -190,6 +190,39 @@ describe('Labs and tests list container with no data', () => {
   });
 });
 
+describe('LabsAndTests does not flash NoRecordsMessage before data loads', () => {
+  it('does not show NoRecordsMessage when labsAndTestsList is undefined', () => {
+    const initialState = {
+      user,
+      mr: {
+        labsAndTests: {
+          labsAndTestsList: undefined, // Data not yet fetched
+          dateRange: {
+            option: '3',
+            fromDate: '2025-08-13',
+            toDate: '2025-11-13',
+          },
+        },
+        alerts: { alertList: [] },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(<LabsAndTests />, {
+      initialState,
+      reducers: reducer,
+      path: '/labs-and-tests',
+    });
+
+    // Should NOT show the no records message when data is undefined
+    expect(
+      screen.queryByText(
+        'There are no lab and test results in your VA medical records.',
+        { exact: false },
+      ),
+    ).to.not.exist;
+  });
+});
+
 describe('Labs and tests list container with errors', () => {
   it('displays an error', async () => {
     const initialState = {

--- a/src/applications/mhv-medical-records/tests/containers/Vaccines.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/Vaccines.unit.spec.jsx
@@ -139,6 +139,33 @@ describe('Vaccines list container with no vaccines', () => {
   });
 });
 
+describe('Vaccines does not flash NoRecordsMessage before data loads', () => {
+  it('does not show NoRecordsMessage when vaccinesList is undefined', () => {
+    const initialState = {
+      user,
+      mr: {
+        vaccines: {
+          vaccinesList: undefined, // Data not yet fetched
+        },
+        alerts: { alertList: [] },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(<Vaccines runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/vaccines',
+    });
+
+    // Should NOT show the no records message when data is undefined
+    expect(
+      screen.queryByText('There are no vaccines in your VA medical records.', {
+        exact: true,
+      }),
+    ).to.not.exist;
+  });
+});
+
 describe('Vaccines list container with errors', async () => {
   const initialState = {
     user,

--- a/src/applications/mhv-medical-records/tests/containers/Vitals.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/Vitals.unit.spec.jsx
@@ -325,6 +325,33 @@ describe('Vitals list container with no vitals of a type', () => {
   });
 });
 
+describe('Vitals does not flash NoRecordsMessage before data loads', () => {
+  it('does not show NoRecordsMessage when vitalsList is undefined', () => {
+    const initialState = {
+      user,
+      mr: {
+        vitals: {
+          vitalsList: undefined, // Data not yet fetched
+        },
+        alerts: { alertList: [] },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(<Vitals />, {
+      initialState,
+      reducers: reducer,
+      path: '/vitals',
+    });
+
+    // Should NOT show the no records message when data is undefined
+    expect(
+      screen.queryByText('There are no vitals in your VA medical records.', {
+        exact: true,
+      }),
+    ).to.not.exist;
+  });
+});
+
 describe('Vitals list container first time loading', () => {
   const initialState = {
     user,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- Added an `undefined` check to prevent the `NoRecordsMessage` component from flashing briefly before records load across all Medical Records domains (Care Summaries & Notes, Labs & Tests, Vitals, Health Conditions, Allergies, Vaccines).

- **Team**: MHV Medical Records team. 

- **Flipper**: N/A - no feature flag required for this bug fix.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124886

## Testing done

- On initial page load, there was a brief moment where `isLoading` was `false` but the data list was still `undefined`. During this window, the `NoRecordsMessage` component would render, causing a flash of "No records found" before the actual records appeared.

- **Tests completed**:
  - Added 6 new unit tests (one per domain) that specifically verify `NoRecordsMessage` does NOT render when the list is `undefined`

- **Console log verification**: Added temporary debug logging that confirmed the fix prevents the bug scenario where `isLoading: false` and `list: undefined` would have shown "No records" without the fix.

## Screenshots

N/A - This is a timing/race condition fix. The visual change is preventing a brief flash that occurs for a single frame during page load. The fix ensures users see a loading spinner instead of a misleading "No records" message.

## What areas of the site does it impact?

Medical Records domains only:
- `/my-health/medical-records/summaries-and-notes`
- `/my-health/medical-records/labs-and-tests`
- `/my-health/medical-records/vitals`
- `/my-health/medical-records/conditions`
- `/my-health/medical-records/allergies`
- `/my-health/medical-records/vaccines`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation changes needed)
- [x] Screenshot of the developed feature is added (N/A - race condition fix, not a visual change)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - no accessibility impact, this fix improves UX by preventing misleading message flash)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - no new logging required)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - existing monitors sufficient)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user