### PR TITLE
41159 - Add aria-current prop to Inner Nav Links for accessibility

### DIFF
--- a/src/applications/mhv-secure-messaging/components/InnerNavigation.jsx
+++ b/src/applications/mhv-secure-messaging/components/InnerNavigation.jsx
@@ -52,7 +52,6 @@ const InnerNavigation = () => {
           <div
             key={i}
             data-testid={path.datatestid}
-            activetab={handleActiveLinksStyle(path)}
             className={`
               vads-u-font-size--lg
               vads-u-display--flex
@@ -67,6 +66,7 @@ const InnerNavigation = () => {
               to={path.path}
               data-dd-action-name={`${path.label} link`}
               onClick={handleLinkClick}
+              aria-current={handleActiveLinksStyle(path) ? 'page' : undefined}
             >
               {path.label}
             </Link>

--- a/src/applications/mhv-secure-messaging/components/InnerNavigation.jsx
+++ b/src/applications/mhv-secure-messaging/components/InnerNavigation.jsx
@@ -52,6 +52,7 @@ const InnerNavigation = () => {
           <div
             key={i}
             data-testid={path.datatestid}
+            activetab={handleActiveLinksStyle(path)}
             className={`
               vads-u-font-size--lg
               vads-u-display--flex
@@ -66,7 +67,11 @@ const InnerNavigation = () => {
               to={path.path}
               data-dd-action-name={`${path.label} link`}
               onClick={handleLinkClick}
-              aria-current={handleActiveLinksStyle(path) ? 'page' : undefined}
+              aria-current={
+                handleActiveLinksStyle(path) === 'active-innerNav-link'
+                  ? 'page'
+                  : undefined
+              }
             >
               {path.label}
             </Link>


### PR DESCRIPTION
## Summary
Added `aria-current` to indicate the active navigation link for improved accessibility.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Related issue(s)

- [_Fixes this staging review ticket created in va.gov-team repo_department-of-veterans-affairs/va.gov-team#118759_](https://github.com/department-of-veterans-affairs/va.gov-team/issues/118759)

## Testing done
Previously, VO did not announce which inner navigation tab the user was currently on as they tabbed through. It now announces "current page [whichever tab is active]".

## What areas of the site does it impact?

Secure Messaging

## Acceptance criteria
- [x] ensure VO announces the current active inner navigation page the user is on. 

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

