### PR TITLE
bug(128405): add bold formatting to Note in claim status unavailable alert

### DIFF
--- a/src/applications/claims-status/components/ServiceUnavailableAlert.jsx
+++ b/src/applications/claims-status/components/ServiceUnavailableAlert.jsx
@@ -9,9 +9,15 @@ const listFmt = new Intl.ListFormat('en', {
 });
 
 const CONTENT = {
-  heading: names => `${names} status is unavailable`,
-  body: names =>
-    `VA.gov is having trouble loading ${names} information at this time. Check back again in an hour.`,
+  heading: headingNames => `${headingNames} status is unavailable`,
+  body: bodyNames =>
+    `VA.gov is having trouble loading ${bodyNames} information at this time. Check back again in an hour.`,
+  note: names => (
+    <>
+      {' '}
+      <strong>Note:</strong> You are still able to review {names} information.
+    </>
+  ),
 };
 
 function formatServiceNames(services, property) {
@@ -44,13 +50,7 @@ function ServiceUnavailableAlert({ services, headerLevel = 3 }) {
       <HeadingTag slot="headline">{CONTENT.heading(headingNames)}</HeadingTag>
       <p className="vads-u-margin-y--0">
         {CONTENT.body(bodyNames)}
-        {availableNames && (
-          <>
-            {' '}
-            <strong>Note:</strong> You are still able to review {availableNames}{' '}
-            information.
-          </>
-        )}
+        {availableNames && CONTENT.note(availableNames)}
       </p>
     </va-alert>
   );

--- a/src/applications/claims-status/components/ServiceUnavailableAlert.jsx
+++ b/src/applications/claims-status/components/ServiceUnavailableAlert.jsx
@@ -12,8 +12,6 @@ const CONTENT = {
   heading: names => `${names} status is unavailable`,
   body: names =>
     `VA.gov is having trouble loading ${names} information at this time. Check back again in an hour.`,
-  note: availableNames =>
-    `Note: You are still able to review ${availableNames} information.`,
 };
 
 function formatServiceNames(services, property) {
@@ -46,7 +44,13 @@ function ServiceUnavailableAlert({ services, headerLevel = 3 }) {
       <HeadingTag slot="headline">{CONTENT.heading(headingNames)}</HeadingTag>
       <p className="vads-u-margin-y--0">
         {CONTENT.body(bodyNames)}
-        {availableNames && ` ${CONTENT.note(availableNames)}`}
+        {availableNames && (
+          <>
+            {' '}
+            <strong>Note:</strong> You are still able to review {availableNames}{' '}
+            information.
+          </>
+        )}
       </p>
     </va-alert>
   );

--- a/src/applications/claims-status/tests/components/ServiceUnavailableAlert.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ServiceUnavailableAlert.unit.spec.jsx
@@ -36,9 +36,15 @@ describe('<ServiceUnavailableAlert>', () => {
         ),
       ).to.be.visible;
 
+      // Verify "Note:" is bold
+      const strongElement = container.querySelector('strong');
+      expect(strongElement).to.exist;
+      expect(strongElement.textContent).to.equal('Note:');
+
+      // Verify the rest of the note text
       expect(
         within(container).getByText(
-          /Note: You are still able to review appeals information/i,
+          /You are still able to review appeals information/i,
         ),
       ).to.be.visible;
     });
@@ -56,9 +62,15 @@ describe('<ServiceUnavailableAlert>', () => {
         ),
       ).to.be.visible;
 
+      // Verify "Note:" is bold
+      const strongElement = container.querySelector('strong');
+      expect(strongElement).to.exist;
+      expect(strongElement.textContent).to.equal('Note:');
+
+      // Verify the rest of the note text
       expect(
         within(container).getByText(
-          /Note: You are still able to review claims information/i,
+          /You are still able to review claims information/i,
         ),
       ).to.be.visible;
     });

--- a/src/applications/claims-status/tests/components/ServiceUnavailableAlert.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ServiceUnavailableAlert.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('<ServiceUnavailableAlert>', () => {
     expect(heading.textContent).to.equal('Claim status is unavailable');
 
     // Test static text once
-    expect(within(container).getByText(/Check back again in an hour/i)).to.be
+    expect(within(container).getByText(/Check back again in an hour./i)).to.be
       .visible;
   });
 
@@ -32,7 +32,7 @@ describe('<ServiceUnavailableAlert>', () => {
 
       expect(
         within(container).getByText(
-          /VA.gov is having trouble loading claims information/i,
+          /VA.gov is having trouble loading claims information at this time\. Check back again in an hour\./,
         ),
       ).to.be.visible;
 
@@ -44,7 +44,7 @@ describe('<ServiceUnavailableAlert>', () => {
       // Verify the rest of the note text
       expect(
         within(container).getByText(
-          /You are still able to review appeals information/i,
+          /You are still able to review appeals information\./,
         ),
       ).to.be.visible;
     });
@@ -58,7 +58,7 @@ describe('<ServiceUnavailableAlert>', () => {
 
       expect(
         within(container).getByText(
-          /VA.gov is having trouble loading appeals information/i,
+          /VA\.gov is having trouble loading appeals information at this time\. Check back again in an hour\./,
         ),
       ).to.be.visible;
 
@@ -70,7 +70,7 @@ describe('<ServiceUnavailableAlert>', () => {
       // Verify the rest of the note text
       expect(
         within(container).getByText(
-          /You are still able to review claims information/i,
+          /You are still able to review claims information\./,
         ),
       ).to.be.visible;
     });
@@ -84,7 +84,7 @@ describe('<ServiceUnavailableAlert>', () => {
 
       expect(
         within(container).getByText(
-          /VA.gov is having trouble loading claims and appeals information/i,
+          'VA.gov is having trouble loading claims and appeals information at this time. Check back again in an hour.',
         ),
       ).to.be.visible;
 

--- a/src/applications/claims-status/tests/e2e/tests/details/claim-layout.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/details/claim-layout.cypress.spec.js
@@ -55,8 +55,10 @@ describe('Claim layout', () => {
       level: 2,
     });
     cy.findByText(
-      'VA.gov is having trouble loading claims information at this time. Check back again in an hour. Note: You are still able to review appeals information.',
+      /VA\.gov is having trouble loading claims information at this time\. Check back again in an hour\./,
     );
+    cy.get('va-alert strong').should('have.text', 'Note:');
+    cy.findByText(/You are still able to review appeals information\./);
 
     cy.axeCheck();
   });

--- a/src/applications/claims-status/tests/e2e/tests/your-claims/your-claims-unavailable.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/your-claims/your-claims-unavailable.cypress.spec.js
@@ -46,8 +46,10 @@ describe('Your claims unavailable,', () => {
       level: 3,
     });
     cy.findByText(
-      'VA.gov is having trouble loading claims information at this time. Check back again in an hour. Note: You are still able to review appeals information.',
+      /VA\.gov is having trouble loading claims information at this time\. Check back again in an hour\./,
     );
+    cy.get('va-alert strong').should('have.text', 'Note:');
+    cy.findByText(/You are still able to review appeals information\./);
 
     cy.axeCheck();
   });
@@ -64,8 +66,10 @@ describe('Your claims unavailable,', () => {
       level: 3,
     });
     cy.findByText(
-      'VA.gov is having trouble loading appeals information at this time. Check back again in an hour. Note: You are still able to review claims information.',
+      /VA\.gov is having trouble loading appeals information at this time\. Check back again in an hour\./,
     );
+    cy.get('va-alert strong').should('have.text', 'Note:');
+    cy.findByText(/You are still able to review claims information\./);
 
     cy.axeCheck();
   });


### PR DESCRIPTION
## Description

This PR addresses a Staging Review finding where the "Claim status unavailable" alert has a note that doesn't follow the bold guidance for notes.

**Change:** The word "Note:" is now bold (`<strong>`), and the text after the colon remains regular weight.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/128405

## Testing done
- [x] Unit tests updated
- [x] E2E tests updated and passing
- [x] Manual verification

## Steps to test locally

1. **Start the mock API server:**
   ```bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   ```

2. **Start the development server:**
   ```bash
   yarn watch --env entry=claims-status
   ```
3. Navigate to: `http://localhost:3001/track-claims/your-claims/`

4. Open DevTools → Network tab → Right-click on the `benefits_claims` request → Select **"Block request URL"**

5. Navigate to: `http://localhost:3001/track-claims/your-claims/3/status`

6. Refresh the page to trigger the unavailable alert

7. Verify that "**Note:**" appears bold and the rest of the text is regular weight

## Screenshots

| Before | After |
|--------|-------|
| <img width="523" height="326" alt="Screenshot 2025-12-22 at 12 36 46 PM" src="https://github.com/user-attachments/assets/cc47d7ec-684a-40f7-af45-dc5fc3ca0e6e" /> | <img width="536" height="326" alt="Screenshot 2025-12-22 at 12 36 04 PM" src="https://github.com/user-attachments/assets/d44b119e-5b52-4f8c-818b-0a42a067ed10" /> |


## What areas of the site does it impact?
Claims Status Tool - Service unavailable alerts on claims list and claim detail pages

## Acceptance criteria
- [x] The word "Note:" is bold in the unavailable alert
- [x] Text after the colon is regular weight