### PR TITLE
Fixed Repeated Calls to Refresh Endpoint

### DIFF
--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.jsx
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.jsx
@@ -703,7 +703,7 @@ describe('OAuth - Utilities', () => {
       expect(global.fetch.firstCall.args[0].includes('/refresh')).to.be.true;
     });
 
-    it('should protect against repeated refresh calls', async () => {
+    it('should protect against repeated refresh calls of the same type', async () => {
       mockFetch();
       setFetchResponse(global.fetch.onFirstCall(), []);
       const refreshPromise1 = oAuthUtils.refresh({ type: 'idme' });

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.jsx
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.jsx
@@ -702,6 +702,18 @@ describe('OAuth - Utilities', () => {
       expect(global.fetch.firstCall.args[0]).to.include('type=logingov');
       expect(global.fetch.firstCall.args[0].includes('/refresh')).to.be.true;
     });
+
+    it('should protect against repeated refresh calls', async () => {
+      mockFetch();
+      setFetchResponse(global.fetch.onFirstCall(), []);
+      const refreshPromise1 = oAuthUtils.refresh({ type: 'idme' });
+      const refreshPromise2 = oAuthUtils.refresh({ type: 'idme' });
+      await Promise.all([refreshPromise1, refreshPromise2]);
+      expect(global.fetch.calledOnce).to.be.true;
+      expect(global.fetch.firstCall.args[1].method).to.equal('POST');
+      expect(global.fetch.firstCall.args[0]).to.include('type=idme');
+      expect(global.fetch.firstCall.args[0].includes('/refresh')).to.be.true;
+    });
   });
 
   describe('updateStateAndVerifier', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the `refresh` function so that repeated calls of the same type do not trigger multiple requests to the `/sign_in/refresh` endpoint.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/879)

## Testing done
- Updated `utilities.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/platform/utilities/tests/oauth/utilities.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `oauth/utilities.js` and the related tests.

## Acceptance criteria
- [x] Fix `refresh` so that repeated calls do not send repeated requests to `/sign_in/refresh`.