### PR TITLE
MBMS-108962 Switched cemeteries end point to the simple forms api

### DIFF
--- a/src/applications/pre-need/tests/utils/cypress-preneed-helpers.js
+++ b/src/applications/pre-need/tests/utils/cypress-preneed-helpers.js
@@ -28,7 +28,7 @@ function interceptSetup() {
       },
     },
   });
-  cy.intercept('GET', '/v0/preneeds/cemeteries', cemeteries);
+  cy.intercept('GET', '/simple_forms_api/v1/cemeteries', cemeteries);
   cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
 }
 

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -750,7 +750,9 @@ export const militaryNameUI = {
 };
 
 export function getCemeteries() {
-  return fetch(`${environment.API_URL}/v0/preneeds/cemeteries`, {
+  const apiUrl = `${environment.API_URL}/simple_forms_api/v1/cemeteries`;
+
+  return fetch(apiUrl, {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
@@ -761,23 +763,19 @@ export function getCemeteries() {
       if (!res.ok) {
         return Promise.reject(res);
       }
-
       return res.json();
     })
-    .then(res =>
-      res.data.map(item => ({
+    .then(res => {
+      return res.data.map(item => ({
         label: item.attributes.name,
         id: item.id,
-      })),
-    )
-    .catch(res => {
-      if (res instanceof Error) {
-        Sentry.captureException(res);
+      }));
+    })
+    .catch(error => {
+      if (error instanceof Error) {
+        Sentry.captureException(error);
         Sentry.captureMessage('vets_preneed_cemeteries_error');
       }
-
-      // May change this to a reject later, depending on how we want
-      // to surface errors in autosuggest field
       return Promise.resolve([]);
     });
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Switched pre-need cemeteries end point to the simple forms api cemeteries end point that pings a list of cemeteries in a json file in vets-api rather than EAOS.

## Related issue(s)
- https://jira.devops.va.gov/browse/MBMS-108962

## Testing done
- [x] Internal Review
- [x] Dev Test Execution
- [x] Unit Tests Passing
- [x] POR/UI/UX Review

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
_**Pre-need cemeteries**_

## Acceptance criteria
- Replace the EOAS call with a vets-api endpoint to fetch the cemeteries list
        1. The cemeteries list is retrieved from vets-api instead of EAOS for pre-integration
        2. The data is displayed correctly in the frontend without any regressions for pre-integration