### PR TITLE
21P-8416 transform weeklyHours to number instead of text

### DIFF
--- a/src/applications/medical-expense-report/config/submit-transformer.js
+++ b/src/applications/medical-expense-report/config/submit-transformer.js
@@ -140,12 +140,31 @@ function renameExpenseConditionalFields(formData) {
   return JSON.stringify(transformedValue);
 }
 
+function transformWeeklyHoursToNumber(formData) {
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = parsedFormData;
+
+  // Transform weeklyHours from string to number in careExpenses
+  if (Array.isArray(transformedValue.careExpenses)) {
+    transformedValue.careExpenses = transformedValue.careExpenses.map(
+      expense => {
+        if (expense?.weeklyHours === undefined) return expense;
+        const weeklyHoursNumber = Number(expense.weeklyHours);
+        return { ...expense, weeklyHours: weeklyHoursNumber };
+      },
+    );
+  }
+
+  return JSON.stringify(transformedValue);
+}
+
 export const transform = (formConfig, form) => {
   let transformedData = transformForSubmit(formConfig, form);
   transformedData = swapNames(transformedData);
   transformedData = splitVaSsnField(transformedData);
   transformedData = switchToInternationalPhone(transformedData);
   transformedData = renameExpenseConditionalFields(transformedData);
+  transformedData = transformWeeklyHoursToNumber(transformedData);
   return JSON.stringify({
     medicalExpenseReportsClaim: {
       form: transformedData,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The vets-json-schema expects a number for weeklyHours but numberUI is sending a string

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128431

## Testing done

- Manual testing with vets-api locally
- Unit tests
- e2e tests

## Screenshots

N/A

## What areas of the site does it impact?

Submit transform function on 21P-8416

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
