### PR TITLE
Travel Pay, Fix mileage expense request body

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -17,6 +17,7 @@ import {
   selectExpenseUpdateLoadingState,
   selectExpenseCreationLoadingState,
   selectAllExpenses,
+  selectAppointment,
 } from '../../../redux/selectors';
 import TravelPayButtonPair from '../../shared/TravelPayButtonPair';
 import {
@@ -33,6 +34,7 @@ const Mileage = () => {
 
   const isEditMode = !!expenseId;
 
+  const { data: appointment } = useSelector(selectAppointment);
   const allExpenses = useSelector(selectAllExpenses);
   const address = useSelector(selectVAPResidentialAddress);
 
@@ -52,7 +54,7 @@ const Mileage = () => {
   });
   const previousHasChangesRef = useRef(false);
 
-  const [formState, setFormState] = useState({ description: 'Mileage' });
+  const [formState, setFormState] = useState({});
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [showTripTypeError, setShowTripTypeError] = useState(false);
   const [showDepartureAddressError, setShowDepartureAddresError] = useState(
@@ -93,7 +95,6 @@ const Mileage = () => {
         const initialState = {
           departureAddress: 'home-address',
           tripType: TRIP_TYPES.ROUND_TRIP.value,
-          description: 'Mileage',
         };
         setFormState(initialState);
         initialFormStateRef.current = initialState;
@@ -121,11 +122,6 @@ const Mileage = () => {
   const handleContinue = async () => {
     if (!validatePage()) return;
 
-    const expenseData = {
-      ...formState,
-      expenseType: EXPENSE_TYPE_KEYS.MILEAGE,
-    };
-
     // Check if user selected "another-address" or "one-way"
     if (
       formState.departureAddress === 'another-address' ||
@@ -134,6 +130,15 @@ const Mileage = () => {
       navigate(`/file-new-claim/${apptId}/${claimId}/unsupported`);
       return;
     }
+
+    // Building the mileage expense request body
+    const expenseData = {
+      purchaseDate: appointment?.localStartTime
+        ? appointment.localStartTime.slice(0, 10) // Only the date portion of the localStartTime
+        : '',
+      description: 'Mileage',
+      tripType: formState.tripType,
+    };
 
     try {
       if (isEditMode) {

--- a/src/applications/travel-pay/constants.js
+++ b/src/applications/travel-pay/constants.js
@@ -262,10 +262,10 @@ export const TRANSPORTATION_OPTIONS = Object.freeze([
 ]);
 
 export const TRANSPORTATION_REASONS = Object.freeze({
-  PrivatelyOwnedVehicleNotAvailable: {
+  'Privately Owned Vehicle Not Available': {
     label: "I don't own a private vehicle or it wasn't available",
   },
-  MedicallyIndicated: {
+  'Medically Indicated': {
     label: 'Medical reasons',
   },
   Other: {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
@@ -28,6 +28,7 @@ describe('Complex Claims Mileage - Add', () => {
           },
           appointmentDate: '2024-01-15',
           appointmentTime: '10:00 AM',
+          localStartTime: '2024-01-15T10:00:00.000-08:00',
         },
         error: null,
         isLoading: false,
@@ -186,8 +187,11 @@ describe('Complex Claims Mileage - Add', () => {
       );
       fireEvent.click(continueBtn);
 
-      // Assert createExpense received correct description
-      expect(stub.firstCall.args[2].description).to.equal('Mileage');
+      // Assert createExpense received correct data
+      const expenseData = stub.firstCall.args[2];
+      expect(expenseData.purchaseDate).to.equal('2024-01-15');
+      expect(expenseData.description).to.equal('Mileage');
+      expect(expenseData.tripType).to.equal('RoundTrip');
 
       stub.restore();
     });
@@ -384,6 +388,7 @@ describe('Complex Claims Mileage - Edit', () => {
           },
           appointmentDate: '2024-01-15',
           appointmentTime: '10:00 AM',
+          localStartTime: '2024-01-15T10:00:00.000-08:00',
         },
         error: null,
         isLoading: false,
@@ -518,8 +523,11 @@ describe('Complex Claims Mileage - Edit', () => {
       );
       fireEvent.click(continueBtn);
 
-      // Assert updateExpense received correct description
-      expect(stub.firstCall.args[3].description).to.equal('Mileage');
+      // Assert updateExpense received correct data
+      const expenseData = stub.firstCall.args[3];
+      expect(expenseData.purchaseDate).to.equal('2024-01-15');
+      expect(expenseData.description).to.equal('Mileage');
+      expect(expenseData.tripType).to.equal('RoundTrip');
     });
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Staging testing has revealed the `purchaseDate` was left out of the mileage expense submission

## Related issue(s)

N/A

## Testing done

Verified with mock data, but testing will need to happen in staging to verify compatibility with TP API

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
