### PR TITLE
Fix empty paragraph in Recent Activity for NEEDED_FROM_OTHERS items

### DIFF
--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -250,9 +250,11 @@ export default function RecentActivity({ claim }) {
               </h4>
               {hasRequestType(item.status) ? (
                 <>
-                  <p className="vads-u-margin-top--0p5 vads-u-margin-bottom--0">
-                    {requestType(item.status)}
-                  </p>
+                  {requestType(item.status) && (
+                    <p className="vads-u-margin-top--0p5 vads-u-margin-bottom--0">
+                      {requestType(item.status)}
+                    </p>
+                  )}
                   <p
                     className="item-description vads-u-margin-top--0 vads-u-margin-bottom--1"
                     data-dd-privacy="mask"

--- a/src/applications/claims-status/tests/local-dev-mock-api/common.js
+++ b/src/applications/claims-status/tests/local-dev-mock-api/common.js
@@ -968,6 +968,17 @@ const baseClaims = [
     ],
     // Tracked items WITHOUT embedded documents (serializer will add them)
     trackedItems: [
+      // NEEDED_FROM_OTHERS item to test empty p tag bug
+      {
+        id: 110,
+        displayName: 'Private medical records from third party',
+        status: 'NEEDED_FROM_OTHERS',
+        requestedDate: '2025-10-01',
+        receivedDate: null,
+        closedDate: null,
+        suspenseDate: '2025-12-15',
+        type: 'other',
+      },
       // Tracked item with NO documents - will show "File name unknown"
       {
         id: 109,


### PR DESCRIPTION
## Summary

Fixes empty `<p>` tag in Recent Activity section that caused screen readers to announce "empty group" for `NEEDED_FROM_OTHERS` tracked items.

## What Changed

1. **`RecentActivity.jsx`:** Added conditional rendering for the "Request for you" paragraph. It now only renders when `requestType()` returns a truthy value. Previously, `NEEDED_FROM_OTHERS` items rendered an empty `<p>` tag because `hasRequestType()` returned true but `requestType()` returned undefined for that status.

2. **`common.js` (mock data):** Added a `NEEDED_FROM_OTHERS` tracked item to claim 9 to help with local testing of this bug.

## Related issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#127715

## How to Test Locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```

3. **Test the fix:**
   - Navigate to: http://localhost:3001/track-claims/your-claims/9/status
   - Look at the Recent Activity section - should see "October 1, 2025" entry with blue info alert
   - Inspect the HTML - no empty `<p>` tag should exist before the item description

## Testing done

- [x] Manual testing verified empty `<p>` tag no longer renders
- [x] Verified `NEEDED_FROM_YOU` items still show "Request for you" text
- [x] Screen readers no longer announce "empty group"

## Screenshots

| Before | After |
| ------ | ----- |
|  <img width="1591" height="248" alt="Screenshot 2025-12-18 at 10 12 07 AM" src="https://github.com/user-attachments/assets/db037307-b4c5-4352-87ca-98eda131c4c1" /> |   <img width="1582" height="204" alt="Screenshot 2025-12-18 at 10 14 14 AM" src="https://github.com/user-attachments/assets/b7d994f7-f4ba-4608-8bb8-d30c04e5d591" />  |