### PR TITLE
form-upload: use sign-in-alert component

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/IntroductionPage.jsx
@@ -5,7 +5,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 import SaveInProgressIntro from '~/platform/forms/save-in-progress/SaveInProgressIntro';
 import FormTitle from '~/platform/forms-system/src/js/components/FormTitle';
 import {
-  VaAlert,
+  VaAlertSignIn,
   VaButton,
   VaLink,
   VaProcessList,
@@ -86,17 +86,14 @@ const IntroductionPage = ({ route }) => {
           customLink={PrimaryActionLink}
         />
       ) : (
-        <VaAlert status="info" visible>
-          <h2 slot="headline">Sign in now to upload your form</h2>
-          <p>
-            By signing in, we can fill in some of your information for you to
-            save you time.
-          </p>
-          <VaButton
-            text="Sign in to start uploading your form"
-            onClick={openLoginModal}
-          />
-        </VaAlert>
+        <VaAlertSignIn status="info" visible>
+          <span slot="SignInButton">
+            <VaButton
+              text="Sign in to start uploading your form"
+              onClick={openLoginModal}
+            />
+          </span>
+        </VaAlertSignIn>
       )}
     </article>
   );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR swaps the va-alert for va-sign-in-alert component on the form-upload introduction page.

## Related issue(s)

[101260](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101260)

## Testing done

local testing

## Screenshots

**Before**: 
<img width="372" height="589" alt="Screenshot 2026-01-02 at 11 49 15 AM" src="https://github.com/user-attachments/assets/376cbfd9-1b30-45c2-a86d-99c9054a30c2" />

**After**:

<img width="365" height="713" alt="Screenshot 2026-01-02 at 11 48 40 AM" src="https://github.com/user-attachments/assets/5a42f690-dcb2-4461-bd40-33e7782e6c67" />


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
