### PR TITLE
[128731] Include rated disabilities stored in the newDisabilities object

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.jsx
@@ -204,6 +204,10 @@ describe('makeSchemaForAllDisabilities', () => {
         {
           condition: 'A new Condition.',
         },
+        {
+          condition: 'Rated Disability',
+          ratedDisability: 'Emphysema',
+        },
       ],
     };
     expect(makeSchemaForAllDisabilities(formData)).to.eql({
@@ -214,6 +218,10 @@ describe('makeSchemaForAllDisabilities', () => {
         },
         anewcondition: {
           title: 'A New Condition.',
+          type: 'boolean',
+        },
+        emphysema: {
+          title: 'Emphysema',
           type: 'boolean',
         },
       },

--- a/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.jsx
@@ -156,6 +156,17 @@ describe('makeSchemaForRatedDisabilitiesInNewDisabilities', () => {
           condition: 'Rated Disability',
           ratedDisability: 'Emphysema',
         },
+        {
+          condition: 'Rated Disability',
+          ratedDisability: '',
+        },
+        {
+          condition: 'Rated Disability',
+        },
+        {
+          condition: 'Rated Disability',
+          ratedDisability: "A condition I haven't claimed before",
+        },
       ],
       ratedDisabilities: [
         {

--- a/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   makeSchemaForNewDisabilities,
   makeSchemaForRatedDisabilities,
+  makeSchemaForRatedDisabilitiesInNewDisabilities,
   makeSchemaForAllDisabilities,
 } from '../../utils/schemas';
 
@@ -129,6 +130,52 @@ describe('makeSchemaForRatedDisabilities', () => {
       properties: {
         diabetesmellitus: {
           title: 'Diabetes Mellitus',
+          type: 'boolean',
+        },
+      },
+    });
+  });
+});
+
+describe('makeSchemaForRatedDisabilitiesInNewDisabilities', () => {
+  it('should return schema for selected rated disabilities in the newDisabilities list only', () => {
+    const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': true,
+        'view:claimingNew': true,
+      },
+      newDisabilities: [
+        {
+          condition: 'Bradycardia',
+        },
+        {
+          condition: 'Rated Disability',
+          ratedDisability: 'Hypertension',
+        },
+        {
+          condition: 'Rated Disability',
+          ratedDisability: 'Emphysema',
+        },
+      ],
+      ratedDisabilities: [
+        {
+          name: 'Ptsd personal trauma',
+          'view:selected': false,
+        },
+        {
+          name: 'Diabetes mellitus',
+          'view:selected': true,
+        },
+      ],
+    };
+    expect(makeSchemaForRatedDisabilitiesInNewDisabilities(formData)).to.eql({
+      properties: {
+        emphysema: {
+          title: 'Emphysema',
+          type: 'boolean',
+        },
+        hypertension: {
+          title: 'Hypertension',
           type: 'boolean',
         },
       },

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -116,8 +116,8 @@ export const makeSchemaForRatedDisabilitiesInNewDisabilities = createSelector(
   formData =>
     Array.isArray(formData?.newDisabilities) ? formData.newDisabilities : [],
 
-  (newRatedDisabilities = []) => {
-    const raw = newRatedDisabilities
+  (newDisabilities = []) => {
+    const raw = newDisabilities
       .map(d => {
         const condition =
           typeof d?.condition === 'string' ? d.condition.trim() : '';
@@ -126,11 +126,11 @@ export const makeSchemaForRatedDisabilitiesInNewDisabilities = createSelector(
           typeof d?.ratedDisability === 'string'
             ? d.ratedDisability.trim()
             : '';
-        if (!ratedDisability || !isPlaceholderRated(condition)) {
-          return '';
+        if (isPlaceholderRated(condition) && ratedDisability) {
+          return ratedDisability;
         }
 
-        return ratedDisability;
+        return '';
       })
       .filter(s => s.length > 0);
 

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -19,6 +19,7 @@ import {
   MILITARY_CITIES,
   MILITARY_STATE_LABELS,
   MILITARY_STATE_VALUES,
+  NEW_CONDITION_OPTION,
   STATE_LABELS,
   STATE_VALUES,
   MAX_FILE_SIZE_BYTES,
@@ -126,7 +127,14 @@ export const makeSchemaForRatedDisabilitiesInNewDisabilities = createSelector(
           typeof d?.ratedDisability === 'string'
             ? d.ratedDisability.trim()
             : '';
-        if (isPlaceholderRated(condition) && ratedDisability) {
+
+        const isNewConditionOption = ratedDisability === NEW_CONDITION_OPTION;
+
+        if (
+          isPlaceholderRated(condition) &&
+          ratedDisability &&
+          !isNewConditionOption
+        ) {
           return ratedDisability;
         }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Adds a function that isolates the rated disabilities that are present in the `newDisabilities` list.
Incorporates this function into another one that compiles the full set of new and rated disabilities. 

- _(If bug, how to reproduce)_
See Steps to Reproduce in https://github.com/department-of-veterans-affairs/va.gov-team/issues/128731.

- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Benefits Crew. Yes.


## Related issue(s)

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/128731

## Testing done

- _Describe what the old behavior was prior to the change_
Prior to the change, if the user was enabled for toggle `disability_compensation_new_conditions_workflow` and the user selected existing rated disabilities, those selections would not appear in the checkboxes for the Supporting Evidence screens ("Request medical records from VA providers", "Request medical records from private providers").  Root cause:  when that toggle is enabled, rated disabilities selections are not added to the `ratedDisabilities` list, which factors into how the checkboxes are compiled.

- _Describe the steps required to verify your changes are working as expected_
1. Log in as a user with rated disabilities.
2. In Step 2, select at least one of the existing rated disabilities.
3. On Step 3's "Types of supporting evidence", for question "Is there any evidence you'd like us to review as part of your claim?", select Yes; and select checkboxes "VA medical records" and "Non-VA treatment records"
4. Observe that in the screens for requesting medical records, the selected rated disabilities are displayed as checkboxes.

- _Describe the tests completed and the results_

Added unit test for new method  `makeSchemaForRatedDisabilitiesInNewDisabilities` and updated test for `makeSchemaForAllDisabilities` to check that rated disabilities in the `newDisabilities` array are returned.



## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._


Testing on local dev: the payload shows one rated disability selected, and present in the `newDisabilities` array; the left shows a checkbox present for the rated disability.
<img width="800"    src="https://github.com/user-attachments/assets/80c03174-fb1a-4caf-8e0d-65c0cf11c2c7" />



|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
