### PR TITLE
10-10EZR | Disable ArrayBuilder edit explanation text

### DIFF
--- a/src/applications/ezr/definitions/deductibleExpenses.js
+++ b/src/applications/ezr/definitions/deductibleExpenses.js
@@ -29,6 +29,7 @@ export const DeductibleExpensesPage = () => ({
       title: `Deductible expenses from ${LAST_YEAR}`,
       description:
         'These deductible expenses will lower the amount of money we count as your income.',
+      showEditExplanationText: false,
     }),
     'view:deductibleMedicalExpenses': {
       'ui:title': content['household-expenses-medical-title'],

--- a/src/applications/ezr/definitions/emergencyContacts.js
+++ b/src/applications/ezr/definitions/emergencyContacts.js
@@ -29,11 +29,11 @@ const {
  * Declare schema attributes for emergency contacts page
  * @returns {PageSchema}
  */
-export const emergencyContactsPage = options => ({
+export const emergencyContactsPage = () => ({
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: content['emergency-contact-title'],
-      nounSingular: options.nounSingular,
+      showEditExplanationText: false,
     }),
     fullName: fullNameUI(title => `Emergency contact's ${title}`, {
       first: {

--- a/src/applications/ezr/definitions/nextOfKin.js
+++ b/src/applications/ezr/definitions/nextOfKin.js
@@ -29,11 +29,11 @@ const {
  * Declare schema attributes for next of kins page
  * @returns {PageSchema}
  */
-export const nextOfKinPage = options => ({
+export const nextOfKinPage = () => ({
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: content['next-of-kin-title'],
-      nounSingular: options.nounSingular,
+      showEditExplanationText: false,
     }),
     fullName: fullNameUI(title => `Next of kin's ${title}`, {
       first: {

--- a/src/applications/ezr/definitions/spouseAnnualIncome.js
+++ b/src/applications/ezr/definitions/spouseAnnualIncome.js
@@ -27,6 +27,7 @@ export const SpouseAnnualIncomePage = () => ({
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: `Spouse's annual income from ${LAST_YEAR}`,
+      showEditExplanationText: false,
     }),
     'view:spouseGrossIncome': {
       ...inlineTitleUI(

--- a/src/applications/ezr/definitions/spousePersonalInformation.js
+++ b/src/applications/ezr/definitions/spousePersonalInformation.js
@@ -13,11 +13,11 @@ import content from '../locales/en/content.json';
 const { spouseFullName } = ezrSchema.properties;
 
 /** @returns {PageSchema} */
-const spousePersonalInformationPage = (options = {}) => ({
+const spousePersonalInformationPage = () => ({
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: content['household-spouse-information-title'],
-      nounSingular: options.nounSingular,
+      showEditExplanationText: false,
     }),
     spouseFullName: fullNameUI(
       title => `${content['household-spouse-name-prefix']} ${title}`,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR disables the default ArrayBuilder edit explanation text for all affected pages.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#128252

## Testing done

- Prior to the change, the explanation text rendered by default on the page
- After the change, the text does not render

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Content matches Figma designs

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
