### PR TITLE
10-10EZR | Remove edit explanation text for Veteran Annual Income

### DIFF
--- a/src/applications/ezr/definitions/veteranAnnualIncome.js
+++ b/src/applications/ezr/definitions/veteranAnnualIncome.js
@@ -27,7 +27,7 @@ export const VeteranAnnualIncomePage = () => ({
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: `Your annual income from ${LAST_YEAR}`,
-      nounSingular: 'income source',
+      showEditExplanationText: false,
     }),
     'view:veteranGrossIncome': {
       ...inlineTitleUI(

--- a/src/applications/ezr/definitions/veteranAnnualIncome.js
+++ b/src/applications/ezr/definitions/veteranAnnualIncome.js
@@ -27,6 +27,7 @@ export const VeteranAnnualIncomePage = () => ({
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: `Your annual income from ${LAST_YEAR}`,
+      nounSingular: 'income source',
     }),
     'view:veteranGrossIncome': {
       ...inlineTitleUI(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR disables the default ArrayBuilder edit explanation text for the Vetetran Annual Income page.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#128252

## Testing done

- Prior to the change, the explanation text rendered by default on the page
- After the change, the text does not render

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Content matches Figma designs

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
