### PR TITLE
Update to be a standard closing parenthesis.

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
@@ -52,7 +52,7 @@ const servicePeriodOptions = {
     cardDescription: item =>
       `Entry date (${formatDate(
         item?.dateEnteredService,
-      )}) - Separation date (${formatDate(item?.dateLeftService)}}`,
+      )}) - Separation date (${formatDate(item?.dateLeftService)})`,
   },
 };
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixed a syntax error in the service periods review page where the closing parenthesis for the separation date was incorrectly rendered as a curly brace `}` instead of a standard closing parenthesis `)`
- Updated the `cardDescription` template string in `service-period-pages.js` to use the correct closing parenthesis for the separation date display
- This is a bug fix for the 21P-530A Interment Allowance form maintained by the Benefits Optimization Aquia team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128463

## Testing done

**Old behavior:**
- On the "Review the Veteran's service periods" summary page, the separation date was displayed as: `Separation date (January 1, 2020}` with a curly brace at the end instead of a closing parenthesis

**New behavior:**
- The separation date is now correctly displayed as: `Separation date (January 1, 2020)` with proper matching parentheses

**Test steps:**
1. Navigate to the service periods section of the 21P-530A form
2. Add a service period with entry and separation dates
3. Proceed to the review/summary page
4. Verify both dates display with proper parentheses: `Entry date (...) - Separation date (...)`

**Test results:**
- Verified no unit tests reference the `cardDescription` string, so no test updates were required
- Manually tested the display format locally
- Linting passed after formatting was auto-applied

## Screenshots

|              | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1380" height="1364" alt="image" src="https://github.com/user-attachments/assets/9466fc27-bb29-43fa-9e6d-0ec6834c7ef6" /> |  <img width="735" height="590" alt="image" src="https://github.com/user-attachments/assets/697f6875-7796-4ab5-b1f8-84df3e46b132" /> |



## What areas of the site does it impact?

21P-530A Interment Allowance form - Service periods review/summary page only. This is an isolated text formatting fix within the service periods array builder.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). - _No tests needed updating as verified no tests reference this display string_
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (link to documentation \*if necessary) - _No documentation updates needed for syntax fix_
- [x] Screenshot of the developed feature is added - _Will be added_
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - _No accessibility impact, text-only syntax fix_

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - _No logging changes_
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - _Not applicable for this fix_

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

None - This is a straightforward syntax correction with minimal risk.