### PR TITLE
Added E2E Tests to Verify App

### DIFF
--- a/src/applications/verify/tests/e2e/verify.cypress.spec.js
+++ b/src/applications/verify/tests/e2e/verify.cypress.spec.js
@@ -1,0 +1,105 @@
+import manifest from '../../manifest.json';
+
+const createMockUser = ({ verified, serviceName }) => ({
+  data: {
+    attributes: {
+      profile: {
+        loa: {
+          current: 3,
+          highest: 3,
+        },
+        verified,
+        signIn: {
+          serviceName,
+        },
+      },
+      vaProfile: {},
+    },
+  },
+});
+
+describe('Verify App', () => {
+  it('should show both ID.me and Login.gov buttons for unauthenticated users', () => {
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.findByRole('heading', {
+      level: 1,
+      name: /Verify your identity/i,
+    }).should('exist');
+    cy.get('.idme-verify-button').should('exist');
+    cy.get('.logingov-verify-button').should('exist');
+  });
+
+  it('should show only ID.me verify button for user signed in with ID.me but not verified', () => {
+    const mockUser = createMockUser({
+      verified: false,
+      serviceName: 'idme',
+    });
+
+    cy.login(mockUser);
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.findByRole('heading', {
+      level: 1,
+      name: /Verify your identity/i,
+    }).should('exist');
+    cy.get('.idme-verify-button').should('exist');
+    cy.get('.logingov-verify-button').should('not.exist');
+  });
+
+  it('should show only Login.gov verify button for user signed in with Login.gov but not verified', () => {
+    const mockUser = createMockUser({
+      verified: false,
+      serviceName: 'logingov',
+    });
+
+    cy.login(mockUser);
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.findByRole('heading', {
+      level: 1,
+      name: /Verify your identity/i,
+    }).should('exist');
+    cy.get('.logingov-verify-button').should('exist');
+    cy.get('.idme-verify-button').should('not.exist');
+  });
+
+  it('should show success message for a verified ID.me user', () => {
+    const mockUser = createMockUser({
+      verified: true,
+      serviceName: 'idme',
+    });
+
+    cy.login(mockUser);
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.findByRole('heading', {
+      level: 1,
+      name: /Verify your identity/i,
+    }).should('exist');
+    cy.get('va-alert[status="success"]').should('exist');
+    cy.findByText(/You’re verified/i).should('exist');
+  });
+
+  it('should show success message for a verified Login.gov user', () => {
+    const mockUser = createMockUser({
+      verified: true,
+      serviceName: 'logingov',
+    });
+
+    cy.login(mockUser);
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.findByRole('heading', {
+      level: 1,
+      name: /Verify your identity/i,
+    }).should('exist');
+    cy.get('va-alert[status="success"]').should('exist');
+    cy.findByText(/You’re verified/i).should('exist');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added E2E tests to the Verify app.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/671)

## Testing done
- Added `src/applications/verify/tests/e2e/verify.cypress.spec.js`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn cy:run --spec src/applications/verify/tests/e2e/verify.cypress.spec.js`.

## What areas of the site does it impact?
This only impacts the Verify tests.

## Acceptance criteria
- [x] Add E2E tests to Verify app.