### PR TITLE
10-7959c | Update conditionals for Medicare Part A denial notice

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/index.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/index.js
@@ -7,8 +7,9 @@ import {
   hasPartC,
   hasPartD,
   hasPartsABorC,
+  needsPartADenialNotice,
 } from '../../utils/helpers';
-import medicareIntro from './introduction';
+import overview from './overview';
 import partACardUpload from './partACardUpload';
 import partADenialNotice from './partADenialNotice';
 import partADenialProofUpload from './partADenialProofUpload';
@@ -33,7 +34,7 @@ export const medicarePagesRev2025 = {
     path: 'medicare-overview',
     title: 'Report Medicare',
     depends: formData => formData[REV2025_TOGGLE_KEY],
-    ...medicareIntro,
+    ...overview,
   },
   reportMedicare: {
     path: 'report-medicare-plan',
@@ -74,7 +75,8 @@ export const medicarePagesRev2025 = {
   medicarePartADenial: {
     path: 'medicare-part-a-denial-notice',
     title: 'Medicare Part A denial',
-    depends: formData => formData[REV2025_TOGGLE_KEY] && hasPartB(formData),
+    depends: formData =>
+      formData[REV2025_TOGGLE_KEY] && needsPartADenialNotice(formData),
     ...partADenialNotice,
   },
   medicarePartADenialProofUpload: {

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/overview.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/overview.js
@@ -2,7 +2,7 @@ import {
   descriptionUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import MedicareIntroDescription from '../../components/FormDescriptions/MedicareIntroDescription';
+import MedicareOverview from '../../components/FormDescriptions/MedicareOverviewDescription';
 import { blankSchema } from '../../definitions';
 import content from '../../locales/en/content.json';
 
@@ -11,7 +11,7 @@ const TITLE_TEXT = content['medicare--intro-title'];
 export default {
   uiSchema: {
     ...titleUI(TITLE_TEXT),
-    ...descriptionUI(MedicareIntroDescription),
+    ...descriptionUI(MedicareOverview),
   },
   schema: blankSchema,
 };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/planTypes.rev2025.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/planTypes.rev2025.js
@@ -23,7 +23,7 @@ export default {
       title: INPUT_LABEL,
       labels: SCHEMA_LABELS,
       updateSchema: formData => {
-        if (formData['view:allowMedicarePlanB']) return {};
+        if (formData['view:beneficiaryAgeOver65']) return {};
         return { enum: SCHEMA_ENUM.slice(0, -1) };
       },
     }),

--- a/src/applications/ivc-champva/10-7959C/components/FormDescriptions/MedicareOverviewDescription.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/FormDescriptions/MedicareOverviewDescription.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const MedicareIntroDescription = (
+const MedicareOverviewDescription = (
   <ul>
     <li>
       <strong>If you currently have Medicare</strong>, provide your plan
@@ -17,4 +17,4 @@ const MedicareIntroDescription = (
   </ul>
 );
 
-export default MedicareIntroDescription;
+export default MedicareOverviewDescription;

--- a/src/applications/ivc-champva/10-7959C/tests/unit/utils/helpers/medicare.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/unit/utils/helpers/medicare.unit.spec.jsx
@@ -1,0 +1,243 @@
+import { expect } from 'chai';
+import {
+  hasMedicare,
+  hasPartsAB,
+  hasPartA,
+  hasPartB,
+  hasPartC,
+  hasPartsABorC,
+  hasPartD,
+  needsPartADenialNotice,
+  hasPartADenialNotice,
+} from '../../../../utils/helpers';
+
+describe('10-7959c Medicare helpers', () => {
+  describe('hasMedicare', () => {
+    it('should return "true" when view:hasMedicare is true', () => {
+      const formData = { 'view:hasMedicare': true };
+      expect(hasMedicare(formData)).to.be.true;
+    });
+
+    it('should return "false" when view:hasMedicare is false', () => {
+      const formData = { 'view:hasMedicare': false };
+      expect(hasMedicare(formData)).to.be.false;
+    });
+
+    it('should return "false" when view:hasMedicare is not set', () => {
+      const formData = {};
+      expect(hasMedicare(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartsAB', () => {
+    it('should return "true" when beneficiary has Medicare and plan type is ab', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'ab',
+      };
+      expect(hasPartsAB(formData)).to.be.true;
+    });
+
+    it('should return "false" when beneficiary has Medicare but plan type is not ab', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+      };
+      expect(hasPartsAB(formData)).to.be.false;
+    });
+
+    it('should return "false" when beneficiary does not have Medicare', () => {
+      const formData = {
+        'view:hasMedicare': false,
+        medicarePlanType: 'ab',
+      };
+      expect(hasPartsAB(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartA', () => {
+    it('should return true when has Medicare and plan type is a', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+      };
+      expect(hasPartA(formData)).to.be.true;
+    });
+
+    it('should return false when plan type is not a', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'b',
+      };
+      expect(hasPartA(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartB', () => {
+    it('should return "true" when beneficiary has Medicare and plan type is "b"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'b',
+      };
+      expect(hasPartB(formData)).to.be.true;
+    });
+
+    it('should return "false" when plan type is not "b"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+      };
+      expect(hasPartB(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartC', () => {
+    it('should return "true" when beneficiary has Medicare and plan type is "c"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'c',
+      };
+      expect(hasPartC(formData)).to.be.true;
+    });
+
+    it('should return "false" when plan type is not "c"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+      };
+      expect(hasPartC(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartsABorC', () => {
+    it('should return "true" when plan type is "ab"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'ab',
+      };
+      expect(hasPartsABorC(formData)).to.be.true;
+    });
+
+    it('should return "true" when plan type is "c"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'c',
+      };
+      expect(hasPartsABorC(formData)).to.be.true;
+    });
+
+    it('should return "false" when plan type is "a"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+      };
+      expect(hasPartsABorC(formData)).to.be.false;
+    });
+
+    it('should return "false" when plan type is "b"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'b',
+      };
+      expect(hasPartsABorC(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartD', () => {
+    it('should return "true" when beneficiary has Medicare, the plan type is "ab" or "c" and hasMedicarePartD is "true"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'ab',
+        hasMedicarePartD: true,
+      };
+      expect(hasPartD(formData)).to.be.true;
+    });
+
+    it('should return "false" when beneficiary has Medicare, the plan type is "ab" or "c" hasMedicarePartD is "false"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'ab',
+        hasMedicarePartD: false,
+      };
+      expect(hasPartD(formData)).to.be.false;
+    });
+
+    it('should return "false" when the plan type is not "ab" or "c"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+        hasMedicarePartD: true,
+      };
+      expect(hasPartD(formData)).to.be.false;
+    });
+  });
+
+  describe('needsPartADenialNotice', () => {
+    it('should return "true" when plan type is "b"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'b',
+      };
+      expect(needsPartADenialNotice(formData)).to.be.true;
+    });
+
+    it('should return "true" when beneficiary does not have Medicare but is age 65 or older', () => {
+      const formData = {
+        'view:hasMedicare': false,
+        'view:beneficiaryAgeOver65': true,
+      };
+      expect(needsPartADenialNotice(formData)).to.be.true;
+    });
+
+    it('should return "false" when plan type is "a"', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+      };
+      expect(needsPartADenialNotice(formData)).to.be.false;
+    });
+
+    it('should return "false" when beneficiary does not have Medicare but is not age 65 or older', () => {
+      const formData = {
+        'view:hasMedicare': false,
+        'view:beneficiaryAgeOver65': false,
+      };
+      expect(needsPartADenialNotice(formData)).to.be.false;
+    });
+  });
+
+  describe('hasPartADenialNotice', () => {
+    it('should return "true" when beneficiary needs denial notice and has it', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'b',
+        'view:hasPartADenial': {
+          hasPartADenial: true,
+        },
+      };
+      expect(hasPartADenialNotice(formData)).to.be.true;
+    });
+
+    it('should return "false" when beneficiary needs denial notice but does not have it', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'b',
+        'view:hasPartADenial': {
+          hasPartADenial: false,
+        },
+      };
+      expect(hasPartADenialNotice(formData)).to.be.false;
+    });
+
+    it('should return "false" when beneficiary does not need denial notice', () => {
+      const formData = {
+        'view:hasMedicare': true,
+        medicarePlanType: 'a',
+        'view:hasPartADenial': {
+          hasPartADenial: true,
+        },
+      };
+      expect(hasPartADenialNotice(formData)).to.be.false;
+    });
+  });
+});

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
@@ -1,4 +1,4 @@
-export const hasMedicare = formData => formData['view:hasMedicare'];
+export const hasMedicare = formData => !!formData['view:hasMedicare'];
 
 export const hasPartsAB = formData =>
   hasMedicare(formData) && formData.medicarePlanType === 'ab';
@@ -23,4 +23,5 @@ export const needsPartADenialNotice = formData =>
   (!hasMedicare(formData) && formData['view:beneficiaryAgeOver65']);
 
 export const hasPartADenialNotice = formData =>
-  needsPartADenialNotice(formData) && formData.hasPartADenial;
+  needsPartADenialNotice(formData) &&
+  formData['view:hasPartADenial'].hasPartADenial;

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
@@ -18,5 +18,9 @@ export const hasPartsABorC = formData =>
 export const hasPartD = formData =>
   hasMedicare(formData) && hasPartsABorC(formData) && formData.hasMedicarePartD;
 
+export const needsPartADenialNotice = formData =>
+  hasPartB(formData) ||
+  (!hasMedicare(formData) && formData['view:beneficiaryAgeOver65']);
+
 export const hasPartADenialNotice = formData =>
-  hasMedicare(formData) && hasPartB(formData) && formData.hasPartADenial;
+  needsPartADenialNotice(formData) && formData.hasPartADenial;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the conditions used for the Medicare Part A Notice of Disallowance page renders. There is also some minor clean-up around naming conventions.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#126790

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Pages render based on correct conditions

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
