### PR TITLE
[#125697] Travel Pay, Complex claims gating for TCP claims

### DIFF
--- a/src/applications/travel-pay/containers/ComplexClaimSubmitFlowWrapper.jsx
+++ b/src/applications/travel-pay/containers/ComplexClaimSubmitFlowWrapper.jsx
@@ -24,8 +24,11 @@ import {
   getComplexClaimDetails,
   clearUnsavedExpenseChanges,
 } from '../redux/actions';
-import { STATUSES } from '../constants';
 import UnsavedChangesModal from '../components/UnsavedChangesModal';
+import {
+  hasUnassociatedDocuments,
+  isClaimIncompleteOrSaved,
+} from '../util/complex-claims-helper';
 
 const getBackRoute = ({
   isIntroductionPage,
@@ -188,15 +191,19 @@ const ComplexClaimSubmitFlowWrapper = () => {
     return null;
   }
 
-  // If there's a claim from the appointment and it's submitted,
-  // redirect to claim details page
+  // Redirect to claim details if:
+  // 1) If there's a claim from the appointment and it's not in progress
+  // 2) If claim source isn't VA.gov
+  // 3) There are unassociated expense documents
   if (claimFromAppointment) {
     const { claimStatus, id: claimIdFromAppt } = claimFromAppointment;
-    const isUnsubmittedStatus =
-      claimStatus === STATUSES.Incomplete.name ||
-      claimStatus === STATUSES.Saved.name;
 
-    if (!isUnsubmittedStatus && claimIdFromAppt) {
+    if (
+      (!isClaimIncompleteOrSaved(claimStatus) ||
+        claimData?.claimSource !== 'VaGov' ||
+        hasUnassociatedDocuments(claimData?.documents)) &&
+      claimIdFromAppt
+    ) {
       return <Navigate to={`/claims/${claimIdFromAppt}`} replace />;
     }
   }

--- a/src/applications/travel-pay/services/mocks/index.js
+++ b/src/applications/travel-pay/services/mocks/index.js
@@ -444,7 +444,7 @@ const responses = {
       }
       default:
         // For any other ID, return the original mock
-        return res.json(appointment.original);
+        return res.json(appointment.savedClaim);
     }
   },
   // 'GET /vaos/v2/appointments/:id': (req, res) => {

--- a/src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx
@@ -829,7 +829,10 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
     it('does NOT redirect when claim status is "Incomplete"', () => {
       const initialState = getData({
         complexClaimsEnabled: true,
-        claimData: { claimId: 'claim-incomplete' },
+        claimData: {
+          claimId: 'claim-incomplete',
+          claimSource: 'VaGov',
+        },
         travelPayClaim: {
           metadata: { status: 200, success: true },
           claim: {
@@ -863,7 +866,10 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
     it('does NOT redirect when claim status is "Saved"', () => {
       const initialState = getData({
         complexClaimsEnabled: true,
-        claimData: { claimId: 'claim-saved' },
+        claimData: {
+          claimId: 'claim-saved',
+          claimSource: 'VaGov',
+        },
         travelPayClaim: {
           metadata: { status: 200, success: true },
           claim: {
@@ -900,6 +906,297 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         travelPayClaim: {
           metadata: { status: 200, success: true },
           claim: null,
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Intro')).to.exist;
+    });
+
+    it('redirects to claim details when claim source is not VaGov', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-789',
+          claimSource: 'BTSSS',
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-789',
+            claimStatus: 'Incomplete',
+          },
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Claim Details')).to.exist;
+    });
+
+    it('does NOT redirect when claim source is VaGov and status is Incomplete', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-vagov',
+          claimSource: 'VaGov',
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-vagov',
+            claimStatus: 'Incomplete',
+          },
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Intro')).to.exist;
+    });
+
+    it('redirects to claim details when there are unassociated documents', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-unassociated-docs',
+          claimSource: 'VaGov',
+          documents: [
+            {
+              id: 'doc1',
+              filename: 'receipt.pdf',
+              mimetype: 'application/pdf',
+              expenseId: null, // Unassociated document
+            },
+          ],
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-unassociated-docs',
+            claimStatus: 'Incomplete',
+          },
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Claim Details')).to.exist;
+    });
+
+    it('does NOT redirect when all documents are associated', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-associated-docs',
+          claimSource: 'VaGov',
+          documents: [
+            {
+              id: 'doc1',
+              filename: 'receipt.pdf',
+              mimetype: 'application/pdf',
+              expenseId: 'expense-1', // Associated document
+            },
+          ],
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-associated-docs',
+            claimStatus: 'Incomplete',
+          },
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Intro')).to.exist;
+    });
+
+    it('redirects when multiple redirect conditions are met', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-multiple',
+          claimSource: 'BTSSS',
+          documents: [
+            {
+              id: 'doc1',
+              filename: 'receipt.pdf',
+              mimetype: 'application/pdf',
+              expenseId: null,
+            },
+          ],
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-multiple',
+            claimStatus: 'Claim submitted',
+          },
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Claim Details')).to.exist;
+    });
+
+    it('does NOT redirect when documents array is empty', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-no-docs',
+          claimSource: 'VaGov',
+          documents: [],
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-no-docs',
+            claimStatus: 'Saved',
+          },
+        },
+      });
+
+      const { getByText } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId"
+              element={<ComplexClaimSubmitFlowWrapper />}
+            >
+              <Route index element={<IntroPage />} />
+            </Route>
+            <Route path="/claims/:id" element={<ClaimDetailsPage />} />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState,
+          reducers: reducer,
+        },
+      );
+
+      expect(getByText('Intro')).to.exist;
+    });
+
+    it('does NOT redirect when documents only contain clerk notes without mimetype', () => {
+      const initialState = getData({
+        complexClaimsEnabled: true,
+        claimData: {
+          claimId: 'claim-clerk-notes',
+          claimSource: 'VaGov',
+          documents: [
+            {
+              id: 'note1',
+              filename: 'clerk-note.txt',
+              // No mimetype = clerk note
+            },
+          ],
+        },
+        travelPayClaim: {
+          metadata: { status: 200, success: true },
+          claim: {
+            id: 'claim-clerk-notes',
+            claimStatus: 'Incomplete',
+          },
         },
       });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding conditions to the claim details redirect from within complex claims for:
1. `claimSource` that is not `VaGov`
2. Claim has unassociated expenses/documents

Claim details has the same conditions driving the link to BTSSS

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/125697

## Testing done

Tweaked mock data to get a data scenario that matched each of the criteria we're using to gate complex claims. Additionally, added tests that touch on each of the scenarios as well as combinations of each.

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user