### PR TITLE
[#128371] Travel Pay, Add useSetPageTitle for complex claims pages

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/AgreementPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/AgreementPage.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useSelector, useDispatch } from 'react-redux';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import TravelAgreementContent from '../../TravelAgreementContent';
 import TravelPayButtonPair from '../../shared/TravelPayButtonPair';
 import { submitComplexClaim } from '../../../redux/actions';
@@ -19,6 +20,10 @@ const AgreementPage = () => {
   const { isSubmitting } = useSelector(selectComplexClaimSubmissionState);
   const [isAgreementChecked, setIsAgreementChecked] = useState(false);
   const [isAgreementError, setIsAgreementError] = useState(false);
+
+  const title = 'Beneficiary travel agreement';
+
+  useSetPageTitle(title);
 
   const onSubmit = async () => {
     setIsAgreementError(!isAgreementChecked);
@@ -44,7 +49,7 @@ const AgreementPage = () => {
 
   return (
     <>
-      <h1>Beneficiary travel agreement</h1>
+      <h1>{title}</h1>
       <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-display--inline">
         Penalty statement:
       </p>{' '}

--- a/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ChooseExpenseType.jsx
@@ -5,6 +5,7 @@ import {
   VaRadio,
   VaButtonPair,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import { EXPENSE_TYPES, EXPENSE_TYPE_KEYS } from '../../../constants';
 import { selectComplexClaim } from '../../../redux/selectors';
 
@@ -17,6 +18,10 @@ const ChooseExpenseType = () => {
 
   // Get claim data
   const { data: claim } = useSelector(selectComplexClaim);
+
+  const title = 'What type of expense do you want to add?';
+
+  useSetPageTitle(title);
 
   // Check if claim already has a mileage expense
   const hasExistingMileageExpense = () => {
@@ -70,9 +75,7 @@ const ChooseExpenseType = () => {
 
   return (
     <>
-      <h1 className="vads-u-margin-bottom--2">
-        What type of expense do you want to add?
-      </h1>
+      <h1 className="vads-u-margin-bottom--2">{title}</h1>
       <p>Select 1 expense. You’ll be able to add other expenses later.</p>
       <p className="vads-u-margin-bottom--0">
         We’ll need to pre-approve any lodging or meals before you request

--- a/src/applications/travel-pay/components/complex-claims/pages/ClaimErrorPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ClaimErrorPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import { PAST_APPOINTMENTS_LINK } from '../../../constants';
 import WhatHappensNextSection from './WhatHappensNextSection';
 import { ComplexClaimsHelpSection } from '../../HelpText';
@@ -12,6 +13,7 @@ const ClaimErrorPage = ({ isCreate }) => {
   const alertDescription = isCreate
     ? 'We’re sorry. We couldn’t start your travel reimbursement claim. Try to file your claim again.'
     : 'We’re sorry. We can’t access your claim information right now. Try again later.';
+  useSetPageTitle(header);
   return (
     <div>
       <h1>{header}</h1>

--- a/src/applications/travel-pay/components/complex-claims/pages/ConfirmationPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ConfirmationPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import { formatDateTime } from '../../../util/dates';
 import {
   selectAppointment,
@@ -43,6 +44,8 @@ const ConfirmationPage = () => {
   const [formattedDate, formattedTime] = appointmentData?.localStartTime
     ? formatDateTime(appointmentData.localStartTime)
     : [null, null];
+
+  useSetPageTitle(pageHeader);
 
   return (
     <>

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -14,6 +14,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import DocumentUpload from './DocumentUpload';
 import { EXPENSE_TYPES, EXPENSE_TYPE_KEYS } from '../../../constants';
 import {
@@ -484,6 +485,14 @@ const ExpensePage = () => {
       setFormState,
     );
   };
+
+  const pageTitle = expenseTypeFields?.expensePageText
+    ? `${expenseTypeFields.expensePageText
+        .charAt(0)
+        .toUpperCase()}${expenseTypeFields.expensePageText.slice(1)} expense`
+    : 'Unknown expense';
+
+  useSetPageTitle(pageTitle);
 
   return (
     <>

--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -7,6 +7,7 @@ import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { BTSSS_PORTAL_URL } from '../../../constants';
 import { createComplexClaim } from '../../../redux/actions';
 import ComplexClaimRedirect from './ComplexClaimRedirect';
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import {
   selectAppointment,
   selectComplexClaim,
@@ -21,6 +22,10 @@ const IntroductionPage = () => {
 
   const { data: appointment } = useSelector(selectAppointment);
   const complexClaim = useSelector(selectComplexClaim);
+
+  const title = 'File a travel reimbursement claim';
+
+  useSetPageTitle(title);
 
   const apptId = appointment?.id;
 
@@ -64,7 +69,7 @@ const IntroductionPage = () => {
     <>
       {shouldShowRedirect && <ComplexClaimRedirect />}
       <div data-testid="introduction-page">
-        <h1>File a travel reimbursement claim</h1>
+        <h1>{title}</h1>
         <div className="vads-u-margin-left--2">
           <va-process-list>
             <va-process-list-item

--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -6,6 +6,7 @@ import {
   VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import {
   createExpense,
   updateExpense,
@@ -34,6 +35,10 @@ const Mileage = () => {
 
   const allExpenses = useSelector(selectAllExpenses);
   const address = useSelector(selectVAPResidentialAddress);
+
+  const title = 'Mileage';
+
+  useSetPageTitle(title);
   const isLoadingExpense = useSelector(
     state =>
       isEditMode
@@ -192,7 +197,7 @@ const Mileage = () => {
 
   return (
     <>
-      <h1>Mileage</h1>
+      <h1>{title}</h1>
       <va-additional-info
         class="vads-u-margin-y--3"
         trigger="How we calculate mileage"

--- a/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import ReviewPageAlert from './ReviewPageAlert';
 import ExpensesAccordion from './ExpensesAccordion';
 import {
@@ -26,6 +27,10 @@ const ReviewPage = () => {
   const expenses = useSelector(selectAllExpenses) ?? [];
   const documents = useSelector(selectAllDocuments) ?? [];
   const alertMessage = useSelector(selectReviewPageAlert);
+
+  const title = 'Your unsubmitted expenses';
+
+  useSetPageTitle(title);
 
   // Get total by expense type and return expenses alphabetically
   const totalByExpenseType = Object.fromEntries(
@@ -78,7 +83,7 @@ const ReviewPage = () => {
 
   return (
     <div data-testid="review-page">
-      <h1>Your unsubmitted expenses</h1>
+      <h1>{title}</h1>
       {isAlertVisible && (
         <ReviewPageAlert
           header={alertMessage.title}

--- a/src/applications/travel-pay/components/complex-claims/pages/UnsupportedMileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/UnsupportedMileage.jsx
@@ -2,14 +2,19 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
+import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import { BTSSS_PORTAL_URL } from '../../../constants';
 
 const UnsupportedMileage = () => {
   const navigate = useNavigate();
 
+  const title = 'You’ll need to file this claim in another tool';
+
+  useSetPageTitle(title);
+
   return (
     <>
-      <h1>You’ll need to file this claim in another tool</h1>
+      <h1>{title}</h1>
       <p>
         Right now you can only file travel reimbursement claims on VA.gov if you
         departed from the address we have on file and traveled round trip.


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

The title in the browser tab was inconsistent for the new complex claims pages. Leveraging our `useSetPageTitle` to inherit the standard title formatting

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/128371

## Testing done

Made sure `document.title` was resolving correctly in the browser locally

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user