### PR TITLE
bug(128389,128396): fix empty subdirectory redirect and add page title for Files we couldn't receive

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -11,7 +11,10 @@ import DocumentCard from './DocumentCard';
 import ClaimsBreadcrumbs from './ClaimsBreadcrumbs';
 import { usePagination } from '../hooks/usePagination';
 import { fetchFailedUploads } from '../actions';
-import { getTrackedItemDisplayNameFromEvidenceSubmission } from '../utils/helpers';
+import {
+  getTrackedItemDisplayNameFromEvidenceSubmission,
+  setDocumentTitle,
+} from '../utils/helpers';
 import { setPageFocus } from '../utils/page';
 import { ITEMS_PER_PAGE } from '../constants';
 import NeedHelp from './NeedHelp';
@@ -51,6 +54,10 @@ const FilesWeCouldntReceive = () => {
     onPageSelect(page);
     setPageFocus('#pagination-info');
   };
+
+  useEffect(() => {
+    setDocumentTitle("Files we couldn't receive");
+  }, []);
 
   useEffect(
     () => {

--- a/src/applications/claims-status/routes.jsx
+++ b/src/applications/claims-status/routes.jsx
@@ -46,7 +46,7 @@ const routes = (
         />
         <Route
           path="needed-from-you"
-          element={<Navigate to="../.." replace />}
+          element={<Navigate to="../status" replace />}
         />
         <Route
           path="needed-from-you/:trackedItemId"
@@ -54,7 +54,7 @@ const routes = (
         />
         <Route
           path="needed-from-others"
-          element={<Navigate to="../.." replace />}
+          element={<Navigate to="../status" replace />}
         />
         <Route
           path="needed-from-others/:trackedItemId"

--- a/src/applications/claims-status/routes.jsx
+++ b/src/applications/claims-status/routes.jsx
@@ -45,8 +45,16 @@ const routes = (
           element={<DocumentRedirectPage />}
         />
         <Route
+          path="needed-from-you"
+          element={<Navigate to="../.." replace />}
+        />
+        <Route
           path="needed-from-you/:trackedItemId"
           element={<DocumentRequestPage />}
+        />
+        <Route
+          path="needed-from-others"
+          element={<Navigate to="../.." replace />}
         />
         <Route
           path="needed-from-others/:trackedItemId"

--- a/src/applications/claims-status/tests/components/DocumentRedirectPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRedirectPage.unit.spec.jsx
@@ -101,7 +101,7 @@ describe('Empty directory redirects', () => {
         <Routes>
           <Route
             path="/your-claims/:id/needed-from-you"
-            element={<Navigate to="/your-claims" replace />}
+            element={<Navigate to="/your-claims/:id/status" replace />}
           />
           <Route
             path="/your-claims/:id/needed-from-you/:trackedItemId"
@@ -109,23 +109,26 @@ describe('Empty directory redirects', () => {
           />
           <Route
             path="/your-claims/:id/needed-from-others"
-            element={<Navigate to="/your-claims" replace />}
+            element={<Navigate to="/your-claims/:id/status" replace />}
           />
           <Route
             path="/your-claims/:id/needed-from-others/:trackedItemId"
             element={<div>Document request page</div>}
           />
-          <Route path="/your-claims" element={<div>Your claims page</div>} />
+          <Route
+            path="/your-claims/:id/status"
+            element={<div>Claim status</div>}
+          />
         </Routes>
       </MemoryRouter>,
     );
 
-  it('redirects /needed-from-you (no trackedItemId) to /your-claims', () => {
+  it('redirects /needed-from-you (no trackedItemId) to /your-claims/123/status', () => {
     const { getByText } = renderWithRoutes('/your-claims/123/needed-from-you');
     expect(getByText('Claim status')).to.exist;
   });
 
-  it('redirects /needed-from-others (no trackedItemId) to /your-claims', () => {
+  it('redirects /needed-from-others (no trackedItemId) to /your-claims/123/status', () => {
     const { getByText } = renderWithRoutes(
       '/your-claims/123/needed-from-others',
     );

--- a/src/applications/claims-status/tests/components/DocumentRedirectPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRedirectPage.unit.spec.jsx
@@ -122,14 +122,14 @@ describe('Empty directory redirects', () => {
 
   it('redirects /needed-from-you (no trackedItemId) to /your-claims', () => {
     const { getByText } = renderWithRoutes('/your-claims/123/needed-from-you');
-    expect(getByText('Your claims page')).to.exist;
+    expect(getByText('Claim status')).to.exist;
   });
 
   it('redirects /needed-from-others (no trackedItemId) to /your-claims', () => {
     const { getByText } = renderWithRoutes(
       '/your-claims/123/needed-from-others',
     );
-    expect(getByText('Your claims page')).to.exist;
+    expect(getByText('Claim status')).to.exist;
   });
 
   it('renders DocumentRequestPage when trackedItemId is provided', () => {
@@ -137,6 +137,6 @@ describe('Empty directory redirects', () => {
       '/your-claims/123/needed-from-you/456',
     );
     expect(getByText('Document request page')).to.exist;
-    expect(queryByText('Your claims page')).not.to.exist;
+    expect(queryByText('Claim status')).not.to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/DocumentRedirectPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRedirectPage.unit.spec.jsx
@@ -4,7 +4,12 @@ import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
-import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat';
+import {
+  MemoryRouter,
+  Navigate,
+  Route,
+  Routes,
+} from 'react-router-dom-v5-compat';
 import DocumentRedirectPage from '../../containers/DocumentRedirectPage';
 
 describe('DocumentRedirectPage routing', () => {
@@ -86,5 +91,52 @@ describe('DocumentRedirectPage routing', () => {
     );
     expect(getByText('Needed from others page')).to.exist;
     expect(queryByText('Needed from you page')).not.to.exist;
+  });
+});
+
+describe('Empty directory redirects', () => {
+  const renderWithRoutes = initialEntry =>
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/your-claims/:id/needed-from-you"
+            element={<Navigate to="/your-claims" replace />}
+          />
+          <Route
+            path="/your-claims/:id/needed-from-you/:trackedItemId"
+            element={<div>Document request page</div>}
+          />
+          <Route
+            path="/your-claims/:id/needed-from-others"
+            element={<Navigate to="/your-claims" replace />}
+          />
+          <Route
+            path="/your-claims/:id/needed-from-others/:trackedItemId"
+            element={<div>Document request page</div>}
+          />
+          <Route path="/your-claims" element={<div>Your claims page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+  it('redirects /needed-from-you (no trackedItemId) to /your-claims', () => {
+    const { getByText } = renderWithRoutes('/your-claims/123/needed-from-you');
+    expect(getByText('Your claims page')).to.exist;
+  });
+
+  it('redirects /needed-from-others (no trackedItemId) to /your-claims', () => {
+    const { getByText } = renderWithRoutes(
+      '/your-claims/123/needed-from-others',
+    );
+    expect(getByText('Your claims page')).to.exist;
+  });
+
+  it('renders DocumentRequestPage when trackedItemId is provided', () => {
+    const { getByText, queryByText } = renderWithRoutes(
+      '/your-claims/123/needed-from-you/456',
+    );
+    expect(getByText('Document request page')).to.exist;
+    expect(queryByText('Your claims page')).not.to.exist;
   });
 });


### PR DESCRIPTION
## Description

This PR addresses two Staging Review findings related to the "Files we couldn't receive" and document request pages:

### 1. Empty subdirectories in URL (#128389)
When navigating to `/track-claims/your-claims/{claimId}/needed-from-you` or `/track-claims/your-claims/{claimId}/needed-from-others` without a specific `trackedItemId`, users previously saw a blank page. This fix redirects users to `/track-claims/your-claims/{claimId}/status` (claim status page) instead.

### 2. Page title for "Files we couldn't receive" (#128396)
The page title tag previously showed "Track Claims | Veterans Affairs" but now correctly displays "Files we couldn't receive | Veterans Affairs" to match the h1 heading.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/128389
- department-of-veterans-affairs/va.gov-team/issues/128396

## Testing done
- [x] Unit tests updated for `DocumentRedirectPage`
- [x] Manual testing for redirect behavior
- [x] Verified page title displays correctly

## Steps to test locally

1. **Start the mock API server:**
   `yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js`

2. **Start the development server:**
   `yarn watch --env entry=claims-status`

### Testing empty subdirectory redirect (#128389)

3. Navigate to: `http://localhost:3001/track-claims/your-claims/1/needed-from-you` (without trackedItemId)

4. Verify you are redirected to: `http://localhost:3001/track-claims/your-claims/1/status`

5. Repeat for: `http://localhost:3001/track-claims/your-claims/1/needed-from-others`

### Testing page title (#128396)

6. Navigate to: `http://localhost:3001/track-claims/files-we-couldnt-receive`

7. Verify the browser tab title shows: "Files we couldn't receive | Veterans Affairs"

## Screenshots

### Page title change
| Before | After |
|--------|-------|
| <img width="773" height="561" alt="Screenshot 2025-12-22 at 12 18 21 PM" src="https://github.com/user-attachments/assets/3b1e48e4-b2ee-462c-a5b7-b5080006203f" /> | <img width="742" height="353" alt="Screenshot 2025-12-22 at 12 16 37 PM" src="https://github.com/user-attachments/assets/c203e090-a270-43ad-a7fa-f0d5768a51ce" /> |

## What areas of the site does it impact?
Claims Status Tool - Document request pages and "Files we couldn't receive" page

## Acceptance criteria

### Empty subdirectory redirect
- [x] Navigating to `/track-claims/your-claims/{claimId}/needed-from-you` (without trackedItemId) redirects to `/track-claims/your-claims`
- [x] Navigating to `/track-claims/your-claims/{claimId}/needed-from-others` (without trackedItemId) redirects to `/track-claims/your-claims`
- [x] Existing routes with `trackedItemId` continue to work as expected

### Page title
- [x] Page title displays "Files we couldn't receive | Veterans Affairs"