### PR TITLE
Fix - Alert above H3 isn’t encountered by screen reader users

### DIFF
--- a/src/applications/simple-forms/21P-601/pages/expensesList.js
+++ b/src/applications/simple-forms/21P-601/pages/expensesList.js
@@ -60,7 +60,7 @@ const summaryPage = {
               href="https://www.va.gov/find-forms/about-form-21p-601/"
               external
               rel="noopener noreferrer"
-              text="Get VA Form 21P-601 to download (opens in a new tab)"
+              text="Get VA Form 21P-601 to download"
             />
           </p>
         </va-alert>

--- a/src/applications/simple-forms/21P-601/pages/expensesList.js
+++ b/src/applications/simple-forms/21P-601/pages/expensesList.js
@@ -60,7 +60,7 @@ const summaryPage = {
               href="https://www.va.gov/find-forms/about-form-21p-601/"
               external
               rel="noopener noreferrer"
-              text="Get VA Form 21P-601 to download"
+              text="Download VA Form 21P-601 (PDF)"
             />
           </p>
         </va-alert>

--- a/src/applications/simple-forms/21P-601/pages/expensesList.js
+++ b/src/applications/simple-forms/21P-601/pages/expensesList.js
@@ -47,6 +47,7 @@ const yesNoOptions = {
 const summaryPage = {
   uiSchema: {
     ...titleUI('Expenses you paid'),
+    'view:hasExpenses': arrayBuilderYesNoUI(options, yesNoOptions),
     'view:expenseInfo': {
       'ui:description': (
         <va-alert status="info" uswds>
@@ -59,13 +60,12 @@ const summaryPage = {
               href="https://www.va.gov/find-forms/about-form-21p-601/"
               external
               rel="noopener noreferrer"
-              text="Download VA Form 21P-601 (PDF)"
+              text="Get VA Form 21P-601 to download (opens in a new tab)"
             />
           </p>
         </va-alert>
       ),
     },
-    'view:hasExpenses': arrayBuilderYesNoUI(options, yesNoOptions),
   },
   schema: {
     type: 'object',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Expense Alert Focus Fix: Reorder Alert to Improve Screen Reader Accessibility**

Reordered the expenses alert to appear below the H3 heading and radio buttons instead of above them, ensuring screen reader users can access critical information when focus is managed to the page H3. Previously, when focus was set to the H3 "Expenses you paid", screen reader users would skip over the alert "You can only request reimbursement for expenses you've already paid" that appeared above it, missing important context about form requirements.

**Changes Made:**
- Reordered uiSchema fields in `expensesList.js` to move `view:expenseInfo` (alert) below `view:hasExpenses` (radio buttons)
- Alert now appears in the DOM after the H3 and radio button question, making it accessible in natural reading order

## How to Reproduce (Bug)

1. Fill out the form until you reach the "Expense reimbursement" page
2. Select "Yes" to indicate you want to be reimbursed
3. Click "Continue" to navigate to the "Do you have an expense to add?" page
4. Turn on a screen reader (JAWS, NVDA, VoiceOver, etc.)
5. Observe that focus is managed to the H3 "Expenses you paid"
6. Notice that the alert "You can only request reimbursement for expenses you've already paid" appears above the H3 in the DOM
7. Tab forward from the H3 - observe that you skip directly to the radio buttons "Do you have an expense to add?"
8. Notice that screen reader users never hear the alert unless they manually navigate backwards, which is unlikely
9. Observe that users miss critical information about form requirements

## Solution and Why

**Solution:** Reordered the uiSchema fields so the alert appears below the H3 heading and radio buttons in the DOM, ensuring it's accessible when users tab forward from the focused H3 element.

**Why This Solution:**
1. **Natural Reading Order:** By placing the alert after the H3 and radio buttons, screen reader users encounter it in the natural tab order after the main question, ensuring they receive critical information
2. **Focus Management Compatibility:** Works with the existing focus management that targets the H3 - users can tab forward from the H3 to the radio buttons and then encounter the alert
3. **Accessibility Best Practice:** Follows the recommendation to place important information in a location that's accessible in the natural reading order, rather than requiring users to navigate backwards
4. **User Experience:** Users receive the critical information about expense reimbursement requirements before they need to make a decision, but in a logical flow that doesn't interrupt the primary task
5. **Screen Reader Friendly:** Screen readers will announce the alert content when users tab through the page in order, without requiring special navigation techniques

**Testing Recommendations:**
- Navigate to the expenses page and verify the alert appears below the H3 and radio buttons visually
- Turn on a screen reader (JAWS, NVDA, VoiceOver) and navigate to the expenses page
- Verify focus lands on the H3 "Expenses you paid" when the page loads
- Tab forward from the H3 and verify the screen reader announces:
  - The radio button question "Do you have an expense to add?"
  - The alert headline "You can only request reimbursement for expenses you've already paid"
  - The alert content about unpaid bills and the paper form link
- Test with keyboard-only navigation (no mouse) to ensure the alert is accessible
- Verify the alert is announced before users need to interact with the radio buttons
- Test on mobile devices with screen readers to ensure consistent behavior
- Verify the visual layout still looks correct (alert should appear below the question)


