### PR TITLE
128534 Restore old CCD format when OH is not enabled

### DIFF
--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -57,9 +57,11 @@ const DownloadReportPage = ({ runningUnitTest }) => {
     },
   } = useSelector(state => state);
 
-  const ccdExtendedFileTypeFlag = useSelector(
-    state => state.featureToggles?.mhv_medical_records_ccd_extended_file_types,
-  );
+  const { ccdExtendedFileTypeFlag, ccdOHFlagEnabled } = useSelector(state => ({
+    ccdExtendedFileTypeFlag:
+      state.featureToggles?.mhv_medical_records_ccd_extended_file_types,
+    ccdOHFlagEnabled: state.featureToggles?.mhv_medical_records_ccd_oh,
+  }));
 
   const [selfEnteredPdfLoading, setSelfEnteredPdfLoading] = useState(false);
   const [successfulSeiDownload, setSuccessfulSeiDownload] = useState(false);
@@ -254,63 +256,66 @@ const DownloadReportPage = ({ runningUnitTest }) => {
     sendDataDogAction('Download self-entered health information PDF link');
   };
 
-  if (hasBothDataSources) {
-    return (
-      <div>
-        <VistaAndOHIntroText
-          ohFacilityNames={ohFacilityNames}
-          vistaFacilityNames={vistaFacilityNames}
-        />
-        <VistaAndOHContent
-          vistaFacilityNames={vistaFacilityNames}
-          ohFacilityNames={ohFacilityNames}
-          handleDownloadCCDV2={handleDownloadCCDV2}
-          ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}
-          failedSeiDomains={failedSeiDomains}
-          getFailedDomainList={getFailedDomainList}
-          lastSuccessfulUpdate={lastSuccessfulUpdate}
-          generatingCCD={generatingCCD}
-          handleDownloadCCD={handleDownloadCCD}
-          handleDownloadSelfEnteredPdf={handleDownloadSelfEnteredPdf}
-          selfEnteredPdfLoading={selfEnteredPdfLoading}
-          successfulSeiDownload={successfulSeiDownload}
-          activeAlert={activeAlert}
-          accessErrors={accessErrors}
-          ccdError={ccdError}
-          ccdDownloadSuccess={ccdDownloadSuccess}
-          CCDRetryTimestamp={CCDRetryTimestamp}
-          failedBBDomains={failedBBDomains}
-          successfulBBDownload={successfulBBDownload}
-        />
-        <NeedHelpSection />
-      </div>
-    );
+  if (ccdOHFlagEnabled) {
+    if (hasBothDataSources) {
+      return (
+        <div>
+          <VistaAndOHIntroText
+            ohFacilityNames={ohFacilityNames}
+            vistaFacilityNames={vistaFacilityNames}
+          />
+          <VistaAndOHContent
+            vistaFacilityNames={vistaFacilityNames}
+            ohFacilityNames={ohFacilityNames}
+            handleDownloadCCDV2={handleDownloadCCDV2}
+            ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}
+            failedSeiDomains={failedSeiDomains}
+            getFailedDomainList={getFailedDomainList}
+            lastSuccessfulUpdate={lastSuccessfulUpdate}
+            generatingCCD={generatingCCD}
+            handleDownloadCCD={handleDownloadCCD}
+            handleDownloadSelfEnteredPdf={handleDownloadSelfEnteredPdf}
+            selfEnteredPdfLoading={selfEnteredPdfLoading}
+            successfulSeiDownload={successfulSeiDownload}
+            activeAlert={activeAlert}
+            accessErrors={accessErrors}
+            ccdError={ccdError}
+            ccdDownloadSuccess={ccdDownloadSuccess}
+            CCDRetryTimestamp={CCDRetryTimestamp}
+            failedBBDomains={failedBBDomains}
+            successfulBBDownload={successfulBBDownload}
+          />
+          <NeedHelpSection />
+        </div>
+      );
+    }
+    if (hasOHOnly) {
+      return (
+        <div>
+          <OHOnlyIntroText />
+          <OHOnlyContent
+            testIdSuffix="OH"
+            ddSuffix="OH"
+            generatingCCD={generatingCCD}
+            handleDownload={handleDownloadCCDV2}
+            ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}
+            lastSuccessfulUpdate={lastSuccessfulUpdate}
+            accessErrors={accessErrors}
+            activeAlert={activeAlert}
+            successfulSeiDownload={successfulSeiDownload}
+            failedSeiDomains={failedSeiDomains}
+            ccdDownloadSuccess={ccdDownloadSuccess}
+            ccdError={ccdError}
+            CCDRetryTimestamp={CCDRetryTimestamp}
+          />
+
+          <NeedHelpSection />
+        </div>
+      );
+    }
   }
 
-  if (hasOHOnly) {
-    return (
-      <div>
-        <OHOnlyIntroText />
-        <OHOnlyContent
-          testIdSuffix="OH"
-          ddSuffix="OH"
-          generatingCCD={generatingCCD}
-          handleDownload={handleDownloadCCDV2}
-          ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}
-          lastSuccessfulUpdate={lastSuccessfulUpdate}
-          accessErrors={accessErrors}
-          activeAlert={activeAlert}
-          successfulSeiDownload={successfulSeiDownload}
-          failedSeiDomains={failedSeiDomains}
-          ccdDownloadSuccess={ccdDownloadSuccess}
-          ccdError={ccdError}
-          CCDRetryTimestamp={CCDRetryTimestamp}
-        />
-
-        <NeedHelpSection />
-      </div>
-    );
-  }
+  // Default case: OH CCD is disabled, *OR* user has only VistA facilities
   return (
     <div>
       <VistaIntroText />

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -8,6 +8,7 @@ import {
 } from '@department-of-veterans-affairs/mhv/exports';
 import { add, compareAsc } from 'date-fns';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import {
   selectPatientFacilities,
   selectIsCernerPatient,
@@ -59,8 +60,11 @@ const DownloadReportPage = ({ runningUnitTest }) => {
 
   const { ccdExtendedFileTypeFlag, ccdOHFlagEnabled } = useSelector(state => ({
     ccdExtendedFileTypeFlag:
-      state.featureToggles?.mhv_medical_records_ccd_extended_file_types,
-    ccdOHFlagEnabled: state.featureToggles?.mhv_medical_records_ccd_oh,
+      state.featureToggles[
+        FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdExtendedFileTypes
+      ],
+    ccdOHFlagEnabled:
+      state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdOH],
   }));
 
   const [selfEnteredPdfLoading, setSelfEnteredPdfLoading] = useState(false);

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -12,9 +12,12 @@ import user from '../fixtures/user.json';
 import { ALERT_TYPE_BB_ERROR } from '../../util/constants';
 
 // Mock facility data for testing different user scenarios
-const vistaOnlyFacilities = [{ facilityId: '123' }];
-const ohOnlyFacilities = [{ facilityId: '456' }];
-const bothFacilities = [{ facilityId: '123' }, { facilityId: '456' }];
+const vistaOnlyFacilities = [{ facilityId: '123', isCerner: false }];
+const ohOnlyFacilities = [{ facilityId: '456', isCerner: true }];
+const bothFacilities = [
+  { facilityId: '123', isCerner: false },
+  { facilityId: '456', isCerner: true },
+];
 
 // Mock EHR data for facility name mapping
 const ehrDataByVhaId = {
@@ -56,6 +59,7 @@ const getBaseState = (facilities = vistaOnlyFacilities, cernerIds = []) => ({
   },
   featureToggles: {
     [FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdExtendedFileTypes]: true,
+    [FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdOH]: true,
   },
 });
 
@@ -416,5 +420,60 @@ describe('DownloadRecordsPage with last successful update timestamp', () => {
 
   it('renders the last updated card', () => {
     expect(screen.getByTestId('new-records-last-updated')).to.exist;
+  });
+});
+
+describe('DownloadRecordsPage - Oracle Health CCD not enabled', () => {
+  it('shows VistaOnlyContent for VistA-only users when flag is false', () => {
+    const state = getBaseState(vistaOnlyFacilities, []);
+    state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdOH] = false;
+
+    const screen = renderWithStoreAndRouter(<DownloadReportPage />, {
+      initialState: state,
+      reducers: reducer,
+      path: '/download-all',
+    });
+
+    expect(
+      screen.getByText(/Download your VA medical records as a single report/i),
+    ).to.exist;
+    expect(screen.getByText('Download your medical records reports')).to.exist;
+  });
+
+  it('shows VistaOnlyContent for OH-only users when flag is false', () => {
+    const state = getBaseState(ohOnlyFacilities, ['456']);
+    state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdOH] = false;
+
+    const screen = renderWithStoreAndRouter(<DownloadReportPage />, {
+      initialState: state,
+      reducers: reducer,
+      path: '/download-all',
+    });
+
+    // Should show VistA intro text, not OH intro text
+    expect(
+      screen.getByText(/Download your VA medical records as a single report/i),
+    ).to.exist;
+    expect(screen.getByText('Download your medical records reports')).to.exist;
+    // Should not show OH-specific singular "report" heading
+    expect(screen.queryByText('Download your medical records report')).to.not
+      .exist;
+  });
+
+  it('shows VistaOnlyContent for users with both facilities when flag is false', () => {
+    const state = getBaseState(bothFacilities, ['456']);
+    state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsCcdOH] = false;
+
+    const screen = renderWithStoreAndRouter(<DownloadReportPage />, {
+      initialState: state,
+      reducers: reducer,
+      path: '/download-all',
+    });
+
+    // Should show VistA intro text, not VistaAndOH intro text
+    expect(
+      screen.getByText(/Download your VA medical records as a single report/i),
+    ).to.exist;
+    expect(screen.getByText('Download your medical records reports')).to.exist;
   });
 });

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-ccd-continuity-of-care-doc-error.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-ccd-continuity-of-care-doc-error.cypress.spec.js
@@ -170,6 +170,7 @@ describe('Medical Records download CCD - API Error Handling', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-ccd-oh-only-content.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-ccd-oh-only-content.cypress.spec.js
@@ -21,6 +21,7 @@ describe('Medical Records Download Page - OHOnlyContent Component', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -63,6 +64,7 @@ describe('Medical Records Download Page - OHOnlyContent Component', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -99,6 +101,7 @@ describe('Medical Records Download Page - OHOnlyContent Component', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -147,6 +150,7 @@ describe('Medical Records Download Page - OHOnlyContent Component', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -163,6 +167,7 @@ describe('Medical Records Download Page - OHOnlyContent Component', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -177,6 +182,7 @@ describe('Medical Records Download Page - OHOnlyContent Component', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -200,6 +206,7 @@ describe('Medical Records Download Page - OHOnlyContent CCD Downloads', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -249,6 +256,7 @@ describe('Medical Records Download Page - OHOnlyContent CCD Downloads', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -281,6 +289,7 @@ describe('Medical Records Download Page - OHOnlyContent CCD Downloads', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: false,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-download-page-conditions.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-download-page-conditions.cypress.spec.js
@@ -24,6 +24,7 @@ describe('Medical Records Download Page - Conditional Rendering', () => {
       site.login(bothSourcesUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -94,6 +95,7 @@ describe('Medical Records Download Page - Conditional Rendering', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -147,6 +149,7 @@ describe('Medical Records Download Page - Conditional Rendering', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -201,6 +204,7 @@ describe('Medical Records Download Page - Feature Flag Conditions', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -217,6 +221,7 @@ describe('Medical Records Download Page - Feature Flag Conditions', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: false,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -238,6 +243,7 @@ describe('Medical Records Download Page - Feature Flag Conditions', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -253,6 +259,7 @@ describe('Medical Records Download Page - Feature Flag Conditions', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: false,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -272,6 +279,7 @@ describe('Medical Records Download Page - Feature Flag Conditions', () => {
       site.login(bothSourcesUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -290,6 +298,7 @@ describe('Medical Records Download Page - Feature Flag Conditions', () => {
       site.login(bothSourcesUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: false,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -311,6 +320,7 @@ describe('Medical Records Download Page - URL Query Params', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
     });
 
@@ -343,6 +353,7 @@ describe('Medical Records Download Page - Self-Entered Health Information', () =
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -371,6 +382,7 @@ describe('Medical Records Download Page - Self-Entered Health Information', () =
       site.login(bothSourcesUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -412,6 +424,7 @@ describe('Medical Records Download Page - CernerFacilityAlert', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -433,6 +446,7 @@ describe('Medical Records Download Page - CernerFacilityAlert', () => {
       site.login(bothSourcesUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -449,6 +463,7 @@ describe('Medical Records Download Page - CernerFacilityAlert', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -468,6 +483,7 @@ describe('Medical Records Download Page - CCD Download Success Alerts', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
       DownloadReportsPage.clickCcdAccordionItem();
@@ -500,6 +516,7 @@ describe('Medical Records Download Page - CCD Download Success Alerts', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -525,6 +542,7 @@ describe('Medical Records Download Page - Loading States', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
       DownloadReportsPage.clickCcdAccordionItem();
@@ -552,6 +570,7 @@ describe('Medical Records Download Page - Loading States', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -586,6 +605,7 @@ describe('Medical Records Download Page - Blue Button Section', () => {
       site.login(vistaOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -608,6 +628,7 @@ describe('Medical Records Download Page - Blue Button Section', () => {
       site.login(bothSourcesUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -624,6 +645,7 @@ describe('Medical Records Download Page - Blue Button Section', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -647,6 +669,7 @@ describe('Medical Records Download Page - AcceleratedCernerFacilityAlert', () =>
       site.mockFeatureToggles({
         isAcceleratingEnabled: true,
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -663,6 +686,7 @@ describe('Medical Records Download Page - AcceleratedCernerFacilityAlert', () =>
       site.mockFeatureToggles({
         isAcceleratingEnabled: true,
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -677,6 +701,7 @@ describe('Medical Records Download Page - AcceleratedCernerFacilityAlert', () =>
       site.mockFeatureToggles({
         isAcceleratingEnabled: true,
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
 
@@ -698,6 +723,7 @@ describe('Medical Records Download Page - CCD Download Functionality', () => {
       site.login(ohOnlyUser, false);
       site.mockFeatureToggles({
         isCcdExtendedFileTypesEnabled: true,
+        isCcdOHEnabled: true,
       });
       DownloadReportsPage.goToReportsPage();
     });
@@ -734,6 +760,7 @@ describe('Medical Records Download Page - Component Differentiation', () => {
     site.login(ohOnlyUser, false);
     site.mockFeatureToggles({
       isCcdExtendedFileTypesEnabled: true,
+      isCcdOHEnabled: true,
     });
     DownloadReportsPage.goToReportsPage();
 
@@ -749,6 +776,7 @@ describe('Medical Records Download Page - Component Differentiation', () => {
     site.login(vistaOnlyUser, false);
     site.mockFeatureToggles({
       isCcdExtendedFileTypesEnabled: true,
+      isCcdOHEnabled: true,
     });
     DownloadReportsPage.goToReportsPage();
 
@@ -761,6 +789,7 @@ describe('Medical Records Download Page - Component Differentiation', () => {
     site.login(bothSourcesUser, false);
     site.mockFeatureToggles({
       isCcdExtendedFileTypesEnabled: true,
+      isCcdOHEnabled: true,
     });
     DownloadReportsPage.goToReportsPage();
 

--- a/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
+++ b/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
@@ -35,6 +35,7 @@ class MedicalRecordsSite {
     isAcceleratingCareNotes = false,
     isAcceleratingConditions = false,
     isCcdExtendedFileTypesEnabled = false,
+    isCcdOHEnabled = false,
   } = {}) => {
     cy.intercept('GET', '/v0/feature_toggles?*', {
       data: {
@@ -75,6 +76,14 @@ class MedicalRecordsSite {
           {
             name: 'mhvMedicalRecordsCcdExtendedFileTypes',
             value: isCcdExtendedFileTypesEnabled,
+          },
+          {
+            name: 'mhv_medical_records_ccd_oh',
+            value: isCcdOHEnabled,
+          },
+          {
+            name: 'mhvMedicalRecordsCcdOH',
+            value: isCcdOHEnabled,
           },
           {
             name: 'mhvMedicalRecordsPhrRefreshOnLogin',

--- a/src/platform/mhv/api/mocks/feature-toggles/index.js
+++ b/src/platform/mhv/api/mocks/feature-toggles/index.js
@@ -12,6 +12,7 @@ const generateFeatureToggles = (toggles = {}) => {
 
     // OH integration work
     mhvMedicalRecordsCcdExtendedFileTypes = true,
+    mhvMedicalRecordsCcdOH = true,
     mhvMedicalRecordsMergeCvixIntoScdf = false,
     mhvAcceleratedDeliveryEnabled = false,
     mhvAcceleratedDeliveryAllergiesEnabled = false,
@@ -109,6 +110,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medical_records_ccd_extended_file_types',
           value: mhvMedicalRecordsCcdExtendedFileTypes,
+        },
+        {
+          name: 'mhv_medical_records_ccd_oh',
+          value: mhvMedicalRecordsCcdOH,
         },
         {
           name: 'mhv_medical_records_merge_cvix_into_scdf',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -170,6 +170,7 @@
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",
   "mhvLandingPageShowShareMyHealthDataLink": "mhv_landing_page_show_share_my_health_data_link",
   "mhvMedicalRecordsCcdExtendedFileTypes": "mhv_medical_records_ccd_extended_file_types",
+  "mhvMedicalRecordsCcdOH": "mhv_medical_records_ccd_oh",
   "mhvMedicalRecordsFilterAndSort": "mhv_medical_records_filter_and_sort",
   "mhvMedicalRecordsMergeCvixIntoScdf": "mhv_medical_records_merge_cvix_into_scdf",
   "mhvMedicalRecordsSupportBackendPaginationAllergy": "mhv_medical_records_support_backend_pagination_allergy",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Improper logic caused Oracle Health endpoints to be rolled out to production. This PR uses a new flag to show Vista-only content to everyone, unless the new flag is enabled.

## Related issue(s)

- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/128534
- Feature flag added here: https://github.com/department-of-veterans-affairs/vets-api/pull/25712

## Testing done

- Added new test suite to test the new flag behavior
- Updated existing tests to handle the new flag

## Screenshots

Screenshots depicting what OH users will see:

| Flag Off | Flag On |
| ------ | ----- |
| <img width="300" height="5624" alt="localhost_3001_my-health_medical-records_download" src="https://github.com/user-attachments/assets/c5cdfffc-3ed7-4c57-bba2-8a46855fbc1e" /> | <img width="300" height="3988" alt="localhost_3001_my-health_medical-records_download (1)" src="https://github.com/user-attachments/assets/2ebb64c0-fcc1-4596-8660-d24d4ce22c30" /> |

## What areas of the site does it impact?

MHV Medical Records Downloads Page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
