### PR TITLE
bug(128395): fix passive voice in files page link text

### DIFF
--- a/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
+++ b/src/applications/claims-status/components/FilesWeCouldntReceive.jsx
@@ -160,8 +160,8 @@ const FilesWeCouldntReceive = () => {
 
                   const link = {
                     href: `/track-claims/your-claims/${file.claimId}/status`,
-                    text: 'Go to claim this file was uploaded for',
-                    label: `Go to the claim this file was uploaded for: ${
+                    text: 'Go to the claim associated with this file',
+                    label: `Go to the claim associated with this file: ${
                       file.fileName
                     }`,
                   };

--- a/src/applications/claims-status/tests/components/DocumentCard.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentCard.unit.spec.jsx
@@ -166,8 +166,8 @@ describe('<DocumentCard>', () => {
   describe('link', () => {
     const linkProps = {
       href: '/track-claims/your-claims/123/status',
-      text: 'Go to claim this file was uploaded for',
-      label: 'Go to the claim this file was uploaded for: test.pdf',
+      text: 'Go to the claim associated with this file',
+      label: 'Go to the claim associated with this file: test.pdf',
     };
 
     it('should not render link when not provided', () => {

--- a/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesWeCouldntReceive.unit.spec.jsx
@@ -269,7 +269,7 @@ describe('<FilesWeCouldntReceive>', () => {
       ];
 
       vaLinks.forEach((link, index) => {
-        const expectedLabel = `Go to the claim this file was uploaded for: ${
+        const expectedLabel = `Go to the claim associated with this file: ${
           expectedFileOrder[index]
         }`;
         expect(link).to.have.attribute('label', expectedLabel);


### PR DESCRIPTION
## Description

This PR addresses a Staging Review finding where the link text on the "Files we couldn't receive" page is difficult to parse and uses passive voice.

**Change:** 
- Before: `"Go to claim this file was uploaded for"`
- After: `"Go to the claim associated with this file"`

The word "claim" was ambiguous (could be verb or noun), and the passive voice "was uploaded for" didn't meet content standards.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/128395

## Testing done
- [x] Unit tests updated
- [x] Manual verification

## Steps to test locally

1. **Start the mock API server:**
   `yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js`

2. **Start the development server:**
   `yarn watch --env entry=claims-status`

3. Navigate to: `http://localhost:3001/track-claims/files-we-couldnt-receive`

4. Verify the link text for each failed file reads: `"Go to the claim associated with this file"`

## Screenshots

| Before | After |
|--------|-------|
| <img width="425" height="142" alt="Screenshot 2025-12-22 at 2 34 27 PM" src="https://github.com/user-attachments/assets/ef71e9a4-2ee3-4290-8eaf-5589abe975c7" /> | <img width="425" height="138" alt="Screenshot 2025-12-22 at 2 33 57 PM" src="https://github.com/user-attachments/assets/4fdb39f3-e22f-4721-9666-53be9120faf5" /> |

## What areas of the site does it impact?
Claims Status Tool - "Files we couldn't receive" page

## Acceptance criteria
- [x] Link text displays "Go to the claim associated with this file"
- [x] Link label (for accessibility) updated to match