### PR TITLE
[Disability Benefits] Update Conditions unit tests to compute current/next year

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/pages/disabilityConditions/shared/newConditionDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/disabilityConditions/shared/newConditionDate.unit.spec.jsx
@@ -135,6 +135,7 @@ describe('526 new condition date shared page', () => {
   });
 
   it('rejects year before 1900', async () => {
+    const maxYear = new Date(Date.now()).getUTCFullYear();
     const onSubmit = sinon.spy();
     const nowStub = sinon
       .stub(Date, 'now')
@@ -154,7 +155,7 @@ describe('526 new condition date shared page', () => {
 
       const dateErrorMsg = getDateErrorMsg(container);
       expect(dateErrorMsg.getAttribute('error')).to.match(
-        /between 1900 and 2025/i,
+        new RegExp(`between\\s+1900\\s+and\\s+${maxYear}`, 'i'),
       );
     } finally {
       nowStub.restore();
@@ -162,13 +163,14 @@ describe('526 new condition date shared page', () => {
   });
 
   it('rejects year after current year (approximate date)', async () => {
+    const maxYear = new Date(Date.now()).getUTCFullYear();
     const onSubmit = sinon.spy();
     const nowStub = sinon
       .stub(Date, 'now')
       .returns(new Date('2025-08-27T12:00:00Z').getTime());
     try {
       const { container } = mountPage(
-        { ...seed, conditionDate: '2026-XX-XX' },
+        { ...seed, conditionDate: `${maxYear + 1}-XX-XX` },
         onSubmit,
       );
       const view = within(container);
@@ -180,7 +182,6 @@ describe('526 new condition date shared page', () => {
       });
 
       const dateErrorMsg = getDateErrorMsg(container);
-      const maxYear = new Date(Date.now()).getUTCFullYear();
       expect(dateErrorMsg.getAttribute('error')).to.match(
         new RegExp(`between\\s+1900\\s+and\\s+${maxYear}`, 'i'),
       );

--- a/src/applications/disability-benefits/all-claims/tests/pages/disabilityConditions/shared/ratedDisabilityDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/disabilityConditions/shared/ratedDisabilityDate.unit.spec.jsx
@@ -139,6 +139,7 @@ describe('526 rated disability date shared page', () => {
   });
 
   it('rejects year before 1900', async () => {
+    const maxYear = new Date(Date.now()).getUTCFullYear();
     const onSubmit = sinon.spy();
     const nowStub = sinon
       .stub(Date, 'now')
@@ -158,7 +159,7 @@ describe('526 rated disability date shared page', () => {
 
       const dateErrorMsg = getDateErrorMsg(container);
       expect(dateErrorMsg.getAttribute('error')).to.match(
-        /between 1900 and 2025/i,
+        new RegExp(`between\\s+1900\\s+and\\s+${maxYear}`, 'i'),
       );
     } finally {
       nowStub.restore();
@@ -166,13 +167,14 @@ describe('526 rated disability date shared page', () => {
   });
 
   it('rejects year after current year (approximate date)', async () => {
+    const maxYear = new Date(Date.now()).getUTCFullYear();
     const onSubmit = sinon.spy();
     const nowStub = sinon
       .stub(Date, 'now')
       .returns(new Date('2025-08-27T12:00:00Z').getTime());
     try {
       const { container } = mountPage(
-        { ...seed, conditionDate: '2026-XX-XX' },
+        { ...seed, conditionDate: `${maxYear + 1}-XX-XX` },
         onSubmit,
       );
       const view = within(container);
@@ -184,7 +186,6 @@ describe('526 rated disability date shared page', () => {
       });
 
       const dateErrorMsg = getDateErrorMsg(container);
-      const maxYear = new Date(Date.now()).getUTCFullYear();
       expect(dateErrorMsg.getAttribute('error')).to.match(
         new RegExp(`between\\s+1900\\s+and\\s+${maxYear}`, 'i'),
       );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Updates unit tests that had hard-coded 2025 as the current year to instead use the value of `new Date(Date.now()).getUTCFullYear();`.

- _(If bug, how to reproduce)_
this command reveals the failing unit tests: `yarn test:unit --app-folder disability-benefits`
As an example of a test failure, we had a test expect that an error message would be this: `Please enter a year between 1900 and 2025`; whereas, as of this week, we should extend that range to include 2026.

- _(What is the solution, why is this the solution)_
Replaces instances where 2025 was hard-coded with a value computed from `Date.new()`.  

- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Benefits Crew, Conditions & Evidence workstream. Yes.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
n/a

## Related issue(s)

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/128939

## Testing done

- _Describe what the old behavior was prior to the change_
Unit tests were failing in app folder `disability-benefits` 
- _Describe the steps required to verify your changes are working as expected_
Run `yarn test:unit --app-folder disability-benefits`.
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
