### PR TITLE
10-10dx | Filter stale supporting docs data on submit

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.supportingDocs.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.supportingDocs.unit.spec.jsx
@@ -44,7 +44,7 @@ const baseData = (applicants, medicare) => ({
   data: { applicants, medicare },
 });
 
-describe('10-10d extened Submit Transformer - Medicare document filtering', () => {
+describe('10-10d extended Submit Transformer - Medicare document filtering', () => {
   const cases = [
     {
       title: 'only includes Part A cards when plan type is "a"',

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.supportingDocs.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.supportingDocs.unit.spec.jsx
@@ -1,0 +1,240 @@
+import { expect } from 'chai';
+import formConfig from '../../../config/form';
+import transformForSubmit from '../../../config/submitTransformer';
+import { toHash } from '../../../../shared/utilities';
+
+const APPLICANT_SSN = '345345345';
+const SSN_HASH = toHash(APPLICANT_SSN);
+
+const doc = (confirmationCode, name = `${confirmationCode}.pdf`) => [
+  { confirmationCode, name },
+];
+
+const makeApplicant = (ssn, name = { first: 'Johnny', last: 'Alvin' }) => ({
+  applicantName: name,
+  applicantSsn: ssn,
+});
+
+const makePlan = (overrides = {}) => ({
+  medicareParticipant: SSN_HASH,
+  medicarePlanType: 'ab',
+  ...overrides,
+});
+
+const supportingDocCodes = testData => {
+  const transformed = JSON.parse(transformForSubmit(formConfig, testData));
+  return new Set(
+    (transformed.supportingDocs || []).map(d => d.confirmationCode),
+  );
+};
+
+const expectIncludes = (set, codes = []) => {
+  codes.forEach(code =>
+    expect(set.has(code), `expected to include ${code}`).to.eq(true),
+  );
+};
+
+const expectExcludes = (set, codes = []) => {
+  codes.forEach(code =>
+    expect(set.has(code), `expected to exclude ${code}`).to.eq(false),
+  );
+};
+
+const baseData = (applicants, medicare) => ({
+  data: { applicants, medicare },
+});
+
+describe('10-10d extened Submit Transformer - Medicare document filtering', () => {
+  const cases = [
+    {
+      title: 'only includes Part A cards when plan type is "a"',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'a',
+            medicarePartAFrontCard: doc('part-a-front-123'),
+            medicarePartABackCard: doc('part-a-back-123'),
+            // filtered out
+            medicarePartBFrontCard: doc('part-b-front-123'),
+            medicarePartAPartBFrontCard: doc('part-ab-front-123'),
+          }),
+        ],
+      ),
+      include: ['part-a-front-123', 'part-a-back-123'],
+      exclude: ['part-b-front-123', 'part-ab-front-123'],
+    },
+    {
+      title:
+        'only includes Part B cards and denial proof when plan type is "b"',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'b',
+            medicarePartBFrontCard: doc('part-b-front-456'),
+            medicarePartBBackCard: doc('part-b-back-456'),
+            medicarePartADenialProof: doc(
+              'denial-proof-456',
+              'denial-letter.pdf',
+            ),
+            // filtered out
+            medicarePartAFrontCard: doc('part-a-front-456'),
+            medicarePartAPartBFrontCard: doc('part-ab-front-456'),
+          }),
+        ],
+      ),
+      include: ['part-b-front-456', 'part-b-back-456', 'denial-proof-456'],
+      exclude: ['part-a-front-456', 'part-ab-front-456'],
+    },
+    {
+      title: 'only includes Part A/B cards when plan type is "ab"',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'ab',
+            medicarePartAPartBFrontCard: doc('part-ab-front-789'),
+            medicarePartAPartBBackCard: doc('part-ab-back-789'),
+            // filtered out
+            medicarePartAFrontCard: doc('part-a-front-789'),
+            medicarePartBFrontCard: doc('part-b-front-789'),
+          }),
+        ],
+      ),
+      include: ['part-ab-front-789', 'part-ab-back-789'],
+      exclude: ['part-a-front-789', 'part-b-front-789'],
+    },
+    {
+      title: 'includes Part C cards when plan type is "c"',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'c',
+            medicarePartCCarrier: 'Advantage Health',
+            medicarePartAPartBFrontCard: doc('part-ab-front-321'),
+            medicarePartAPartBBackCard: doc('part-ab-back-321'),
+            medicarePartCFrontCard: doc('part-c-front-321'),
+            medicarePartCBackCard: doc('part-c-back-321'),
+            // filtered out
+            medicarePartAFrontCard: doc('part-a-front-321'),
+            medicarePartBFrontCard: doc('part-b-front-321'),
+          }),
+        ],
+      ),
+      include: [
+        'part-ab-front-321',
+        'part-ab-back-321',
+        'part-c-front-321',
+        'part-c-back-321',
+      ],
+      exclude: ['part-a-front-321', 'part-b-front-321'],
+    },
+    {
+      title: 'includes Part D cards when hasMedicarePartD is true',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'ab',
+            hasMedicarePartD: true,
+            medicarePartAPartBFrontCard: doc('part-ab-front-555'),
+            medicarePartAPartBBackCard: doc('part-ab-back-555'),
+            medicarePartDFrontCard: doc('part-d-front-555'),
+            medicarePartDBackCard: doc('part-d-back-555'),
+          }),
+        ],
+      ),
+      include: [
+        'part-ab-front-555',
+        'part-ab-back-555',
+        'part-d-front-555',
+        'part-d-back-555',
+      ],
+    },
+    {
+      title: 'excludes Part D cards when hasMedicarePartD is false',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'ab',
+            hasMedicarePartD: false,
+            medicarePartAPartBFrontCard: doc('part-ab-front-666'),
+            medicarePartAPartBBackCard: doc('part-ab-back-666'),
+            // should be filtered out
+            medicarePartDFrontCard: doc('part-d-front-666'),
+            medicarePartDBackCard: doc('part-d-back-666'),
+          }),
+        ],
+      ),
+      include: ['part-ab-front-666', 'part-ab-back-666'],
+      exclude: ['part-d-front-666', 'part-d-back-666'],
+    },
+    {
+      title: 'handles scenario where user changes plan type from "a" to "ab"',
+      data: baseData(
+        [makeApplicant(APPLICANT_SSN)],
+        [
+          makePlan({
+            medicarePlanType: 'ab',
+            // stale docs from old "a"
+            medicarePartAFrontCard: doc('old-part-a-front'),
+            medicarePartABackCard: doc('old-part-a-back'),
+            // new docs for "ab"
+            medicarePartAPartBFrontCard: doc('new-part-ab-front'),
+            medicarePartAPartBBackCard: doc('new-part-ab-back'),
+          }),
+        ],
+      ),
+      include: ['new-part-ab-front', 'new-part-ab-back'],
+      exclude: ['old-part-a-front', 'old-part-a-back'],
+    },
+  ];
+
+  cases.forEach(({ title, data, include = [], exclude = [] }) => {
+    it(title, () => {
+      const codes = supportingDocCodes(data);
+      expectIncludes(codes, include);
+      expectExcludes(codes, exclude);
+    });
+  });
+
+  it('handles multiple medicare plans with different types', () => {
+    const applicant2Ssn = '456456456';
+    const applicant2Hash = toHash(applicant2Ssn);
+
+    const data = baseData(
+      [
+        makeApplicant(APPLICANT_SSN),
+        makeApplicant(applicant2Ssn, { first: 'Jane', last: 'Smith' }),
+      ],
+      [
+        makePlan({
+          medicareParticipant: SSN_HASH,
+          medicarePlanType: 'a',
+          medicarePartAFrontCard: doc('applicant1-part-a-front'),
+          medicarePartABackCard: doc('applicant1-part-a-back'),
+        }),
+        makePlan({
+          medicareParticipant: applicant2Hash,
+          medicarePlanType: 'b',
+          medicarePartBFrontCard: doc('applicant2-part-b-front'),
+          medicarePartBBackCard: doc('applicant2-part-b-back'),
+        }),
+      ],
+    );
+
+    const codes = supportingDocCodes(data);
+
+    expectIncludes(codes, [
+      'applicant1-part-a-front',
+      'applicant1-part-a-back',
+    ]);
+    expectIncludes(codes, [
+      'applicant2-part-b-front',
+      'applicant2-part-b-back',
+    ]);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds additional filtering for supporting docs from the Medicare array to ensure we are only sending docs associated with the currently-selected plan type.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#127759

## Testing done

- Before this change, if you choose one plan type, upload the docs, then go back and change the plan type, the previously-uploaded docs would be included in the payload.
- After this change, only the docs associated with the current plan type get included in the payload.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Payload contains only active page data

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user