### PR TITLE
#128412 [Benefits Management Tools] [Team 2] Update logic on claims list page to only show results once all data is gathered

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -179,12 +179,10 @@ class YourClaimsPageV2 extends React.Component {
     let pageInfo;
     const allRequestsLoaded =
       !claimsLoading && !appealsLoading && !stemClaimsLoading;
-    const allRequestsLoading =
-      claimsLoading && appealsLoading && stemClaimsLoading;
-    const atLeastOneRequestLoading =
-      claimsLoading || appealsLoading || stemClaimsLoading;
     const emptyList = !(list && list.length);
-    if (allRequestsLoading || (atLeastOneRequestLoading && emptyList)) {
+    // Wait for all requests to complete before rendering results
+    // This prevents multiple re-renders as each request completes
+    if (!allRequestsLoaded) {
       content = <ClaimCardLoadingSkeleton />;
     } else if (!emptyList) {
       const listLen = list.length;
@@ -207,7 +205,6 @@ class YourClaimsPageV2 extends React.Component {
           {pageInfo}
           <div className="claim-list">
             {pageItems.map(claim => this.renderListItem(claim))}
-            <ClaimCardLoadingSkeleton isLoading={atLeastOneRequestLoading} />
             {shouldPaginate && (
               <VaPagination
                 page={this.state.page}
@@ -218,7 +215,7 @@ class YourClaimsPageV2 extends React.Component {
           </div>
         </Type2FailureAnalyticsProvider>
       );
-    } else if (allRequestsLoaded) {
+    } else {
       content = <NoClaims />;
     }
 

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -205,6 +205,7 @@ class YourClaimsPageV2 extends React.Component {
           {pageInfo}
           <div className="claim-list">
             {pageItems.map(claim => this.renderListItem(claim))}
+            <ClaimCardLoadingSkeleton isLoading={false} />
             {shouldPaginate && (
               <VaPagination
                 page={this.state.page}

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -142,6 +142,24 @@ describe('<YourClaimsPageV2>', () => {
     wrapper.unmount();
   });
 
+  it('should render a loading skeleton even when list has data if any request is still loading', () => {
+    const props = cloneDeep(defaultProps);
+    // List has data but one request is still loading
+    props.claimsLoading = false;
+    props.appealsLoading = false;
+    props.stemClaimsLoading = true;
+    // props.list already has data from defaultProps
+    const wrapper = shallow(<YourClaimsPageV2 {...props} />);
+    const expectComponentCount = (component, count) => {
+      expect(wrapper.find(component).length).to.equal(count);
+    };
+    // Should show loading skeleton, not the list
+    expectComponentCount('ClaimCardLoadingSkeleton', 1);
+    expectComponentCount('ClaimsListItem', 0);
+    expectComponentCount('AppealListItem', 0);
+    wrapper.unmount();
+  });
+
   it('should not show visible loading skeleton but announce content loaded when claims have loaded', () => {
     const props = cloneDeep(defaultProps);
     props.claimsLoading = false;


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Updates the loading logic on the claims list page to fix loading state issue where claims, appeals, and STEM claims were rendering incrementally as each request completed, rather than waiting for all requests to finish.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
Benefits Management Tools Team 2
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
https://github.com/department-of-veterans-affairs/va.gov-team/issues/128412
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
Prior to the change, the page would render as soon as any results came back. If more came back after the initial load, the page would render a second time, making the experience of viewing claims suboptimal.
- _Describe the steps required to verify your changes are working as expected_
# Testing the Claims Loading State Fix
### 1. Add Response Delay Configuration to common.js
In `src/applications/claims-status/tests/local-dev-mock-api/common.js`, add the following configuration after the `RETURN_EMPTY_DATA` block (around line 18):

```javascript
const RESPONSE_DELAY_MS = {
  claims: 2000,      // Returns after 2 seconds
  appeals: 4000,     // Returns after 4 seconds
  stemClaims: 5000,  // Returns after 5 seconds
};
```

### 2. Update the Claims Endpoint

Find the `'GET /v0/benefits_claims'` endpoint (around line 1532) and replace it with:

```javascript
'GET /v0/benefits_claims': (_req, res) => {
  const sendResponse = () => {
    if (!SERVICE_AVAILABILITY.claims) {
      return res.status(500).json({ errors: [] });
    }
    const claimsData = RETURN_EMPTY_DATA.claims
      ? []
      : claimsToUse.map(getClaimSummary);
    return res.status(200).json({
      data: claimsData,
      meta: {
        pagination: {
          currentPage: 1,
          perPage: 10,
          totalPages: RETURN_EMPTY_DATA.claims ? 0 : 3,
          totalEntries: RETURN_EMPTY_DATA.claims ? 0 : claimsData.length,
        },
      },
    });
  };

  if (RESPONSE_DELAY_MS.claims > 0) {
    return setTimeout(sendResponse, RESPONSE_DELAY_MS.claims);
  }
  return sendResponse();
},
```

### 3. Update the Appeals Endpoint

Find the `'GET /v0/appeals'` endpoint (around line 1756) and replace it with:

```javascript
'GET /v0/appeals': (_req, res) => {
  const sendResponse = () => {
    if (!SERVICE_AVAILABILITY.appeals) {
      return res.status(500).json({ errors: [] });
    }
    return res
      .status(200)
      .json(RETURN_EMPTY_DATA.appeals ? { data: [] } : appealData);
  };

  if (RESPONSE_DELAY_MS.appeals > 0) {
    return setTimeout(sendResponse, RESPONSE_DELAY_MS.appeals);
  }
  return sendResponse();
},
```

### 4. Add the STEM Claims Endpoint

Add this new endpoint after the `'GET /v0/appeals/1'` entry:

```javascript
'GET /v0/education_benefits_claims/stem_claim_status': (_req, res) => {
  const stemClaim = baseClaims.find(
    c => c.data.type === 'education_benefits_claims',
  );
  const sendResponse = () => {
    return res.status(200).json({
      data: stemClaim ? [stemClaim.data] : [],
    });
  };

  if (RESPONSE_DELAY_MS.stemClaims > 0) {
    return setTimeout(sendResponse, RESPONSE_DELAY_MS.stemClaims);
  }
  return sendResponse();
},
```
### 2. Start the Mock API Server
In one terminal, run:
```bash
yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js
```
### 3. Start the Development Server
In another terminal, run:
```bash
yarn watch --env entry=auth,claims-status
```
### 4. View the Page
1. Navigate to: http://localhost:3001/track-claims/your-claims
2. Log in using mock authentication
### 5. Verify the Fix
**Expected behavior:**
- The loading skeleton should remain visible until the slowest request completes
- All claims, appeals, and STEM claims should appear together once loading finishes
- There should be no intermediate states where partial data is shown
---
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### Before
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2w1OWMxcXdqYzBqbHF1Mmhob3F5NHk0cG03bG5qc21vbzVhOTRndyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TFuIcv0vfgfFDn9fvi/giphy.gif)

### After
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGdvNjl3MmVuNzAyOWF5d3cwcGU4azk1enlpZnY3Y2FubW50b3hzeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/4tVkSPfW9rBfru4dl2/giphy.gif)

## What areas of the site does it impact?
Claims Status Tool

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
