### PR TITLE
125852-125853-SelectCareTeam content change and refactor to use constants

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
+++ b/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
@@ -20,7 +20,12 @@ import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/sour
 import { datadogRum } from '@datadog/browser-rum';
 
 import { populatedDraft } from '../selectors';
-import { ErrorMessages, Paths, PageTitles } from '../util/constants';
+import {
+  ErrorMessages,
+  Paths,
+  PageTitles,
+  SelectCareTeamPage,
+} from '../util/constants';
 import RecipientsSelect from '../components/ComposeForm/RecipientsSelect';
 import EmergencyNote from '../components/EmergencyNote';
 import { updateDraftInProgress } from '../actions/threadDetails';
@@ -476,15 +481,15 @@ const SelectCareTeam = () => {
         <div className="vads-u-margin-top--2">
           <p className="vads-u-margin-bottom--1">
             <Link to={Paths.CARE_TEAM_HELP}>
-              What to do if you can’t find your care team
+              {SelectCareTeamPage.CANT_FIND_CARE_TEAM_LINK}
             </Link>
           </p>
         </div>
         {showContactListLink && (
           <div className="vads-u-margin-top--2">
             <p className="vads-u-margin-bottom--1">
-              <strong>Note:</strong> You can add more care teams to select from
-              by updating your contact list.
+              <strong>Note:</strong>{' '}
+              {SelectCareTeamPage.CANT_FIND_CARE_TEAM_NOTE}
             </p>
             <Link to={Paths.CONTACT_LIST}>Update your contact list</Link>
           </div>

--- a/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
@@ -11,7 +11,7 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import App from '../../containers/App';
 import * as SmApi from '../../api/SmApi';
 import reducer from '../../reducers';
-import { PageHeaders, Paths } from '../../util/constants';
+import { PageHeaders, Paths, SelectCareTeamPage } from '../../util/constants';
 
 describe('App', () => {
   const initialState = {
@@ -329,7 +329,7 @@ describe('App', () => {
 
     // Navigate to Care Team Help route
     const link = await screen.findByText(
-      'What to do if you can’t find your care team',
+      SelectCareTeamPage.CANT_FIND_CARE_TEAM_LINK,
     );
     fireEvent.click(link);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-back-to-facility-selection.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-back-to-facility-selection.cypress.spec.js
@@ -1,6 +1,6 @@
 import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
-import { AXE_CONTEXT, Locators, Paths } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Paths, Data } from '../utils/constants';
 import GeneralFunctionsPage from '../pages/GeneralFunctionsPage';
 import PilotEnvPage from '../pages/PilotEnvPage';
 import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
@@ -125,6 +125,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
       .shadow()
       .find('input')
       .should('have.value', 'TG-7410');
+    cy.injectAxeThenAxeCheck(AXE_CONTEXT);
   });
 
   it('verify route guard when draft is not saved', () => {
@@ -146,7 +147,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     cy.intercept(`GET`, Paths.INTERCEPT.SENT_THREADS, mockSentThreads).as(
       'sentThreadsResponse',
     );
-    cy.findByText(/Update your contact list/i).click();
+    cy.findByText(Data.CURATED_LIST.CONTACT_LIST_UPDATE).click();
     cy.get('va-modal[modal-title="We can\'t save this message yet"]').should(
       'be.visible',
     );
@@ -158,7 +159,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     PatientComposePage.selectCategory(draftMessage.category);
     PatientComposePage.getMessageSubjectField().type(draftMessage.subject);
 
-    cy.findByText(/Select a different care team/i).click();
+    cy.findByText(Data.CURATED_LIST.SELECT_CARE_TEAM).click();
     cy.get('va-modal[modal-title="We can\'t save this message yet"]').should(
       'not.be.visible',
     );
@@ -182,8 +183,8 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     );
     cy.wait('@new_draft');
     cy.injectAxeThenAxeCheck(AXE_CONTEXT);
-    cy.findByText(/Select a different care team/i).click();
-    cy.findByText(/Update your contact list/i).click();
+    cy.findByText(Data.CURATED_LIST.SELECT_CARE_TEAM).click();
+    cy.findByText(Data.CURATED_LIST.CONTACT_LIST_UPDATE).click();
     cy.get(
       'va-modal[modal-title="Do you want to save your changes to this draft?"]',
     ).should('not.exist');
@@ -210,7 +211,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     cy.intercept(`GET`, Paths.INTERCEPT.SENT_THREADS, mockSentThreads).as(
       'sentThreadsResponse',
     );
-    cy.findByText(/Update your contact list/i).click();
+    cy.findByText(Data.CURATED_LIST.CONTACT_LIST_UPDATE).click();
     cy.get('va-modal[modal-title="We can\'t save this message yet"]').should(
       'be.visible',
     );
@@ -222,7 +223,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     PatientComposePage.selectCategory(draftMessage.category);
     PatientComposePage.getMessageSubjectField().type(draftMessage.subject);
 
-    cy.findByText(/Select a different care team/i).click();
+    cy.findByText(Data.CURATED_LIST.SELECT_CARE_TEAM).click();
     cy.get('va-modal[modal-title="We can\'t save this message yet"]').should(
       'not.be.visible',
     );
@@ -246,11 +247,11 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     );
     cy.wait('@new_draft');
     cy.injectAxeThenAxeCheck(AXE_CONTEXT);
-    cy.findByText(/Select a different care team/i).click();
+    cy.findByText(Data.CURATED_LIST.SELECT_CARE_TEAM).click();
     cy.findByTestId(`compose-recipient-combobox`).click();
     PatientComposePage.selectComboBoxRecipient('###ABC_XYZ_TRIAGE_TEAM###');
 
-    cy.findByText(/Update your contact list/i).click();
+    cy.findByText(Data.CURATED_LIST.CONTACT_LIST_UPDATE).click();
     cy.get(
       'va-modal[modal-title="Do you want to save your changes to this draft?"]',
     ).should('exist');
@@ -267,7 +268,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
 
     PatientComposePage.selectComboBoxRecipient('Jeasmitha-Cardio-Clinic');
 
-    cy.contains(/What to do if you can’t find your care team/i).click({
+    cy.contains(Data.CURATED_LIST.CANT_FIND_TEAM_LINK).click({
       force: true,
     });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-breadcrumbs.cypress.spec.js
@@ -75,7 +75,9 @@ describe('SM CURATED LIST BREADCRUMBS', () => {
       cy.injectAxeThenAxeCheck(AXE_CONTEXT);
 
       // Navigate to Care team help page via link
-      cy.findByRole('link', { name: Data.CURATED_LIST.CANT_FIND_TEAM }).click();
+      cy.findByRole('link', {
+        name: Data.CURATED_LIST.CANT_FIND_TEAM_LINK,
+      }).click();
 
       // Removed the "Can't" in verifyPageHeader for testing purposes
       GeneralFunctionsPage.verifyPageHeader('find your care team?');

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PilotEnvPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PilotEnvPage.js
@@ -224,7 +224,7 @@ class PilotEnvPage {
     cy.get(`va-radio-option`).should('have.length', 5);
     cy.get(`.vads-u-margin-bottom--1 > a`)
       .should(`have.attr`, `href`, Data.LINKS.CARE_TEAM_HELP)
-      .and('have.text', Data.CURATED_LIST.CANT_FIND_TEAM);
+      .and('have.text', Data.CURATED_LIST.CANT_FIND_TEAM_LINK);
 
     cy.get(`.vads-u-margin-top--2 > a`)
       .should(`have.attr`, `href`, Data.LINKS.CONTACT_LIST)

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -442,7 +442,7 @@ export const Data = {
   READ_RECEIPT: `Opened by your care team`,
   UNREAD_RECEIPT: `Not yet opened by your care team`,
   CURATED_LIST: {
-    CANT_FIND_TEAM: `What to do if you can’t find your care team`,
+    CANT_FIND_TEAM_LINK: `Learn what to do if you can’t find your care team`,
     CONTACT_LIST_UPDATE: `Update your contact list`,
     SELECT_CARE_TEAM: `Select a different care team`,
   },

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -337,8 +337,7 @@ export const Categories = {
 };
 
 export const SelectCareTeamPage = {
-  CANT_FIND_CARE_TEAM_NOTE: `If you can’t find the care team you want to
-              select, update your contact list to add it here.`,
+  CANT_FIND_CARE_TEAM_NOTE: `If you can’t find the care team you want to select, update your contact list to add it here.`,
   CANT_FIND_CARE_TEAM_LINK: `Learn what to do if you can’t find your care team`,
 };
 

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -336,6 +336,12 @@ export const Categories = {
   EDUCATION: 'Education',
 };
 
+export const SelectCareTeamPage = {
+  CANT_FIND_CARE_TEAM_NOTE: `If you can’t find the care team you want to
+              select, update your contact list to add it here.`,
+  CANT_FIND_CARE_TEAM_LINK: `Learn what to do if you can’t find your care team`,
+};
+
 export const MessageHintText = {
   RX_RENEWAL_ERROR: 'Include as many of these medication details as possible.',
   RX_RENEWAL_SUCCESS: 'Review the medication details we added to your message.',


### PR DESCRIPTION
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- This PR addresses staging review tickets 125852 & 125853 to clarify the content of the Select Care Team Link and Note. 
- Moved care team help link and note text into the SelectCareTeamPage constants object for consistency and easier maintenance. Updated references in components and tests to use the new constants.

## Related issue(s)

- _[https://github.com/department-of-veterans-affairs/va.gov-team/issues/125852](https://github.com/department-of-veterans-affairs/va.gov-team/issues/125852)_
- _[https://github.com/department-of-veterans-affairs/va.gov-team/issues/125853](https://github.com/department-of-veterans-affairs/va.gov-team/issues/125853)_

## Testing done

- Replaced tests with constants for better maintenance_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | <img width="759" height="514" alt="516485370-89928d53-6593-40ee-b502-51affd5787cc" src="https://github.com/user-attachments/assets/adbdfb39-f7d9-48a4-adc6-63233f743f32" /> | <img width="964" height="368" alt="Screenshot 2025-12-31 at 11 08 00 AM" src="https://github.com/user-attachments/assets/f0ac92d8-c9d0-4456-96ec-e1618c3dfcc0" /> |

## What areas of the site does it impact?
Secure Messaging

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

