### PR TITLE
fix: add role=img and aria-labelledby to claim phase diagrams for iOS VoiceOver

### DIFF
--- a/src/applications/claims-status/components/claim-overview-tab/DesktopClaimPhaseDiagram.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/DesktopClaimPhaseDiagram.jsx
@@ -27,13 +27,15 @@ export default function DesktopClaimPhaseDiagram({ currentPhase }) {
   return (
     <div className="desktop vads-u-margin-bottom--4">
       <svg
+        role="img"
+        aria-labelledby="desktopClaimPhaseDiagramTitle"
         width="570"
         height="166"
         viewBox="0 0 570 166"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>{accessibilityTitle}</title>
+        <title id="desktopClaimPhaseDiagramTitle">{accessibilityTitle}</title>
         <rect
           x="178.279"
           y="33.9127"

--- a/src/applications/claims-status/components/claim-overview-tab/MobileClaimPhaseDiagram.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/MobileClaimPhaseDiagram.jsx
@@ -27,12 +27,14 @@ export default function MobileClaimPhaseDiagram({ currentPhase }) {
   return (
     <div className="mobile vads-u-margin-bottom--4">
       <svg
+        role="img"
+        aria-labelledby="mobileClaimPhaseDiagramTitle"
         style={{ maxWidth: '100%' }}
         viewBox="0 0 352 115"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>{accessibilityTitle}</title>
+        <title id="mobileClaimPhaseDiagramTitle">{accessibilityTitle}</title>
         <rect
           width="352"
           height="114"

--- a/src/applications/claims-status/tests/components/claim-overview-tab/DesktopClaimPhaseDiagram.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-overview-tab/DesktopClaimPhaseDiagram.unit.spec.jsx
@@ -17,4 +17,21 @@ describe('<DesktopClaimPhaseDiagram>', () => {
       ),
     );
   });
+
+  it('should have proper accessibility attributes for iOS VoiceOver', () => {
+    const { container } = render(<DesktopClaimPhaseDiagram currentPhase={5} />);
+    const svg = $('svg', container);
+
+    expect(svg).to.exist;
+    expect(svg.getAttribute('role')).to.equal('img');
+    expect(svg.getAttribute('aria-labelledby')).to.equal(
+      'desktopClaimPhaseDiagramTitle',
+    );
+
+    const title = $('title#desktopClaimPhaseDiagramTitle', container);
+    expect(title).to.exist;
+    expect(title.textContent).to.equal(
+      'Your current step is 5 of 8 in the claims process. Steps 3 through 6 can be repeated.',
+    );
+  });
 });

--- a/src/applications/claims-status/tests/components/claim-overview-tab/MobileClaimPhaseDiagram.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-overview-tab/MobileClaimPhaseDiagram.unit.spec.jsx
@@ -17,4 +17,21 @@ describe('<MobileClaimPhaseDiagram>', () => {
       ),
     );
   });
+
+  it('should have proper accessibility attributes for iOS VoiceOver', () => {
+    const { container } = render(<MobileClaimPhaseDiagram currentPhase={3} />);
+    const svg = $('svg', container);
+
+    expect(svg).to.exist;
+    expect(svg.getAttribute('role')).to.equal('img');
+    expect(svg.getAttribute('aria-labelledby')).to.equal(
+      'mobileClaimPhaseDiagramTitle',
+    );
+
+    const title = $('title#mobileClaimPhaseDiagramTitle', container);
+    expect(title).to.exist;
+    expect(title.textContent).to.equal(
+      'Your current step is 3 of 8 in the claims process. Steps 3 through 6 can be repeated.',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Fixes an accessibility issue where iOS VoiceOver ignores the claim process graphic on the Overview page. Users couldn't access the image via swipe gestures.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/128410

## Changes
- Added `role="img"` and `aria-labelledby` attributes to the SVG elements in both `MobileClaimPhaseDiagram` and `DesktopClaimPhaseDiagram` components
- Added `id` attribute to the `<title>` element to link with `aria-labelledby`
- Added unit tests to verify the accessibility attributes are present

## Testing

### How to Navigate to the Test Page
1. **Start the mock API and developement server:**
   ``` bash
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
   yarn watch --env entry=claims-status
   ```
2. Navigate to: `http://localhost:3001/track-claims/your-claims/1/overview`
3. Set `localStorage.setItem('hasSession', true)` in browser console
4. The claim phase diagram (circular progress graphic with steps 1-8) should be visible near the top of the page

---

### Option 1: Testing with iOS VoiceOver (Recommended)

The staging reviewer used iOS VoiceOver to identify this issue. My iOS Simulator didn't have VoiceOver available, but if you have it on your simulator or device, this is the recommended way to verify the fix.

---

### Option 2: Testing with Xcode Accessibility Inspector

*My iOS Simulator didn't have VoiceOver available, so I verified the fix using Xcode's Accessibility Inspector:*

1. **Open Xcode** and go to **Xcode → Open Developer Tool → Accessibility Inspector**
2. **Open iOS Simulator** and navigate to the Overview page in Safari:
   - URL: `http://localhost:3001/track-claims/your-claims/1/overview`
   - If prompted to sign in, open Safari Web Inspector (Develop → iPhone Simulator → localhost) and run: `localStorage.setItem('hasSession', true)` then refresh
3. **In Accessibility Inspector:**
   - Select your simulator from the device dropdown (e.g., "iPhone 16 Pro Max")
   - Click the **crosshair/target icon** to enable inspection mode
4. **Hover over the claim phase diagram** (the circular graphic showing steps 1-8)
5. **Verify the following in the Inspector:**
   - **Label:** "Your current step is X of 8 in the claims process. Steps 3 through 6 can be repeated."
   - **Type:** image
   - Element should NOT be ignored

📸 **Screenshot of Accessibility Inspector verification:**
<img width="1191" height="1008" alt="Screenshot 2025-12-22 at 4 18 40 PM" src="https://github.com/user-attachments/assets/ee714ced-e04d-4d25-b851-4b5a669b6fbc" />

### Unit Tests
- Added tests verifying `role="img"` attribute is present on SVG
- Added tests verifying `aria-labelledby` points to the correct title ID
- Added tests verifying title element contains the expected accessibility text

## Acceptance Criteria
- [x] Claim process graphic is accessible to iOS VoiceOver users
- [x] Screen readers announce the current step information when navigating to the graphic
- [x] Unit tests pass