### PR TITLE
feat(mhv-secure-messaging): [Design debt] Replace folder creation modal with inline form

### DIFF
--- a/src/applications/mhv-secure-messaging/components/FoldersList.jsx
+++ b/src/applications/mhv-secure-messaging/components/FoldersList.jsx
@@ -43,7 +43,7 @@ const FoldersList = props => {
                     {highlightName &&
                       folder.name === highlightName && (
                         <span
-                          className="folder-new-tag"
+                          className="usa-label vads-u-background-color--primary vads-u-margin-left--1"
                           data-testid="folder-new-tag"
                         >
                           NEW

--- a/src/applications/mhv-secure-messaging/components/FoldersList.jsx
+++ b/src/applications/mhv-secure-messaging/components/FoldersList.jsx
@@ -5,7 +5,7 @@ import { folderPathByFolderId, isCustomFolder } from '../util/helpers';
 import { DefaultFolders as Folders } from '../util/constants';
 
 const FoldersList = props => {
-  const { folders, showUnread } = props;
+  const { folders, showUnread, highlightName } = props;
 
   const folderNameDdAction = useCallback(folder => {
     const { id } = folder;
@@ -40,6 +40,15 @@ const FoldersList = props => {
                     {folder.id === Folders.DELETED.id
                       ? Folders.DELETED.header
                       : folder.name}{' '}
+                    {highlightName &&
+                      folder.name === highlightName && (
+                        <span
+                          className="folder-new-tag"
+                          data-testid="folder-new-tag"
+                        >
+                          NEW
+                        </span>
+                      )}
                     {showUnread &&
                       folder.unreadCount > 0 &&
                       folder.id !== Folders.DRAFTS.id &&
@@ -56,7 +65,7 @@ const FoldersList = props => {
 
 FoldersList.propTypes = {
   folders: PropTypes.array,
-  highlightId: PropTypes.string,
+  highlightName: PropTypes.string,
   showUnread: PropTypes.bool,
 };
 

--- a/src/applications/mhv-secure-messaging/components/FoldersList/CreateFolderInline.jsx
+++ b/src/applications/mhv-secure-messaging/components/FoldersList/CreateFolderInline.jsx
@@ -1,0 +1,143 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { datadogRum } from '@datadog/browser-rum';
+import recordEvent from 'platform/monitoring/record-event';
+import { Alerts } from '../../util/constants';
+
+const CreateFolderInline = ({ folders, onConfirm, onFolderCreated }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [folderName, setFolderName] = useState('');
+  const [nameWarning, setNameWarning] = useState('');
+  const folderNameInput = useRef();
+
+  useEffect(
+    () => {
+      if (isExpanded && folderNameInput.current) {
+        focusElement(
+          folderNameInput.current.shadowRoot?.querySelector('input'),
+        );
+      }
+    },
+    [isExpanded],
+  );
+
+  useEffect(
+    () => {
+      if (nameWarning.length && folderNameInput.current) {
+        focusElement(
+          folderNameInput.current.shadowRoot?.querySelector('input'),
+        );
+      }
+    },
+    [nameWarning],
+  );
+
+  const handleCancel = useCallback(() => {
+    setFolderName('');
+    setNameWarning('');
+    setIsExpanded(false);
+    datadogRum.addAction('Create New Folder Inline Cancelled');
+  }, []);
+
+  const handleCreate = useCallback(
+    () => {
+      const folderMatch = folders.filter(folder => folder.name === folderName);
+
+      if (folderName === '' || folderName.match(/^[\s]+$/)) {
+        setNameWarning(Alerts.Folder.CREATE_FOLDER_ERROR_NOT_BLANK);
+      } else if (folderMatch.length > 0) {
+        setNameWarning(Alerts.Folder.CREATE_FOLDER_ERROR_EXSISTING_NAME);
+      } else if (folderName.match(/^[0-9a-zA-Z\s]+$/)) {
+        onConfirm(folderName, () => {
+          setFolderName('');
+          setNameWarning('');
+          setIsExpanded(false);
+          if (onFolderCreated) onFolderCreated(folderName);
+        });
+      } else {
+        setNameWarning(Alerts.Folder.CREATE_FOLDER_ERROR_CHAR_TYPE);
+      }
+    },
+    [folders, folderName, onConfirm, onFolderCreated],
+  );
+
+  const handleExpand = () => {
+    setIsExpanded(true);
+    recordEvent({
+      event: 'cta-button-click',
+      'button-type': 'primary',
+      'button-click-label': 'Create new folder',
+    });
+    datadogRum.addAction('Create New Folder Inline Expanded');
+  };
+
+  if (!isExpanded) {
+    return (
+      <va-button
+        onClick={handleExpand}
+        text={Alerts.Folder.CREATE_FOLDER_MODAL_HEADER}
+        data-testid="create-new-folder"
+        data-dd-action-name="Create New Folder Button"
+      />
+    );
+  }
+
+  return (
+    <div
+      className="create-folder-inline-form"
+      data-testid="create-folder-inline"
+    >
+      <VaTextInput
+        data-dd-privacy="mask"
+        ref={folderNameInput}
+        label={Alerts.Folder.CREATE_FOLDER_MODAL_LABEL}
+        hint="50 characters allowed"
+        className="input"
+        width="2xl"
+        value={folderName}
+        onInput={e => {
+          setFolderName(e.target.value);
+          setNameWarning(
+            e.target.value ? '' : Alerts.Folder.CREATE_FOLDER_ERROR_NOT_BLANK,
+          );
+        }}
+        maxlength="50"
+        error={nameWarning}
+        name="folder-name"
+        data-testid="folder-name"
+        data-dd-action-name="Create Folder Inline Input Field"
+        charcount
+      />
+      <div className="vads-u-margin-top--2">
+        <va-button
+          text="Create"
+          onClick={handleCreate}
+          data-testid="create-folder-button"
+          data-dd-action-name="Confirm Create Folder Inline Button"
+        />
+        <va-button
+          class="vads-u-margin-left--1"
+          secondary
+          text="Cancel"
+          onClick={handleCancel}
+          data-testid="cancel-folder-button"
+          data-dd-action-name="Cancel Create Folder Inline Button"
+        />
+      </div>
+    </div>
+  );
+};
+
+CreateFolderInline.propTypes = {
+  folders: PropTypes.array.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onFolderCreated: PropTypes.func,
+};
+
+CreateFolderInline.defaultProps = {
+  onFolderCreated: null,
+};
+
+export default CreateFolderInline;

--- a/src/applications/mhv-secure-messaging/components/FoldersList/CreateFolderInline.jsx
+++ b/src/applications/mhv-secure-messaging/components/FoldersList/CreateFolderInline.jsx
@@ -85,10 +85,7 @@ const CreateFolderInline = ({ folders, onConfirm, onFolderCreated }) => {
   }
 
   return (
-    <div
-      className="create-folder-inline-form"
-      data-testid="create-folder-inline"
-    >
+    <div className="vads-u-margin-top--2" data-testid="create-folder-inline">
       <VaTextInput
         data-dd-privacy="mask"
         ref={folderNameInput}

--- a/src/applications/mhv-secure-messaging/components/FoldersList/CreateFolderInline.jsx
+++ b/src/applications/mhv-secure-messaging/components/FoldersList/CreateFolderInline.jsx
@@ -85,12 +85,14 @@ const CreateFolderInline = ({ folders, onConfirm, onFolderCreated }) => {
   }
 
   return (
-    <div className="vads-u-margin-top--2" data-testid="create-folder-inline">
+    <div
+      className="vads-u-margin-top--2 vads-u-margin-left--0p5 vads-u-border-left--5px vads-u-border-color--primary vads-u-padding-left--2"
+      data-testid="create-folder-inline"
+    >
       <VaTextInput
         data-dd-privacy="mask"
         ref={folderNameInput}
         label={Alerts.Folder.CREATE_FOLDER_MODAL_LABEL}
-        hint="50 characters allowed"
         className="input"
         width="2xl"
         value={folderName}

--- a/src/applications/mhv-secure-messaging/sass/folders-list.scss
+++ b/src/applications/mhv-secure-messaging/sass/folders-list.scss
@@ -77,3 +77,24 @@
     margin: 0;
   }
 }
+
+.folder-new-tag {
+  display: inline-block;
+  background-color: var(--vads-color-primary);
+  color: var(--vads-color-white);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 3px;
+  margin-left: 8px;
+  text-transform: uppercase;
+}
+
+.create-folder-inline-form {
+  margin-top: 16px;
+  max-width: 400px;
+
+  .input {
+    margin-left: 0;
+  }
+}

--- a/src/applications/mhv-secure-messaging/sass/folders-list.scss
+++ b/src/applications/mhv-secure-messaging/sass/folders-list.scss
@@ -77,24 +77,3 @@
     margin: 0;
   }
 }
-
-.folder-new-tag {
-  display: inline-block;
-  background-color: var(--vads-color-primary);
-  color: var(--vads-color-white);
-  font-size: 0.75rem;
-  font-weight: 700;
-  padding: 2px 6px;
-  border-radius: 3px;
-  margin-left: 8px;
-  text-transform: uppercase;
-}
-
-.create-folder-inline-form {
-  margin-top: 16px;
-  max-width: 400px;
-
-  .input {
-    margin-left: 0;
-  }
-}

--- a/src/applications/mhv-secure-messaging/tests/components/FoldersList/CreateFolderInline.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/FoldersList/CreateFolderInline.unit.spec.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { expect } from 'chai';
+import { fireEvent, waitFor } from '@testing-library/dom';
+import { cleanup } from '@testing-library/react';
+import sinon from 'sinon';
+import { inputVaTextInput } from '@department-of-veterans-affairs/platform-testing/helpers';
+import folderList from '../../fixtures/folder-response.json';
+import reducer from '../../../reducers';
+import CreateFolderInline from '../../../components/FoldersList/CreateFolderInline';
+import { Alerts } from '../../../util/constants';
+
+describe('CreateFolderInline component', () => {
+  let sandbox;
+
+  const initialState = {
+    sm: {
+      folders: {
+        folderList,
+      },
+      alerts: {
+        alertVisible: false,
+        alertFocusOut: null,
+        alertList: [],
+      },
+    },
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    cleanup();
+  });
+
+  const setup = (props = {}) => {
+    const defaultProps = {
+      folders: folderList,
+      onConfirm: sandbox.stub(),
+      onFolderCreated: sandbox.stub(),
+    };
+    return renderWithStoreAndRouter(
+      <CreateFolderInline {...defaultProps} {...props} />,
+      {
+        initialState,
+        reducers: reducer,
+      },
+    );
+  };
+
+  it('renders the "Create new folder" button when not expanded', () => {
+    const screen = setup();
+    expect(screen.getByTestId('create-new-folder')).to.exist;
+    expect(screen.queryByTestId('create-folder-inline')).to.be.null;
+  });
+
+  it('expands inline form when "Create new folder" button is clicked', async () => {
+    const screen = setup();
+
+    const createNewFolderBtn = screen.getByTestId('create-new-folder');
+    fireEvent.click(createNewFolderBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-folder-inline')).to.exist;
+      expect(screen.getByTestId('folder-name')).to.exist;
+      expect(screen.getByTestId('create-folder-button')).to.exist;
+      expect(screen.getByTestId('cancel-folder-button')).to.exist;
+    });
+  });
+
+  it('collapses inline form when Cancel button is clicked', async () => {
+    const screen = setup();
+
+    // Expand the form
+    const createNewFolderBtn = screen.getByTestId('create-new-folder');
+    fireEvent.click(createNewFolderBtn);
+    expect(screen.getByTestId('create-folder-inline')).to.exist;
+
+    // Click cancel button
+    const cancelBtn = document.querySelector('va-button[text="Cancel"]');
+    fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('create-folder-inline')).to.be.null;
+    });
+  });
+
+  it('shows validation error when folder name is empty and Create is clicked', async () => {
+    const screen = setup();
+
+    // Expand the form
+    fireEvent.click(screen.getByTestId('create-new-folder'));
+
+    // Try to create without entering a name
+    const createBtn = document.querySelector('va-button[text="Create"]');
+    fireEvent.click(createBtn);
+
+    await waitFor(() => {
+      const textInput = document.querySelector('va-text-input');
+      expect(textInput).to.have.attribute(
+        'error',
+        Alerts.Folder.CREATE_FOLDER_ERROR_NOT_BLANK,
+      );
+    });
+  });
+
+  it('displays text input with proper attributes for folder name entry', async () => {
+    const screen = setup();
+
+    // Expand the form
+    fireEvent.click(screen.getByTestId('create-new-folder'));
+
+    await waitFor(() => {
+      const textInput = document.querySelector('va-text-input');
+      expect(textInput).to.have.attribute('label', 'Folder name');
+      expect(textInput).to.have.attribute('maxlength', '50');
+      expect(textInput).to.have.attribute('charcount', 'true');
+    });
+  });
+
+  it('allows text input value to be set', async () => {
+    const screen = setup();
+
+    // Expand and enter a valid new name
+    fireEvent.click(screen.getByTestId('create-new-folder'));
+    inputVaTextInput(screen.container, 'My New Folder');
+
+    await waitFor(() => {
+      expect(document.querySelector('va-text-input[value="My New Folder"]')).to
+        .exist;
+    });
+  });
+
+  it('renders Create and Cancel buttons with correct text', async () => {
+    const screen = setup();
+
+    fireEvent.click(screen.getByTestId('create-new-folder'));
+
+    await waitFor(() => {
+      const createBtn = document.querySelector('va-button[text="Create"]');
+      const cancelBtn = document.querySelector('va-button[text="Cancel"]');
+      expect(createBtn).to.exist;
+      expect(cancelBtn).to.exist;
+      expect(cancelBtn).to.have.attribute('secondary', 'true');
+    });
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/containers/Folders.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/Folders.unit.spec.jsx
@@ -78,11 +78,11 @@ describe('Folders Landing Page', () => {
     );
   });
 
-  it('opens and closes Create New Folder modal', async () => {
+  it('opens and closes Create New Folder inline form', async () => {
     const createNewFolderBtn = screen.getByTestId('create-new-folder');
     fireEvent.click(createNewFolderBtn);
-    const createNewFolderModal = screen.getByTestId('create-folder-modal');
-    expect(createNewFolderModal).to.be.visible;
+    const createFolderInline = screen.getByTestId('create-folder-inline');
+    expect(createFolderInline).to.exist;
 
     const vaTextInput = screen.getByTestId('folder-name');
     expect(vaTextInput).to.exist;
@@ -94,16 +94,16 @@ describe('Folders Landing Page', () => {
     expect(cancelFolderButton).to.exist;
     fireEvent.click(cancelFolderButton);
     await waitFor(() => {
-      expect(createNewFolderModal.getAttribute('visible')).to.equal('false');
+      expect(screen.queryByTestId('create-folder-inline')).to.be.null;
     });
   });
 
-  it('should allow input field text changes in Create New Folder Modal', () => {
-    // opens create new folder modal
+  it('should allow input field text changes in Create New Folder inline form', () => {
+    // opens create new folder inline form
     const createNewFolderBtn = screen.getByTestId('create-new-folder');
     fireEvent.click(createNewFolderBtn);
-    const createNewFolderModal = screen.getByTestId('create-folder-modal');
-    expect(createNewFolderModal).to.be.visible;
+    const createFolderInline = screen.getByTestId('create-folder-inline');
+    expect(createFolderInline).to.exist;
 
     // checks input field to be empty
     const vaTextInput = screen.queryByTestId('folder-name');

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderManagementPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderManagementPage.js
@@ -9,7 +9,7 @@ class FolderManagementPage {
 
   createANewFolderButton = () => {
     return cy
-      .get(Locators.ALERTS.CREAT_NEW_TEXT_FOLD)
+      .get(Locators.ALERTS.CREATE_NEW_FOLDER)
       .shadow()
       .find('[type="button"]');
   };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **What**: Replace `CreateFolderModal` with `CreateFolderInline` component on the Folders page per VADS guidance
- **Why**: VADS states that "Modals should not contain long forms. Modal content must be brief and not include complicated interactions."
- **Pattern**: Inline conditional reveal - clicking "Create new folder" expands an inline form instead of opening a modal
- **Team**: MHV Secure Messaging team
- **Scope**: Replaces Create Folder modal with inline form (ticket scope confirmed by designer)

### Changes Made
| File | Change |
|------|--------|
| `components/FoldersList/CreateFolderInline.jsx` | **NEW** - Inline folder creation with conditional reveal pattern |
| `containers/Folders.jsx` | Replace modal with inline component, add NEW tag state management |
| `components/FoldersList.jsx` | Add `highlightName` prop for NEW tag display using `usa-label` + VADS utility classes |
| `sass/folders-list.scss` | No custom styles added - uses VADS utility classes per team guidance |
| `tests/containers/Folders.unit.spec.jsx` | Update tests for inline form |
| `tests/components/FoldersList/CreateFolderInline.unit.spec.jsx` | **NEW** - 7 unit tests |

### Design Decisions
1. **Kept `CreateFolderModal.jsx`** - Still used by `MoveMessageToFolderBtn.jsx` for move message flow
2. **Local state for NEW tag** - Uses `useState` so tag naturally clears on page reload per design spec
3. **VADS utility classes over custom SCSS** - Per team guidance, uses `usa-label` with `vads-u-background-color--primary` and `vads-u-margin-left--1` instead of custom CSS (following pattern from `mhv-landing-page/components/NavCard.jsx`)

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#123477
- Epic: MHV-68765
- [Figma Design](https://www.figma.com/design/S0unbFz4j8oC4AY7iCd6KU/Z---Custom-folder-explorations?node-id=2443-8728)

## Testing done

### Before/After Behavior
- **Before**: Clicking "Create new folder" opened a modal dialog
- **After**: Clicking "Create new folder" reveals an inline form below the button

### Verification Steps
1. Navigate to `/my-health/secure-messages/folders`
2. Click "Create new folder" button
3. Verify inline form appears with text input, Create button, Cancel button
4. Enter folder name and click Create
5. Verify success alert and NEW tag appears on created folder
6. Refresh page and verify NEW tag disappears

### Test Results
| Type | Count | Status |
|------|-------|--------|
| Unit Tests | 13 | ✅ All passing |
| E2E Tests | 11 | ✅ All passing |
| Axe Checks | Included in E2E | ✅ No violations |

### Specs Covered
- `Folders.unit.spec.jsx` - 6 tests (updated for inline form)
- `CreateFolderInline.unit.spec.jsx` - 7 tests (NEW)
- `secure-messaging-create-folder-errors.cypress.spec.js` - 2 tests
- `secure-messaging-folders.cypress.spec.js` - 4 tests
- `secure-messaging-manage-folder.cypress.spec.js` - 2 tests
- `secure-messaging-custom-folders-redesign.cypress.spec.js` - 3 tests

## Screenshots

> Screenshots showing inline form pattern per Figma design.

|         | Before (Modal) | After (Inline) |
| ------- | ------ | ----- |
| Desktop | Modal overlay for folder creation | Inline form revealed below button |
| Mobile  | Modal overlay (full width) | Inline form within page flow |

Before: 
<img width="1259" height="875" alt="Screenshot 2026-01-05 at 11 37 19" src="https://github.com/user-attachments/assets/35aaab94-6d21-4c6d-98c5-1913afcdf1cf" />


After:
<img width="689" height="580" alt="image" src="https://github.com/user-attachments/assets/44a5fbe2-83fd-4e96-8d89-74f83d4c29fc" />



**User to provide actual screenshots before marking ready for review**

## What areas of the site does it impact?

- **MHV Secure Messaging** - Folders page (`/my-health/secure-messages/folders`)
- No impact to other applications or platform code

## Acceptance criteria

### Quality Assurance &amp; Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (README adequate, no changes needed)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (axeCheck in E2E tests)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (DataDog RUM with PII masking)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - uses existing folder creation monitoring

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please review:
1. Inline conditional reveal pattern implementation
2. NEW tag behavior (local state, clears on reload)
3. Decision to keep `CreateFolderModal.jsx` for move message flow
4. Use of `usa-label` + VADS utility classes instead of custom SCSS