### PR TITLE
10-7959c | Wire up Medicare pages for Rev2025 form flow

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/index.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/index.js
@@ -1,0 +1,138 @@
+import { FEATURE_TOGGLES } from '../../hooks/useDefaultFormData';
+import {
+  hasMedicare,
+  hasPartA,
+  hasPartADenialNotice,
+  hasPartB,
+  hasPartC,
+  hasPartD,
+  hasPartsABorC,
+} from '../../utils/helpers';
+import medicareIntro from './introduction';
+import partACardUpload from './partACardUpload';
+import partADenialNotice from './partADenialNotice';
+import partADenialProofUpload from './partADenialProofUpload';
+import partAEffectiveDates from './partAEffectiveDates';
+import partAPartBCardUpload from './partAPartBCardUpload';
+import partAPartBEffectiveDates from './partAPartBEffectiveDates';
+import partBCardUpload from './partBCardUpload';
+import partBEffectiveDates from './partBEffectiveDates';
+import partCCardUpload from './partCCardUpload';
+import partCEffectiveDate from './partCEffectiveDate';
+import partCPharmacyBenefits from './partCPharmacyBenefits';
+import partDCardUpload from './partDCardUpload';
+import partDEffectiveDate from './partDEffectiveDate';
+import partDStatus from './partDStatus.rev2025';
+import planTypes from './planTypes.rev2025';
+import reportPlans from './reportPlans.rev2025';
+
+const REV2025_TOGGLE_KEY = `view:${FEATURE_TOGGLES[0]}`;
+
+export const medicarePagesRev2025 = {
+  medicareOverview: {
+    path: 'medicare-overview',
+    title: 'Report Medicare',
+    depends: formData => formData[REV2025_TOGGLE_KEY],
+    ...medicareIntro,
+  },
+  reportMedicare: {
+    path: 'report-medicare-plan',
+    title: 'Report Medicare plan',
+    depends: formData => formData[REV2025_TOGGLE_KEY],
+    ...reportPlans,
+  },
+  medicarePlanType: {
+    path: 'medicare-plan-type',
+    title: 'Medicare plan type',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasMedicare(formData),
+    ...planTypes,
+  },
+  medicarePartAEffectiveDate: {
+    path: 'medicare-part-a-effective-date',
+    title: 'Medicare Part A effective date',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartA(formData),
+    ...partAEffectiveDates,
+  },
+  medicarePartACardUpload: {
+    path: 'medicare-part-a-card',
+    title: 'Upload Medicare Part A card',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartA(formData),
+    ...partACardUpload,
+  },
+  medicarePartBEffectiveDate: {
+    path: 'medicare-part-b-effective-date',
+    title: 'Medicare Part B effective date',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartB(formData),
+    ...partBEffectiveDates,
+  },
+  medicarePartBCardUpload: {
+    path: 'medicare-part-b-card',
+    title: 'Upload Medicare Part B card',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartB(formData),
+    ...partBCardUpload,
+  },
+  medicarePartADenial: {
+    path: 'medicare-part-a-denial-notice',
+    title: 'Medicare Part A denial',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartB(formData),
+    ...partADenialNotice,
+  },
+  medicarePartADenialProofUpload: {
+    path: 'medicare-proof-of-part-a-denial',
+    title: 'Upload proof of Medicare ineligibility',
+    depends: formData =>
+      formData[REV2025_TOGGLE_KEY] && hasPartADenialNotice(formData),
+    ...partADenialProofUpload,
+  },
+  medicarePartAPartBEffectiveDates: {
+    path: 'medicare-parts-a-and-b-effective-dates',
+    title: 'Medicare effective dates',
+    depends: formData =>
+      formData[REV2025_TOGGLE_KEY] && hasPartsABorC(formData),
+    ...partAPartBEffectiveDates,
+  },
+  medicareABCardUpload: {
+    path: 'medicare-parts-a-and-b-card',
+    title: 'Medicare card (A/B)',
+    depends: formData =>
+      formData[REV2025_TOGGLE_KEY] && hasPartsABorC(formData),
+    ...partAPartBCardUpload,
+  },
+  medicarePartCCarrierEffectiveDate: {
+    path: 'medicare-part-c-carrier-and-effective-date',
+    title: 'Medicare Part C carrier and effective date',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartC(formData),
+    ...partCEffectiveDate,
+  },
+  medicarePartCPharmacyBenefits: {
+    path: 'medicare-part-c-pharmacy-benefits',
+    title: 'Medicare Part C pharmacy benefits',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartC(formData),
+    ...partCPharmacyBenefits,
+  },
+  medicarePartCCardUpload: {
+    path: 'medicare-part-c-card',
+    title: 'Medicare Part C card',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartC(formData),
+    ...partCCardUpload,
+  },
+  medicarePartDStatus: {
+    path: 'medicare-part-d-status',
+    title: 'Medicare Part D status',
+    depends: formData =>
+      formData[REV2025_TOGGLE_KEY] && hasPartsABorC(formData),
+    ...partDStatus,
+  },
+  medicarePartDCarrierEffectiveDate: {
+    path: 'medicare-part-d-carrier-and-effective-date',
+    title: 'Medicare Part D carrier and effective date',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartD(formData),
+    ...partDEffectiveDate,
+  },
+  medicarePartDCardUpload: {
+    path: 'medicare-part-d-card',
+    title: 'Medicare Part D card',
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartD(formData),
+    ...partDCardUpload,
+  },
+};

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/introduction.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/introduction.js
@@ -1,0 +1,17 @@
+import {
+  descriptionUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import MedicareIntroDescription from '../../components/FormDescriptions/MedicareIntroDescription';
+import { blankSchema } from '../../definitions';
+import content from '../../locales/en/content.json';
+
+const TITLE_TEXT = content['medicare--intro-title'];
+
+export default {
+  uiSchema: {
+    ...titleUI(TITLE_TEXT),
+    ...descriptionUI(MedicareIntroDescription),
+  },
+  schema: blankSchema,
+};

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partADenialNotice.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partADenialNotice.js
@@ -14,9 +14,9 @@ const HINT_TEXT = content['medicare--part-a-denial-notice-hint'];
 export default {
   uiSchema: {
     ...descriptionUI(ProofOfMedicareAlert),
-    'view:partADenialNotice': {
+    'view:hasPartADenial': {
       ...titleWithNameUI(TITLE_TEXT),
-      applicantMedicarePartADenialNotice: yesNoUI({
+      hasPartADenial: yesNoUI({
         title: INPUT_LABEL,
         hint: HINT_TEXT,
       }),
@@ -25,11 +25,11 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:partADenialNotice': {
+      'view:hasPartADenial': {
         type: 'object',
-        required: ['applicantMedicarePartADenialNotice'],
+        required: ['hasPartADenial'],
         properties: {
-          applicantMedicarePartADenialNotice: yesNoSchema,
+          hasPartADenial: yesNoSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partADenialProofUpload.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partADenialProofUpload.js
@@ -14,16 +14,16 @@ export default {
   uiSchema: {
     ...titleUI(TITLE_TEXT, MedicareIneligibilityDescription),
     ...descriptionUI(FileUploadDescription),
-    medicarePartADenialProof: attachmentUI({
+    proofOfIneligibilityUpload: attachmentUI({
       label: TITLE_TEXT,
       attachmentId: ATTACHMENT_IDS.ssaLetter,
     }),
   },
   schema: {
     type: 'object',
-    required: ['medicarePartADenialProof'],
+    required: ['proofOfIneligibilityUpload'],
     properties: {
-      medicarePartADenialProof: singleAttachmentSchema,
+      proofOfIneligibilityUpload: singleAttachmentSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partAEffectiveDates.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partAEffectiveDates.js
@@ -20,7 +20,7 @@ export default {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      applicantMedicarePartAEffectiveDate: currentOrPastDateUI({
+      medicarePartAEffectiveDate: currentOrPastDateUI({
         title: INPUT_LABEL,
         hint: HINT_TEXT,
         classNames: 'vads-u-margin-top--neg1p5',
@@ -32,9 +32,9 @@ export default {
     properties: {
       'view:medicarePartAEffectiveDate': {
         type: 'object',
-        required: ['applicantMedicarePartAEffectiveDate'],
+        required: ['medicarePartAEffectiveDate'],
         properties: {
-          applicantMedicarePartAEffectiveDate: currentOrPastDateSchema,
+          medicarePartAEffectiveDate: currentOrPastDateSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partAPartBEffectiveDates.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partAPartBEffectiveDates.js
@@ -27,7 +27,7 @@ export default {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      applicantMedicarePartAEffectiveDate: currentOrPastDateUI({
+      medicarePartAEffectiveDate: currentOrPastDateUI({
         title: INPUT_LABEL,
         hint: HINT_TEXT.partA,
         classNames: 'vads-u-margin-top--neg1p5',
@@ -39,7 +39,7 @@ export default {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      applicantMedicarePartBEffectiveDate: currentOrPastDateUI({
+      medicarePartBEffectiveDate: currentOrPastDateUI({
         title: INPUT_LABEL,
         hint: HINT_TEXT.partB,
         classNames: 'vads-u-margin-top--neg1p5',
@@ -51,16 +51,16 @@ export default {
     properties: {
       'view:medicarePartAEffectiveDate': {
         type: 'object',
-        required: ['applicantMedicarePartAEffectiveDate'],
+        required: ['medicarePartAEffectiveDate'],
         properties: {
-          applicantMedicarePartAEffectiveDate: currentOrPastDateSchema,
+          medicarePartAEffectiveDate: currentOrPastDateSchema,
         },
       },
       'view:medicarePartBEffectiveDate': {
         type: 'object',
-        required: ['applicantMedicarePartBEffectiveDate'],
+        required: ['medicarePartBEffectiveDate'],
         properties: {
-          applicantMedicarePartBEffectiveDate: currentOrPastDateSchema,
+          medicarePartBEffectiveDate: currentOrPastDateSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partBEffectiveDates.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partBEffectiveDates.js
@@ -20,7 +20,7 @@ export default {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      applicantMedicarePartBEffectiveDate: currentOrPastDateUI({
+      medicarePartBEffectiveDate: currentOrPastDateUI({
         title: INPUT_LABEL,
         hint: HINT_TEXT,
         classNames: 'vads-u-margin-top--neg1p5',
@@ -32,9 +32,9 @@ export default {
     properties: {
       'view:medicarePartBEffectiveDate': {
         type: 'object',
-        required: ['applicantMedicarePartBEffectiveDate'],
+        required: ['medicarePartBEffectiveDate'],
         properties: {
-          applicantMedicarePartBEffectiveDate: currentOrPastDateSchema,
+          medicarePartBEffectiveDate: currentOrPastDateSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partCEffectiveDate.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partCEffectiveDate.js
@@ -20,24 +20,21 @@ const HINT_TEXT = {
 export default {
   uiSchema: {
     ...titleWithNameUI(TITLE_TEXT),
-    applicantMedicarePartCCarrier: textUI({
+    medicarePartCCarrier: textUI({
       title: INPUT_LABELS.carrier,
       hint: HINT_TEXT.carrier,
     }),
-    applicantMedicarePartCEffectiveDate: currentOrPastDateUI({
+    medicarePartCEffectiveDate: currentOrPastDateUI({
       title: INPUT_LABELS.effectiveDate,
       hint: HINT_TEXT.effectiveDate,
     }),
   },
   schema: {
     type: 'object',
-    required: [
-      'applicantMedicarePartCCarrier',
-      'applicantMedicarePartCEffectiveDate',
-    ],
+    required: ['medicarePartCCarrier', 'medicarePartCEffectiveDate'],
     properties: {
-      applicantMedicarePartCCarrier: textSchema,
-      applicantMedicarePartCEffectiveDate: currentOrPastDateSchema,
+      medicarePartCCarrier: textSchema,
+      medicarePartCEffectiveDate: currentOrPastDateSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partCPharmacyBenefits.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partCPharmacyBenefits.js
@@ -12,16 +12,16 @@ const HINT_TEXT = content['medicare--part-c-pharmacy-hint'];
 export default {
   uiSchema: {
     ...titleWithNameUI(TITLE_TEXT),
-    applicantHasPharmacyBenefits: yesNoUI({
+    hasPharmacyBenefits: yesNoUI({
       title: INPUT_LABEL,
       hint: HINT_TEXT,
     }),
   },
   schema: {
     type: 'object',
-    required: ['applicantHasPharmacyBenefits'],
+    required: ['hasPharmacyBenefits'],
     properties: {
-      applicantHasPharmacyBenefits: yesNoSchema,
+      hasPharmacyBenefits: yesNoSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partDCardUpload.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partDCardUpload.js
@@ -19,11 +19,11 @@ export default {
   uiSchema: {
     ...titleUI(TITLE_TEXT, DESC_TEXT),
     ...descriptionUI(FileUploadDescription),
-    applicantMedicarePartDCardFront: attachmentUI({
+    medicarePartDCardFront: attachmentUI({
       label: INPUT_LABELS.cardFront,
       attachmentId: ATTACHMENT_IDS.medicareDCardFront,
     }),
-    applicantMedicarePartDCardBack: attachmentUI({
+    medicarePartDCardBack: attachmentUI({
       label: INPUT_LABELS.cardBack,
       attachmentId: ATTACHMENT_IDS.medicareDCardBack,
     }),
@@ -31,8 +31,8 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      applicantMedicarePartDCardFront: singleAttachmentSchema,
-      applicantMedicarePartDCardBack: singleAttachmentSchema,
+      medicarePartDCardFront: singleAttachmentSchema,
+      medicarePartDCardBack: singleAttachmentSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/partDStatus.rev2025.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/partDStatus.rev2025.js
@@ -1,0 +1,23 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { titleWithNameUI } from '../../utils/titles';
+import content from '../../locales/en/content.json';
+
+const TITLE_TEXT = content['medicare--part-d-status-title'];
+const INPUT_LABEL = content['medicare--part-d-status-label'];
+
+export default {
+  uiSchema: {
+    ...titleWithNameUI(TITLE_TEXT),
+    hasMedicarePartD: yesNoUI(INPUT_LABEL),
+  },
+  schema: {
+    type: 'object',
+    required: ['hasMedicarePartD'],
+    properties: {
+      hasMedicarePartD: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/reportPlans.rev2025.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/reportPlans.rev2025.js
@@ -1,0 +1,23 @@
+import {
+  titleUI,
+  yesNoSchema,
+  yesNoUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import content from '../../locales/en/content.json';
+
+const TITLE_TEXT = content['medicare--report-plan-title'];
+const INPUT_LABEL = content['medicare--report-plan-label'];
+
+export default {
+  uiSchema: {
+    ...titleUI(TITLE_TEXT),
+    'view:hasMedicare': yesNoUI(INPUT_LABEL),
+  },
+  schema: {
+    type: 'object',
+    required: ['view:hasMedicare'],
+    properties: {
+      'view:hasMedicare': yesNoSchema,
+    },
+  },
+};

--- a/src/applications/ivc-champva/10-7959C/components/FormDescriptions/MedicareIntroDescription.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/FormDescriptions/MedicareIntroDescription.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const MedicareIntroDescription = (
+  <ul>
+    <li>
+      <strong>If you currently have Medicare</strong>, provide your plan
+      information to help us complete your CHAMPVA benefits application. This
+      also helps us coordinate benefits and process your claims faster.
+    </li>
+    <li>
+      <strong>
+        If you’re pre-enrolled in Medicare with a future effective date
+      </strong>
+      , you need to submit using the Other Health Insurance Certification (VA
+      Form 10-7959c) before you file your first claim.
+    </li>
+  </ul>
+);
+
+export default MedicareIntroDescription;

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -30,6 +30,7 @@ import medicareCardUpload from '../chapters/medicare/partsABCardUpload';
 import medicarePartDStatus from '../chapters/medicare/partDStatus';
 import medicarePartDCarrier from '../chapters/medicare/partDCarrier';
 import medicarePartDCardUpload from '../chapters/medicare/partDCardUpload';
+import { medicarePagesRev2025 } from '../chapters/medicare';
 
 import {
   applicantHasInsuranceSchema,
@@ -232,16 +233,20 @@ const formConfig = {
     medicareInformation: {
       title: 'Medicare information',
       pages: {
+        ...medicarePagesRev2025,
         hasMedicareAB: {
           path: 'medicare-ab-status',
           title: 'Report Medicare plans',
+          depends: formData => !formData[REV2025_TOGGLE_KEY],
           ...medicareReportPlans,
           scrollAndFocusTarget,
         },
         medicareClass: {
           path: 'medicare-plan',
           title: 'Medicare plan types',
-          depends: formData => get('applicantMedicareStatus', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantMedicareStatus', formData),
           ...medicarePlanTypes,
           scrollAndFocusTarget,
         },
@@ -249,7 +254,7 @@ const formConfig = {
           path: 'medicare-pharmacy',
           title: 'Medicare pharmacy benefits',
           depends: formData =>
-            !formData['view:champvaForm107959cRev2025'] &&
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantMedicareStatus', formData) &&
             ['advantage', 'other'].includes(
               get('applicantMedicareClass', formData),
@@ -260,21 +265,27 @@ const formConfig = {
         partACarrier: {
           path: 'medicare-a-carrier',
           title: 'Medicare Part A carrier',
-          depends: formData => get('applicantMedicareStatus', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantMedicareStatus', formData),
           ...medicarePartACarrier,
           scrollAndFocusTarget,
         },
         partBCarrier: {
           path: 'medicare-b-carrier',
           title: 'Medicare Part B carrier',
-          depends: formData => get('applicantMedicareStatus', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantMedicareStatus', formData),
           ...medicarePartBCarrier,
           scrollAndFocusTarget,
         },
         medicareABCards: {
           path: 'medicare-ab-upload',
           title: 'Medicare card for hospital and medical coverage',
-          depends: formData => get('applicantMedicareStatus', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantMedicareStatus', formData),
           CustomPage: FileFieldWrapped,
           CustomPageReview: null,
           ...medicareCardUpload,
@@ -283,7 +294,9 @@ const formConfig = {
         hasMedicareD: {
           path: 'medicare-d-status',
           title: 'Medicare Part D status',
-          depends: formData => get('applicantMedicareStatus', formData),
+          depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
+            get('applicantMedicareStatus', formData),
           ...medicarePartDStatus,
           scrollAndFocusTarget,
         },
@@ -291,6 +304,7 @@ const formConfig = {
           path: 'medicare-d-carrier',
           title: 'Medicare Part D carrier',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantMedicareStatus', formData) &&
             get('applicantMedicareStatusD', formData),
           ...medicarePartDCarrier,
@@ -300,6 +314,7 @@ const formConfig = {
           path: 'medicare-d-upload',
           title: 'Medicare Part D card',
           depends: formData =>
+            !formData[REV2025_TOGGLE_KEY] &&
             get('applicantMedicareStatus', formData) &&
             get('applicantMedicareStatusD', formData),
           CustomPage: FileFieldWrapped,

--- a/src/applications/ivc-champva/10-7959C/locales/en/content.json
+++ b/src/applications/ivc-champva/10-7959C/locales/en/content.json
@@ -78,6 +78,7 @@
   "medicare--general-pharmacy-title": "%s Medicare pharmacy benefits",
   "medicare--general-pharmacy-label": "Does the beneficiary’s Medicare plan provide pharmacy benefits?",
   "medicare--general-pharmacy-hint": "You can find this information on the front of the Medicare card.",
+  "medicare--intro-title": "Report Medicare",
   "medicare--parts-ab-card-title": "Upload Medicare card for Hospital and Medical insurance",
   "medicare--parts-ab-card-label--front": "Upload front of Original Medicare card",
   "medicare--parts-ab-card-label--back": "Upload back of Original Medicare card",

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/index.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/index.js
@@ -1,1 +1,2 @@
 export * from './formatting';
+export * from './medicare';

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
@@ -1,0 +1,22 @@
+export const hasMedicare = formData => formData['view:hasMedicare'];
+
+export const hasPartsAB = formData =>
+  hasMedicare(formData) && formData.medicarePlanType === 'ab';
+
+export const hasPartA = formData =>
+  hasMedicare(formData) && formData.medicarePlanType === 'a';
+
+export const hasPartB = formData =>
+  hasMedicare(formData) && formData.medicarePlanType === 'b';
+
+export const hasPartC = formData =>
+  hasMedicare(formData) && formData.medicarePlanType === 'c';
+
+export const hasPartsABorC = formData =>
+  (hasMedicare(formData) && hasPartsAB(formData)) || hasPartC(formData);
+
+export const hasPartD = formData =>
+  hasMedicare(formData) && hasPartsABorC(formData) && formData.hasMedicarePartD;
+
+export const hasPartADenialNotice = formData =>
+  hasMedicare(formData) && hasPartB(formData) && formData.hasPartADenial;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR wires up the Medicare Rev2025 form flow pages to the feature toggle and inserts into the config. The PR also updates data keys to match the BE controller expectations for PDF filling.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#126790

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Content meets C/IA standards
- Data matches the Rev2025 PDF expectations

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
