### PR TITLE
[#128253] Travel Pay, Complex claims create/update expense store data fix

### DIFF
--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -363,7 +363,7 @@ export function getComplexClaimDetails(claimId) {
       dispatch(fetchComplexClaimDetailsSuccess(response));
       return response;
     } catch (error) {
-      dispatch(fetchComplexClaimDetailsFailure(error));
+      dispatch(fetchComplexClaimDetailsFailure(error?.toString() ?? ''));
       throw error;
     }
   };
@@ -384,10 +384,6 @@ export const clearUnsavedExpenseChanges = () => ({
 const updateExpenseStart = expenseId => ({
   type: UPDATE_EXPENSE_STARTED,
   expenseId,
-});
-const updateExpenseSuccess = data => ({
-  type: UPDATE_EXPENSE_SUCCESS,
-  payload: data,
 });
 const updateExpenseFailure = (error, expenseId) => ({
   type: UPDATE_EXPENSE_FAILURE,
@@ -417,20 +413,17 @@ export function updateExpense(claimId, expenseType, expenseId, expenseData) {
       const expenseUrl = `${
         environment.API_URL
       }/travel_pay/v0/expenses/${expenseType}/${expenseId}`;
-      await apiRequest(expenseUrl, options);
-      const result = { ...expenseData, id: expenseId };
+      const response = await apiRequest(expenseUrl, options);
 
       // Fetch the complete complex claim details and load expenses into store
-      try {
-        await dispatch(getComplexClaimDetails(claimId));
-      } catch (fetchError) {
-        // Silently continue if fetching details fails
-      }
+      // The API only returns { id: '...' }, so we need to fetch full claim details
+      // to get the complete expense data with document info
+      await dispatch(getComplexClaimDetails(claimId));
 
-      // Dispatch success only after claim details are fetched
-      dispatch(updateExpenseSuccess(result));
-
-      return result;
+      // We don't need to dispatch an updateExpenseSuccess action since
+      // getComplexClaimDetails is responsible for loading the full expense
+      // data into the store
+      return response;
     } catch (error) {
       dispatch(updateExpenseFailure(error, expenseId));
       throw error;
@@ -477,11 +470,7 @@ export function deleteExpense(claimId, expenseType, expenseId) {
       await apiRequest(expenseUrl, options);
 
       // Fetch the complete complex claim details and load expenses into store
-      try {
-        await dispatch(getComplexClaimDetails(claimId));
-      } catch (fetchError) {
-        // Silently continue if fetching details fails
-      }
+      await dispatch(getComplexClaimDetails(claimId));
 
       // Dispatch success only after claim details are fetched
       dispatch(deleteExpenseSuccess(expenseId));
@@ -498,10 +487,6 @@ export function deleteExpense(claimId, expenseType, expenseId) {
 // Creating a new expense
 const createExpenseStart = () => ({
   type: CREATE_EXPENSE_STARTED,
-});
-const createExpenseSuccess = data => ({
-  type: CREATE_EXPENSE_SUCCESS,
-  payload: data,
 });
 const createExpenseFailure = error => ({
   type: CREATE_EXPENSE_FAILURE,
@@ -529,22 +514,16 @@ export function createExpense(claimId, expenseType, expenseData) {
         environment.API_URL
       }/travel_pay/v0/claims/${claimId}/expenses/${expenseType}`;
       const response = await apiRequest(expenseUrl, options);
-      const result = {
-        ...expenseData,
-        id: response.id,
-      };
 
       // Fetch the complete complex claim details and load expenses into store
-      try {
-        await dispatch(getComplexClaimDetails(claimId));
-      } catch (fetchError) {
-        // Silently continue if fetching details fails
-      }
+      // The API only returns { id: '...' }, so we need to fetch full claim details
+      // to get the complete expense data with document info
+      await dispatch(getComplexClaimDetails(claimId));
 
-      // Dispatch success only after claim details are fetched
-      dispatch(createExpenseSuccess(result));
-
-      return result;
+      // We don't need to dispatch an updateExpenseSuccess action since
+      // getComplexClaimDetails is responsible for loading the full expense
+      // data into the store
+      return response;
     } catch (error) {
       dispatch(createExpenseFailure(error));
       throw error;
@@ -589,11 +568,7 @@ export function deleteDocument(claimId, documentId) {
       await apiRequest(documentUrl, options);
 
       // Fetch the complete complex claim details and load expenses into store
-      try {
-        await dispatch(getComplexClaimDetails(claimId));
-      } catch (fetchError) {
-        // Silently continue if fetching details fails
-      }
+      await dispatch(getComplexClaimDetails(claimId));
 
       // Dispatch success only after claim details are fetched
       dispatch(deleteDocumentSuccess(documentId));
@@ -634,10 +609,6 @@ export function updateExpenseDeleteDocument(
         environment.API_URL
       }/travel_pay/v0/expenses/${expenseType}/${expenseId}`;
       await apiRequest(expenseUrl, updateExpenseOptions);
-      const result = { ...expenseData, id: expenseId };
-
-      // Dispatch success only after claim details are fetched
-      dispatch(updateExpenseSuccess(result));
     } catch (error) {
       dispatch(updateExpenseFailure(error, expenseId));
       throw error;
@@ -765,11 +736,7 @@ export function deleteExpenseDeleteDocument(
        * If this fetch fails, we ignore the error because the deletions have
        * already completed successfully.
        */
-      try {
-        await dispatch(getComplexClaimDetails(claimId));
-      } catch (fetchError) {
-        // Silently ignore fetch errors
-      }
+      await dispatch(getComplexClaimDetails(claimId));
     }
   };
 }

--- a/src/applications/travel-pay/redux/reducer.js
+++ b/src/applications/travel-pay/redux/reducer.js
@@ -5,7 +5,6 @@ import {
   CREATE_COMPLEX_CLAIM_SUCCESS,
   CREATE_EXPENSE_FAILURE,
   CREATE_EXPENSE_STARTED,
-  CREATE_EXPENSE_SUCCESS,
   DELETE_DOCUMENT_FAILURE,
   DELETE_DOCUMENT_STARTED,
   DELETE_DOCUMENT_SUCCESS,
@@ -36,7 +35,6 @@ import {
   SUBMIT_COMPLEX_CLAIM_SUCCESS,
   UPDATE_EXPENSE_FAILURE,
   UPDATE_EXPENSE_STARTED,
-  UPDATE_EXPENSE_SUCCESS,
   SET_REVIEW_PAGE_ALERT,
   CLEAR_REVIEW_PAGE_ALERT,
 } from './actions';
@@ -387,25 +385,6 @@ function travelPayReducer(state = initialState, action) {
           },
         },
       };
-    case UPDATE_EXPENSE_SUCCESS: {
-      return {
-        ...state,
-        complexClaim: {
-          ...state.complexClaim,
-          expenses: {
-            ...state.complexClaim.expenses,
-            update: {
-              id: '',
-              isLoading: false,
-              error: null,
-            },
-            data: mergeExpenses(state.complexClaim.expenses.data, [
-              action.payload,
-            ]),
-          },
-        },
-      };
-    }
     case UPDATE_EXPENSE_FAILURE:
       return {
         ...state,
@@ -484,24 +463,6 @@ function travelPayReducer(state = initialState, action) {
               isLoading: true,
               error: null,
             },
-          },
-        },
-      };
-
-    case CREATE_EXPENSE_SUCCESS:
-      return {
-        ...state,
-        complexClaim: {
-          ...state.complexClaim,
-          expenses: {
-            ...state.complexClaim.expenses,
-            creation: {
-              isLoading: false,
-              error: null,
-            },
-            data: mergeExpenses(state.complexClaim.expenses.data, [
-              action.payload,
-            ]),
           },
         },
       };

--- a/src/applications/travel-pay/services/mocks/index.js
+++ b/src/applications/travel-pay/services/mocks/index.js
@@ -258,6 +258,7 @@ const responses = {
     details.documents = [
       {
         documentId: '4f6f751b-87ff-ef11-9341-001dd809b68c',
+        expenseId: 'e82h82h8-ghg9-8e66-c799-g5ed16186jif',
         filename: 'Parking.docx',
         mimetype:
           'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -265,36 +266,42 @@ const responses = {
       },
       {
         documentId: 'a5137021-87ff-ef11-9341-001dd809b68c',
+        expenseId: 'f93i93i9-hih0-9f77-d800-h6fe27297kjg',
         filename: 'Toll.pdf',
         mimetype: 'application/pdf',
         createdon: '2025-03-12T21:15:33Z',
       },
       {
         documentId: '4f6f751b-87ff-ef11-9341-001dd854jutt',
+        expenseId: 'g04j04j0-iji1-0g88-e911-i7gf38308lkh',
         filename: 'CommonCarrier.jpg',
         mimetype: 'image/jpeg',
         createdon: '2025-03-24T14:02:52.893Z',
       },
       {
         documentId: '0ab14628-6531-4a6c-b836-97a92fb35a9e',
+        expenseId: 'h15k15k1-jkj2-1h99-f022-j8hg49419mli',
         filename: 'Airtravel.jpg',
         mimetype: 'image/jpeg',
         createdon: '2025-03-24T14:04:00.893Z',
       },
       {
         documentId: '887ead10-d849-428c-b83b-50a054fd968b',
+        expenseId: 'b59e59e5-ded6-5b33-9466-d2ba83853gfc',
         filename: 'lodging.txt',
         mimetype: '',
         createdon: '2025-03-24T14:06:52.893Z',
       },
       {
         documentId: '887ead10-d849-428c-b83b-50a05434rtfe',
+        expenseId: 'c60f60f6-efe7-6c44-a577-e3cb94964hgd',
         filename: 'meal.txt',
         mimetype: '',
         createdon: '2025-03-24T14:06:52.893Z',
       },
       {
         documentId: '887ead10-d849-428c-b83b-50a053re44wr',
+        expenseId: 'd71g71g7-fgf8-7d55-b688-f4dc05075ihe',
         filename: 'other.txt',
         mimetype: '',
         createdon: '2025-03-24T14:06:52.893Z',

--- a/src/applications/travel-pay/services/mocks/index.js
+++ b/src/applications/travel-pay/services/mocks/index.js
@@ -258,7 +258,6 @@ const responses = {
     details.documents = [
       {
         documentId: '4f6f751b-87ff-ef11-9341-001dd809b68c',
-        expenseId: 'e82h82h8-ghg9-8e66-c799-g5ed16186jif',
         filename: 'Parking.docx',
         mimetype:
           'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -266,42 +265,36 @@ const responses = {
       },
       {
         documentId: 'a5137021-87ff-ef11-9341-001dd809b68c',
-        expenseId: 'f93i93i9-hih0-9f77-d800-h6fe27297kjg',
         filename: 'Toll.pdf',
         mimetype: 'application/pdf',
         createdon: '2025-03-12T21:15:33Z',
       },
       {
         documentId: '4f6f751b-87ff-ef11-9341-001dd854jutt',
-        expenseId: 'g04j04j0-iji1-0g88-e911-i7gf38308lkh',
         filename: 'CommonCarrier.jpg',
         mimetype: 'image/jpeg',
         createdon: '2025-03-24T14:02:52.893Z',
       },
       {
         documentId: '0ab14628-6531-4a6c-b836-97a92fb35a9e',
-        expenseId: 'h15k15k1-jkj2-1h99-f022-j8hg49419mli',
         filename: 'Airtravel.jpg',
         mimetype: 'image/jpeg',
         createdon: '2025-03-24T14:04:00.893Z',
       },
       {
         documentId: '887ead10-d849-428c-b83b-50a054fd968b',
-        expenseId: 'b59e59e5-ded6-5b33-9466-d2ba83853gfc',
         filename: 'lodging.txt',
         mimetype: '',
         createdon: '2025-03-24T14:06:52.893Z',
       },
       {
         documentId: '887ead10-d849-428c-b83b-50a05434rtfe',
-        expenseId: 'c60f60f6-efe7-6c44-a577-e3cb94964hgd',
         filename: 'meal.txt',
         mimetype: '',
         createdon: '2025-03-24T14:06:52.893Z',
       },
       {
         documentId: '887ead10-d849-428c-b83b-50a053re44wr',
-        expenseId: 'd71g71g7-fgf8-7d55-b688-f4dc05075ihe',
         filename: 'other.txt',
         mimetype: '',
         createdon: '2025-03-24T14:06:52.893Z',

--- a/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
@@ -537,556 +537,581 @@ describe('Redux - actions', () => {
     });
   });
 
-  describe('Expense Management', () => {
-    describe('Create Expense', () => {
-      it('should call correct actions for create expense success', async () => {
-        const mockDispatch = sinon.spy();
-        const mockResponse = { id: 'exp123' };
-        apiStub.resolves(mockResponse);
-
-        const expenseData = {
-          expenseType: 'Mileage',
-          tripType: 'OneWay',
-          address: {
-            addressLine1: '123 Main St',
-            city: 'Denver',
-            stateCode: 'CO',
-            zipCode: '80202',
-          },
-        };
-
-        await createExpense('claim123', 'mileage', expenseData)(mockDispatch);
-
-        expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'CREATE_EXPENSE_SUCCESS',
-            payload: {
-              ...expenseData,
-              id: 'exp123',
-            },
-          }),
-        ).to.be.true;
-      });
-
-      it('should call correct actions for create expense failure', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.rejects(new Error('Failed to create expense'));
-
-        const expenseData = { expenseType: 'Parking', amount: 10.0 };
-
-        try {
-          await createExpense('claim123', 'parking', expenseData)(mockDispatch);
-        } catch (error) {
-          // Expected to throw
+  describe('Create Expense', () => {
+    it('should call correct actions for create expense success', async () => {
+      const mockDispatch = sinon.stub();
+      // Make mockDispatch execute thunks when they're dispatched
+      mockDispatch.callsFake(action => {
+        if (typeof action === 'function') {
+          return action(mockDispatch);
         }
-
-        expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'CREATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
+        return action;
       });
 
-      it('should throw error when expense type is missing', async () => {
-        const mockDispatch = sinon.spy();
-        const expenseData = { amount: 10.0 };
+      const mockExpenseResponse = { id: 'exp123' };
+      const mockClaimDetails = {
+        expenses: [{ id: 'exp123', documentId: 'doc123' }],
+      };
+      apiStub.onFirstCall().resolves(mockExpenseResponse); // POST expense
+      apiStub.onSecondCall().resolves(mockClaimDetails); // GET claim details
 
-        try {
-          await createExpense('claim123', null, expenseData)(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
+      const expenseData = {
+        expenseType: 'Mileage',
+        tripType: 'OneWay',
+        address: {
+          addressLine1: '123 Main St',
+          city: 'Denver',
+          stateCode: 'CO',
+          zipCode: '80202',
+        },
+      };
 
-        expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'CREATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
+      await createExpense('claim123', 'mileage', expenseData)(mockDispatch);
 
-      it('should throw error when expense type is undefined', async () => {
-        const mockDispatch = sinon.spy();
-        const expenseData = { amount: 10.0 };
-
-        try {
-          await createExpense('claim123', undefined, expenseData)(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'CREATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should still dispatch CREATE_EXPENSE_SUCCESS even if getComplexClaimDetails fails', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.onFirstCall().resolves({ id: 'exp123' }); // expense POST
-        apiStub
-          .onSecondCall()
-          .rejects(new Error('Failed to fetch claim details')); // fetch
-
-        const expenseData = { expenseType: 'Parking', amount: 10.0 };
-
-        await createExpense('claim123', 'Parking', expenseData)(mockDispatch);
-
-        expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'CREATE_EXPENSE_SUCCESS',
-            payload: { ...expenseData, id: 'exp123' },
-          }),
-        ).to.be.true;
-      });
+      expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      // Should call getComplexClaimDetails to load full expense data
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'FETCH_COMPLEX_CLAIM_DETAILS_STARTED',
+        }),
+      ).to.be.true;
     });
 
-    describe('Update Expense', () => {
-      it('should call correct actions for update expense success', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.resolves(); // updateExpense doesn't use the response
+    it('should call correct actions for create expense failure', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.rejects(new Error('Failed to create expense'));
 
-        const expenseData = {
-          amount: 30.75,
-          tripType: 'RoundTrip',
-        };
+      const expenseData = { expenseType: 'Parking', amount: 10.0 };
 
+      try {
+        await createExpense('claim123', 'parking', expenseData)(mockDispatch);
+      } catch (error) {
+        // Expected to throw
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'CREATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense type is missing', async () => {
+      const mockDispatch = sinon.spy();
+      const expenseData = { amount: 10.0 };
+
+      try {
+        await createExpense('claim123', null, expenseData)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'CREATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense type is undefined', async () => {
+      const mockDispatch = sinon.spy();
+      const expenseData = { amount: 10.0 };
+
+      try {
+        await createExpense('claim123', undefined, expenseData)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'CREATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error if getComplexClaimDetails fails', async () => {
+      const mockDispatch = sinon.stub();
+      // Make mockDispatch execute thunks when they're dispatched
+      mockDispatch.callsFake(action => {
+        if (typeof action === 'function') {
+          return action(mockDispatch);
+        }
+        return action;
+      });
+
+      apiStub.onFirstCall().resolves({ id: 'exp123' }); // expense POST
+      apiStub
+        .onSecondCall()
+        .rejects(new Error('Failed to fetch claim details')); // fetch
+
+      const expenseData = { expenseType: 'Parking', amount: 10.0 };
+
+      try {
+        await createExpense('claim123', 'Parking', expenseData)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Failed to fetch claim details');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'CREATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'FETCH_COMPLEX_CLAIM_DETAILS_STARTED',
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('Update Expense', () => {
+    it('should call correct actions for update expense success', async () => {
+      const mockDispatch = sinon.stub();
+      // Make mockDispatch execute thunks when they're dispatched
+      mockDispatch.callsFake(action => {
+        if (typeof action === 'function') {
+          return action(mockDispatch);
+        }
+        return action;
+      });
+
+      const mockExpenseResponse = { id: 'exp123' };
+      const mockClaimDetails = {
+        expenses: [
+          {
+            id: 'exp123',
+            amount: 30.75,
+            tripType: 'RoundTrip',
+            documentId: 'doc123',
+          },
+        ],
+      };
+      apiStub.onFirstCall().resolves(mockExpenseResponse); // PATCH expense
+      apiStub.onSecondCall().resolves(mockClaimDetails); // GET claim details
+
+      const expenseData = {
+        amount: 30.75,
+        tripType: 'RoundTrip',
+      };
+
+      await updateExpense('claim123', 'mileage', 'exp123', expenseData)(
+        mockDispatch,
+      );
+
+      expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      // Should call getComplexClaimDetails to load full expense data
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'FETCH_COMPLEX_CLAIM_DETAILS_STARTED',
+        }),
+      ).to.be.true;
+    });
+
+    it('should call correct actions for update expense failure', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.rejects(new Error('Failed to update expense'));
+
+      const expenseData = { amount: 25.0 };
+
+      try {
         await updateExpense('claim123', 'mileage', 'exp123', expenseData)(
           mockDispatch,
         );
+      } catch (error) {
+        // Expected to throw
+      }
 
-        expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'UPDATE_EXPENSE_SUCCESS',
-            payload: {
-              ...expenseData,
-              id: 'exp123',
-            },
-          }),
-        ).to.be.true;
-      });
-
-      it('should call correct actions for update expense failure', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.rejects(new Error('Failed to update expense'));
-
-        const expenseData = { amount: 25.0 };
-
-        try {
-          await updateExpense('claim123', 'mileage', 'exp123', expenseData)(
-            mockDispatch,
-          );
-        } catch (error) {
-          // Expected to throw
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'UPDATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense type is missing', async () => {
-        const mockDispatch = sinon.spy();
-        const expenseData = { amount: 25.0 };
-
-        try {
-          await updateExpense('claim123', null, 'exp123', expenseData)(
-            mockDispatch,
-          );
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'UPDATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense id is missing', async () => {
-        const mockDispatch = sinon.spy();
-        const expenseData = { amount: 25.0 };
-
-        try {
-          await updateExpense('claim123', 'mileage', null, expenseData)(
-            mockDispatch,
-          );
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense id');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'UPDATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense type is undefined', async () => {
-        const mockDispatch = sinon.spy();
-        const expenseData = { amount: 25.0 };
-
-        try {
-          await updateExpense('claim123', undefined, 'exp123', expenseData)(
-            mockDispatch,
-          );
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'UPDATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense id is undefined', async () => {
-        const mockDispatch = sinon.spy();
-        const expenseData = { amount: 25.0 };
-
-        try {
-          await updateExpense('claim123', 'mileage', undefined, expenseData)(
-            mockDispatch,
-          );
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense id');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'UPDATE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
+      expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'UPDATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
     });
 
-    describe('Delete Expense', () => {
-      it('should call correct actions for delete expense success', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.resolves(); // DELETE requests typically return empty response
+    it('should throw error when expense type is missing', async () => {
+      const mockDispatch = sinon.spy();
+      const expenseData = { amount: 25.0 };
 
+      try {
+        await updateExpense('claim123', null, 'exp123', expenseData)(
+          mockDispatch,
+        );
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'UPDATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense id is missing', async () => {
+      const mockDispatch = sinon.spy();
+      const expenseData = { amount: 25.0 };
+
+      try {
+        await updateExpense('claim123', 'mileage', null, expenseData)(
+          mockDispatch,
+        );
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'UPDATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense type is undefined', async () => {
+      const mockDispatch = sinon.spy();
+      const expenseData = { amount: 25.0 };
+
+      try {
+        await updateExpense('claim123', undefined, 'exp123', expenseData)(
+          mockDispatch,
+        );
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'UPDATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense id is undefined', async () => {
+      const mockDispatch = sinon.spy();
+      const expenseData = { amount: 25.0 };
+
+      try {
+        await updateExpense('claim123', 'mileage', undefined, expenseData)(
+          mockDispatch,
+        );
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'UPDATE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'UPDATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('Delete Expense', () => {
+    it('should call correct actions for delete expense success', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.resolves(); // DELETE requests typically return empty response
+
+      await deleteExpense('claim123', 'mileage', 'exp123')(mockDispatch);
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_SUCCESS',
+          expenseId: 'exp123',
+        }),
+      ).to.be.true;
+    });
+
+    it('should call correct actions for delete expense failure', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.rejects(new Error('Failed to delete expense'));
+
+      try {
         await deleteExpense('claim123', 'mileage', 'exp123')(mockDispatch);
+      } catch (error) {
+        // Expected to throw
+      }
 
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_EXPENSE_SUCCESS',
-            expenseId: 'exp123',
-          }),
-        ).to.be.true;
-      });
-
-      it('should call correct actions for delete expense failure', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.rejects(new Error('Failed to delete expense'));
-
-        try {
-          await deleteExpense('claim123', 'mileage', 'exp123')(mockDispatch);
-        } catch (error) {
-          // Expected to throw
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense type is missing', async () => {
-        const mockDispatch = sinon.spy();
-
-        try {
-          await deleteExpense('claim123', null, 'exp123')(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense id is missing', async () => {
-        const mockDispatch = sinon.spy();
-
-        try {
-          await deleteExpense('claim123', 'mileage', null)(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense id');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense type is undefined', async () => {
-        const mockDispatch = sinon.spy();
-
-        try {
-          await deleteExpense('claim123', undefined, 'exp123')(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when expense id is undefined', async () => {
-        const mockDispatch = sinon.spy();
-
-        try {
-          await deleteExpense('claim123', 'mileage', undefined)(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense id');
-        }
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_EXPENSE_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
     });
 
-    describe('Delete Document', () => {
-      const claimId = 'a48d48d4-cdc5-4922-8355-c1a9b2742feb';
-      const documentId = '4f6f751b-87ff-ef11-9341-001dd809b68c';
-      it('should call correct actions for delete document success', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.resolves(); // DELETE requests typically return empty response
+    it('should throw error when expense type is missing', async () => {
+      const mockDispatch = sinon.spy();
 
+      try {
+        await deleteExpense('claim123', null, 'exp123')(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense id is missing', async () => {
+      const mockDispatch = sinon.spy();
+
+      try {
+        await deleteExpense('claim123', 'mileage', null)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense type is undefined', async () => {
+      const mockDispatch = sinon.spy();
+
+      try {
+        await deleteExpense('claim123', undefined, 'exp123')(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when expense id is undefined', async () => {
+      const mockDispatch = sinon.spy();
+
+      try {
+        await deleteExpense('claim123', 'mileage', undefined)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('Delete Document', () => {
+    const claimId = 'a48d48d4-cdc5-4922-8355-c1a9b2742feb';
+    const documentId = '4f6f751b-87ff-ef11-9341-001dd809b68c';
+    it('should call correct actions for delete document success', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.resolves(); // DELETE requests typically return empty response
+
+      await deleteDocument(claimId, documentId)(mockDispatch);
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_SUCCESS',
+          documentId,
+        }),
+      ).to.be.true;
+    });
+
+    it('should call correct actions for delete document failure', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.rejects(new Error('Failed to delete document'));
+
+      try {
         await deleteDocument(claimId, documentId)(mockDispatch);
+      } catch (error) {
+        // Expected to throw
+      }
 
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }),
-        ).to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_DOCUMENT_SUCCESS',
-            documentId,
-          }),
-        ).to.be.true;
-      });
-
-      it('should call correct actions for delete document failure', async () => {
-        const mockDispatch = sinon.spy();
-        apiStub.rejects(new Error('Failed to delete document'));
-
-        try {
-          await deleteDocument(claimId, documentId)(mockDispatch);
-        } catch (error) {
-          // Expected to throw
-        }
-
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }),
-        ).to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_DOCUMENT_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when document id is missing', async () => {
-        const mockDispatch = sinon.spy();
-
-        try {
-          await deleteDocument(claimId)(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing document id');
-        }
-
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }),
-        ).to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_DOCUMENT_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
-
-      it('should throw error when document id is undefined', async () => {
-        const mockDispatch = sinon.spy();
-
-        try {
-          await deleteDocument(claimId, undefined)(mockDispatch);
-          expect.fail('Expected an error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing document id');
-        }
-
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }),
-        ).to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({
-            type: 'DELETE_DOCUMENT_FAILURE',
-            error: sinon.match.instanceOf(Error),
-          }),
-        ).to.be.true;
-      });
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
     });
 
-    describe('deleteExpenseDeleteDocument', () => {
-      let mockDispatch;
-      beforeEach(() => {
-        mockDispatch = sinon.spy();
-      });
+    it('should throw error when document id is missing', async () => {
+      const mockDispatch = sinon.spy();
 
-      const claimId = 'claim123';
-      const expenseId = 'exp123';
-      const documentId = 'doc123';
+      try {
+        await deleteDocument(claimId)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing document id');
+      }
 
-      it('should delete both expense and document for non-mileage expense', async () => {
-        const expenseType = EXPENSE_TYPES.Parking.route;
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
 
-        apiStub.resolves(); // resolve for DELETE requests
+    it('should throw error when document id is undefined', async () => {
+      const mockDispatch = sinon.spy();
 
+      try {
+        await deleteDocument(claimId, undefined)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing document id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('deleteExpenseDeleteDocument', () => {
+    let mockDispatch;
+    beforeEach(() => {
+      mockDispatch = sinon.spy();
+    });
+
+    const claimId = 'claim123';
+    const expenseId = 'exp123';
+    const documentId = 'doc123';
+
+    it('should delete both expense and document for non-mileage expense', async () => {
+      const expenseType = EXPENSE_TYPES.Parking.route;
+
+      apiStub.resolves(); // resolve for DELETE requests
+
+      await deleteExpenseDeleteDocument(
+        claimId,
+        documentId,
+        expenseType,
+        expenseId,
+      )(mockDispatch);
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_SUCCESS' }))
+        .to.be.true;
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_SUCCESS' }))
+        .to.be.true;
+    });
+
+    it('should skip document deletion for MILEAGE expense', async () => {
+      const expenseType = EXPENSE_TYPES.Mileage.route;
+
+      apiStub.resolves(); // resolve for DELETE requests
+
+      await deleteExpenseDeleteDocument(
+        claimId,
+        documentId,
+        expenseType,
+        expenseId,
+      )(mockDispatch);
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
+        .to.be.true;
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_SUCCESS' }))
+        .to.be.true;
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.false; // document deletion should be skipped
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_SUCCESS' }))
+        .to.be.false;
+    });
+
+    it('should throw error if expenseType is missing', async () => {
+      try {
+        await deleteExpenseDeleteDocument(claimId, documentId, null, expenseId)(
+          mockDispatch,
+        );
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense type');
+      }
+    });
+
+    it('should throw error if expenseId is missing', async () => {
+      try {
         await deleteExpenseDeleteDocument(
           claimId,
           documentId,
-          expenseType,
-          expenseId,
+          EXPENSE_TYPES.Parking.route,
+          null,
         )(mockDispatch);
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_SUCCESS' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }),
-        ).to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_SUCCESS' }),
-        ).to.be.true;
-      });
-
-      it('should skip document deletion for MILEAGE expense', async () => {
-        const expenseType = EXPENSE_TYPES.Mileage.route;
-
-        apiStub.resolves(); // resolve for DELETE requests
-
-        await deleteExpenseDeleteDocument(
-          claimId,
-          documentId,
-          expenseType,
-          expenseId,
-        )(mockDispatch);
-
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-          .to.be.true;
-        expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_SUCCESS' }))
-          .to.be.true;
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }),
-        ).to.be.false; // document deletion should be skipped
-        expect(
-          mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_SUCCESS' }),
-        ).to.be.false;
-      });
-
-      it('should throw error if expenseType is missing', async () => {
-        try {
-          await deleteExpenseDeleteDocument(
-            claimId,
-            documentId,
-            null,
-            expenseId,
-          )(mockDispatch);
-          expect.fail('Expected error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense type');
-        }
-      });
-
-      it('should throw error if expenseId is missing', async () => {
-        try {
-          await deleteExpenseDeleteDocument(
-            claimId,
-            documentId,
-            EXPENSE_TYPES.Parking.route,
-            null,
-          )(mockDispatch);
-          expect.fail('Expected error to be thrown');
-        } catch (error) {
-          expect(error.message).to.equal('Missing expense id');
-        }
-      });
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing expense id');
+      }
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fix bug where expense document information doesn't display immediately after creating or updating an expense, requiring a page refresh to see the document data.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/128253

## Testing done

Difficult to test locally, but ensured behavior was unchanged with local mocks

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user