### PR TITLE
10-10EZR | Contact info required field hotfix

### DIFF
--- a/src/applications/ezr/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/ezr/config/chapters/veteranInformation/contactInformation.js
@@ -13,24 +13,16 @@ export default {
   uiSchema: {
     'view:contactInformation': {
       ...titleUI(content['vet-contact-info-title'], ContactInfoDescription),
-      homePhone: {
-        ...phoneUI(content['vet-home-phone-label']),
-        'ui:errorMessages': {
-          required: content['phone-number-error-message'],
-          pattern: content['phone-number-error-message'],
-        },
-      },
-      mobilePhone: {
-        ...phoneUI(content['vet-mobile-phone-label']),
-        'ui:errorMessages': {
-          required: content['phone-number-error-message'],
-          pattern: content['phone-number-error-message'],
-        },
-      },
+      homePhone: phoneUI({
+        title: content['vet-home-phone-label'],
+        errorMessages: { pattern: content['phone-number-error-message'] },
+      }),
+      mobilePhone: phoneUI({
+        title: content['vet-mobile-phone-label'],
+        errorMessages: { pattern: content['phone-number-error-message'] },
+      }),
       email: emailUI({
-        errorMessages: {
-          pattern: content['email-pattern-error-message'],
-        },
+        errorMessages: { pattern: content['email-pattern-error-message'] },
       }),
     },
   },

--- a/src/applications/ezr/utils/helpers/prefill-transformer.js
+++ b/src/applications/ezr/utils/helpers/prefill-transformer.js
@@ -67,11 +67,11 @@ export function prefillTransformer(pages, formData, metadata, state) {
   );
 
   const {
-    email = '',
-    homePhone = '',
-    maritalStatus = '',
-    isMedicaidEligible = undefined,
-    isEnrolledMedicarePartA = undefined,
+    email,
+    homePhone,
+    maritalStatus,
+    isMedicaidEligible,
+    isEnrolledMedicarePartA,
   } = formData;
 
   let newData = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR applies a bugfix to the app related to contact info data. The issue was found to be the prefill transformer defaulting data values to an empty string, which will fail pattern validation (even though the fields are not required). The fix is to not default the value to anything--let it remain undefined if no value exists.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#111241

## Testing done

- Without the fix, the values default to an empty string. This empty string can fail pattern validation on interaction
- With the fix, the value default to `undefined`, which is fine for validation because the values arent required

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Input fields follow the set rules (required/pattern/etc)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user