### PR TITLE
added AWS credential config step for bypass steps in main-deployment job

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
+      - name: Configure AWS credentials for secret injection (bypass)
+        if: ${{ github.event.inputs.bypass_freeze == 'true' }}
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_region: us-gov-west-1
+          role: ${{ vars.AWS_ASSUME_ROLE }}  
+
       - name: Get bot token from Parameter Store (bypass)
         if: ${{ github.event.inputs.bypass_freeze == 'true' }}
         uses: ./.github/workflows/inject-secrets


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _While attempting to perform an OOB deployment during a holiday code freeze, I encountered an error based in AWS setup performed during the workflow.  The failing step is only triggered during a holiday code freeze bypass.  I am adding an extra checkout step to mimic the default workflow flow that includes said checkout step._

## Related issue(s)

- No ticket exists at present for this work.

## Testing done

- _Testing will only work with live CI runs that I can then cancel._

