### PR TITLE
Fix reason code bug for DS appointments

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -285,7 +285,7 @@ describe('VAOS Page: ReviewPage direct scheduling', () => {
       locationId: '983',
       clinic: '455',
       reasonCode: {
-        text: '|comments:I need an appt',
+        text: 'comments:I need an appt',
       },
       extension: {
         desiredDate: '2021-05-06T00:00:00+00:00',

--- a/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
@@ -58,7 +58,11 @@ export function getReasonCode({ data, isCC, isDS, updateLimits }) {
     appointmentInfo = ``;
     reasonText = `comments:${data.reasonAdditionalInfo.slice(0, maxChars)}`;
   }
-  return {
-    text: data.reasonAdditionalInfo ? `${appointmentInfo}|${reasonText}` : null,
-  };
+
+  if (data.reasonAdditionalInfo) {
+    return {
+      text: appointmentInfo ? `${appointmentInfo}|${reasonText}` : reasonText,
+    };
+  }
+  return { text: null };
 }

--- a/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('VAOS helper: getReasonCode', () => {
         isDS: true,
       });
 
-      expect(result.text).to.include('comments:');
+      expect(result.text).to.equal('comments:Test reason for appointment');
     });
 
     it('should truncate DS comments to REASON_MAX_CHARS', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We introduced a bug in https://github.com/department-of-veterans-affairs/vets-website/pull/40868 where DS appointments now create appointments with the reason code text as "|comments:<input>". The leading pipe is breaking vets-api parsing.
  - We are updating vets-api to handle this case, but for we should also update vets-website so it doesn't add the leading pipe
- United Appointments Experience
- This is not behind a Flipper.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127025

## Testing done

- Updated unit tests

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
