### PR TITLE
feat(ci): allow component-library updates in dependency check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,26 +30,26 @@ jobs:
 
           # Check if package.json or yarn.lock have been modified
           if git diff --name-only origin/main...HEAD | grep -qE '^(package\.json|yarn\.lock)$'; then
-            echo "⚠️  Dependency files modified. Checking if only vets-json-schema was updated..."
+            echo "⚠️  Dependency files modified. Checking if only approved packages were updated..."
 
-            # Get the diff and check if any non-vets-json-schema changes exist
+            # Get the diff and check if any non-approved package changes exist
             PACKAGE_JSON_DIFF=$(git diff origin/main...HEAD package.json 2>/dev/null || echo "")
             YARN_LOCK_DIFF=$(git diff origin/main...HEAD yarn.lock 2>/dev/null || echo "")
 
-            # Check if there are any changes to package.json that don't involve vets-json-schema or scripts
+            # Check if there are any changes to package.json that don't involve approved packages or scripts
             if [ -n "$PACKAGE_JSON_DIFF" ]; then
-              # Get changed lines (excluding context lines and vets-json-schema)
-              CHANGED_LINES=$(echo "$PACKAGE_JSON_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' || echo "")
+              # Get changed lines (excluding context lines and approved packages)
+              CHANGED_LINES=$(echo "$PACKAGE_JSON_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' | grep -v 'component-library' || echo "")
 
               if [ -n "$CHANGED_LINES" ]; then
                 # Check if changes contain dependency version bumps (lines with version patterns like ^, ~, >=, etc.)
-                # or dependency section headers, excluding vets-json-schema
+                # or dependency section headers, excluding approved packages
                 DEPENDENCY_CHANGES=$(echo "$CHANGED_LINES" | grep -E '": "[\^~>=<]|"(dev|peer|optional)?[Dd]ependencies"' || echo "")
 
                 if [ -n "$DEPENDENCY_CHANGES" ]; then
-                  echo "❌ ERROR: package.json has dependency changes other than vets-json-schema."
+                  echo "❌ ERROR: package.json has dependency changes other than approved packages."
                   echo "This is temporarily blocked to prevent Shai Hulud 2.0 vulnerabilities."
-                  echo "Only updates to vets-json-schema and the scripts section are allowed."
+                  echo "Only updates to vets-json-schema, @department-of-veterans-affairs/component-library, and the scripts section are allowed."
                   echo ""
                   echo "Dependency changes detected:"
                   echo "$DEPENDENCY_CHANGES"
@@ -60,34 +60,34 @@ jobs:
               fi
             fi
 
-            # Check if there are any changes to yarn.lock that don't involve vets-json-schema
+            # Check if there are any changes to yarn.lock that don't involve approved packages
             if [ -n "$YARN_LOCK_DIFF" ]; then
-              # For yarn.lock, we need to check if changes are only in vets-json-schema sections
-              # Get all added/removed lines that don't contain vets-json-schema
-              NON_VETS_JSON_LOCK_CHANGES=$(echo "$YARN_LOCK_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' || echo "")
+              # For yarn.lock, we need to check if changes are only in approved package sections
+              # Get all added/removed lines that don't contain approved packages
+              NON_APPROVED_LOCK_CHANGES=$(echo "$YARN_LOCK_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' | grep -v 'component-library' || echo "")
 
               # Also check for package entry headers that might not contain the name on the same line
               # In yarn.lock, package entries start with "package-name@version:"
               # We need to be more lenient here as yarn.lock structure can have dependencies listed
-              # We'll check if there are substantial non-vets-json-schema changes
-              if [ -n "$NON_VETS_JSON_LOCK_CHANGES" ]; then
+              # We'll check if there are substantial non-approved package changes
+              if [ -n "$NON_APPROVED_LOCK_CHANGES" ]; then
                 # Count lines to determine if changes are substantial
-                CHANGE_COUNT=$(echo "$NON_VETS_JSON_LOCK_CHANGES" | wc -l)
+                CHANGE_COUNT=$(echo "$NON_APPROVED_LOCK_CHANGES" | wc -l)
 
-                # If there are more than 10 lines of non-vets-json-schema changes, it's likely other packages
+                # If there are more than 10 lines of non-approved package changes, it's likely other packages
                 # This is a heuristic - yarn.lock changes for a single package typically affect surrounding context
                 if [ "$CHANGE_COUNT" -gt 10 ]; then
-                  echo "❌ ERROR: yarn.lock has been modified with substantial changes beyond vets-json-schema."
+                  echo "❌ ERROR: yarn.lock has been modified with substantial changes beyond approved packages."
                   echo "This is temporarily blocked to prevent Shai Hulud 2.0 vulnerabilities."
-                  echo "Only updates to vets-json-schema are allowed."
+                  echo "Only updates to vets-json-schema and @department-of-veterans-affairs/component-library are allowed."
                   echo ""
-                  echo "Detected $CHANGE_COUNT lines of non-vets-json-schema changes in yarn.lock"
+                  echo "Detected $CHANGE_COUNT lines of non-approved package changes in yarn.lock"
                   exit 1
                 fi
               fi
             fi
 
-            echo "✓ Only vets-json-schema updates detected. Allowing changes."
+            echo "✓ Only approved package updates detected. Allowing changes."
           else
             echo "✓ No dependency file changes detected."
           fi


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Extends the CI dependency check to allow updates to `@department-of-veterans-affairs/component-library` in addition to the existing `vets-json-schema` exception
- The `check-dependency-files` job in the CI workflow was blocking all dependency bumps except for `vets-json-schema`
- This change adds `component-library` to the grep filters for both `package.json` and `yarn.lock` diff checks
- Updated error messages and comments to refer to "approved packages" instead of just `vets-json-schema`

## Related issue(s)

- No related issue

## Testing done

Tested the filtering logic with 4 scenarios:
1. **Unapproved dependency update** (e.g., lodash) → Correctly **BLOCKED**
2. **vets-json-schema update only** → Correctly **ALLOWED**
3. **component-library update only** → Correctly **ALLOWED**
4. **Mixed approved + unapproved updates** → Correctly **BLOCKED**

Tests verified using simulated diff outputs through the bash grep filtering logic.

## Screenshots

N/A - This is a CI workflow change, not a UI change.

## What areas of the site does it impact?

This change only affects the CI workflow and does not impact any areas of the site directly. It allows the component-library dependency to be updated without triggering the dependency check failure.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - code comments updated inline)
- [x] Screenshot of the developed feature is added (N/A - not a UI change)
- [x] Accessibility testing has been performed (N/A - not a UI change)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - CI change only)
- [x] Events are being sent to the appropriate logging solution (N/A - CI change only)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - CI change only)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - CI change only)