### PR TITLE
feat(ci): allow css-library updates in dependency check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,7 +39,7 @@ jobs:
             # Check if there are any changes to package.json that don't involve approved packages or scripts
             if [ -n "$PACKAGE_JSON_DIFF" ]; then
               # Get changed lines (excluding context lines and approved packages)
-              CHANGED_LINES=$(echo "$PACKAGE_JSON_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' | grep -v 'component-library' || echo "")
+              CHANGED_LINES=$(echo "$PACKAGE_JSON_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' | grep -v 'component-library' | grep -v 'css-library' || echo "")
 
               if [ -n "$CHANGED_LINES" ]; then
                 # Check if changes contain dependency version bumps (lines with version patterns like ^, ~, >=, etc.)
@@ -49,7 +49,7 @@ jobs:
                 if [ -n "$DEPENDENCY_CHANGES" ]; then
                   echo "❌ ERROR: package.json has dependency changes other than approved packages."
                   echo "This is temporarily blocked to prevent Shai Hulud 2.0 vulnerabilities."
-                  echo "Only updates to vets-json-schema, @department-of-veterans-affairs/component-library, and the scripts section are allowed."
+                  echo "Only updates to vets-json-schema, @department-of-veterans-affairs/component-library, @department-of-veterans-affairs/css-library, and the scripts section are allowed."
                   echo ""
                   echo "Dependency changes detected:"
                   echo "$DEPENDENCY_CHANGES"
@@ -64,7 +64,7 @@ jobs:
             if [ -n "$YARN_LOCK_DIFF" ]; then
               # For yarn.lock, we need to check if changes are only in approved package sections
               # Get all added/removed lines that don't contain approved packages
-              NON_APPROVED_LOCK_CHANGES=$(echo "$YARN_LOCK_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' | grep -v 'component-library' || echo "")
+              NON_APPROVED_LOCK_CHANGES=$(echo "$YARN_LOCK_DIFF" | grep -E '^\+|^-' | grep -v '+++\|---' | grep -v 'vets-json-schema' | grep -v 'component-library' | grep -v 'css-library' || echo "")
 
               # Also check for package entry headers that might not contain the name on the same line
               # In yarn.lock, package entries start with "package-name@version:"
@@ -79,7 +79,7 @@ jobs:
                 if [ "$CHANGE_COUNT" -gt 10 ]; then
                   echo "❌ ERROR: yarn.lock has been modified with substantial changes beyond approved packages."
                   echo "This is temporarily blocked to prevent Shai Hulud 2.0 vulnerabilities."
-                  echo "Only updates to vets-json-schema and @department-of-veterans-affairs/component-library are allowed."
+                  echo "Only updates to vets-json-schema, @department-of-veterans-affairs/component-library, and @department-of-veterans-affairs/css-library are allowed."
                   echo ""
                   echo "Detected $CHANGE_COUNT lines of non-approved package changes in yarn.lock"
                   exit 1


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Extends the CI dependency check to allow updates to `@department-of-veterans-affairs/css-library` in addition to the existing `vets-json-schema` and `component-library` exceptions
- Added `css-library` to the grep filters for both `package.json` and `yarn.lock` diff checks
- Updated error messages to include the new approved package

## Related issue(s)

- No related issue

## Testing done

Tested the filtering logic to verify css-library updates are correctly allowed:
- **css-library update only** → Correctly **ALLOWED**

## Screenshots

N/A - This is a CI workflow change, not a UI change.

## What areas of the site does it impact?

This change only affects the CI workflow and does not impact any areas of the site directly. It allows the css-library dependency to be updated without triggering the dependency check failure.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - code comments updated inline)
- [x] Screenshot of the developed feature is added (N/A - not a UI change)
- [x] Accessibility testing has been performed (N/A - not a UI change)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - CI change only)
- [x] Events are being sent to the appropriate logging solution (N/A - CI change only)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - CI change only)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - CI change only)