### PR TITLE
[VACMS-18415] va-link Conversion

### DIFF
--- a/src/applications/discharge-wizard/components/RequestDD214.jsx
+++ b/src/applications/discharge-wizard/components/RequestDD214.jsx
@@ -74,21 +74,6 @@ const RequestDD214 = ({ router, formResponses, viewedIntroPage }) => {
                 show how serious you are about your case.
               </li>
             </ul>
-            {/* <a
-              className="vads-u-display--block vads-u-margin-bottom--1 step-1-download"
-              download
-              href="https://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <va-icon
-                icon="file_download"
-                size={3}
-                className="vads-u-margin-top--0p5 vads-u-padding-right--1"
-              />
-              Download Form 149 (opens in a new tab)
-            </a> */}
-            TEST HI TEST
             <va-link
               download
               filetype="PDF"
@@ -96,6 +81,10 @@ const RequestDD214 = ({ router, formResponses, viewedIntroPage }) => {
               filename="dd0149.pdf"
               text="Download Form 149 (opens in a new tab)"
               href="https://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf"
+              onClick={e => {
+                e.preventDefault();
+                window.open(e.currentTarget.href, '_blank');
+              }}
             />
           </va-process-list-item>
           <va-process-list-item header="Mail your completed form" level="2">

--- a/src/applications/discharge-wizard/components/RequestDD214.jsx
+++ b/src/applications/discharge-wizard/components/RequestDD214.jsx
@@ -74,7 +74,7 @@ const RequestDD214 = ({ router, formResponses, viewedIntroPage }) => {
                 show how serious you are about your case.
               </li>
             </ul>
-            <a
+            {/* <a
               className="vads-u-display--block vads-u-margin-bottom--1 step-1-download"
               download
               href="https://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf"
@@ -87,7 +87,16 @@ const RequestDD214 = ({ router, formResponses, viewedIntroPage }) => {
                 className="vads-u-margin-top--0p5 vads-u-padding-right--1"
               />
               Download Form 149 (opens in a new tab)
-            </a>
+            </a> */}
+            TEST HI TEST
+            <va-link
+              download
+              filetype="PDF"
+              pages={3}
+              filename="dd0149.pdf"
+              text="Download Form 149 (opens in a new tab)"
+              href="https://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf"
+            />
           </va-process-list-item>
           <va-process-list-item header="Mail your completed form" level="2">
             <p>

--- a/src/applications/discharge-wizard/components/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/resultsComponents/StepOne.jsx
@@ -185,7 +185,6 @@ const StepOne = ({ formResponses }) => {
         download
         className="vads-u-margin-bottom--1"
         filetype="PDF"
-        pages={3}
         filename={formFileName}
         text={`Download ${formTitle} (opens in a new tab)`}
         href={formLink}

--- a/src/applications/discharge-wizard/components/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/resultsComponents/StepOne.jsx
@@ -180,21 +180,18 @@ const StepOne = ({ formResponses }) => {
       RESPONSES.REASON_DD215_UPDATE_TO_DD214
         ? dd214Tips
         : nonDd2014Tips}
-      {/* Intentionally not using <va-link> per Platform Analytics team */}
-      <a
-        className="vads-u-display--block vads-u-margin-bottom--1 step-1-download"
+      <va-link
         download
+        disable-analytics
+        filetype="PDF"
+        filename={`${formNumber}.pdf`}
+        text={`Download ${formTitle} (opens in a new tab)`}
         href={formLink}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <va-icon
-          icon="file_download"
-          size={3}
-          className="vads-u-margin-top--0p5 vads-u-padding-right--1"
-        />
-        Download {formTitle} (opens in a new tab)
-      </a>
+        onClick={e => {
+          e.preventDefault();
+          window.open(formLink, '_blank');
+        }}
+      />
       <AlertMessage
         content={
           <>
@@ -204,13 +201,11 @@ const StepOne = ({ formResponses }) => {
             <p>
               You can appoint an accredited attorney, claims agent, or Veterans
               Service Organization (VSO) representative.{' '}
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
+              <va-link
+                external
+                text="Get help from an accredited representative"
                 href="/get-help-from-accredited-representative/find-rep"
-              >
-                Get help from an accredited representative (opens in a new tab)
-              </a>
+              />
               .
             </p>
           </>

--- a/src/applications/discharge-wizard/components/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/resultsComponents/StepOne.jsx
@@ -166,6 +166,7 @@ const StepOne = ({ formResponses }) => {
 
   const { num: formNumber, link: formLink } = determineFormData(formResponses);
   let formTitle = `Form ${formNumber}`;
+  const formFileName = formLink.split('/').pop();
 
   if ([293, 149].includes(formNumber)) {
     formTitle = `DOD Form ${formNumber}`;
@@ -182,9 +183,10 @@ const StepOne = ({ formResponses }) => {
         : nonDd2014Tips}
       <va-link
         download
-        disable-analytics
+        className="vads-u-margin-bottom--1"
         filetype="PDF"
-        filename={`${formNumber}.pdf`}
+        pages={3}
+        filename={formFileName}
         text={`Download ${formTitle} (opens in a new tab)`}
         href={formLink}
         onClick={e => {

--- a/src/applications/static-pages/find-forms/components/DownloadModal.jsx
+++ b/src/applications/static-pages/find-forms/components/DownloadModal.jsx
@@ -27,29 +27,20 @@ const DownloadModal = ({
           If you want to fill out a paper copy, open the PDF in your browser and
           print it from there.
         </p>{' '}
-        <a
+        <va-link
+          external
           data-e2e-id="adobe-link"
           href="https://get.adobe.com/reader/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Get Acrobat Reader for free from Adobe
-        </a>
-        <a
+          text="Get Acrobat Reader for free from Adobe"
+        />
+        <va-link
+          download
+          filetype="PDF"
+          className="vads-u-margin-top--2"
           data-e2e-id="modal-download-link"
           href={formUrl}
-          className="vads-u-margin-top--2"
-          download
-        >
-          <va-icon
-            className="vads-u-margin-right--1"
-            icon="file_download"
-            size="3"
-          />
-          <span className="vads-u-text-decoration--underline">
-            Download VA Form {formName} (PDF)
-          </span>
-        </a>
+          text={`Download VA Form ${formName}`}
+        />
       </div>
     </VaModal>
   );

--- a/src/applications/static-pages/find-forms/components/DownloadModal.jsx
+++ b/src/applications/static-pages/find-forms/components/DownloadModal.jsx
@@ -29,7 +29,6 @@ const DownloadModal = ({
         </p>{' '}
         <va-link
           external
-          data-e2e-id="adobe-link"
           href="https://get.adobe.com/reader/"
           text="Get Acrobat Reader for free from Adobe"
         />
@@ -37,7 +36,6 @@ const DownloadModal = ({
           download
           filetype="PDF"
           className="vads-u-margin-top--2"
-          data-e2e-id="modal-download-link"
           href={formUrl}
           text={`Download VA Form ${formName}`}
         />

--- a/src/applications/static-pages/find-forms/tests/components/DownloadModal.unit.spec.jsx
+++ b/src/applications/static-pages/find-forms/tests/components/DownloadModal.unit.spec.jsx
@@ -9,7 +9,7 @@ const url = 'https://test.com/';
 
 describe('DownloadModal', () => {
   describe('download button', () => {
-    it('should have the correct attributes', async () => {
+    it('should have the correct attributes', () => {
       const { container } = render(
         <DownloadModal
           closeModal={removeSpy}

--- a/src/applications/static-pages/find-forms/tests/components/DownloadModal.unit.spec.jsx
+++ b/src/applications/static-pages/find-forms/tests/components/DownloadModal.unit.spec.jsx
@@ -21,12 +21,14 @@ describe('DownloadModal', () => {
 
       expect(
         screen
-          .getByRole('link', { name: 'Get Acrobat Reader for free from Adobe' })
+          .getByRole('va-link', {
+            text: 'Get Acrobat Reader for free from Adobe',
+          })
           .getAttribute('href'),
       ).to.eq('https://get.adobe.com/reader/');
       expect(
         screen
-          .getByRole('link', { name: 'Download VA Form 10109 (PDF)' })
+          .getByRole('va-link', { text: 'Download VA Form 10109 (PDF)' })
           .getAttribute('href'),
       ).to.eq(url);
     });

--- a/src/applications/static-pages/find-forms/tests/components/DownloadModal.unit.spec.jsx
+++ b/src/applications/static-pages/find-forms/tests/components/DownloadModal.unit.spec.jsx
@@ -9,8 +9,8 @@ const url = 'https://test.com/';
 
 describe('DownloadModal', () => {
   describe('download button', () => {
-    it('should have the correct attributes', () => {
-      const screen = render(
+    it('should have the correct attributes', async () => {
+      const { container } = render(
         <DownloadModal
           closeModal={removeSpy}
           formName={10109}
@@ -19,18 +19,18 @@ describe('DownloadModal', () => {
         />,
       );
 
-      expect(
-        screen
-          .getByRole('va-link', {
-            text: 'Get Acrobat Reader for free from Adobe',
-          })
-          .getAttribute('href'),
-      ).to.eq('https://get.adobe.com/reader/');
-      expect(
-        screen
-          .getByRole('va-link', { text: 'Download VA Form 10109 (PDF)' })
-          .getAttribute('href'),
-      ).to.eq(url);
+      const links = container.querySelectorAll('va-link');
+
+      expect(links[0].getAttribute('href')).to.eq(
+        'https://get.adobe.com/reader/',
+      );
+      expect(links[0].getAttribute('text')).to.eq(
+        'Get Acrobat Reader for free from Adobe',
+      );
+
+      expect(links[1].getAttribute('href')).to.eq(url);
+      expect(links[1].getAttribute('text')).to.eq('Download VA Form 10109');
+      expect(links[1].getAttribute('filetype')).to.eq('PDF');
     });
   });
 });

--- a/src/applications/static-pages/find-forms/tests/cypress/find-forms-results.cypress.spec.js
+++ b/src/applications/static-pages/find-forms/tests/cypress/find-forms-results.cypress.spec.js
@@ -128,18 +128,18 @@ describe('find forms search results', () => {
     modal()
       .scrollIntoView()
       .within(() => {
-        cy.get(h.ADOBE_LINK)
-          .should('contain.text', 'Get Acrobat Reader for free from Adobe')
-          .should('have.attr', 'href')
-          .and('include', 'https://get.adobe.com/reader/');
+        cy.get('va-link[external]')
+          .should('have.attr', 'text', 'Get Acrobat Reader for free from Adobe')
+          .should('have.attr', 'href', 'https://get.adobe.com/reader/');
 
-        cy.get(h.MODAL_DOWNLOAD_LINK)
-          .should('contain.text', 'Download VA Form 10-252')
-          .should('have.attr', 'href')
-          .and(
-            'include',
+        cy.get('va-link[download]')
+          .should('have.attr', 'text', 'Download VA Form 10-252')
+          .should(
+            'have.attr',
+            'href',
             'https://www.va.gov/vaforms/medical/pdf/10-252%20Authorization%20To%20Release%20Protected%20Health%20Information%20To%20State%20Local%20Public%20Authorities.pdf',
-          );
+          )
+          .should('have.attr', 'filetype', 'PDF');
 
         cy.get(h.MODAL_CLOSE_BUTTON).click();
       });

--- a/src/applications/static-pages/find-forms/tests/cypress/helpers.js
+++ b/src/applications/static-pages/find-forms/tests/cypress/helpers.js
@@ -8,8 +8,6 @@ export const FINDFORM_REQUIRED = '[data-e2e-id="find-form-required"]';
 export const FINDFORM_ERROR_MSG = '[data-e2e-id="find-form-error-message"]';
 export const SEARCH_RESULT_TITLE = '[data-e2e-id="result-title"]';
 export const SORT_SELECT_WIDGET = 'va-select[name="findFormsSortBySelect"]';
-export const ADOBE_LINK = '[data-e2e-id="adobe-link"]';
-export const MODAL_DOWNLOAD_LINK = '[data-e2e-id="modal-download-link"]';
 export const MODAL_CLOSE_BUTTON = '.va-modal-close';
 export const MODAL = 'va-modal';
 export const FORM_DETAIL_HEADER = '[data-testid="va_form--downloadable-pdf"]';


### PR DESCRIPTION
## Related issue(s)

- Fixes department-of-veterans-affairs/va.gov-cms#18415

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

### Changes made
- updated to use `va-link` for download links in Find a Forms Modal and Discharge Wizard

#### How to Reproduce

##### Find a Form
1. Go to `/forms/?q=health`
2. On any search result, click Download button to launch modal
3. On the Download modal, confirm that both links are using the `va-link` component

##### Discharge Wizard (basic)
1. Go to `/discharge-upgrade-instructions/introduction`
2. Follow these responses for the discharge wizard: <img width="307" height="520" alt="Screenshot 2025-12-30 at 3 54 35 PM" src="https://github.com/user-attachments/assets/8057da94-1f10-4fed-8c0d-73cbcc80fdfd" />
3. Confirm that download links in Step 1 are using the `va-link` component 

##### Discharge Wizard (Request DD-214)
1. Go to `/discharge-upgrade-instructions/introduction`
2. Follow these responses for the discharge wizard: <img width="597" height="853" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/c611fae7-7685-4f91-8055-c0508c43736d" />
3. Click on the Find out how to request a DD214 for your period of honorable service" link in the alert box
4. you should now be on the `discharge-upgrade-instructions/request-dd214` page
5. Confirm "Download Form 149" link is using `va-link`

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

### Find a Form Download Modal
|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1024" height="665" alt="Screenshot 2025-12-30 at 3 23 02 PM" src="https://github.com/user-attachments/assets/0f0b20df-524b-4d28-af3d-4aae445534c7" /><img width="1015" height="588" alt="Screenshot 2025-12-30 at 3 23 35 PM" src="https://github.com/user-attachments/assets/7573fa69-856d-423d-9fe7-77e1d1c19278" /><img width="1019" height="596" alt="Screenshot 2025-12-30 at 3 25 39 PM" src="https://github.com/user-attachments/assets/ca34bb85-3d6c-49ec-bb03-b5c4013bb24f" /> | <img width="1017" height="595" alt="Screenshot 2025-12-30 at 3 31 18 PM" src="https://github.com/user-attachments/assets/bc6c65d5-a0f0-443c-9cb3-e5109b498b52" /><img width="1020" height="541" alt="Screenshot 2025-12-30 at 3 31 32 PM" src="https://github.com/user-attachments/assets/60c000ef-2da0-4e7a-b18d-b7a0cb16227c" /><img width="1013" height="588" alt="Screenshot 2025-12-30 at 3 25 50 PM" src="https://github.com/user-attachments/assets/73428545-83b5-4cd9-a965-f0a68911a072" /> |
| Mobile  | <img width="671" height="586" alt="Screenshot 2025-12-30 at 4 43 25 PM" src="https://github.com/user-attachments/assets/fa7feaa5-4c4a-4e4e-b83c-dce6c7cfb142" /> | <img width="705" height="551" alt="Screenshot 2025-12-30 at 4 55 42 PM" src="https://github.com/user-attachments/assets/a01a90e4-2dd5-422f-9e58-67665d71479c" /> |
| Tablet | <img width="869" height="592" alt="Screenshot 2025-12-30 at 4 43 01 PM" src="https://github.com/user-attachments/assets/a23f2f86-ac6e-4ec0-a6d8-4b8138f1cf15" /> | <img width="986" height="592" alt="Screenshot 2025-12-30 at 3 26 17 PM" src="https://github.com/user-attachments/assets/b1d9da9f-3dbe-40f1-9198-c81c10e6a9c0" /> |

### Discharge Wizard (Basic)
|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1018" height="591" alt="Screenshot 2025-12-30 at 4 17 58 PM" src="https://github.com/user-attachments/assets/77041237-0891-4093-9873-ae8917713f36" /><img width="1018" height="592" alt="Screenshot 2025-12-30 at 4 18 20 PM" src="https://github.com/user-attachments/assets/8733f215-39dc-4959-97fb-04678bcd966b" /><img width="726" height="591" alt="Screenshot 2025-12-30 at 4 21 55 PM" src="https://github.com/user-attachments/assets/1406ecc9-0b8d-4a8a-8602-600cf0000b9f" /> | <img width="1017" height="520" alt="Screenshot 2025-12-31 at 12 48 47 PM" src="https://github.com/user-attachments/assets/33c0a926-17a4-417e-913b-28d74785ae4b" /><img width="1001" height="541" alt="Screenshot 2025-12-31 at 12 49 18 PM" src="https://github.com/user-attachments/assets/7fcc3757-3309-438b-b0c3-9b8e45858f37" /><img width="988" height="569" alt="Screenshot 2025-12-31 at 12 51 01 PM" src="https://github.com/user-attachments/assets/71fa5ca1-e7ca-4698-8236-6d12c51fc9d1" /> |
| Mobile  | <img width="725" height="565" alt="Screenshot 2025-12-30 at 4 39 30 PM" src="https://github.com/user-attachments/assets/0e4c0cde-8d6f-4acd-aeb6-556dd8bbee86" /> | <img width="703" height="585" alt="Screenshot 2025-12-31 at 12 52 21 PM" src="https://github.com/user-attachments/assets/5e7e866e-5b70-4c12-8a30-ab95e825cb2b" /> |
| Tablet | <img width="812" height="395" alt="Screenshot 2025-12-30 at 4 39 03 PM" src="https://github.com/user-attachments/assets/d5d3d051-583c-41a5-bcf6-4bc6b798c506" /> | <img width="847" height="552" alt="Screenshot 2025-12-31 at 12 52 36 PM" src="https://github.com/user-attachments/assets/ffd9e2f9-25df-45d7-90b1-da553d57f9d3" /> |

### Discharge Wizard (Request DD-214)
|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1008" height="511" alt="Screenshot 2025-12-31 at 1 57 28 PM" src="https://github.com/user-attachments/assets/2459bee0-322e-4ff5-b155-eb15e5a35b96" /><img width="726" height="522" alt="Screenshot 2025-12-31 at 2 00 10 PM" src="https://github.com/user-attachments/assets/416e8ad0-93b8-492e-a75b-3c7ddefbd500" /> | <img width="1019" height="520" alt="Screenshot 2025-12-31 at 2 15 11 PM" src="https://github.com/user-attachments/assets/bcc5e837-ed6d-4484-a553-c384ef90311c" /><img width="828" height="515" alt="Screenshot 2025-12-31 at 2 15 25 PM" src="https://github.com/user-attachments/assets/24123260-dac7-48da-b87d-be52eac1a217" /> |
| Mobile  | <img width="634" height="550" alt="Screenshot 2025-12-31 at 2 01 30 PM" src="https://github.com/user-attachments/assets/a6907f53-9918-4234-91af-b4c124115958" /> | <img width="710" height="551" alt="Screenshot 2025-12-31 at 2 15 45 PM" src="https://github.com/user-attachments/assets/34b88e85-88dc-4105-9180-b5c577066f71" /> |
| Tablet | <img width="864" height="506" alt="Screenshot 2025-12-31 at 2 00 46 PM" src="https://github.com/user-attachments/assets/d716dbb8-9772-42f7-85f6-74ad52ec2bb7" /> | <img width="785" height="555" alt="Screenshot 2025-12-31 at 2 16 21 PM" src="https://github.com/user-attachments/assets/bf41d6a0-45f8-43ce-8cfc-91e5fb70136a" /> |

## What areas of the site does it impact?

- `/forms/`
- `/discharge-upgrade-instructions/results`
- `/discharge-upgrade-instructions/request-dd214`

## Acceptance criteria

- [ ] RequestDD214.jsx now uses va-link
  - [ ] If no custom analytics, then the va-link analytics have been enabled for RequestDD214.jsx
- [ ] StepOne.jsx now uses va-link
  - [ ]  If no custom analytics, then the va-link analytics have been enabled for StepOne.jsx
- [ ] DownloadModal.jsx now uses va-link
  - [ ]  If no custom analytics, then the va-link analytics have been enabled for DownloadModal.jsx

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
- Review tests to ensure coverage
