### PR TITLE
IVC-CHAMPVA | Disable ArrayBuilder edit explanation text

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation/planTypes.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation/planTypes.js
@@ -20,7 +20,10 @@ const SCHEMA_ENUM = Object.keys(SCHEMA_LABELS);
 
 export default {
   uiSchema: {
-    ...arrayBuilderItemFirstPageTitleUI({ title: TITLE_TEXT }),
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: TITLE_TEXT,
+      showEditExplanationText: false,
+    }),
     insuranceType: radioUI({
       title: INPUT_LABEL,
       hint: HINT_TEXT,

--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsurance/planTypes.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsurance/planTypes.js
@@ -20,7 +20,10 @@ const SCHEMA_ENUM = Object.keys(SCHEMA_LABELS);
 
 export default {
   uiSchema: {
-    ...arrayBuilderItemFirstPageTitleUI({ title: TITLE_TEXT }),
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: TITLE_TEXT,
+      showEditExplanationText: false,
+    }),
     insuranceType: radioUI({
       title: INPUT_LABEL,
       hint: HINT_TEXT,

--- a/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
@@ -135,7 +135,7 @@ const policyPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Policy information',
-      nounSingular: insuranceOptions.nounSingular,
+      showEditExplanationText: false,
     }),
     name: textUI('Name of insurance provider'),
     policyNum: textUI('Policy number'),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR disables the default ArrayBuilder edit explanation text for all affected pages.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#128252

## Testing done

- Prior to the change, the explanation text rendered by default on the page
- After the change, the text does not render

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Content matches Figma designs

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
