### PR TITLE
[128631] Copy of submission not populating required fields

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/confirmationFields/ConfirmationNewDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/components/confirmationFields/ConfirmationNewDisabilities.jsx
@@ -4,145 +4,189 @@ import { capitalizeEachWord } from '../../utils';
 import { formatDateString } from '../../content/conditions';
 import { DISABILITY_CAUSE_LABELS } from '../../constants';
 
-const getCauseLabel = cause => {
-  return DISABILITY_CAUSE_LABELS[cause] || '';
-};
+const getCauseLabel = cause => DISABILITY_CAUSE_LABELS[cause] || '';
 
 const ConfirmationNewDisabilities = ({ formData }) => {
   const { newDisabilities = [] } = formData || {};
 
   return (
     <>
-      {newDisabilities.map(dis => {
-        // guard is necessary for legacy 0781 conditions that do not have a cause
-        const cause = dis?.cause || 'Claimed';
-        const capitalizedConditionType =
-          cause === 'VA'
-            ? 'VA'
-            : cause.charAt(0).toUpperCase() + cause.slice(1).toLowerCase();
-        const causeLabel = getCauseLabel(cause);
-        const conditionDate = formatDateString(dis?.conditionDate);
+      {newDisabilities
+        .filter(dis => dis?.condition !== 'Rated Disability')
+        .map((dis, index) => {
+          // Guard is necessary for legacy 0781 conditions that do not have a cause
+          const cause = dis?.cause || 'Claimed';
+          const capitalizedConditionType =
+            cause === 'VA'
+              ? 'VA'
+              : cause.charAt(0).toUpperCase() + cause.slice(1).toLowerCase();
+          const causeLabel = getCauseLabel(cause);
+          const conditionDate = formatDateString(dis?.conditionDate);
+          const condition = dis?.condition?.trim();
+          // const hasCondition = condition && condition !== 'Rated Disability';
+          const key = condition
+            ? `${cause}-${condition}`
+            : `${cause}-unknown-${index}`;
 
-        return (
-          <li key={dis.condition}>
-            <h4>{capitalizeEachWord(dis.condition)}</h4>
+          // --- Backward-compatible field accessors ---
+          // SECONDARY (new shape OR legacy nested shape)
+          const causedByDisability =
+            dis?.causedByDisability ??
+            dis?.['view:secondaryFollowUp']?.causedByDisability;
 
-            {capitalizedConditionType && (
-              <>
-                <div className="vads-u-color--gray">Type of condition</div>
-                <div className="vads-u-margin-bottom--2">
-                  {capitalizedConditionType} condition
-                </div>
-              </>
-            )}
+          const causedByDisabilityDescription =
+            dis?.causedByDisabilityDescription ??
+            dis?.['view:secondaryFollowUp']?.causedByDisabilityDescription;
 
-            {causeLabel && (
-              <>
-                <div className="vads-u-color--gray">Cause</div>
-                <div className="vads-u-margin-bottom--2">{causeLabel}</div>
-              </>
-            )}
+          // WORSENED (new shape OR legacy nested shape)
+          const worsenedDescription =
+            dis?.worsenedDescription ??
+            dis?.['view:worsenedFollowUp']?.worsenedDescription;
 
-            {dis.primaryDescription && (
-              <>
-                <div className="vads-u-color--gray">Description</div>
-                <div className="vads-u-margin-bottom--2">
-                  {dis.primaryDescription}
-                </div>
-              </>
-            )}
+          const worsenedEffects =
+            dis?.worsenedEffects ??
+            dis?.['view:worsenedFollowUp']?.worsenedEffects;
 
-            {conditionDate && (
-              <>
-                <div className="vads-u-color--gray">Date</div>
-                <div className="vads-u-margin-bottom--2">{conditionDate}</div>
-              </>
-            )}
+          // VA (new shape OR legacy nested shape)
+          const vaMistreatmentDescription =
+            dis?.vaMistreatmentDescription ??
+            dis?.['view:vaFollowUp']?.vaMistreatmentDescription;
 
-            {dis.cause === 'SECONDARY' &&
-              dis?.['view:secondaryFollowUp']?.causedByDisability && (
+          const vaMistreatmentLocation =
+            dis?.vaMistreatmentLocation ??
+            dis?.['view:vaFollowUp']?.vaMistreatmentLocation;
+
+          const vaMistreatmentDate =
+            dis?.vaMistreatmentDate ??
+            dis?.['view:vaFollowUp']?.vaMistreatmentDate;
+
+          return (
+            <li key={key}>
+              <h4>{capitalizeEachWord(condition)}</h4>
+
+              {capitalizedConditionType && (
                 <>
-                  <div className="vads-u-color--gray">Caused by</div>
+                  <div className="vads-u-color--gray">Type of condition</div>
                   <div className="vads-u-margin-bottom--2">
-                    {dis['view:secondaryFollowUp']?.causedByDisability}
+                    {capitalizedConditionType} condition
                   </div>
-                  {dis['view:secondaryFollowUp']
-                    ?.causedByDisabilityDescription && (
-                    <>
-                      <div className="vads-u-color--gray">Description</div>
-                      <div className="vads-u-margin-bottom--2">
-                        {
-                          dis['view:secondaryFollowUp']
-                            ?.causedByDisabilityDescription
-                        }
-                      </div>
-                    </>
-                  )}
                 </>
               )}
 
-            {dis.cause === 'WORSENED' &&
-              dis?.['view:worsenedFollowUp'] && (
+              {causeLabel && (
                 <>
-                  {dis['view:worsenedFollowUp'].worsenedDescription && (
-                    <>
-                      <div className="vads-u-color--gray">
-                        Worsened description
-                      </div>
-                      <div className="vads-u-margin-bottom--2">
-                        {dis['view:worsenedFollowUp'].worsenedDescription}
-                      </div>
-                    </>
-                  )}
-                  {dis['view:worsenedFollowUp'].worsenedEffects && (
-                    <>
-                      <div className="vads-u-color--gray">Worsened effects</div>
-                      <div className="vads-u-margin-bottom--2">
-                        {dis['view:worsenedFollowUp'].worsenedEffects}
-                      </div>
-                    </>
-                  )}
+                  <div className="vads-u-color--gray">Cause</div>
+                  <div className="vads-u-margin-bottom--2">{causeLabel}</div>
                 </>
               )}
 
-            {dis.cause === 'VA' &&
-              dis?.['view:vaFollowUp'] && (
+              {dis?.primaryDescription && (
                 <>
-                  {dis['view:vaFollowUp'].vaMistreatmentDescription && (
-                    <>
-                      <div className="vads-u-color--gray">
-                        VA mistreatment description
-                      </div>
-                      <div className="vads-u-margin-bottom--2">
-                        {dis['view:vaFollowUp'].vaMistreatmentDescription}
-                      </div>
-                    </>
-                  )}
-                  {dis['view:vaFollowUp'].vaMistreatmentLocation && (
-                    <>
-                      <div className="vads-u-color--gray">
-                        VA mistreatment location
-                      </div>
-                      <div className="vads-u-margin-bottom--2">
-                        {dis['view:vaFollowUp'].vaMistreatmentLocation}
-                      </div>
-                    </>
-                  )}
-                  {dis['view:vaFollowUp'].vaMistreatmentDate && (
-                    <>
-                      <div className="vads-u-color--gray">
-                        VA mistreatment date
-                      </div>
-                      <div className="vads-u-margin-bottom--2">
-                        {dis['view:vaFollowUp'].vaMistreatmentDate}
-                      </div>
-                    </>
-                  )}
+                  <div className="vads-u-color--gray">Description</div>
+                  <div className="vads-u-margin-bottom--2">
+                    {dis.primaryDescription}
+                  </div>
                 </>
               )}
-          </li>
-        );
-      })}
+
+              {conditionDate && (
+                <>
+                  <div className="vads-u-color--gray">Date</div>
+                  <div className="vads-u-margin-bottom--2">{conditionDate}</div>
+                </>
+              )}
+
+              {/* SECONDARY */}
+              {cause === 'SECONDARY' &&
+                causedByDisability && (
+                  <>
+                    <div className="vads-u-color--gray">Caused by</div>
+                    <div className="vads-u-margin-bottom--2">
+                      {causedByDisability}
+                    </div>
+
+                    {causedByDisabilityDescription && (
+                      <>
+                        <div className="vads-u-color--gray">Description</div>
+                        <div className="vads-u-margin-bottom--2">
+                          {causedByDisabilityDescription}
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+
+              {/* WORSENED */}
+              {cause === 'WORSENED' &&
+                (worsenedDescription || worsenedEffects) && (
+                  <>
+                    {worsenedDescription && (
+                      <>
+                        <div className="vads-u-color--gray">
+                          Worsened description
+                        </div>
+                        <div className="vads-u-margin-bottom--2">
+                          {worsenedDescription}
+                        </div>
+                      </>
+                    )}
+
+                    {worsenedEffects && (
+                      <>
+                        <div className="vads-u-color--gray">
+                          Worsened effects
+                        </div>
+                        <div className="vads-u-margin-bottom--2">
+                          {worsenedEffects}
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+
+              {/* VA */}
+              {cause === 'VA' &&
+                (vaMistreatmentDescription ||
+                  vaMistreatmentLocation ||
+                  vaMistreatmentDate) && (
+                  <>
+                    {vaMistreatmentDescription && (
+                      <>
+                        <div className="vads-u-color--gray">
+                          VA mistreatment description
+                        </div>
+                        <div className="vads-u-margin-bottom--2">
+                          {vaMistreatmentDescription}
+                        </div>
+                      </>
+                    )}
+
+                    {vaMistreatmentLocation && (
+                      <>
+                        <div className="vads-u-color--gray">
+                          VA mistreatment location
+                        </div>
+                        <div className="vads-u-margin-bottom--2">
+                          {vaMistreatmentLocation}
+                        </div>
+                      </>
+                    )}
+
+                    {vaMistreatmentDate && (
+                      <>
+                        <div className="vads-u-color--gray">
+                          VA mistreatment date
+                        </div>
+                        <div className="vads-u-margin-bottom--2">
+                          {vaMistreatmentDate}
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+            </li>
+          );
+        })}
     </>
   );
 };

--- a/src/applications/disability-benefits/all-claims/components/confirmationFields/ConfirmationRatedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/components/confirmationFields/ConfirmationRatedDisabilities.jsx
@@ -2,9 +2,78 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { capitalizeEachWord } from '../../utils';
 
+const normalize = val => (typeof val === 'string' ? val.trim() : '');
+
+const deriveRatedIncreaseSelections = (formData = {}) => {
+  const ratedDisabilities = Array.isArray(formData.ratedDisabilities)
+    ? formData.ratedDisabilities
+    : [];
+
+  const newDisabilities = Array.isArray(formData.newDisabilities)
+    ? formData.newDisabilities
+    : [];
+
+  // --- Build lookup for ratedDisabilities by name (case-insensitive) ---
+  const ratedByName = new Map(
+    ratedDisabilities
+      .filter(d => d && typeof d.name === 'string')
+      .map(d => [d.name.toLowerCase(), d]),
+  );
+
+  // 1) Current workflow (view:selected)
+  const fromRatedDisabilities = ratedDisabilities
+    .filter(d => d && d['view:selected'])
+    .map(d => ({
+      name: normalize(d.name),
+      ratingPercentage: d.ratingPercentage,
+      source: 'ratedDisabilities',
+    }))
+    .filter(d => d.name);
+
+  // 2) New conditions workflow (rated increases inside newDisabilities)
+  const fromNewDisabilities = newDisabilities
+    .filter(d => d && typeof d === 'object')
+    .filter(d => {
+      const ratedName = normalize(d.ratedDisability);
+      const condition = normalize(d.condition).toLowerCase();
+
+      return (
+        ratedName &&
+        (condition === 'rated disability' || d.cause === 'WORSENED') &&
+        ratedByName.has(ratedName.toLowerCase())
+      );
+    })
+    .map(d => {
+      const ratedName = normalize(d.ratedDisability);
+      const ratedMatch = ratedByName.get(ratedName.toLowerCase());
+
+      return {
+        name: ratedName,
+        ratingPercentage: ratedMatch?.ratingPercentage,
+        source: 'newDisabilities',
+      };
+    });
+
+  const combined = [...fromRatedDisabilities, ...fromNewDisabilities];
+
+  const deduped = new Map();
+  combined.forEach(item => {
+    const key = item.name.toLowerCase();
+    const existing = deduped.get(key);
+
+    if (
+      !existing ||
+      (existing.ratingPercentage == null && item.ratingPercentage != null)
+    ) {
+      deduped.set(key, item);
+    }
+  });
+
+  return [...deduped.values()];
+};
+
 const ConfirmationRatedDisabilities = ({ formData }) => {
-  const { ratedDisabilities = [] } = formData || {};
-  const selectedRated = ratedDisabilities.filter(d => d['view:selected']);
+  const selectedRated = deriveRatedIncreaseSelections(formData);
 
   return (
     <>
@@ -12,11 +81,14 @@ const ConfirmationRatedDisabilities = ({ formData }) => {
         <li key={dis.name}>
           <h4>{capitalizeEachWord(dis.name)}</h4>
           <div className="vads-u-color--gray">Description</div>
-          {dis.ratingPercentage && (
+
+          {dis.ratingPercentage != null ? (
             <span>
               {'Claiming an increase from current '}
               {dis.ratingPercentage}% rating
             </span>
+          ) : (
+            <span>Claiming an increase</span>
           )}
         </li>
       ))}
@@ -27,6 +99,7 @@ const ConfirmationRatedDisabilities = ({ formData }) => {
 ConfirmationRatedDisabilities.propTypes = {
   formData: PropTypes.shape({
     ratedDisabilities: PropTypes.array,
+    newDisabilities: PropTypes.array,
   }),
 };
 

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationNewDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationNewDisabilities.unit.spec.jsx
@@ -370,5 +370,29 @@ describe('ConfirmationNewDisabilities', () => {
       expect(getByText('Condition A')).to.exist;
       expect(getByText('Caused by description A')).to.exist;
     });
+
+    it('should not render when condition is Rated Disability', () => {
+      const formData = {
+        newDisabilities: [{ condition: 'Rated Disability', cause: 'NEW' }],
+      };
+
+      const { container } = render(
+        <ConfirmationNewDisabilities formData={formData} />,
+      );
+
+      expect(container.querySelectorAll('li')).to.have.length(0);
+    });
+
+    it('does not render when condition is Rated Disability', () => {
+      const formData = {
+        newDisabilities: [{ condition: 'Rated Disability' }],
+      };
+
+      const { container } = render(
+        <ConfirmationNewDisabilities formData={formData} />,
+      );
+
+      expect(container.querySelectorAll('li')).to.have.length(0);
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationRatedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationRatedDisabilities.unit.spec.jsx
@@ -38,4 +38,15 @@ describe('ConfirmationRatedDisabilities', () => {
     );
     expect(container.querySelectorAll('h4')).to.have.length(0);
   });
+
+  it('renders fallback text when ratingPercentage is missing', () => {
+    const formData = {
+      ratedDisabilities: [{ name: 'Condition 1', 'view:selected': true }],
+    };
+
+    const { getByText } = render(
+      <ConfirmationRatedDisabilities formData={formData} />,
+    );
+    expect(getByText(/claiming an increase$/i)).to.exist;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

After a veteran submits a disability benefits application, they are shown a Copy of Submission (confirmation) page. This page allows the veteran to review all submitted information, including claimed conditions, and to generate a PDF copy.

When the new conditions workflow is used, the conditions entered by the veteran do not appear on the Copy of Submission page or in the generated PDF. This issue does not occur with the legacy workflow.

**Note:** It is not possible to test the code changes 

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/128631

## Steps to Reproduce - Staging

### Pre-requisite

The disability_compensation_new_conditions_workflow feature flag is enabled for the following users:

- Rated disabilities:
   - vets.gov.user+220@gmail.com 
   - vets.gov.user+226@gmail.com
   - vets.gov.user+228@gmail.com 
   - vets.gov.user+230@gmail.com 
   - vets.gov.user+234@gmail.com
   - vets.gov.user+235@gmail.com

- No rated disabilities
   - vets.gov.user+204@gmail.com
   - vets.gov.user+208@gmail.com
   - vets.gov.user+209@gmail.com
   - vets.gov.user+211@gmail.com
   - vets.gov.user+232@gmail.com 
   - vets.gov.user+246@gmail.com

Passwords are available in the va.gov-team-sensitive repo. 

**All other users should not have this flag enabled.**

### Staging

1. Visit staging.va.gov
2. Use a test user with the new conditions workflow enabled
3. Log in to the disability benefits application
4. Navigate to the Conditions section
5. Enter one or more new conditions
6. Enter one or more rated disabilities (if applicable)
7. Navigate to the Review and submit page
8. Verify that the conditions are listed correctly
9. Submit the application
10. Wait for the confirmation (Copy of Submission) page to load
11. Observe the alert showing which conditions were submitted
12. Scroll down to the accordion section
13. Open the accordion
14. Observe that the conditions do not appear alongside the other submitted information
15. Click the button below the accordion to print/save the submission
16. Observe that the generated PDF also does not include the conditions

**Note:** This issue cannot be reproduced in a local development environment.

## Expected Behavior

- Conditions entered using the new conditions workflow should appear:
   - On the Copy of Submission page
   - In the generated PDF
   
- Behavior should be consistent with the legacy disability benefits workflow.

## Actual Behavior

- Conditions entered using the new conditions workflow do not appear on:
   - The Copy of Submission page
   - The generated PDF

## Proposed Fix

Files: 

- `/vets-website-sip/src/applications/disability-benefits/all claims/components/confirmationFields/ConfirmationNewDisabilities.jsx`
- `/vets-website-sip/src/applications/disability-benefits/all claims/components/confirmationFields/ConfirmationRatedDisabilities.jsx`

Update the confirmation logic so that conditions from both the legacy disability benefits workflow, and the new conditions workflow are correctly rendered on the confirmation page and included in the generated PDF.  

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#128631
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Steps to Reproduce - Local ENV

### Pre-requisite

- Seed the application with the following set of rated disabilities from this [gist](https://gist.github.com/sdbars/baf1da55b2ba5c2ed837510c01a733b8)
- Replace the Summary of Evidence (src/applications/disability-benefits/all-claims/pages/summaryOfEvidence.js) with the code from this [gist] (https://gist.github.com/sdbars/5435be0b5f2e02abb660acce43c8459fhttps://gist.github.com/sdbars/5435be0b5f2e02abb660acce43c8459f) 
- Ensure the disability_compensation_new_conditions_workflow feature flag is enabled

Since it is not possible to submit the form and obtain a response via the confirmation page in a local environment, the pre-requisites provide a workaround  in order to test that the list conditions are rendered. 

### Steps

1. Run application
2. Navigate to Conditions section
3. Add a rated disability and proceed to Summary page
4. Continue adding conditions rated or new 
5. On the summary page, select No and navigate through the remaining pages until the summary of evidence page

The summary of evidence page mimics what the Copy of Submission page should render. If new and/or rated disabilities have been added, they will appear in the alert.  Note the alert itself does not conditionally render.

## Videos

### Staging ENV - BEFORE

https://github.com/user-attachments/assets/78449cd6-1a62-4786-9ea2-fdd25b48e31c

### Local ENV - AFTER

https://github.com/user-attachments/assets/3e23c401-636c-4c4d-b458-8aa3f4a0c918

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings hae been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Ensure to test users using the new conditions and the current disabilities benefits workflows.