### PR TITLE
Add confirmation page warning about not being able to access later

### DIFF
--- a/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
@@ -338,7 +338,7 @@ export const PrintThisPage = ({ className = '' }) => {
       <h2 className="vads-u-font-size--h4">Print this confirmation page</h2>
       <p>
         If you’d like to keep a copy of the information on this page, you can
-        print it now.
+        print it now. You won’t be able to access this page later.
       </p>
       <va-button
         onClick={onPrintPageClick}

--- a/src/platform/forms-system/test/js/components/ConfirmationView/ConfirmationView.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ConfirmationView/ConfirmationView.unit.spec.jsx
@@ -107,7 +107,7 @@ describe('Confirmation view', () => {
   });
 
   it('it should allow for manual child component specification', () => {
-    const { container } = render(
+    const { container, getByText } = render(
       <Provider store={mockStore(storeBase)}>
         <ConfirmationView
           formConfig={formConfig}
@@ -140,6 +140,11 @@ describe('Confirmation view', () => {
       .exist;
     expect(container.querySelector('.confirmation-go-back-link-section')).to
       .exist;
+    expect(
+      getByText(text =>
+        text.includes('You won’t be able to access this page later.'),
+      ),
+    ).to.exist;
   });
 
   it('it should allow for component omission', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

[This updates confirmation page to be explicit about being unable to return to page](https://github.com/department-of-veterans-affairs/va.gov-team/issues/127365).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127365 

## Testing done

- Old behavior was nothing 
- Created test line to check for added text 

## Screenshots

<img width="1918" height="1011" alt="image" src="https://github.com/user-attachments/assets/f2ff4288-4a7e-4c3c-b6de-0e51a9b150f5" />

## What areas of the site does it impact?

Confirmation pages will now show additional text. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
