### PR TITLE
21P-8416 limit characters on fields with box lengths

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -287,12 +287,16 @@ const costPage = {
       const provider = formData?.provider ?? '';
       return provider ? `Cost of care for ${provider}` : 'Cost of care';
     }),
-    monthlyAmount: currencyUI('What’s the monthly cost of this care?'),
+    monthlyAmount: currencyUI({
+      title: 'What’s the total monthly cost of this care?',
+      max: 999999.99,
+    }),
     hourlyRate: {
       ...currencyUI({
         title: 'What is the care provider’s hourly rate?',
         hideIf: (formData, index, fullData) =>
           hideIfInHomeCare(formData, index, fullData),
+        max: 999,
       }),
       'ui:required': (formData, index, fullData) =>
         requiredIfInHomeCare(formData, index, fullData),
@@ -302,6 +306,7 @@ const costPage = {
         title: 'How many hours per week does the care provider work?',
         hideIf: (formData, index, fullData) =>
           hideIfInHomeCare(formData, index, fullData),
+        max: 999,
       }),
       'ui:required': (formData, index, fullData) =>
         requiredIfInHomeCare(formData, index, fullData),

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/careExpensesPages.js
@@ -288,7 +288,7 @@ const costPage = {
       return provider ? `Cost of care for ${provider}` : 'Cost of care';
     }),
     monthlyAmount: currencyUI({
-      title: 'What’s the total monthly cost of this care?',
+      title: 'What’s the monthly cost of this care?',
       max: 999999.99,
     }),
     hourlyRate: {

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/medicalExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/medicalExpensesPage.js
@@ -206,7 +206,10 @@ const frequencyPage = {
       title: 'How often do you make this payment?',
       labels: careFrequencyLabels,
     }),
-    paymentAmount: currencyUI('How much is each payment?'),
+    paymentAmount: currencyUI({
+      title: 'How much is each payment?',
+      max: 999999.99,
+    }),
   },
   schema: {
     type: 'object',

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
@@ -181,7 +181,10 @@ const destinationPage = {
       required: (formData, index, fullData) =>
         requiredIfMileageLocationOther(formData, index, fullData),
     }),
-    travelMilesTraveled: numberUI('How many miles were traveled?'),
+    travelMilesTraveled: numberUI({
+      title: 'How many miles were traveled?',
+      max: 9999,
+    }),
     travelDate: currentOrPastDateUI({
       title: 'What was the date of travel?',
       monthSelect: false,

--- a/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
+++ b/src/applications/medical-expense-report/config/chapters/02-expenses/mileageExpensesPage.js
@@ -215,6 +215,7 @@ const reimbursementPage = {
       ...currencyUI({
         title: 'How much money was reimbursed?',
         expandUnder: 'travelReimbursed',
+        max: 999999.99,
         expandUnderCondition: field => field === true,
       }),
       'ui:required': (formData, index, fullData) =>

--- a/src/applications/medical-expense-report/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/medical-expense-report/tests/e2e/fixtures/data/minimal-test.json
@@ -52,7 +52,7 @@
         "travelReimbursementAmount": 123,
         "travelLocation": "OTHER",
         "otherTravelLocation": "Other location",
-        "travelMilesTraveled": "12312",
+        "travelMilesTraveled": "45",
         "travelDate": "2004-04-04",
         "traveler": "VETERAN"
       }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add max length to pdf fields that have limited boxes to enter text into
- This PR focuses just on the high priority ones, the text fields will normally cut text off when it doesn't fit but some of these would break and not fill in if it didn't fit the thousands/hundreds/cents pattern.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128211

## Testing done

- Tested the form making sure the max setting worked
- Tested the output with maxes and the pdf_filler in vets-api to make sure it would add the correct value there. 

## Screenshots

<img width="1048" height="321" alt="Screenshot 2025-12-18 at 4 33 38 PM" src="https://github.com/user-attachments/assets/6ddd367b-ec8f-49b8-90e6-416ec64f7d25" />
<img width="1039" height="360" alt="Screenshot 2025-12-18 at 4 33 33 PM" src="https://github.com/user-attachments/assets/4f4ba1b5-f246-4c79-aaca-c357fa1c21ac" />
<img width="1027" height="367" alt="Screenshot 2025-12-18 at 4 33 29 PM" src="https://github.com/user-attachments/assets/960b3f0f-b0a9-40aa-a858-a874ca050349" />
[7c6672a8e6ba729ec72942709bf9e72c.pdf](https://github.com/user-attachments/files/24245576/7c6672a8e6ba729ec72942709bf9e72c.pdf)
<img width="668" height="334" alt="Screenshot 2025-12-18 at 4 32 28 PM" src="https://github.com/user-attachments/assets/966d0d90-52a3-4230-8b47-3a2e43027ba2" />
<img width="712" height="273" alt="Screenshot 2025-12-18 at 4 32 14 PM" src="https://github.com/user-attachments/assets/65ba09c3-b042-4066-9c65-b025b46858e9" />
<img width="680" height="371" alt="Screenshot 2025-12-18 at 4 31 59 PM" src="https://github.com/user-attachments/assets/4d49c76e-f04c-45ae-b04c-ac9d89e71586" />
<img width="582" height="554" alt="Screenshot 2025-12-18 at 4 31 33 PM" src="https://github.com/user-attachments/assets/a3efed3d-09a9-4721-95ed-4b7190ceb221" />


## What areas of the site does it impact?

The expense pages on 21P-8416

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
