### PR TITLE
removed service locations and rank requirements

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
@@ -36,12 +36,7 @@ const servicePeriodOptions = {
   nounPlural: 'service periods',
   required: false,
   isItemIncomplete: item =>
-    !item.serviceBranch &&
-    !item.dateEnteredService &&
-    !item.placeEnteredService &&
-    !item.rankAtSeparation &&
-    !item.dateLeftService &&
-    !item.placeLeftService,
+    !item.serviceBranch && !item.dateEnteredService && !item.dateLeftService,
   text: {
     summaryTitle: "Review the Veteran's service periods",
     getItemName: item =>

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
@@ -111,7 +111,6 @@ const serviceLocationsAndRankPage = {
   },
   schema: {
     type: 'object',
-    required: ['placeEnteredService', 'placeLeftService', 'rankAtSeparation'],
     properties: {
       placeEnteredService: textSchema,
       placeLeftService: textSchema,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed required validation for service location fields in the service period section of form 21P-530a (Interment Allowance)
- SMEs determined that primary users (state/tribal cemetery officials) may not have access to detailed service location information
- Made the following fields optional in the service period conditional loop:
  - Place the Veteran entered active service (`placeEnteredService`)
  - Place the Veteran separated from active service (`placeLeftService`)
  - Grade, rank, or rating (`rankAtSeparation`)
- Veterans/claimants can now submit the form without providing these service location details if unavailable
- Service dates and branch remain required to maintain minimal service record validation
- This change reduces friction in the application process while still collecting essential service period information
- The Benefits Optimization Aquia (BIO) team owns the maintenance of this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128449

## Testing done

- **Old behavior**: The service locations and rank page within the service period loop required users to provide place entered service, place separated from service, and rank at separation. The form would not allow submission if these fields were left empty, displaying validation errors.
  
- **Steps to verify changes**:
  1. Navigate to the 21P-530a Interment Allowance form
  2. Add a service period with branch and dates
  3. Navigate to the "Locations and rank" page
  4. Leave the "Place the Veteran entered active service" field empty
  5. Leave the "Place the Veteran separated active service" field empty
  6. Leave the "Grade, rank, or rating" field empty
  7. Attempt to continue to the next page
  8. Verify that no validation errors appear for the empty location/rank fields
  9. Complete and submit the form successfully without service location information
  10. Verify the backend accepts the submission without these optional fields

- **Test results**:
  - Schema updated to remove required array from `serviceLocationsAndRankPage`
  - Backend schema in vets-api confirmed these fields are already optional (no required validation)
  - All existing unit tests passing
  - Manual testing confirmed users can proceed without entering location/rank fields
  - Form submission successful without these fields
  - _[You will run and confirm Cypress e2e tests]_

- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="739" height="909" alt="image" src="https://github.com/user-attachments/assets/e2c2b241-549f-4b72-a1c8-2164322c8826" /> | <img width="757" height="908" alt="image" src="https://github.com/user-attachments/assets/6856de7f-b581-4596-a408-f474f738383b" />|

## What areas of the site does it impact?

This change impacts the 21P-530a Interment Allowance application form, specifically the service locations and rank page within the service period array builder section of the Benefits Optimization Aquia (BIO) forms suite. No other applications or areas of the site are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) - N/A for this validation change
- [ ] Screenshot of the developed feature is added - _[You will add]_
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - _[Please confirm and check]_

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution - N/A for this validation change
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A for this change

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user - _[Please test and confirm]_

## Requested Feedback

(OPTIONAL) Please review the schema changes to ensure removing these required fields aligns with business requirements and doesn't have any unintended downstream effects. Backend validation was confirmed to already support optional fields for these service location attributes.