### PR TITLE
eselkin/128483 OH and VistA fixes for content staging review

### DIFF
--- a/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
@@ -127,7 +127,7 @@ describe('VAOS Component: CCLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/This is a test:Additional information/i));
@@ -231,7 +231,7 @@ describe('VAOS Component: CCLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/This is a test:Additional information/i));
@@ -321,7 +321,7 @@ describe('VAOS Component: CCLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/This is a test:Additional information/i));
@@ -425,7 +425,7 @@ describe('VAOS Component: CCLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/This is a test:Additional information/i));

--- a/src/applications/vaos/components/layouts/CCRequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/CCRequestLayout.unit.spec.jsx
@@ -143,7 +143,7 @@ describe('VAOS Component: CCRequestLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you.d like to share with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/This is a test:Additional information/i));
@@ -283,7 +283,7 @@ describe('VAOS Component: CCRequestLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you.d like to share with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/This is a test:Additional information/i));

--- a/src/applications/vaos/components/layouts/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layouts/DetailPageLayout.jsx
@@ -204,7 +204,7 @@ export default function DetailPageLayout({
     window.scrollTo(0, 0);
     // Focus on the heading after render -- added function to utilities/ui/focus.js to shorten this interval
     // but still allows cypress tests to run properly
-    const wait = waitTime(50);
+    const wait = waitTime(100);
     waitForRenderThenFocus(
       '#vaos-appointment-details-page-heading',
       document,

--- a/src/applications/vaos/components/layouts/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layouts/DetailPageLayout.jsx
@@ -201,6 +201,7 @@ export default function DetailPageLayout({
   );
 
   useEffect(() => {
+    window.scrollTo(0, 0);
     // Focus on the heading after render -- added function to utilities/ui/focus.js to shorten this interval
     // but still allows cypress tests to run properly
     const wait = waitTime(50);

--- a/src/applications/vaos/components/layouts/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layouts/DetailPageLayout.jsx
@@ -83,10 +83,8 @@ Prepare.propTypes = {
   children: PropTypes.node,
 };
 
-export function CCDetails({ otherDetails, request, level = 2 }) {
-  const heading = request
-    ? 'Details you’d like to share with your provider'
-    : 'Details you shared with your provider';
+export function CCDetails({ otherDetails, level = 2 }) {
+  const heading = 'Reason for appointment';
   return (
     <Section heading={heading} level={level}>
       <span className="vaos-u-word-break--break-word" data-dd-privacy="mask">
@@ -98,21 +96,13 @@ export function CCDetails({ otherDetails, request, level = 2 }) {
 CCDetails.propTypes = {
   level: PropTypes.number,
   otherDetails: PropTypes.string,
-  request: PropTypes.bool,
 };
 
-export function Details({
-  otherDetails,
-  request,
-  level = 2,
-  isCerner = false,
-}) {
+export function Details({ otherDetails, level = 2, isCerner = false }) {
   // Do not display details for Oracle (Cerner) appointments
   if (isCerner) return null;
 
-  const heading = request
-    ? 'Details you’d like to share with your provider'
-    : 'Details you shared with your provider';
+  const heading = 'Reason for appointment';
   return (
     <Section heading={heading} level={level}>
       <span className="vaos-u-word-break--break-word" data-dd-privacy="mask">
@@ -125,8 +115,6 @@ Details.propTypes = {
   isCerner: PropTypes.bool,
   level: PropTypes.number,
   otherDetails: PropTypes.string,
-  reason: PropTypes.string,
-  request: PropTypes.bool,
 };
 
 export function ClinicOrFacilityPhone({

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
@@ -269,12 +269,9 @@ describe('VAOS Component: InPersonLayout', () => {
           },
         );
         // Assert
-        expect(
-          screen.queryByText(/Details you’d like to share with your provider/i),
-        ).not.to.exist;
+        expect(screen.queryByText(/Reason for appointment/i)).not.to.exist;
 
-        expect(screen.queryByText(/Details you shared with your provider'/i))
-          .not.to.exist;
+        expect(screen.queryByText(/Reason for appointment'/i)).not.to.exist;
       });
 
       it('should not display location heading when physical location is missing', async () => {
@@ -409,7 +406,7 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -507,7 +504,7 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -590,7 +587,7 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -697,7 +694,7 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -780,7 +777,7 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
@@ -89,7 +89,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
 
@@ -222,12 +222,9 @@ describe('VAOS Component: PhoneLayout', () => {
           },
         );
         // Assert
-        expect(
-          screen.queryByText(/Details you’d like to share with your provider/i),
-        ).not.to.exist;
+        expect(screen.queryByText(/Reason for appointment/i)).not.to.exist;
 
-        expect(screen.queryByText(/Details you shared with your provider'/i))
-          .not.to.exist;
+        expect(screen.queryByText(/Reason for appointment'/i)).not.to.exist;
       });
     });
   });
@@ -313,7 +310,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -409,7 +406,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -507,7 +504,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -598,7 +595,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -702,7 +699,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you shared with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));

--- a/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
@@ -146,7 +146,7 @@ describe('VAOS Component: VARequestLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you.d like to share with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -276,7 +276,7 @@ describe('VAOS Component: VARequestLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you.d like to share with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));
@@ -406,7 +406,7 @@ describe('VAOS Component: VARequestLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
-          name: /Details you.d like to share with your provider/i,
+          name: /Reason for appointment/i,
         }),
       );
       expect(screen.getByText(/Additional information:colon/i));

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -35,7 +35,11 @@ import {
   routeToPreviousAppointmentPage,
   routeToRequestAppointmentPage,
 } from '../../redux/actions';
-import { getChosenClinicInfo, getDateTimeSelect } from '../../redux/selectors';
+import {
+  getChosenClinicInfo,
+  getDateTimeSelect,
+  selectSelectedProvider,
+} from '../../redux/selectors';
 import UrgentCareLinks from '../UrgentCareLinks';
 
 const pageKey = 'selectDateTime';
@@ -228,6 +232,7 @@ export default function DateTimeSelectPage() {
 
   const isInitialLoad = useIsInitialLoad(loadingSlots);
   const clinic = useSelector(state => getChosenClinicInfo(state));
+  const selectedProvider = useSelector(state => selectSelectedProvider(state));
   const upcomingAppointments = useSelector(selectUpcomingAppointments);
 
   // Effect to focus on validation message whenever error state changes
@@ -315,8 +320,10 @@ export default function DateTimeSelectPage() {
         (loadingSlots || slotAvailable) && (
           <>
             <p>
-              {clinic && `Scheduling at ${clinic.serviceName}`}
-              {clinic && timezone && <br />}
+              {clinic && `Scheduling at ${clinic.serviceName}.`}
+              {selectedProvider &&
+                `Scheduling with ${selectedProvider.providerName}.`}
+              {(clinic || selectedProvider) && timezone ? <span> </span> : null}
               {timezone && `Times are displayed in ${timezoneDescription}.`}
             </p>
             <CalendarWidget

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
@@ -61,7 +61,7 @@ export default function ProviderCard({ provider }) {
 
       <hr
         aria-hidden="true"
-        className="vads-u-margin-bottom--2 vads-u-margin-top--2"
+        className="vads-u-margin-bottom--2 vads-u-margin-top--2 vads-u-border-color--gray-medium"
       />
     </div>
   );

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
@@ -34,9 +34,9 @@ export default function ScheduleWithDifferentProvider({
       <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-margin-top--1">
         Option 1: Request your preferred date and time online
       </h3>
-      <p className="vads-u-margin-top--0">
+      <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
         We’ll contact you within 2 business days after we receive your request
-        and help you finish scheduling your appointment.
+        to help you finish scheduling your appointment.
       </p>
       <va-link
         active
@@ -50,7 +50,7 @@ export default function ScheduleWithDifferentProvider({
       />
 
       <h3
-        className="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-margin-top--1"
+        className="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-margin-top--3"
         data-testid="cc-eligible-header"
       >
         Option 2: Call the facility

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
@@ -59,7 +59,10 @@ export default function ScheduleWithDifferentProvider({
         Call and ask to schedule with that provider:{' '}
         <FacilityPhone contact={facilityPhone} icon={false} />
       </p>
-      <hr aria-hidden="true" className="vads-u-margin-y--2" />
+      <hr
+        aria-hidden="true"
+        className="vads-u-margin-y--2 vads-u-border-color--gray-medium"
+      />
     </>
   );
 }

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
@@ -32,7 +32,7 @@ export default function ReasonForAppointmentSection({ data }) {
         <div className="vads-l-row vads-u-justify-content--space-between">
           <div className="vads-u-flex--1 vads-u-padding-right--1">
             <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
-              Reason for your appointment
+              Reason for appointment
             </h2>
             {!reasonAdditionalInfo && <span>No details shared</span>}
             <span

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
@@ -32,7 +32,7 @@ export default function ReasonForAppointmentSection({ data }) {
         <div className="vads-l-row vads-u-justify-content--space-between">
           <div className="vads-u-flex--1 vads-u-padding-right--1">
             <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
-              Details to share with your provider
+              Reason for your appointment
             </h2>
             {!reasonAdditionalInfo && <span>No details shared</span>}
             <span

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
@@ -45,7 +45,7 @@ export default function ReasonForAppointmentSection({ data }) {
           <div>
             <va-link
               href={reason.url}
-              label="Edit details you’d like to share with your provider"
+              label="Edit reason for appointment"
               text="Edit"
               data-testid="edit-new-appointment"
               onClick={handleClick(history, home, reason)}

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -165,9 +165,7 @@ describe('VAOS Page: ReviewPage direct scheduling', () => {
       formatInTimeZone(start, 'America/Denver', 'h:mm aaaa'),
     );
 
-    expect(reasonHeading).to.contain.text(
-      'Details to share with your provider',
-    );
+    expect(reasonHeading).to.contain.text('Reason for appointment');
     expect(screen.baseElement).to.contain.text('I need an appt');
 
     expect(contactHeading).to.contain.text('Your contact information');
@@ -244,9 +242,7 @@ describe('VAOS Page: ReviewPage direct scheduling', () => {
     expect(providerHeading).to.contain.text('Provider');
     expect(screen.baseElement).to.contain.text('Doe, Mary D, MD');
     expect(dateHeading).to.contain.text('Date and time');
-    expect(reasonHeading).to.contain.text(
-      'Details to share with your provider',
-    );
+    expect(reasonHeading).to.contain.text('Reason for appointment');
     expect(contactHeading).to.contain.text('Your contact information');
   });
 

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -78,7 +78,8 @@ import { distanceBetween } from '../../utils/address';
 import { isTypeOfCareSupported } from '../../services/location';
 
 const REASON_ADDITIONAL_INFO_TITLES = {
-  va: 'Add any details you’d like to share with your provider.',
+  va:
+    'Enter a brief reason for this appointment. Your provider will contact you if they need more details.',
   ccRequest:
     'Share any information that you think will help the provider prepare for your appointment. You don’t have to share anything if you don’t want to.',
 };

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -361,6 +361,14 @@ export function selectPatientProviderRelationships(state) {
   };
 }
 
+export function selectSelectedProvider(state) {
+  const providerRelationships = selectPatientProviderRelationships(state);
+  const data = getFormData(state);
+  return providerRelationships?.patientProviderRelationships?.find(
+    provider => provider.providerId === data.selectedProvider,
+  );
+}
+
 function getChosenVACityState(state) {
   const schema =
     state.newAppointment.pages.ccPreferences?.properties.communityCareSystemId;

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
@@ -44,6 +44,8 @@ const { idV2: typeOfCareId, cceType } = getTypeOfCareById(
   TYPE_OF_CARE_IDS.OPTOMETRY_ID,
 );
 
+const labelRegexReasonForAppointment = /Enter a brief reason for this appointment\. Your provider will contact you if they need more details\./;
+
 describe('VAOS direct schedule flow - Optometry', () => {
   beforeEach(() => {
     vaosSetup();
@@ -134,7 +136,7 @@ describe('VAOS direct schedule flow - Optometry', () => {
 
           ReasonForAppointmentPageObject.assertUrl()
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -190,7 +192,7 @@ describe('VAOS direct schedule flow - Optometry', () => {
 
           ReasonForAppointmentPageObject.assertUrl()
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -288,7 +290,7 @@ describe('VAOS direct schedule flow - Optometry', () => {
 
           ReasonForAppointmentPageObject.assertUrl()
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({ content: 'This is a test' })
             .clickNextButton();
@@ -342,7 +344,7 @@ describe('VAOS direct schedule flow - Optometry', () => {
 
           ReasonForAppointmentPageObject.assertUrl()
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({ content: 'This is a test' })
             .clickNextButton();

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/home-sleep-testing.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/home-sleep-testing.cypress.spec.js
@@ -40,6 +40,7 @@ const { idV2: typeOfCareId } = getTypeOfCareById(
   TYPE_OF_CARE_IDS.HOME_SLEEP_TESTING_ID,
 );
 const typeOfCareRegex = /Sleep medicine/i;
+const labelRegexReasonForAppointment = /Enter a brief reason for this appointment\. Your provider will contact you if they need more details\./;
 
 describe('VAOS request schedule flow - sleep care', () => {
   describe('When patient has no history and flipper for MH past filtering is enabled', () => {
@@ -141,7 +142,7 @@ describe('VAOS request schedule flow - sleep care', () => {
             name: /What.s the reason for this appointment/i,
           })
           .assertLabel({
-            label: /Add any details you.d like to share with your provider/,
+            label: labelRegexReasonForAppointment,
           })
           .typeAdditionalText({
             content: 'This is a test',

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
@@ -37,6 +37,7 @@ import {
 } from '../../vaos-cypress-helpers';
 import TypeOfVisitPageObject from '../../page-objects/TypeOfVisitPageObject';
 
+const labelRegexReasonForAppointment = /Enter a brief reason for this appointment\. Your provider will contact you if they need more details\./;
 const typeOfCareRegex = /Mental health/i;
 
 describe('VAOS request schedule flow - Mental health', () => {
@@ -142,7 +143,7 @@ describe('VAOS request schedule flow - Mental health', () => {
               name: /What.s the reason for this appointment/i,
             })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -287,7 +288,7 @@ describe('VAOS request schedule flow - Mental health', () => {
               name: /What.s the reason for this appointment/i,
             })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -38,6 +38,7 @@ import {
 const { idV2: typeOfCareId, cceType } = getTypeOfCareById(
   TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID,
 );
+const labelRegexReasonForAppointment = /Enter a brief reason for this appointment\. Your provider will contact you if they need more details\./;
 
 describe('OH request flow - Food and Nutrition', () => {
   beforeEach(() => {
@@ -129,7 +130,7 @@ describe('OH request flow - Food and Nutrition', () => {
               name: /What.s the reason for this appointment/i,
             })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -233,7 +234,7 @@ describe('OH request flow - Food and Nutrition', () => {
               name: /What.s the reason for this appointment/i,
             })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -337,7 +338,7 @@ describe('OH request flow - Food and Nutrition', () => {
               name: /What.s the reason for this appointment/i,
             })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -438,7 +439,7 @@ describe('OH request flow - Food and Nutrition', () => {
               name: /What.s the reason for this appointment/i,
             })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/primary-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/primary-care.cypress.spec.js
@@ -37,6 +37,7 @@ import {
 const { idV2: typeOfCareId, cceType } = getTypeOfCareById(
   TYPE_OF_CARE_IDS.PRIMARY_CARE,
 );
+const labelRegexReasonForAppointment = /Enter a brief reason for this appointment\. Your provider will contact you if they need more details\./;
 
 describe('VAOS request schedule flow - Primary care', () => {
   beforeEach(() => {
@@ -127,7 +128,7 @@ describe('VAOS request schedule flow - Primary care', () => {
           ReasonForAppointmentPageObject.assertUrl()
             .assertHeading({ name: /What.s the reason for this appointment/i })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -186,7 +187,7 @@ describe('VAOS request schedule flow - Primary care', () => {
           ReasonForAppointmentPageObject.assertUrl()
             .assertHeading({ name: /What.s the reason for this appointment/i })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -285,7 +286,7 @@ describe('VAOS request schedule flow - Primary care', () => {
           ReasonForAppointmentPageObject.assertUrl()
             .assertHeading({ name: /What.s the reason for this appointment/i })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -343,7 +344,7 @@ describe('VAOS request schedule flow - Primary care', () => {
           ReasonForAppointmentPageObject.assertUrl()
             .assertHeading({ name: /What.s the reason for this appointment/i })
             .assertLabel({
-              label: /Add any details you.d like to share with your provider/,
+              label: labelRegexReasonForAppointment,
             })
             .typeAdditionalText({
               content: 'This is a test',
@@ -447,7 +448,7 @@ describe('VAOS request schedule flow - Primary care', () => {
         ReasonForAppointmentPageObject.assertUrl()
           .assertHeading({ name: /What.s the reason for this appointment/i })
           .assertLabel({
-            label: /Add any details you.d like to share with your provider/,
+            label: labelRegexReasonForAppointment,
           })
           .typeAdditionalText({
             content: 'This is a test',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request standardizes the heading for appointment details across several VAOS components and updates related tests and UI elements. The most significant change is replacing various forms of "Details you shared with your provider" and similar phrases with the consistent heading "Reason for appointment." Additionally, minor UI and accessibility improvements are included, such as updating class names, adjusting spacing, and ensuring the correct focus behavior on page load.

**Heading and Label Standardization:**

* Updated the heading in the `CCDetails` and `Details` components in `DetailPageLayout.jsx` to always display "Reason for appointment" instead of conditional or varied text, and removed the unused `request` prop and its associated prop types. [[1]](diffhunk://#diff-040f53c251f1b2a3f33efda0a06b7fdb1b8934804ec3f822f2f27eae40813772L86-R87) [[2]](diffhunk://#diff-040f53c251f1b2a3f33efda0a06b7fdb1b8934804ec3f822f2f27eae40813772L101-R105) [[3]](diffhunk://#diff-040f53c251f1b2a3f33efda0a06b7fdb1b8934804ec3f822f2f27eae40813772L128-L129)
* Updated all related unit tests in `CCLayout.unit.spec.jsx`, `CCRequestLayout.unit.spec.jsx`, `InPersonLayout.unit.spec.jsx`, `PhoneLayout.unit.spec.jsx`, and `VARequestLayout.unit.spec.jsx` to expect "Reason for appointment" as the heading, replacing previous expectations for "Details you shared with your provider" or similar. [[1]](diffhunk://#diff-7abc85cb3051309a8edce8eb62baabf7b71dac05bc34753ba2d0d00c114238aeL130-R130) [[2]](diffhunk://#diff-7abc85cb3051309a8edce8eb62baabf7b71dac05bc34753ba2d0d00c114238aeL234-R234) [[3]](diffhunk://#diff-7abc85cb3051309a8edce8eb62baabf7b71dac05bc34753ba2d0d00c114238aeL324-R324) [[4]](diffhunk://#diff-7abc85cb3051309a8edce8eb62baabf7b71dac05bc34753ba2d0d00c114238aeL428-R428) [[5]](diffhunk://#diff-86c81776be1f1494fb72236e49517b45b4d9313e49e0b44084bed420cfb572e9L146-R146) [[6]](diffhunk://#diff-86c81776be1f1494fb72236e49517b45b4d9313e49e0b44084bed420cfb572e9L286-R286) [[7]](diffhunk://#diff-53f806b9f60dface04fd3e4c17528fe1489431844cce5b0f5d0316149ca514f1L272-R274) [[8]](diffhunk://#diff-53f806b9f60dface04fd3e4c17528fe1489431844cce5b0f5d0316149ca514f1L412-R409) [[9]](diffhunk://#diff-53f806b9f60dface04fd3e4c17528fe1489431844cce5b0f5d0316149ca514f1L510-R507) [[10]](diffhunk://#diff-53f806b9f60dface04fd3e4c17528fe1489431844cce5b0f5d0316149ca514f1L593-R590) [[11]](diffhunk://#diff-53f806b9f60dface04fd3e4c17528fe1489431844cce5b0f5d0316149ca514f1L700-R697) [[12]](diffhunk://#diff-53f806b9f60dface04fd3e4c17528fe1489431844cce5b0f5d0316149ca514f1L783-R780) [[13]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL92-R92) [[14]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL225-R227) [[15]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL316-R313) [[16]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL412-R409) [[17]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL510-R507) [[18]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL601-R598) [[19]](diffhunk://#diff-148fee270772d0c9577aaa13bb44e0d19304278f620ee08b6cad1a5148ac631fL705-R702) [[20]](diffhunk://#diff-dc04a4a05395c1bfe746cc49e2368ca73128f7a493ad070379e1402b8d86a4caL149-R149) [[21]](diffhunk://#diff-dc04a4a05395c1bfe746cc49e2368ca73128f7a493ad070379e1402b8d86a4caL279-R279) [[22]](diffhunk://#diff-dc04a4a05395c1bfe746cc49e2368ca73128f7a493ad070379e1402b8d86a4caL409-R409)

**UI and Accessibility Improvements:**

* Increased the wait time for focusing the heading on detail page load and ensured the page scrolls to the top on mount in `DetailPageLayout.jsx`.
* Added a gray border color to the horizontal rule in `ProviderCard.jsx` for improved visual distinction.
* Adjusted spacing and improved the clarity of instructional text in `ScheduleWithDifferentProvider.jsx`. [[1]](diffhunk://#diff-0611f99f74e73db4a63c0a65d951cbbaef549198c54e388994e537ca9042ec91L37-R39) [[2]](diffhunk://#diff-0611f99f74e73db4a63c0a65d951cbbaef549198c54e388994e537ca9042ec91L53-R53)

**Provider Selection and Scheduling Enhancements:**

* Imported and used the `selectSelectedProvider` selector in `DateTimeSelectPage/index.jsx` to display the selected provider's name when scheduling, and improved the display logic for location and timezone information. [[1]](diffhunk://#diff-dab615af2e8aaf7e535761d5d070f1266bb93c202e915ef18b9aa1d655815b93L38-R42) [[2]](diffhunk://#diff-dab615af2e8aaf7e535761d5d070f1266bb93c202e915ef18b9aa1d655815b93R235) [[3]](diffhunk://#diff-dab615af2e8aaf7e535761d5d070f1266bb93c202e915ef18b9aa1d655815b93L318-R326)

- Orion/Appointments/UAE team
- OH is behind several flippers, but the changes to VistA and other uniformity changes will be visible

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128483

## Testing done

- Tested locally with OH and VistA and CC appts
- Updated tests to handle text changes

## Screenshots

<details><summary>VistA updates to date-time selection page subheading</summary>
<img width="1728" height="1117" alt="Screenshot 2025-12-23 at 5 56 09 PM" src="https://github.com/user-attachments/assets/b52bf27f-8ea1-4cff-a06f-e10bd5b5ede7" />
</details>


<details><summary>OH updates to date-time selection page that include pulling in provider if selected</summary>
<img width="1728" height="1117" alt="Screenshot 2025-12-23 at 5 55 06 PM" src="https://github.com/user-attachments/assets/8a88409b-36bd-4d10-bbfe-3a862b719ea2" />
</details>

<details><summary>Spacing between link and option 2 larger than link to bottom of option 1</summary>

**Has providers**
<img width="1728" height="1117" alt="Screenshot 2025-12-29 at 3 35 08 PM" src="https://github.com/user-attachments/assets/7ee730fe-805a-402a-a40c-0c4db76167c2" />


**No providers**
<img width="1728" height="1117" alt="Screenshot 2025-12-29 at 3 38 05 PM" src="https://github.com/user-attachments/assets/7efc2ad2-d19a-45f2-b7cf-0d2983e10718" />

</details>

<details><summary>Change in wording for add details for provider</summary>

**Request**
<img width="1920" height="1080" alt="Screenshot 2025-12-30 at 12 19 27 PM (2)" src="https://github.com/user-attachments/assets/2dfd29f1-c7bb-49c7-b141-34cf8f3abeb8" />

**Direct Schedul**
<img width="1920" height="1080" alt="Screenshot 2025-12-30 at 12 19 01 PM (2)" src="https://github.com/user-attachments/assets/769a4b78-4152-4e2e-9002-d168643e690f" />

</details>

<details><summary>Review screen wording change for Reason for appointment</summary>
<img width="1920" height="1080" alt="Screenshot 2025-12-30 at 12 19 49 PM (2)" src="https://github.com/user-attachments/assets/6a7cab2c-254a-4d92-86fb-70baf90e833a" />
</details>


<details><summary>Label change for Edit for Reason for appointment</summary>
<img width="1693" height="234" alt="Screenshot 2025-12-30 at 12 43 24 PM" src="https://github.com/user-attachments/assets/4dbfcfe5-531a-48ba-a7f9-c66f96fc9dea" />

</details>


## What areas of the site does it impact?

Appointment DS and Request for OH and VistA and some CC appts

## Acceptance criteria



### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
