### PR TITLE
[#125868] Travel Pay, appointment details link goes to claim details for unfinished claims

### DIFF
--- a/src/applications/vaos/components/AppointmentTasksSection.jsx
+++ b/src/applications/vaos/components/AppointmentTasksSection.jsx
@@ -43,7 +43,11 @@ export default function AppointmentTasksSection({ appointment }) {
       <va-link-action
         data-testid="file-claim-link"
         className="vads-u-margin-top--1"
-        href={`/my-health/travel-pay/file-new-claim/${appointment.id}`}
+        href={
+          isClaimInProgress
+            ? `/my-health/travel-pay/claims/${claimData?.claim?.id}`
+            : `/my-health/travel-pay/file-new-claim/${appointment.id}`
+        }
         onClick={() => {
           sessionStorage.setItem(
             TRAVEL_PAY_FILE_NEW_CLAIM_ENTRY.SESSION_KEY,

--- a/src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx
@@ -292,7 +292,7 @@ describe('VAOS Component: AppointmentTasks', () => {
     expect(screen.getByText(/Appointment tasks/i)).to.exist;
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/file-new-claim/${appointmentId}`,
+      `/my-health/travel-pay/claims/1234`,
     );
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'text',
@@ -341,7 +341,7 @@ describe('VAOS Component: AppointmentTasks', () => {
     expect(screen.getByText(/Appointment tasks/i)).to.exist;
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/file-new-claim/${appointmentId}`,
+      `/my-health/travel-pay/claims/1234`,
     );
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'text',

--- a/src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx
@@ -289,10 +289,12 @@ describe('VAOS Component: AppointmentTasks', () => {
       { travelPayEnableComplexClaims: true },
     );
 
+    const claimId = appointment.vaos.apiData.travelPayClaim.claim.id;
+
     expect(screen.getByText(/Appointment tasks/i)).to.exist;
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/claims/1234`,
+      `/my-health/travel-pay/claims/${claimId}`,
     );
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'text',
@@ -338,10 +340,12 @@ describe('VAOS Component: AppointmentTasks', () => {
       { travelPayEnableComplexClaims: true },
     );
 
+    const claimId = appointment.vaos.apiData.travelPayClaim.claim.id;
+
     expect(screen.getByText(/Appointment tasks/i)).to.exist;
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/claims/1234`,
+      `/my-health/travel-pay/claims/${claimId}`,
     );
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'text',

--- a/src/applications/vaos/components/TravelReimbursementSection.jsx
+++ b/src/applications/vaos/components/TravelReimbursementSection.jsx
@@ -125,8 +125,8 @@ export default function TravelReimbursementSection({ appointment }) {
               onPrimaryButtonClick={() => {
                 setShowModal(false);
                 setClaimEntry();
-                window.location.href = `/my-health/travel-pay/file-new-claim/${
-                  appointment.id
+                window.location.href = `/my-health/travel-pay/claims/${
+                  claimData.claim.id
                 }`;
               }}
               onSecondaryButtonClick={() => setShowModal(false)}
@@ -159,7 +159,7 @@ export default function TravelReimbursementSection({ appointment }) {
           <p className="vads-u-margin-y--0p5">
             <va-link
               data-testid="view-claim-link"
-              href={`/my-health/travel-pay/file-new-claim/${appointment.id}`}
+              href={`/my-health/travel-pay/claims/${claimData.claim.id}`}
               onClick={setClaimEntry}
               text="Complete and file your claim"
             />

--- a/src/applications/vaos/components/TravelReimbursementSection.unit.spec.jsx
+++ b/src/applications/vaos/components/TravelReimbursementSection.unit.spec.jsx
@@ -213,15 +213,18 @@ describe('VAOS Component: TravelReimbursement', () => {
       { travelPayEnableComplexClaims: true },
     );
 
+    const claimId = appointment.vaos.apiData.travelPayClaim.claim.id;
+
     expect(
       screen.getByText(
         /You already started a claim for this appointment. Add your expenses and file within 30 days days of your appointment date./i,
       ),
     );
+
     expect(screen.getByTestId('view-claim-link')).to.exist;
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/claims/1234`,
+      `/my-health/travel-pay/claims/${claimId}`,
     );
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'text',
@@ -263,6 +266,8 @@ describe('VAOS Component: TravelReimbursement', () => {
       { travelPayEnableComplexClaims: true },
     );
 
+    const claimId = appointment.vaos.apiData.travelPayClaim.claim.id;
+
     expect(
       screen.getByText(
         /You already started a claim for this appointment. Add your expenses and file within 30 days days of your appointment date./i,
@@ -271,7 +276,7 @@ describe('VAOS Component: TravelReimbursement', () => {
     expect(screen.getByTestId('view-claim-link')).to.exist;
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/claims/1234`,
+      `/my-health/travel-pay/claims/${claimId}`,
     );
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'text',
@@ -469,13 +474,15 @@ describe('VAOS Component: TravelReimbursement', () => {
       <TravelReimbursementSection appointment={appointment} />,
     );
 
+    const claimId = appointment.vaos.apiData.travelPayClaim.claim.id;
+
     expect(
       screen.getByText(/You’ve already filed a claim for this appointment/i),
     );
     expect(screen.getByTestId('view-claim-link')).to.exist;
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'href',
-      '/my-health/travel-pay/claims/1234',
+      `/my-health/travel-pay/claims/${claimId}`,
     );
   });
   ['Saved', 'Incomplete'].forEach(claimStatus => {
@@ -513,6 +520,8 @@ describe('VAOS Component: TravelReimbursement', () => {
         { travelPayEnableComplexClaims: false },
       );
 
+      const claimId = appointment.vaos.apiData.travelPayClaim.claim.id;
+
       // Should show finished claim view, not unfinished claim view
       expect(
         screen.getByText(/You’ve already filed a claim for this appointment/i),
@@ -520,7 +529,7 @@ describe('VAOS Component: TravelReimbursement', () => {
       expect(screen.getByTestId('view-claim-link')).to.exist;
       expect(screen.getByTestId('view-claim-link')).to.have.attribute(
         'href',
-        '/my-health/travel-pay/claims/1234',
+        `/my-health/travel-pay/claims/${claimId}`,
       );
       expect(screen.getByTestId('view-claim-link')).to.have.attribute(
         'text',

--- a/src/applications/vaos/components/TravelReimbursementSection.unit.spec.jsx
+++ b/src/applications/vaos/components/TravelReimbursementSection.unit.spec.jsx
@@ -221,7 +221,7 @@ describe('VAOS Component: TravelReimbursement', () => {
     expect(screen.getByTestId('view-claim-link')).to.exist;
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/file-new-claim/${appointment.id}`,
+      `/my-health/travel-pay/claims/1234`,
     );
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'text',
@@ -271,7 +271,7 @@ describe('VAOS Component: TravelReimbursement', () => {
     expect(screen.getByTestId('view-claim-link')).to.exist;
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'href',
-      `/my-health/travel-pay/file-new-claim/${appointment.id}`,
+      `/my-health/travel-pay/claims/1234`,
     );
     expect(screen.getByTestId('view-claim-link')).to.have.attribute(
       'text',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
An appointment with an unfinished (Saved or Incomplete) travel claim should show a link that takes the user to the claim details page. From there, they can continue their claim on VA.gov or if necessary continue it on BTSSS.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/127044

## Testing done
1) Run `yarn test:unit src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx`
2) Run `yarn test:unit src/applications/vaos/components/TravelReimbursementSection.jsx`

### Steps to test
1) Run `yarn watch --env entry=travel-pay,auth,vaos,mhv-landing-page,terms-of-use,profile` in one terminal window
2) Run `yarn mock-api --responses src/applications/travel-pay/services/mocks/index.js` in the second terminal window
3) Go to `http://localhost:3001/my-health/appointments/past/167328` in your browser.  This is an appointment with a Saved claim.
4) Click the "Complete your travel reimbursement claim" link at the top. It should take you to the claim details page.
5) Go back and click the "Complete and file your claim" link at the bottom. It should also take you to the claim details page.
6) Go to 'http://localhost:3001/my-health/appointments/past/167327' in your browser. This is an appointment with no claim.
7) Click the "File a travel reimbursement claim" link at the bottom. It should take you to the start of filing flow.

## Screenshots
Nothing visual has changed here, but where the links take you has changed (claim details if the claim is Saved or Incomplete).
<img width="287" height="451" alt="image" src="https://github.com/user-attachments/assets/22b911b0-2e78-434d-bb75-58c7ae2fb45f" />

## What areas of the site does it impact?
- Travel pay on appointment details.

The travel pay link on AppointmentTasksSection was updated to take you to the claim details when the claim is in progress.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
