### PR TITLE
10-10EZR | Add feature toggle name for RUM isolation

### DIFF
--- a/src/applications/ezr/README.md
+++ b/src/applications/ezr/README.md
@@ -109,7 +109,7 @@ This uses the Health Care Application EZR API endpoints:
 - Names start with `ezr` for both long-lived and feature-development toggles:
 - `ezrProdEnabled` - Enables the EZR application in production
 - Some overarching Health Applications functionality, prefixed with `hca`, also affects EZR:
-- `hcaBrowserMonitoringEnabled` - Enables DataDog browser monitoring for the application
+- `ezrBrowserMonitoringEnabled` - Enables DataDog browser monitoring for the application
 
 ### Data Flow
 

--- a/src/applications/ezr/tests/unit/utils/selectors/feature-toggles.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/selectors/feature-toggles.unit.spec.jsx
@@ -5,7 +5,7 @@ describe('ezr FeatureToggles selector', () => {
   const state = {
     featureToggles: {
       /* eslint-disable camelcase */
-      hca_browser_monitoring_enabled: true,
+      ezr_browser_monitoring_enabled: true,
       ezr_upload_enabled: true,
       ezr_emergency_contacts_enabled: true,
       loading: false,

--- a/src/applications/ezr/utils/selectors/feature-toggles.js
+++ b/src/applications/ezr/utils/selectors/feature-toggles.js
@@ -6,7 +6,7 @@ const selectFeatureToggles = createSelector(
   state => ({
     isLoadingFeatureFlags: state?.featureToggles?.loading,
     isBrowserMonitoringEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.hcaBrowserMonitoringEnabled
+      FEATURE_FLAG_NAMES.ezrBrowserMonitoringEnabled
     ],
     isUploadEnabled: toggleValues(state)[FEATURE_FLAG_NAMES.ezrUploadEnabled],
     isEmergencyContactsEnabled: toggleValues(state)[

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -80,6 +80,7 @@
   "disputeDebt": "dispute_debt",
   "emptyStateBenefitLetters": "empty_state_benefit_letters",
   "enrollmentVerification": "enrollment_verification",
+  "ezrBrowserMonitoringEnabled": "ezr_browser_monitoring_enabled",
   "ezrDownloadPdfEnabled": "ezr_download_pdf_enabled",
   "ezrProdEnabled": "ezr_prod_enabled",
   "ezrFormPrefillWithProvidersAndDependents": "ezr_form_prefill_with_providers_and_dependents",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR isolates the browser monitoring feature toggle for 10-10EZR from that of the one utilized by the 10-10EZ.  

## Related issue(s)

department-of-veterans-affairs/va.gov-team#120127

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- HCA and EZR browser monitoring functionality is isolated.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
