### PR TITLE
Chatbot/aw/2769/change skip link for chatbot

### DIFF
--- a/src/applications/virtual-agent/components/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/Chatbox.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
+import React, { useState } from 'react';
+
 import useBotOutgoingActivityEventListener from '../hooks/useBotOutgoingActivityEventListener';
 import useWebMessageActivityEventListener from '../hooks/useWebMessageActivityEventListener';
 import Bot from './Bot';
@@ -22,7 +23,11 @@ export default function Chatbox() {
   return (
     <div className="vads-u-padding--1p5 vads-u-background-color--gray-lightest">
       <div className="vads-u-background-color--primary-darker vads-u-padding--1p5">
-        <h2 className="vads-u-font-size--lg vads-u-color--white vads-u-margin--0">
+        <h2
+          className="vads-u-font-size--lg vads-u-color--white vads-u-margin--0"
+          id="chatbot-header"
+          tabIndex="-1"
+        >
           VA chatbot (beta)
         </h2>
       </div>

--- a/src/applications/virtual-agent/components/StickyBot.jsx
+++ b/src/applications/virtual-agent/components/StickyBot.jsx
@@ -1,25 +1,12 @@
 import React from 'react';
 
+import useSkipLinkFix from '../hooks/useSkipLinkFix';
 import Chatbox from './Chatbox';
 import Disclaimer from './Disclaimer/Disclaimer';
 
-// Update the "Skip to content" link to point to the chatbot header for accessibility
-// https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/2769
-const updateSkipToContentLink = () => {
-  const skipToContentLink = document.querySelector(
-    'a.show-on-focus[href="#content"]',
-  );
-  if (skipToContentLink) {
-    skipToContentLink.removeAttribute('onclick');
-    skipToContentLink.innerHTML = 'Skip to chatbot';
-    skipToContentLink.setAttribute('href', '#chatbot-header');
-  }
-};
-
 export default function StickyBot() {
-  React.useEffect(() => {
-    updateSkipToContentLink();
-  }, []);
+  useSkipLinkFix();
+
   return (
     <div className="vads-l-grid-container desktop-lg:vads-u-padding-x--0">
       <div className="vads-l-row vads-u-margin-x--neg2p5 vads-u-margin-y--4">

--- a/src/applications/virtual-agent/components/StickyBot.jsx
+++ b/src/applications/virtual-agent/components/StickyBot.jsx
@@ -1,8 +1,25 @@
 import React from 'react';
-import Disclaimer from './Disclaimer/Disclaimer';
+
 import Chatbox from './Chatbox';
+import Disclaimer from './Disclaimer/Disclaimer';
+
+// Update the "Skip to content" link to point to the chatbot header for accessibility
+// https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/2769
+const updateSkipToContentLink = () => {
+  const skipToContentLink = document.querySelector(
+    'a.show-on-focus[href="#content"]',
+  );
+  if (skipToContentLink) {
+    skipToContentLink.removeAttribute('onclick');
+    skipToContentLink.innerHTML = 'Skip to chatbot';
+    skipToContentLink.setAttribute('href', '#chatbot-header');
+  }
+};
 
 export default function StickyBot() {
+  React.useEffect(() => {
+    updateSkipToContentLink();
+  }, []);
   return (
     <div className="vads-l-grid-container desktop-lg:vads-u-padding-x--0">
       <div className="vads-l-row vads-u-margin-x--neg2p5 vads-u-margin-y--4">

--- a/src/applications/virtual-agent/hooks/useSkipLinkFix.js
+++ b/src/applications/virtual-agent/hooks/useSkipLinkFix.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+/**
+ * Updates the "Skip to content" link to point at the chatbot container header for accessibility.
+ * Runs once on mount and mutates the DOM outside virtual agent's app render tree (the website header).
+ */
+const useSkipLinkFix = () => {
+  useEffect(() => {
+    const skipToContentLink = document.querySelector(
+      'a.show-on-focus[href="#content"]',
+    );
+    if (skipToContentLink) {
+      skipToContentLink.removeAttribute('onclick');
+      skipToContentLink.innerHTML = 'Skip to chatbot';
+      skipToContentLink.setAttribute('href', '#chatbot-header');
+    }
+  }, []);
+};
+
+export default useSkipLinkFix;

--- a/src/applications/virtual-agent/hooks/useSkipLinkFix.js
+++ b/src/applications/virtual-agent/hooks/useSkipLinkFix.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 /**
- * Updates the "Skip to content" link to point at the chatbot container header for accessibility.
+ * Adds a "Skip to Chatbot" link after the existing "Skip to content" link for accessibility.
  * Runs once on mount and mutates the DOM outside virtual agent's app render tree (the website header).
  */
 const useSkipLinkFix = () => {
@@ -10,9 +10,11 @@ const useSkipLinkFix = () => {
       'a.show-on-focus[href="#content"]',
     );
     if (skipToContentLink) {
-      skipToContentLink.removeAttribute('onclick');
-      skipToContentLink.innerHTML = 'Skip to chatbot';
-      skipToContentLink.setAttribute('href', '#chatbot-header');
+      const chatbotSkipLink = document.createElement('a');
+      chatbotSkipLink.className = 'show-on-focus';
+      chatbotSkipLink.setAttribute('href', '#chatbot-header');
+      chatbotSkipLink.innerHTML = 'Skip to Chatbot';
+      skipToContentLink.after(chatbotSkipLink);
     }
   }, []);
 };

--- a/src/applications/virtual-agent/tests/hooks/useSkipLinkFix.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useSkipLinkFix.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('useSkipLinkFix', () => {
     document.body.innerHTML = '';
   });
 
-  it('updates the skip link to target the chatbot header', () => {
+  it('adds a chatbot skip link after the content skip link', () => {
     const skipLink = document.createElement('a');
     skipLink.className = 'show-on-focus';
     skipLink.setAttribute('href', '#content');
@@ -18,9 +18,15 @@ describe('useSkipLinkFix', () => {
 
     renderHook(() => useSkipLinkFix());
 
-    expect(skipLink.hasAttribute('onclick')).to.be.false;
-    expect(skipLink.innerHTML).to.equal('Skip to chatbot');
-    expect(skipLink.getAttribute('href')).to.equal('#chatbot-header');
+    expect(skipLink.hasAttribute('onclick')).to.be.true;
+    expect(skipLink.innerHTML).to.equal('Skip to content');
+    expect(skipLink.getAttribute('href')).to.equal('#content');
+
+    const chatbotSkipLink = skipLink.nextElementSibling;
+    expect(chatbotSkipLink).to.not.equal(null);
+    expect(chatbotSkipLink.className).to.equal('show-on-focus');
+    expect(chatbotSkipLink.getAttribute('href')).to.equal('#chatbot-header');
+    expect(chatbotSkipLink.innerHTML).to.equal('Skip to Chatbot');
   });
 
   it('ignores the DOM when the skip link does not match', () => {
@@ -33,5 +39,6 @@ describe('useSkipLinkFix', () => {
 
     expect(otherLink.getAttribute('href')).to.equal('#other');
     expect(otherLink.innerHTML).to.equal('');
+    expect(otherLink.nextElementSibling).to.equal(null);
   });
 });

--- a/src/applications/virtual-agent/tests/hooks/useSkipLinkFix.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useSkipLinkFix.unit.spec.jsx
@@ -1,0 +1,37 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { expect } from 'chai';
+
+import useSkipLinkFix from '../../hooks/useSkipLinkFix';
+
+describe('useSkipLinkFix', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('updates the skip link to target the chatbot header', () => {
+    const skipLink = document.createElement('a');
+    skipLink.className = 'show-on-focus';
+    skipLink.setAttribute('href', '#content');
+    skipLink.setAttribute('onclick', 'return false');
+    skipLink.innerHTML = 'Skip to content';
+    document.body.appendChild(skipLink);
+
+    renderHook(() => useSkipLinkFix());
+
+    expect(skipLink.hasAttribute('onclick')).to.be.false;
+    expect(skipLink.innerHTML).to.equal('Skip to chatbot');
+    expect(skipLink.getAttribute('href')).to.equal('#chatbot-header');
+  });
+
+  it('ignores the DOM when the skip link does not match', () => {
+    const otherLink = document.createElement('a');
+    otherLink.className = 'show-on-focus';
+    otherLink.setAttribute('href', '#other');
+    document.body.appendChild(otherLink);
+
+    renderHook(() => useSkipLinkFix());
+
+    expect(otherLink.getAttribute('href')).to.equal('#other');
+    expect(otherLink.innerHTML).to.equal('');
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes an a11y item where the chatbot application wants to provide a "skip to chatbot" link in addition to the usual "skip to content" link at the top of the page for screenreaders
- introduced a hook for the needed dom updates
- added a couple unit tests for the simple manipulations
- updated the heading for the chatbot container to have a specific id attr as well as a tab index so that it can be focused on click of the link

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/2769

## Testing done

- tested locally
- unit tests adde d

## Screenshots

NA no ui changes just a hidden link change

## What areas of the site does it impact?

chatbot / virtual agent

## Acceptance criteria

- skip link is available and able to be clicked and will focus on the header of the chatbot/scroll into view 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
