### PR TITLE
Show default value for `EducationFacilitySearch`

### DIFF
--- a/src/applications/ask-va/components/EducationFacilitySearch.jsx
+++ b/src/applications/ask-va/components/EducationFacilitySearch.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 
+import { VaRadioOption } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { URL, envUrl } from '../constants';
 import { convertLocation } from '../utils/mapbox';
 import EducationSearchItem from './search/EducationSearchItem';
@@ -13,6 +15,7 @@ const facilities = {
 };
 
 export default function EducationFacilitySearch({ onChange }) {
+  const school = useSelector(state => state.form?.data?.school);
   const [apiData, setApiData] = useState(facilities);
   const [isSearching, setIsSearching] = useState(false);
   const [pageURL, setPageURL] = useState('');
@@ -77,6 +80,8 @@ export default function EducationFacilitySearch({ onChange }) {
     return getFacilitiesByCode(input);
   };
 
+  const showInitialValue = school && !isSearching && !apiData.data?.length;
+
   return (
     <div className="facility-locator vads-u-margin-top--2">
       <SearchControls
@@ -85,6 +90,7 @@ export default function EducationFacilitySearch({ onChange }) {
         searchTitle="Search for your school"
         searchHint="You can search by school name, code or location."
       />
+      {showInitialValue && <VaRadioOption label={school} checked />}
       {isSearching ? (
         <va-loading-indicator label="Loading" message="Loading..." set-focus />
       ) : (
@@ -94,6 +100,7 @@ export default function EducationFacilitySearch({ onChange }) {
           getData={getApiData}
           onChange={onChange}
           dataError={fetchDataError}
+          defaultValue={school}
         />
       )}
     </div>

--- a/src/applications/ask-va/components/search/EducationSearchItem.jsx
+++ b/src/applications/ask-va/components/search/EducationSearchItem.jsx
@@ -16,8 +16,9 @@ const EducationSearchItem = ({
   onChange,
   searchInput,
   dataError,
+  defaultValue,
 }) => {
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState(defaultValue);
 
   const onPageChange = async page => {
     await getData(`${pageURL}&page=${page}&per_page=10`);
@@ -131,6 +132,7 @@ EducationSearchItem.propTypes = {
     hasError: PropTypes.bool,
     errorMessage: PropTypes.string,
   }),
+  defaultValue: PropTypes.string,
   facilityData: PropTypes.shape({
     data: PropTypes.arrayOf(
       PropTypes.shape({


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders 

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Changes made:
  - Add check for current `state.form.data.school` value and display it as a single radio button, unless the location auto-search was used, in which case, prefill the radio button on the list of options.
- As described in department-of-veterans-affairs/ask-va#2086 and department-of-veterans-affairs/ask-va#1822, the bug was that navigating back to the school facility search page didn't show previously entered info, even when it was correctly stored in Redux state.
  - To reproduce, follow the steps in [this comment](https://github.com/department-of-veterans-affairs/ask-va/issues/1822#issuecomment-3603516911).
- This is the solution because it is the simplest way to let the user know their previous choice will be recognized and they don't have to search again.
- Ask VA owns all this code


## Related issue(s)

- Closes department-of-veterans-affairs/ask-va#2086
- Closes department-of-veterans-affairs/ask-va#1822

## Testing done

- Prior to the change, when the component rendered, there was not prefilled value.
- To verify the solution works properly, follow the steps in [this comment](https://github.com/department-of-veterans-affairs/ask-va/issues/1822#issuecomment-3603516911) and note that a prefilled radio button appears with the previously selected value. 
  - Alternately, instead of searching by text in step 5, try the "Use my location" button.
- Added unit tests for displaying a previously stored value, as well as NOT showing that value if the user searches for something else.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="337" height="471" alt="Mobile before" src="https://github.com/user-attachments/assets/c9380e6e-ef9b-4f11-8a06-3baa1f4de9ab" /> | <img width="337" height="530" alt="Mobile after" src="https://github.com/user-attachments/assets/8d38697e-5665-4807-b481-d39c5911f0d1" /> |
| Desktop | <img width="540" height="419" alt="Desktop before" src="https://github.com/user-attachments/assets/8c3a88f4-81a1-4b1f-9916-e8cb5b783d03" /> | <img width="518" height="446" alt="Desktop after" src="https://github.com/user-attachments/assets/e837f9cd-b87a-4920-92b6-d62199c16eef" /> |

## What areas of the site does it impact?

Only Ask VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
  - [x] Color contrast
  - [x] axe devtools auto check
  - [x] Zoom issues (screen width: 1200px, zoom to 200%, 300%, 400%)
  - [x] Keyboard navigation

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user