### PR TITLE
Update links from OH review feedback

### DIFF
--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
@@ -10,9 +10,12 @@ import {
   updateSelectedProvider,
 } from '../../redux/actions';
 import { getFormData } from '../../redux/selectors';
+import getNewAppointmentFlow from '../../newAppointmentFlow';
 
 function handleClick({ history, dispatch, data, provider, pageKey }) {
-  return () => {
+  return e => {
+    // Stop default behavior for anchor tag since we are using React routing.
+    e.preventDefault();
     dispatch(startDirectScheduleFlow({ isRecordEvent: false }));
     dispatch(routeToNextAppointmentPage(history, pageKey, data));
     dispatch(updateSelectedProvider(provider));
@@ -25,6 +28,7 @@ export default function ProviderCard({ provider }) {
   const history = useHistory();
   const pageKey = useSelector(state => state?.newAppointment?.currentPageKey);
   const data = useSelector(getFormData);
+  const { preferredDate } = useSelector(getNewAppointmentFlow);
 
   return (
     <div>
@@ -46,6 +50,8 @@ export default function ProviderCard({ provider }) {
 
       {hasAvailability && (
         <VaLink
+          href={preferredDate.url}
+          aria-label={`Choose your preferred date and time with ${providerName}`}
           active
           data-testid="choose-date-time"
           text="Choose your preferred date and time"

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector } from 'react-redux';
-import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaButton,
+  VaSelect,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { selectFacilitiesRadioWidget } from '../../redux/selectors';
 import State from '../../../components/State';
 import InfoAlert from '../../../components/InfoAlert';
@@ -102,14 +105,14 @@ export default function FacilitiesRadioWidget({
               level="3"
             >
               <p>Make sure your browser’s location feature is turned on.</p>
-              <va-link
+              <VaButton
                 text="Retry searching based on current location"
-                className="va-button-link"
                 onClick={() =>
                   updateFacilitySortMethod(
                     FACILITY_SORT_METHODS.distanceFromCurrentLocation,
                   )
                 }
+                uswds
               />
             </InfoAlert>
           </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update appointments links based on OH Scheduling Staging Review feedback
  - Convert retry link into button since it's an in page action
  - Add an href to the OH scheduling link so it's navigable and has an appropriate destination address
  - Add an aria-label to the OH scheduling link so it includes the provider name
- _(If bug, how to reproduce)_
- United Appointments Experience
- OH scheduling updates are behind the `va_online_scheduling_OH_direct_schedule` flag

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128355
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128363

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| OH schedule links *(note the bottom left)  |    <img width="603" height="428" alt="image" src="https://github.com/user-attachments/assets/5310aca2-58b1-44a2-8eab-7b5d25d55e35" />   |    <img width="595" height="428" alt="image" src="https://github.com/user-attachments/assets/910a508a-70cc-4aa8-a02d-9b83fa8e1b6f" />  |
| Retry link |    <img width="689" height="655" alt="image" src="https://github.com/user-attachments/assets/5064af20-e5e1-4dfe-a969-3a9e97fd35db" />   |   <img width="701" height="673" alt="image" src="https://github.com/user-attachments/assets/55e3dc38-1852-4afd-9ef5-38917ca0e1c6" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
