### PR TITLE
10-10EZR | Update punctuation in financial summary card

### DIFF
--- a/src/applications/ezr/components/FormDescriptions/FinancialSummaryCardDescription.jsx
+++ b/src/applications/ezr/components/FormDescriptions/FinancialSummaryCardDescription.jsx
@@ -39,7 +39,7 @@ const renderList = (rows, keyPrefix) => (
   <ul className="no-bullets">
     {rows.map(({ key, label, value }) => (
       <li key={`${keyPrefix}-${key}`}>
-        {label} {formatCurrency(value)}
+        {label}: {formatCurrency(value)}
       </li>
     ))}
   </ul>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR corrects a punctuation issue in the Financial Summary Cards where the income lists are missing the colon between the label and the value.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#128248

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Content is correctly punctuated

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
