### PR TITLE
fix(script): use bash instead of sh for review-entrypoint

### DIFF
--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Build vets-website
 set -e

--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Build vets-website
 set -e
@@ -10,8 +10,8 @@ npm run build -- --buildtype=localhost --api='${API_URL}' --host='${WEB_HOST}' -
 cd ../content-build
 cp .env.example .env && yarn install --production=false
 # Build necessary node modules since ignore-scripts is set globally.
-pushd node_modules/node-libcurl/ && npm run install && popd
-pushd node_modules/node-sass/ && npm run install && popd
+cd node_modules/node-libcurl/ && npm run install && cd -
+cd node_modules/node-sass/ && npm run install && cd -
 npm run fetch-drupal-cache
 
 npm run build -- --buildtype=localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}' --apps-directory-name=application


### PR DESCRIPTION
## Description

The [previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/41003) uses shell builtins that are specific to bash.

## Related Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127875


