### PR TITLE
8416 update readme and add new content to intro

### DIFF
--- a/src/applications/medical-expense-report/README.md
+++ b/src/applications/medical-expense-report/README.md
@@ -4,7 +4,7 @@
 
 | Option | Command |
 | ------ | ----------- |
-| Site   | http://localhost:3001/pension/medical-expense-report-form-21p-8416 |
+| Site   | http://localhost:3001/supporting-forms-for-claims/submit-medical-expense-report-form-21p-8416 |
 | Watch  | yarn watch --env entry=medical-expense-report |
 | Mock API (not implemented) | yarn mock-api --responses src/applications/medical-expense-report/tests/fixtures/mocks/local-mock-responses.js | 
 | Unit tests | yarn test:unit --app-folder medical-expense-report --log-level all |

--- a/src/applications/medical-expense-report/containers/IntroductionPage.jsx
+++ b/src/applications/medical-expense-report/containers/IntroductionPage.jsx
@@ -43,6 +43,15 @@ const ProcessList = () => {
             keep your receipts for your own records.
           </li>
         </ul>
+        <va-additional-info trigger="Why you should keep your receipts">
+          <p>
+            We recommend keeping all receipts or other documentation of payments
+            for at least 3 years after receiving a decision on your medical
+            expense claim. If we need to verify your expenses later and these
+            records aren’t available, your benefits may be retroactively reduced
+            or discontinued.
+          </p>
+        </va-additional-info>
       </va-process-list-item>
       <va-process-list-item header="Types of expenses you may report">
         <ul className="vads-u-padding-top--1p5">

--- a/src/applications/medical-expense-report/containers/IntroductionPage.jsx
+++ b/src/applications/medical-expense-report/containers/IntroductionPage.jsx
@@ -32,7 +32,8 @@ const ProcessList = () => {
         <ul className="vads-u-padding-top--1p5">
           <li>
             You can report expenses that you’ve paid for yourself or for a
-            family member living in your household.
+            dependent family member living in your household, such as a spouse,
+            child, grandchild, or parent.
           </li>
           <li>
             Don’t report expenses that were already reimbursed or will be


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add new additional info element to introduction page
- update localhost url in readme

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128492

## Testing done

- Visual testing
- Ran local tests to make sure they passed

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="798" height="590" alt="Screenshot 2026-01-05 at 12 02 36 PM" src="https://github.com/user-attachments/assets/9d587bc1-0dce-488b-934a-178fa8e2dc9a" /> | <img width="771" height="501" alt="Screenshot 2026-01-05 at 2 33 21 PM" src="https://github.com/user-attachments/assets/18d73103-3aaa-4ce3-9375-c31169295c81" /> |

## What areas of the site does it impact?

21P-8416 form's introduction page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
