### PR TITLE
bug(128392,128393): fix punctuation and update link text per staging review

### DIFF
--- a/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
@@ -40,7 +40,7 @@ export default function WhatWeAreDoing({
     : getClaimStatusDescription(status);
   const linkText = showEightPhases
     ? 'Learn more about this step'
-    : 'Overview of the process';
+    : 'Learn more about the review process';
 
   return (
     <div className="what-were-doing-container vads-u-margin-bottom--4">

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -243,7 +243,7 @@ class YourClaimsPageV2 extends React.Component {
               <va-additional-info
                 id="claims-combined"
                 class="claims-combined"
-                trigger="Find out why we sometimes combine claims."
+                trigger="Find out why we sometimes combine claims"
               >
                 <div>
                   If you turn in a new claim while we’re reviewing another one

--- a/src/applications/claims-status/tests/components/claim-status-tab/WhatWeAreDoing.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-status-tab/WhatWeAreDoing.unit.spec.jsx
@@ -544,7 +544,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 2', () => {
         const {
@@ -568,7 +570,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 3', () => {
         const {
@@ -592,7 +596,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 4', () => {
         const {
@@ -616,7 +622,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 5', () => {
         const {
@@ -640,7 +648,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 6', () => {
         const {
@@ -664,7 +674,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 7', () => {
         const {
@@ -688,7 +700,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
     });
   });
@@ -717,7 +731,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 2', () => {
         const {
@@ -741,7 +757,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 3', () => {
         const {
@@ -765,7 +783,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 4', () => {
         const {
@@ -789,7 +809,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 5', () => {
         const {
@@ -813,7 +835,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 6', () => {
         const {
@@ -837,7 +861,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 7', () => {
         const {
@@ -861,7 +887,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
     });
 
@@ -888,7 +916,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 2', () => {
         const {
@@ -912,7 +942,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 3', () => {
         const {
@@ -936,7 +968,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 4', () => {
         const {
@@ -960,7 +994,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 5', () => {
         const {
@@ -984,7 +1020,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 6', () => {
         const {
@@ -1008,7 +1046,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when claim phase 7', () => {
         const {
@@ -1032,7 +1072,9 @@ describe('<WhatWeAreDoing>', () => {
         getByText(getClaimStatusDescription(status));
         expect(queryByText('Moved to this step on February 8, 2023')).to.not
           .exist;
-        expect(getByRole('link')).to.have.text('Overview of the process');
+        expect(getByRole('link')).to.have.text(
+          'Learn more about the review process',
+        );
       });
       it('should render a WhatWereDoing section when current phase back is set to true', () => {
         const {

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -872,7 +872,7 @@ class TrackClaimsPageV2 {
     );
     cy.get('.what-were-doing-container va-card')
       .find('.active-va-link')
-      .should('contain', 'Overview of the process');
+      .should('contain', 'Learn more about the review process');
     cy.get('.what-were-doing-container va-card')
       .find('.active-va-link')
       .click();

--- a/src/applications/claims-status/tests/e2e/tests/details/claim-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/details/claim-status.cypress.spec.js
@@ -240,7 +240,9 @@ describe('Claim status', () => {
             cy.findByText(expectedStep);
             cy.findByText(expectedDescription);
             cy.findByText('Moved to this step on January 2, 2025');
-            cy.findByRole('link', { name: 'Overview of the process' });
+            cy.findByRole('link', {
+              name: 'Learn more about the review process',
+            });
 
             cy.axeCheck();
           });

--- a/src/applications/claims-status/tests/e2e/tests/your-claims/your-claims.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/your-claims/your-claims.cypress.spec.js
@@ -75,7 +75,7 @@ describe('Your claims', () => {
     cy.get('va-additional-info')
       .shadow()
       .findByRole('button', {
-        name: 'Find out why we sometimes combine claims.',
+        name: 'Find out why we sometimes combine claims',
       });
 
     cy.findByText(
@@ -89,7 +89,7 @@ describe('Your claims', () => {
     cy.get('va-additional-info')
       .shadow()
       .findByRole('button', {
-        name: 'Find out why we sometimes combine claims.',
+        name: 'Find out why we sometimes combine claims',
       })
       .click();
 


### PR DESCRIPTION
## Description

This PR addresses two Staging Review content findings:

### 1. No punctuation for additional info component (#128392)
Removed the trailing period from the `va-additional-info` trigger text on the claims list page.

**Change:** `"Find out why we sometimes combine claims."` → `"Find out why we sometimes combine claims"`

### 2. Link text should be more descriptive (#128393)
Updated the link text in the "What we're doing" section to be more descriptive.

**Change:** `"Overview of the process"` → `"Learn more about the review process"`

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/128392
- department-of-veterans-affairs/va.gov-team/issues/128393

## Testing done
- [x] Unit tests updated
- [x] E2E tests updated and passing
- [x] Manual verification

## Steps to test locally

1. **Start the mock API server:**
   `yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js`

2. **Start the development server:**
   `yarn watch --env entry=claims-status`

### Testing punctuation fix (#128392)

3. Navigate to: `http://localhost:3001/track-claims/your-claims`

4. Verify the additional info trigger text reads `"Find out why we sometimes combine claims"` (no period)

### Testing link text (#128393)

5. Navigate to: `http://localhost:3001/track-claims/your-claims/8/status`

6. Scroll to the "What we're doing" section

7. Verify the link text reads `"Learn more about the review process"`

## Screenshots

### Punctuation fix (#128392)
| Before | After |
|--------|-------|
| <img width="427" height="112" alt="Screenshot 2025-12-22 at 1 05 53 PM" src="https://github.com/user-attachments/assets/3ab7071a-bdf8-4ed0-9d87-a7ce35d0c7e0" /> | <img width="447" height="139" alt="Screenshot 2025-12-22 at 1 02 56 PM" src="https://github.com/user-attachments/assets/86387941-465e-4fa3-9894-c08716fbfa11" /> |

### Link text fix (#128393)
| Before | After |
|--------|-------|
| <img width="505" height="207" alt="Screenshot 2025-12-22 at 1 05 05 PM" src="https://github.com/user-attachments/assets/a8e439cf-b0c5-4b54-a20d-800ee6d970cc" /> | <img width="518" height="209" alt="Screenshot 2025-12-22 at 1 04 37 PM" src="https://github.com/user-attachments/assets/4ca02a43-babb-44ee-991d-c752f930b6d1" />
 |


## What areas of the site does it impact?
Claims Status Tool - Claims list page and claim status page

## Acceptance criteria

### Punctuation (#128392)
- [x] Additional info trigger has no trailing period

### Link text (#128393)
- [x] Link text displays "Learn more about the review process"