### PR TITLE
city and state of birth no longer required

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-birth-information.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-birth-information.js
@@ -24,12 +24,11 @@ export const veteranBirthInformationPage = {
     properties: {
       veteranInformation: {
         type: 'object',
-        required: ['dateOfBirth', 'placeOfBirth'],
+        required: ['dateOfBirth'],
         properties: {
           dateOfBirth: currentOrPastDateSchema,
           placeOfBirth: {
             type: 'object',
-            required: ['city', 'state'],
             properties: {
               city: textSchema,
               state: {

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/fixtures/data/minimal.json
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/fixtures/data/minimal.json
@@ -6,10 +6,6 @@
   "veteranInformation": {
     "dateOfDeath": "2005-05-19",
     "dateOfBirth": "1920-05-04",
-    "placeOfBirth": {
-      "city": "Naboo",
-      "state": "New Mexico"
-    },
     "ssn": "800121234",
     "fullName": {
       "first": "Sheev",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed the required validation for city and state fields in the veteran's place of birth section of form 21P-530a (Interment Allowance)
- The `placeOfBirth` object is no longer required in the schema, and its nested `city` and `state` fields no longer have required validation
- Veterans/claimants can now submit the form without providing the city and state of birth information
- Updated test fixtures to reflect the optional nature of these fields
- This change aligns with business requirements to reduce friction in the application process while still collecting the veteran's date of birth
- The Benefits Optimization Aquia (BIO) team owns the maintenance of this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128448


## Testing done

- **Old behavior**: The veteran birth information page required users to provide both city and state of birth. The form would not allow submission if these fields were left empty, displaying validation errors.
  
- **Steps to verify changes**:
  1. Navigate to the 21P-530a Interment Allowance form
  2. Proceed to the veteran birth information page
  3. Enter a valid date of birth
  4. Leave the city and/or state of birth fields empty
  5. Attempt to continue to the next page
  6. Verify that no validation errors appear for the empty city/state fields
  7. Complete and submit the form successfully without city/state of birth information

- **Test results**:
  - Unit tests updated and passing for the `veteran-birth-information.js` schema
  - Test fixtures updated to reflect optional fields in `minimal.json`
  - Manual testing confirmed users can proceed without entering city and state of birth
  - Form submission successful without these fields
  - All existing Cypress e2e tests passing

- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | _[You will add]_ | _[You will add]_ |
| Desktop | <img width="705" height="700" alt="image" src="https://github.com/user-attachments/assets/29d1fde4-b0ef-42fc-850b-33ea997ac8ff" /> | <img width="798" height="630" alt="image" src="https://github.com/user-attachments/assets/61be8cbd-9ea3-481c-a706-21c1a83d4bbf" /> |

## What areas of the site does it impact?

This change impacts the 21P-530a Interment Allowance application form, specifically the veteran birth information page within the Benefits Optimization Aquia (BIO) forms suite. No other applications or areas of the site are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) - N/A for this change
- [ ] Screenshot of the developed feature is added - _[You will add]_
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - _[Please confirm and check]_

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution - N/A for this validation change
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A for this change

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user - _[Please test and confirm]_

## Requested Feedback

(OPTIONAL) Please review the schema changes to ensure the optional fields don't have any unintended downstream effects in data processing or submission transformers. The change is straightforward, but a second set of eyes on the validation logic would be appreciated.