### PR TITLE
FIX Accessibility issues - Description text not announced when user p…

### DIFF
--- a/src/applications/simple-forms/21P-601/pages/hasAlreadyFiled.js
+++ b/src/applications/simple-forms/21P-601/pages/hasAlreadyFiled.js
@@ -28,6 +28,8 @@ export default {
           </ul>
         </>
       ),
+      messageAriaDescribedby:
+        "If you've filled out either of these applications, you don't need to fill out this form: Application for DIC, Survivors Pension, and/or Accrued Benefits (VA Form 534EZ), Application for Dependency and Indemnity Compensation by Parent(s) (VA Form 21P-535)",
     }),
   },
   schema: {

--- a/src/applications/simple-forms/21P-601/pages/hasUnpaidCreditors.js
+++ b/src/applications/simple-forms/21P-601/pages/hasUnpaidCreditors.js
@@ -8,18 +8,20 @@ import {
 export default {
   uiSchema: {
     ...titleUI('Creditor information'),
-    hasUnpaidCreditors: yesNoUI(
-      "Are you seeking reimbursement for expenses you haven't paid yet?",
-    ),
-    'ui:description': (
-      <>
-        <p>
-          If you're asking VA to reimburse you for funeral or medical expenses
-          that you haven't paid, the people or companies you owe money to will
-          need to sign the form too.
-        </p>
-      </>
-    ),
+    hasUnpaidCreditors: yesNoUI({
+      title: "Are you seeking reimbursement for expenses you haven't paid yet?",
+      description: (
+        <>
+          <p>
+            If you're asking VA to reimburse you for funeral or medical expenses
+            that you haven't paid, the people or companies you owe money to will
+            need to sign the form too.
+          </p>
+        </>
+      ),
+      messageAriaDescribedby:
+        "If you're asking VA to reimburse you for funeral or medical expenses that you haven't paid, the people or companies you owe money to will need to sign the form too.",
+    }),
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/21P-601/pages/waiverOfSubstitution.js
+++ b/src/applications/simple-forms/21P-601/pages/waiverOfSubstitution.js
@@ -8,8 +8,13 @@ import {
 export default {
   uiSchema: {
     ...titleUI('Waiver of substitution'),
-    'view:substitutionInfo': {
-      'ui:description': (
+    wantsToWaiveSubstitution: yesNoUI({
+      title: 'Do you want to waive your right to substitution?',
+      labels: {
+        Y: 'Yes, I want to waive my right to substitution',
+        N: 'No, I want to take over pending claims or appeals',
+      },
+      description: (
         <>
           <p>
             If the beneficiary had a pending claim or appeal, you can ask to
@@ -24,22 +29,13 @@ export default {
           </p>
         </>
       ),
-    },
-    wantsToWaiveSubstitution: yesNoUI({
-      title: 'Do you want to waive your right to substitution?',
-      labels: {
-        Y: 'Yes, I want to waive my right to substitution',
-        N: 'No, I want to take over pending claims or appeals',
-      },
+      messageAriaDescribedby:
+        "If the beneficiary had a pending claim or appeal, you can ask to take over that claim or appeal on their behalf (also called substitution). This lets you submit more evidence to support the claim or appeal for potential accrued benefits. You can also waive your right to substitution. If you do, we'll still consider any claims or appeals with the evidence we already have.",
     }),
   },
   schema: {
     type: 'object',
     properties: {
-      'view:substitutionInfo': {
-        type: 'object',
-        properties: {},
-      },
       wantsToWaiveSubstitution: yesNoSchema,
     },
   },


### PR DESCRIPTION
…uts focus on input

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Radio Button Accessibility Fix: Complete Implementation with messageAriaDescribedby**

Completed the accessibility fix for radio button groups with preceding descriptive paragraphs by adding `messageAriaDescribedby` to all affected pages and fixing two additional pages that were missed in the previous fix. Previously, when screen readers focused on Yes/No radio buttons using TAB navigation, they would skip over descriptive paragraphs that provided necessary context to answer the questions. The description text was not properly associated with the form controls, making it impossible for screen reader users to understand what they were being asked.

**Changes Made:**
- Added `messageAriaDescribedby` to `hasAlreadyFiled.js` to complete the previous fix
- Moved description from `view:substitutionInfo` to `yesNoUI` object's `description` property and added `messageAriaDescribedby` in `waiverOfSubstitution.js`
- Moved page-level `ui:description` to `yesNoUI` object's `description` property and added `messageAriaDescribedby` in `hasUnpaidCreditors.js`
- Removed `view:substitutionInfo` field from `waiverOfSubstitution.js` schema

## How to Reproduce (Bug)

1. Turn on a desktop screen reader (JAWS on Windows or VoiceOver on macOS)
2. Navigate to one of the affected pages:
   - "Check your eligibility" → "Waiver of substitution" (`/waiver-of-substitution`)
   - "Check your eligibility" → "Creditor information" (`/unpaid-creditors`)
   - "Check your eligibility" → "Previous applications" (`/already-filed`)
3. Tab until focus is on the "Yes" radio button input
4. Observe that the screen reader announces only "Yes, radio button not checked" without the question title
5. Notice that the description text explaining the context (e.g., what substitution means, what unpaid creditors require) is NOT announced
6. Notice that users cannot answer the question without reading the description above, which they skipped by using TAB navigation

**Affected Pages:**
- `/already-filed` (Previous applications) - was partially fixed but missing `messageAriaDescribedby`
- `/waiver-of-substitution` (Waiver of substitution) - not previously fixed
- `/unpaid-creditors` (Creditor information) - not previously fixed

**Issue Severity:**
- Expected WCAG failure: n/a (this isn't a WCAG issue per se, but affects user experience)
- Expected 508 audit severity: n/a
- Expected CC severity level: a11y-defect-2 (Labels or calls to action must be descriptive to assistive devices)
- Expected experience standard: User can complete necessary flows

## Solution and Why

**Solution:** Moved description content from page-level `ui:description` or separate `view:*` fields into the `yesNoUI` object's `description` property, and added `messageAriaDescribedby` to `uiOptions` to ensure proper association with the radio buttons via the VADS radio component's `message-aria-describedby` functionality.

**Why This Solution:**
1. **Proper ARIA Association:** The `messageAriaDescribedby` property ensures the VADS `VaRadio` component properly associates the description with the radio buttons, making it accessible to screen readers when users TAB to the controls
2. **Completes Previous Fix:** The previous fix added `description` but was missing `messageAriaDescribedby`, which is necessary because `vaRadioFieldMapping.jsx` has a known a11y issue where `textDescription` alone is not read out (see line 33 comment)
3. **WCAG Compliance:** Addresses accessibility concerns by ensuring form controls have associated descriptions that are announced by screen readers
4. **Screen Reader Experience:** Users now hear the complete context when focusing on radio buttons: the question title, the description text, and the form options, making it clear what they're being asked
5. **Follows VADS Pattern:** Aligns with the recommended VADS radio button component pattern using description message with `message-aria-describedby` slot as referenced in the VADS Storybook documentation

**Technical Approach:**
- Moved description content from page-level `ui:description` or `view:*` fields into `yesNoUI` object's `description` property (for visual rendering)
- Added `messageAriaDescribedby` property to `yesNoUI` options with the description text as a plain string (for screen reader association)
- The `messageAriaDescribedby` gets passed through `uiOptions` → `commonFieldMapping` → `VaRadio` component's `messageAriaDescribedby` prop
- Removed unnecessary `view:substitutionInfo` field from schema in `waiverOfSubstitution.js`
- The `yesNoUI` helper function spreads `...uiOptions`, allowing `messageAriaDescribedby` to be passed through correctly

