### PR TITLE
Date validation for service periods

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/service-period-pages.js
@@ -13,6 +13,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import DEFAULT_BRANCH_LABELS from 'platform/forms-system/src/js/web-component-patterns/content/serviceBranch.json';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { validateEndDateAfterStartDate } from '../utils/validationHelpers';
 
 const formatDate = dateStr => {
   if (!dateStr) return '';
@@ -84,7 +85,20 @@ const serviceDatesPage = {
           : 'Service Dates',
     ),
     dateEnteredService: currentOrPastDateUI('Service start date'),
-    dateLeftService: currentOrPastDateUI('Service end date'),
+    dateLeftService: {
+      ...currentOrPastDateUI('Service end date'),
+      'ui:validations': [
+        (errors, fieldData, formData) => {
+          validateEndDateAfterStartDate(
+            errors,
+            fieldData,
+            formData,
+            'dateEnteredService',
+            'Please enter a service end date later than the service start date.',
+          );
+        },
+      ],
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/validationHelpers.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/validationHelpers.js
@@ -1,0 +1,26 @@
+/**
+ * Validates that an end date is later than a start date
+ * @param {Object} errors - Error object to add validation errors to
+ * @param {string} endDate - The end date field value (fieldData)
+ * @param {Object} formData - The complete form data object
+ * @param {string} startDateField - The name of the start date field in formData
+ * @param {string} errorMessage - Custom error message to display
+ */
+export const validateEndDateAfterStartDate = (
+  errors,
+  endDate,
+  formData,
+  startDateField,
+  errorMessage = 'Please enter an end date later than the start date.',
+) => {
+  const startDate = formData?.[startDateField];
+
+  if (startDate && endDate) {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+
+    if (end <= start) {
+      errors.addError(errorMessage);
+    }
+  }
+};

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/validationHelpers.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/utils/validationHelpers.unit.spec.jsx
@@ -1,0 +1,155 @@
+/**
+ * @module tests/utils/validationHelpers.unit.spec
+ * @description Unit tests for validation helper functions
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { validateEndDateAfterStartDate } from './validationHelpers';
+
+describe('validateEndDateAfterStartDate', () => {
+  let errors;
+
+  beforeEach(() => {
+    errors = {
+      addError: sinon.spy(),
+    };
+  });
+
+  it('should not add error when end date is after start date', () => {
+    const endDate = '2020-02-15';
+    const formData = {
+      dateEnteredService: '2020-01-15',
+    };
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+      'Test error message',
+    );
+
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('should add error when end date is before start date', () => {
+    const endDate = '2020-01-10';
+    const formData = {
+      dateEnteredService: '2020-01-15',
+    };
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+      'Test error message',
+    );
+
+    expect(errors.addError.calledOnce).to.be.true;
+    expect(errors.addError.firstCall.args[0]).to.equal('Test error message');
+  });
+
+  it('should add error when end date equals start date', () => {
+    const endDate = '2020-01-15';
+    const formData = {
+      dateEnteredService: '2020-01-15',
+    };
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+      'Test error message',
+    );
+
+    expect(errors.addError.calledOnce).to.be.true;
+    expect(errors.addError.firstCall.args[0]).to.equal('Test error message');
+  });
+
+  it('should not add error when start date is missing', () => {
+    const endDate = '2020-02-15';
+    const formData = {};
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+      'Test error message',
+    );
+
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('should not add error when end date is missing', () => {
+    const endDate = null;
+    const formData = {
+      dateEnteredService: '2020-01-15',
+    };
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+      'Test error message',
+    );
+
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('should not add error when both dates are missing', () => {
+    const endDate = null;
+    const formData = {};
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+      'Test error message',
+    );
+
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('should use default error message when not provided', () => {
+    const endDate = '2020-01-10';
+    const formData = {
+      dateEnteredService: '2020-01-15',
+    };
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'dateEnteredService',
+    );
+
+    expect(errors.addError.calledOnce).to.be.true;
+    expect(errors.addError.firstCall.args[0]).to.equal(
+      'Please enter an end date later than the start date.',
+    );
+  });
+
+  it('should handle different field names', () => {
+    const endDate = '2020-01-10';
+    const formData = {
+      customStartField: '2020-01-15',
+    };
+
+    validateEndDateAfterStartDate(
+      errors,
+      endDate,
+      formData,
+      'customStartField',
+      'Custom error',
+    );
+
+    expect(errors.addError.calledOnce).to.be.true;
+    expect(errors.addError.firstCall.args[0]).to.equal('Custom error');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixed date validation bug in form 21P-530a service period section where users could enter a service end date that occurs before the service start date
- Bug reproduction: Navigate to service period section → Add new service period → Enter start date (e.g., 01/15/2020) → Enter end date before start date (e.g., 01/10/2020) → Form accepts invalid date range
- Solution: Added custom validation to the `dateLeftService` field that compares it against `dateEnteredService` and displays error message when end date is not later than start date
- Created reusable validation helper function (`validateEndDateAfterStartDate`) in `utils/validationHelpers.js` for use across multiple form sections with similar validation requirements
- Benefits Optimization Aquia team - this component is part of the 21P-530a Interment Allowance form maintained by our team
- This is the first of three date validation fixes for form 21P-530a

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128454

## Testing done

- Old behavior: Users could enter a service end date that was the same as or earlier than the service start date, allowing invalid date ranges to be submitted
- Steps to verify changes:
  1. Navigate to the 21P-530a form service period section
  2. Add a new service period
  3. Select a branch of service
  4. On the service dates page, enter a service start date (e.g., 01/15/2020)
  5. Attempt to enter a service end date that is before or equal to the start date (e.g., 01/10/2020 or 01/15/2020)
  6. Verify error message appears: "Please enter a service end date later than the service start date."
  7. Update the end date to be after the start date (e.g., 01/20/2020)
  8. Verify error clears and form allows progression to next page
  9. Test with multiple service periods to ensure validation works for each instance
- Unit tests: 8 test cases added covering all validation scenarios (passing)
- E2E tests: Existing Cypress tests passing with validation in place
- Manual testing completed in local environment with various date combinations (same dates, end before start, end after start)
- Verified validation only triggers when both dates are present

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    <img width="1380" height="1376" alt="image" src="https://github.com/user-attachments/assets/345e977a-7f18-47fe-86ee-5980bdfbd14b" /> |  <img width="743" height="769" alt="image" src="https://github.com/user-attachments/assets/7c6e7362-c0e7-4362-9f8d-23908a8849af" /> |

## What areas of the site does it impact?

Form 21P-530a (Interment Allowance) - specifically the service period section where veterans' service dates are collected. Changes are isolated to the service period date validation and do not affect other parts of the application.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (inline JSDoc comments added to validation helper function)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is the first of three date validation fixes for form 21P-530a. The validation helper function created here (`validateEndDateAfterStartDate`) will be reused for the other two sections in subsequent PRs. Please review the validation logic to ensure it aligns with the pattern used elsewhere in the platform.