### PR TITLE
#128402: Fix alert keyboard accessibility by focusing h2 and adding role=alert

### DIFF
--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -106,6 +106,7 @@ export default function ClaimDetailLayout(props) {
                 body={
                   <Type1UnknownUploadError errorFiles={type1UnknownErrors} />
                 }
+                role="alert"
                 type="error"
                 onSetFocus={focusNotificationAlert}
               />

--- a/src/applications/claims-status/components/Notification.jsx
+++ b/src/applications/claims-status/components/Notification.jsx
@@ -4,6 +4,7 @@ import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/
 
 export default function Notification({
   body,
+  role,
   title,
   type,
   onClose,
@@ -13,9 +14,10 @@ export default function Notification({
   useEffect(
     () => {
       if (typeof onSetFocus === 'function') {
+        // Delay ensures focus lands on alert, not competing elements
         setTimeout(() => {
           onSetFocus();
-        });
+        }, 150);
       }
     },
     [title, body, onSetFocus],
@@ -28,6 +30,7 @@ export default function Notification({
       className="claims-alert"
       closeable={closeable}
       onCloseEvent={onClose}
+      role={role}
       status={type}
       visible
     >
@@ -44,6 +47,7 @@ Notification.defaultProps = {
 Notification.propTypes = {
   body: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   title: PropTypes.string.isRequired,
+  role: PropTypes.oneOf(['alert', 'alertdialog', 'status']),
   type: PropTypes.string,
   onClose: PropTypes.func,
   onSetFocus: PropTypes.func,

--- a/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
@@ -112,6 +112,7 @@ export default function DefaultPage({
             <Notification
               title="We need you to submit files by mail or in person"
               body={<Type1UnknownUploadError errorFiles={type1UnknownErrors} />}
+              role="alert"
               type="error"
               onSetFocus={!message ? focusNotificationAlert : undefined}
             />

--- a/src/applications/claims-status/tests/components/Notification.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/Notification.unit.spec.jsx
@@ -60,4 +60,14 @@ describe('<Notification>', () => {
       expect(document.activeElement).to.equal(selector);
     });
   });
+
+  it('should pass role prop to va-alert', () => {
+    const { container } = render(
+      <Notification title={title} body={body} role="alert" type="error" />,
+    );
+
+    const selector = container.querySelector('va-alert');
+    expect(selector).to.exist;
+    expect(selector).to.have.attr('role', 'alert');
+  });
 });

--- a/src/applications/claims-status/tests/local-dev-mock-api/common.js
+++ b/src/applications/claims-status/tests/local-dev-mock-api/common.js
@@ -1816,7 +1816,7 @@ const responses = {
     // - 'invalidClaimant',
     // - 'unknown'
     // - null for success only
-    const errorPattern = ['duplicate'];
+    const errorPattern = ['unknown'];
 
     return (_req, res) => {
       uploadCount += 1;


### PR DESCRIPTION
## Summary
Fixes keyboard accessibility issues with the "We need you to submit files by mail or in person" alert (Type 1 error). The alert link was not keyboard focusable, and screen readers were not announcing the alert when it appeared dynamically.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/128402

## Changes
- **Focus management**: Changed `focusNotificationAlert` to focus on the `h2` headline inside the alert instead of the `va-alert` container. This preserves SHIFT+TAB navigation to interactive elements within the alert.
- **Screen reader announcement**: Added `role="alert"` to Type 1 error notifications so screen readers immediately announce the error when it appears.
- **Race condition fix**: Added 150ms delay to `onSetFocus` to ensure consistent focus on the alert's h2 after file upload.
- **Notification component**: Added optional `role` prop to support different ARIA roles.

## Testing
### Steps to test locally
1. Start the mock API and local server:
   ```
   yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api
   yarn watch --env entry=claims-status
   ```
2. Navigate to: http://localhost:3001/track-claims/your-claims/9/files
3. Log in locally (open console and run `localStorage.setItem('hasSession', true)`, then refresh)
4. Upload a file (any PDF/JPG) - it will trigger a Type 1 UNKNOWN error
5. **Verify the following:**
   - [ ] Focus lands on the alert's h2 heading ("We need you to submit files by mail or in person")
   - [ ] Press TAB - focus moves to the link inside the alert ("Check the status of your submission")
   - [ ] Press TAB again - focus moves to the X close button
   - [ ] Press TAB again - focus moves out of the alert
   - [ ] Press SHIFT+TAB - focus returns to the X close button
   - [ ] Press SHIFT+TAB again - focus returns to the link
   - [ ] Press SHIFT+TAB again - focus returns to the h2

### Testing different alert types

In `src/applications/claims-status/tests/local-dev-mock-api/common.js`, find line ~1819:

const errorPattern = ['unknown'];| Change to | Alert type |

`['unknown']` = 🔴 Type 1 error alert (default) 
`null` = 🟢 Success alert 

After changing, restart the mock API server.

### Screen recording

https://github.com/user-attachments/assets/7fb10e85-2172-4f4f-a308-3c0e92f013bb

## Acceptance Criteria
- [x] Focus moves to alert h2 instead of entire alert container
- [x] Can TAB forwards and SHIFT+TAB backwards to links and X button inside alert
- [x] `role="alert"` added to Type 1 error alerts for screen reader announcement
- [x] Green success alerts also work correctly (verified manually)

## Unit Tests
- Added test for `role` prop in `Notification.unit.spec.jsx`