### PR TITLE
Update getAppUrl to use 686 v2

### DIFF
--- a/src/applications/dependents/dependents-verification/tests/e2e/0538-dependents-verification.cypress.spec.js
+++ b/src/applications/dependents/dependents-verification/tests/e2e/0538-dependents-verification.cypress.spec.js
@@ -6,7 +6,7 @@ import maximalTestData from './fixtures/data/maximal-test.json';
 import manifest from '../../manifest.json';
 
 const FORM_ID = '21-0538';
-const STOP_PAGE = getAppUrl('686C-674');
+const STOP_PAGE = getAppUrl('686C-674-v2');
 
 const cypressSetup = (user = mockUser) => {
   Cypress.config('waitForAnimations', true);

--- a/src/applications/dependents/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/dependents/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -7,7 +7,7 @@ import { getAppUrl } from 'platform/utilities/registry-helpers';
 import { errorFragment } from '../../layouts/helpers';
 import { PAGE_TITLE } from '../../util';
 
-const form686Url = getAppUrl('686C-674');
+const form686Url = getAppUrl('686C-674-v2');
 
 const CALLSTATUS = {
   pending: 'pending',

--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -7,7 +7,7 @@ import { getAppUrl } from '~/platform/utilities/registry-helpers';
 export const viewDependentsUrl = getAppUrl('dependents-view-dependents');
 
 export const disabilityBenefitsUrls = {
-  '686c': getAppUrl('686C-674'),
+  '686c': getAppUrl('686C-674-v2'),
   'view-payments': getAppUrl('view-payments'),
 };
 

--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
@@ -11,7 +11,7 @@ import DependencyVerificationHeader from './dependencyVerificationHeader';
 import DependencyVerificationList from './dependencyVerificationList';
 import DependencyVerificationFooter from './dependencyVerificationFooter';
 
-const disabilityBenefits686cUrl = getAppUrl('686C-674');
+const disabilityBenefits686cUrl = getAppUrl('686C-674-v2');
 
 const DependencyVerificationModal = props => {
   const nodeToWatch = document.getElementsByTagName('body')[0];


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates uses of getAppUrl to always point to 686 v2

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128946

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
