### PR TITLE
service branches are now capitalized when editing

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
@@ -87,6 +87,8 @@ const serviceDatesPage = {
           ? DEFAULT_BRANCH_LABELS[formData.serviceBranch]?.label ||
             formData.serviceBranch
           : 'Service Dates',
+      undefined,
+      false,
     ),
     dateEnteredService: currentOrPastDateUI('Service start date'),
     dateLeftService: currentOrPastDateUI('Service end date'),

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
@@ -85,7 +85,7 @@ const serviceDatesPage = {
       ({ formData }) =>
         formData?.serviceBranch
           ? DEFAULT_BRANCH_LABELS[formData.serviceBranch]?.label ||
-            formData.serviceBranch
+            capitalize(formData.serviceBranch)
           : 'Service Dates',
       undefined,
       false,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixed a capitalization issue in the service periods section where the service branch name was displayed in lowercase when editing a service period
- When editing a service period, the page title would show "Edit air force" instead of "Edit Air Force"
- Applied the `capitalize()` function to ensure the service branch name is always capitalized, and set the `lowerCase` parameter to `false` in `arrayBuilderItemSubsequentPageTitleUI` to prevent the array builder pattern from automatically lowercasing the first character
- This change is maintained by the Benefits Optimization Aquia team for the 21P-530A Interment Allowance form

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128533

## Testing done

**Old behavior:**
- When a user added a service period and then clicked "Edit" on the service dates page, the page title would display "Edit air force" (or other service branches in lowercase) instead of properly capitalizing the branch name

**Steps to verify:**
1. Navigate to the 21P-530A form service periods section
2. Add a new service period and select a branch of service
3. Proceed to add service dates
4. Save and return to the summary page
5. Click "Edit" on the service period's service dates
6. Verify the page title now displays "Edit Air Force" (or the appropriate capitalized branch name) instead of "Edit air force"

**Test results:**
- Verified no unit tests required updating as no tests directly reference the page title formatting
- Manually tested the edit flow locally with multiple service branches
- Confirmed service branch names are now properly capitalized in edit mode
- Linting passed

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |    <img width="772" height="851" alt="image" src="https://github.com/user-attachments/assets/553809ec-22fc-4df4-ba90-e362a3a483d2" />    |   <img width="823" height="877" alt="image" src="https://github.com/user-attachments/assets/86517238-3701-4464-a9e1-8a59b35033cf" />    |

## What areas of the site does it impact?

21P-530A Interment Allowance form - Service periods section only. Specifically affects the page title display when editing service dates for a service period.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). - _No tests needed updating as verified no tests reference the page title string_
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary) - _No documentation updates needed for display formatting fix_
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - _No accessibility impact, text formatting only_

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - _No logging changes_
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - _Not applicable for this display fix_

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

None - This is a straightforward display formatting fix with minimal risk.