### PR TITLE
125262 – Unify delete draft modal prompts and update tests

### DIFF
--- a/src/applications/mhv-secure-messaging/components/Draft/DeleteDraft.jsx
+++ b/src/applications/mhv-secure-messaging/components/Draft/DeleteDraft.jsx
@@ -205,7 +205,6 @@ const DeleteDraft = props => {
       </button>
       <DeleteDraftModal
         draftSequence={draftSequence}
-        unsavedDraft={unsavedDraft}
         visible={isModalVisible}
         onClose={handleDeleteModalClose}
         onDelete={handleDeleteDraftConfirm}

--- a/src/applications/mhv-secure-messaging/components/Modals/DeleteDraftModal.jsx
+++ b/src/applications/mhv-secure-messaging/components/Modals/DeleteDraftModal.jsx
@@ -5,40 +5,30 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 import { Prompts } from '../../util/constants';
 
 const DeleteDraftModal = props => {
-  const { unsavedDraft, draftSequence } = props;
+  const { draftSequence } = props;
   return (
     <VaModal
       id={`delete-draft-modal${draftSequence ? `-${draftSequence}` : ''}`}
       data-testid={`delete-draft-modal${
         draftSequence ? `-${draftSequence}` : ''
       }`}
-      data-dd-action-name={` ${
-        unsavedDraft
-          ? Prompts.Draft.DELETE_NEW_DRAFT_TITLE
-          : Prompts.Draft.DELETE_DRAFT_CONFIRM
-      } Modal${draftSequence ? ` ${draftSequence}` : ''}`}
-      modalTitle={
-        unsavedDraft
-          ? Prompts.Draft.DELETE_NEW_DRAFT_TITLE
-          : Prompts.Draft.DELETE_DRAFT_CONFIRM
-      }
+      data-dd-action-name={`${Prompts.Draft.DELETE_DRAFT_CONFIRM_HEADER} Modal${
+        draftSequence ? ` ${draftSequence}` : ''
+      }`}
+      modalTitle={Prompts.Draft.DELETE_DRAFT_CONFIRM_HEADER}
       onCloseEvent={() => {
         props.onClose();
         datadogRum.addAction(
-          `${
-            unsavedDraft
-              ? Prompts.Draft.DELETE_NEW_DRAFT_TITLE
-              : Prompts.Draft.DELETE_DRAFT_CONFIRM
-          } Modal${draftSequence ? ` ${draftSequence} Closed` : ' Closed'}`,
+          `${Prompts.Draft.DELETE_DRAFT_CONFIRM_HEADER} Modal${
+            draftSequence ? ` ${draftSequence} Closed` : ' Closed'
+          }`,
         );
       }}
       visible={props.visible}
       status="warning"
     >
       <p style={{ whiteSpace: 'pre-line' }}>
-        {unsavedDraft
-          ? Prompts.Draft.DELETE_NEW_DRAFT_CONTENT
-          : Prompts.Draft.DELETE_DRAFT_CONFIRM_NOTE}
+        {Prompts.Draft.DELETE_DRAFT_CONFIRM_CONTENT}
       </p>
       <div className="vads-u-display--flex vads-u-flex-direction--column mobile-lg:vads-u-flex-direction--row">
         <va-button

--- a/src/applications/mhv-secure-messaging/components/Modals/DeleteDraftModal.jsx
+++ b/src/applications/mhv-secure-messaging/components/Modals/DeleteDraftModal.jsx
@@ -59,7 +59,6 @@ const DeleteDraftModal = props => {
 DeleteDraftModal.propTypes = {
   draftSequence: PropTypes.number,
   id: PropTypes.number,
-  unsavedDraft: PropTypes.bool,
   visible: PropTypes.bool,
   onClose: PropTypes.func,
   onDelete: PropTypes.func,

--- a/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
@@ -93,9 +93,9 @@ describe('Delete Draft component', () => {
       expect(deleteDraftModal).to.have.attribute('visible', 'true');
       expect(deleteDraftModal).to.have.attribute(
         'modal-title',
-        Prompts.Draft.DELETE_DRAFT_CONFIRM,
+        Prompts.Draft.DELETE_DRAFT_CONFIRM_HEADER,
       );
-      screen.getByText(Prompts.Draft.DELETE_DRAFT_CONFIRM_NOTE);
+      screen.getByText(Prompts.Draft.DELETE_DRAFT_CONFIRM_CONTENT);
       screen.getByText('Delete draft');
       screen.getByTestId('cancel-delete-draft');
     });
@@ -294,7 +294,7 @@ describe('Delete Draft component', () => {
       'true',
     );
     expect(screen.getByTestId('delete-draft-modal')).to.have.text(
-      Prompts.Draft.DELETE_NEW_DRAFT_CONTENT,
+      Prompts.Draft.DELETE_DRAFT_CONFIRM_CONTENT,
     );
     fireEvent.click(screen.getByTestId('cancel-delete-draft'));
     expect(screen.queryByTestId('delete-draft-modal')).to.have.attribute(
@@ -346,7 +346,7 @@ describe('Delete Draft component', () => {
     );
 
     expect(screen.getByTestId('delete-draft-modal')).to.have.text(
-      Prompts.Draft.DELETE_DRAFT_CONFIRM_NOTE,
+      Prompts.Draft.DELETE_DRAFT_CONFIRM_CONTENT,
     );
     fireEvent.click(screen.getByTestId('cancel-delete-draft'));
     expect(screen.queryByTestId('delete-draft-modal')).to.have.attribute(
@@ -400,7 +400,9 @@ describe('Delete Draft component', () => {
     const deleteModal = getByTestId('delete-draft-modal');
     expect(deleteModal).to.exist;
     expect(deleteModal).to.have.attribute('visible', 'true');
-    expect(deleteModal).to.have.text(Prompts.Draft.DELETE_DRAFT_CONFIRM_NOTE);
+    expect(deleteModal).to.have.text(
+      Prompts.Draft.DELETE_DRAFT_CONFIRM_CONTENT,
+    );
 
     const deleteModalButton = getByTestId('confirm-delete-draft');
     fireEvent.click(deleteModalButton);

--- a/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/DeleteDraft.unit.spec.jsx
@@ -114,7 +114,6 @@ describe('Delete Draft component', () => {
       draftId: 123456,
       draftsCount: 1,
       savedDraft: true,
-      unsavedDraft: false,
       activeFolder: { folderId: '1' },
     };
 
@@ -194,7 +193,6 @@ describe('Delete Draft component', () => {
       draftBody: '',
       messageBody: '',
       savedDraft: false,
-      unsavedDraft: true,
       editableDraft: false,
     };
 
@@ -273,7 +271,6 @@ describe('Delete Draft component', () => {
         draftId={undefined}
         formPopulated={undefined}
         messageBody=""
-        unsavedDraft
         blankReplyDraft
         draftBody={undefined}
         savedReplyDraft={false}
@@ -325,7 +322,6 @@ describe('Delete Draft component', () => {
       <DeleteDraft
         draftId={mockDraft[0].messageId}
         messageBody={mockDraft[0].body}
-        unsavedDraft={false}
         blankReplyDraft={false}
         draftBody={mockDraft[0].body}
         savedReplyDraft
@@ -377,7 +373,6 @@ describe('Delete Draft component', () => {
       <DeleteDraft
         draftId={mockDraft[0].messageId}
         messageBody={mockDraft[0].body}
-        unsavedDraft={false}
         blankReplyDraft={false}
         draftBody={mockDraft[0].body}
         savedReplyDraft

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -266,11 +266,8 @@ export const Prompts = {
       'Messages in the trash folder won’t be permanently deleted.',
   },
   Draft: {
-    DELETE_DRAFT_CONFIRM: 'Are you sure you want to delete this draft?',
-    DELETE_DRAFT_CONFIRM_NOTE:
-      "Drafts are permanently deleted and this action can't be undone. Deleting a draft won't affect other messages in this conversation.",
-    DELETE_NEW_DRAFT_TITLE: 'Delete this draft?',
-    DELETE_NEW_DRAFT_CONTENT: `If you delete a draft, you can't get it back.`,
+    DELETE_DRAFT_CONFIRM_HEADER: 'Delete this draft?',
+    DELETE_DRAFT_CONFIRM_CONTENT: `If you delete a draft, you can’t get it back. But deleting it won’t affect other messages in this conversation.`,
   },
 };
 


### PR DESCRIPTION
## Summary
Consolidated draft deletion modal titles and content into DELETE_DRAFT_CONFIRM_HEADER and DELETE_DRAFT_CONFIRM_CONTENT in constants. Updated DeleteDraftModal and related unit tests to use the new unified prompt keys for consistency.

Why:
The Modal was showing different messages based on the draft's saved state. UX decided to consolidate and unify all delete draft interactions into one consistent message for all scenarios (saved drafts, unsaved drafts, reply drafts, etc.) instead of showing different messages based on draft state.

Impact:

No test changes required (unit and E2E tests already expect the unified message)
No functional changes to user experience
Cleaner, more maintainable code


- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Related issue(s)

- [_Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/125262)

## Testing done

- No new functionality to test, but updated `DeleteDraft.unit.spec.jsx` to reflect new consistent content.

## Screenshots 

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        | <img width="329" height="707" alt="Screenshot 2025-12-29 at 11 51 29 AM" src="https://github.com/user-attachments/assets/029de0e4-298a-4248-986e-09bda3bad945" /> |
| Desktop | <img width="703" height="814" alt="Screenshot 2025-12-29 at 1 55 01 PM" src="https://github.com/user-attachments/assets/22aee660-46f0-49ad-9aea-4e2ff93b3acc" /> | <img width="1261" height="1113" alt="Screenshot 2025-12-29 at 11 50 53 AM" src="https://github.com/user-attachments/assets/262eb91e-0d18-491a-b3e1-c36b7a93a63e" /> |

## What areas of the site does it impact?
Secure Messaging

## Acceptance criteria

- [x] Make the alert have consistent content.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
