### PR TITLE
Consolidate date range selector logic into reusable hook

### DIFF
--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -15,6 +15,7 @@ import {
 } from '../actions/careSummariesAndNotes';
 import useListRefresh from '../hooks/useListRefresh';
 import useReloadResetListOnUnmount from '../hooks/useReloadResetListOnUnmount';
+import useDateRangeSelector from '../hooks/useDateRangeSelector';
 import {
   ALERT_TYPE_ERROR,
   DEFAULT_DATE_RANGE,
@@ -28,20 +29,13 @@ import {
 import useAlerts from '../hooks/use-alerts';
 import RecordListSection from '../components/shared/RecordListSection';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
-import DateRangeSelector, {
-  getDateRangeList,
-} from '../components/shared/DateRangeSelector';
+import DateRangeSelector from '../components/shared/DateRangeSelector';
 import AdditionalReportsInfo from '../components/shared/AdditionalReportsInfo';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 import TrackedSpinner from '../components/shared/TrackedSpinner';
 import { useTrackAction } from '../hooks/useTrackAction';
 import { Actions } from '../util/actionTypes';
-import {
-  calculateDateRange,
-  getTimeFrame,
-  getDisplayTimeFrame,
-  sendDataDogAction,
-} from '../util/helpers';
+import { getTimeFrame, getDisplayTimeFrame } from '../util/helpers';
 
 const CareSummariesAndNotes = () => {
   const dispatch = useDispatch();
@@ -113,28 +107,11 @@ const CareSummariesAndNotes = () => {
     isAcceleratingCareNotes && listState === loadStates.FETCHING;
 
   // Handle date range selection from DateRangeSelector component
-  const handleDateRangeSelect = useCallback(
-    event => {
-      const { value } = event.detail;
-      const { fromDate, toDate } = calculateDateRange(value);
-
-      // Update Redux with new range
-      dispatch(updateNotesDateRange(value, fromDate, toDate));
-
-      dispatch({
-        type: Actions.CareSummariesAndNotes.UPDATE_LIST_STATE,
-        payload: loadStates.PRE_FETCH,
-      });
-
-      // DataDog tracking
-      const selectedOption = getDateRangeList().find(
-        option => option.value === value,
-      );
-      const label = selectedOption ? selectedOption.label : 'Unknown';
-      sendDataDogAction(`Notes date option - ${label}`);
-    },
-    [dispatch],
-  );
+  const handleDateRangeSelect = useDateRangeSelector({
+    updateDateRangeAction: updateNotesDateRange,
+    updateListStateActionType: Actions.CareSummariesAndNotes.UPDATE_LIST_STATE,
+    dataDogLabel: 'Notes date option',
+  });
 
   return (
     <div id="care-summaries-and-notes">

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -28,21 +28,15 @@ import {
   loadStates,
   statsdFrontEndActions,
 } from '../util/constants';
-import {
-  calculateDateRange,
-  getTimeFrame,
-  getDisplayTimeFrame,
-  sendDataDogAction,
-} from '../util/helpers';
+import { getTimeFrame, getDisplayTimeFrame } from '../util/helpers';
 
 import RecordListSection from '../components/shared/RecordListSection';
 import useAlerts from '../hooks/use-alerts';
 import useListRefresh from '../hooks/useListRefresh';
 import useReloadResetListOnUnmount from '../hooks/useReloadResetListOnUnmount';
+import useDateRangeSelector from '../hooks/useDateRangeSelector';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
-import DateRangeSelector, {
-  getDateRangeList,
-} from '../components/shared/DateRangeSelector';
+import DateRangeSelector from '../components/shared/DateRangeSelector';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 import { fetchImageRequestStatus } from '../actions/images';
 import JobCompleteAlert from '../components/shared/JobsCompleteAlert';
@@ -139,28 +133,11 @@ const LabsAndTests = () => {
     [dispatch],
   );
 
-  const handleDateRangeSelect = useCallback(
-    event => {
-      const { value } = event.detail;
-      const { fromDate, toDate } = calculateDateRange(value);
-
-      // Update Redux with new range
-      dispatch(updateLabsAndTestDateRange(value, fromDate, toDate));
-
-      dispatch({
-        type: Actions.LabsAndTests.UPDATE_LIST_STATE,
-        payload: loadStates.PRE_FETCH,
-      });
-
-      // DataDog tracking
-      const selectedOption = getDateRangeList().find(
-        option => option.value === value,
-      );
-      const label = selectedOption ? selectedOption.label : 'Unknown';
-      sendDataDogAction(`Date range option - ${label}`);
-    },
-    [dispatch],
-  );
+  const handleDateRangeSelect = useDateRangeSelector({
+    updateDateRangeAction: updateLabsAndTestDateRange,
+    updateListStateActionType: Actions.LabsAndTests.UPDATE_LIST_STATE,
+    dataDogLabel: 'Date range option',
+  });
 
   return (
     <div id="labs-and-tests">

--- a/src/applications/mhv-medical-records/hooks/useDateRangeSelector.js
+++ b/src/applications/mhv-medical-records/hooks/useDateRangeSelector.js
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { calculateDateRange, sendDataDogAction } from '../util/helpers';
+import { getDateRangeList } from '../components/shared/DateRangeSelector';
+import { loadStates } from '../util/constants';
+
+/**
+ * Custom hook for handling date range selection across domains.
+ * Consolidates the duplicated handleDateRangeSelect logic from
+ * LabsAndTests.jsx and CareSummariesAndNotes.jsx.
+ *
+ * @param {Object} options - Configuration options
+ * @param {Function} options.updateDateRangeAction - Redux action creator to update date range
+ * @param {string} options.updateListStateActionType - Action type for updating list state
+ * @param {string} options.dataDogLabel - Label for DataDog tracking
+ * @returns {Function} handleDateRangeSelect callback
+ *
+ * @example
+ * const handleDateRangeSelect = useDateRangeSelector({
+ *   updateDateRangeAction: updateNotesDateRange,
+ *   updateListStateActionType: Actions.CareSummariesAndNotes.UPDATE_LIST_STATE,
+ *   dataDogLabel: 'Notes date option',
+ * });
+ */
+const useDateRangeSelector = ({
+  updateDateRangeAction,
+  updateListStateActionType,
+  dataDogLabel,
+}) => {
+  const dispatch = useDispatch();
+
+  return useCallback(
+    event => {
+      const { value } = event.detail;
+      const { fromDate, toDate } = calculateDateRange(value);
+
+      // Update Redux with new range
+      dispatch(updateDateRangeAction(value, fromDate, toDate));
+
+      // Update list state to trigger refetch
+      dispatch({
+        type: updateListStateActionType,
+        payload: loadStates.PRE_FETCH,
+      });
+
+      // DataDog tracking
+      const selectedOption = getDateRangeList().find(
+        option => option.value === value,
+      );
+      const label = selectedOption ? selectedOption.label : 'Unknown';
+      sendDataDogAction(`${dataDogLabel} - ${label}`);
+    },
+    [dispatch, updateDateRangeAction, updateListStateActionType, dataDogLabel],
+  );
+};
+
+export default useDateRangeSelector;

--- a/src/applications/mhv-medical-records/tests/hooks/useDateRangeSelector.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/hooks/useDateRangeSelector.unit.spec.jsx
@@ -1,0 +1,277 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import useDateRangeSelector from '../../hooks/useDateRangeSelector';
+import { loadStates } from '../../util/constants';
+import * as helpers from '../../util/helpers';
+import * as DateRangeSelector from '../../components/shared/DateRangeSelector';
+
+// Mock store creator
+const createMockStore = () => ({
+  getState: () => ({}),
+  subscribe: () => () => {},
+  dispatch: sinon.spy(),
+});
+
+// Test component that uses the hook
+function TestComponent({
+  updateDateRangeAction,
+  updateListStateActionType,
+  dataDogLabel,
+  onHandleSelect,
+}) {
+  const handleDateRangeSelect = useDateRangeSelector({
+    updateDateRangeAction,
+    updateListStateActionType,
+    dataDogLabel,
+  });
+
+  // Expose the handler to the test
+  React.useEffect(
+    () => {
+      if (onHandleSelect) {
+        onHandleSelect(handleDateRangeSelect);
+      }
+    },
+    [handleDateRangeSelect, onHandleSelect],
+  );
+
+  return <div data-testid="test-component" />;
+}
+
+TestComponent.propTypes = {
+  dataDogLabel: PropTypes.string.isRequired,
+  updateDateRangeAction: PropTypes.func.isRequired,
+  updateListStateActionType: PropTypes.string.isRequired,
+  onHandleSelect: PropTypes.func,
+};
+
+describe('useDateRangeSelector', () => {
+  let mockStore;
+  let sandbox;
+  let calculateDateRangeStub;
+  let sendDataDogActionStub;
+  let getDateRangeListStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    mockStore = createMockStore();
+
+    // Stub helper functions
+    calculateDateRangeStub = sandbox.stub(helpers, 'calculateDateRange');
+    sendDataDogActionStub = sandbox.stub(helpers, 'sendDataDogAction');
+    getDateRangeListStub = sandbox.stub(DateRangeSelector, 'getDateRangeList');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const renderHook = props => {
+    let capturedHandler = null;
+
+    render(
+      <Provider store={mockStore}>
+        <TestComponent
+          {...props}
+          onHandleSelect={handler => {
+            capturedHandler = handler;
+          }}
+        />
+      </Provider>,
+    );
+
+    return { capturedHandler: () => capturedHandler, store: mockStore };
+  };
+
+  it('should return a function', async () => {
+    const updateDateRangeAction = sinon.stub().returns({ type: 'TEST_ACTION' });
+
+    const { capturedHandler } = renderHook({
+      updateDateRangeAction,
+      updateListStateActionType: 'UPDATE_LIST_STATE',
+      dataDogLabel: 'Test label',
+    });
+
+    await waitFor(() => {
+      expect(typeof capturedHandler()).to.equal('function');
+    });
+  });
+
+  it('should dispatch updateDateRangeAction with calculated date range', async () => {
+    const updateDateRangeAction = sinon
+      .stub()
+      .returns({ type: 'SET_DATE_RANGE' });
+    const updateListStateActionType = 'UPDATE_LIST_STATE';
+
+    calculateDateRangeStub.returns({
+      fromDate: '2024-01-01',
+      toDate: '2024-03-31',
+    });
+    getDateRangeListStub.returns([{ value: '3', label: 'Last 3 months' }]);
+
+    const { capturedHandler, store } = renderHook({
+      updateDateRangeAction,
+      updateListStateActionType,
+      dataDogLabel: 'Test label',
+    });
+
+    await waitFor(() => {
+      expect(capturedHandler()).to.not.be.null;
+    });
+
+    // Simulate the event
+    const mockEvent = { detail: { value: '3' } };
+    capturedHandler()(mockEvent);
+
+    await waitFor(() => {
+      expect(calculateDateRangeStub.calledWith('3')).to.be.true;
+      expect(updateDateRangeAction.calledWith('3', '2024-01-01', '2024-03-31'))
+        .to.be.true;
+      expect(store.dispatch.called).to.be.true;
+    });
+  });
+
+  it('should dispatch UPDATE_LIST_STATE action with PRE_FETCH payload', async () => {
+    const updateDateRangeAction = sinon
+      .stub()
+      .returns({ type: 'SET_DATE_RANGE' });
+    const updateListStateActionType = 'TEST_UPDATE_LIST_STATE';
+
+    calculateDateRangeStub.returns({
+      fromDate: '2024-01-01',
+      toDate: '2024-03-31',
+    });
+    getDateRangeListStub.returns([{ value: '3', label: 'Last 3 months' }]);
+
+    const { capturedHandler, store } = renderHook({
+      updateDateRangeAction,
+      updateListStateActionType,
+      dataDogLabel: 'Test label',
+    });
+
+    await waitFor(() => {
+      expect(capturedHandler()).to.not.be.null;
+    });
+
+    const mockEvent = { detail: { value: '3' } };
+    capturedHandler()(mockEvent);
+
+    await waitFor(() => {
+      // Check that the UPDATE_LIST_STATE action was dispatched
+      const updateListStateCall = store.dispatch
+        .getCalls()
+        .find(
+          call =>
+            call.args[0]?.type === updateListStateActionType &&
+            call.args[0]?.payload === loadStates.PRE_FETCH,
+        );
+      expect(updateListStateCall).to.not.be.undefined;
+    });
+  });
+
+  it('should send DataDog action with correct label', async () => {
+    const updateDateRangeAction = sinon
+      .stub()
+      .returns({ type: 'SET_DATE_RANGE' });
+    const dataDogLabel = 'Notes date option';
+
+    calculateDateRangeStub.returns({
+      fromDate: '2024-01-01',
+      toDate: '2024-03-31',
+    });
+    getDateRangeListStub.returns([{ value: '3', label: 'Last 3 months' }]);
+
+    const { capturedHandler } = renderHook({
+      updateDateRangeAction,
+      updateListStateActionType: 'UPDATE_LIST_STATE',
+      dataDogLabel,
+    });
+
+    await waitFor(() => {
+      expect(capturedHandler()).to.not.be.null;
+    });
+
+    const mockEvent = { detail: { value: '3' } };
+    capturedHandler()(mockEvent);
+
+    await waitFor(() => {
+      expect(
+        sendDataDogActionStub.calledWith('Notes date option - Last 3 months'),
+      ).to.be.true;
+    });
+  });
+
+  it('should use "Unknown" label when option is not found in date range list', async () => {
+    const updateDateRangeAction = sinon
+      .stub()
+      .returns({ type: 'SET_DATE_RANGE' });
+
+    calculateDateRangeStub.returns({
+      fromDate: '2024-01-01',
+      toDate: '2024-12-31',
+    });
+    getDateRangeListStub.returns([{ value: '3', label: 'Last 3 months' }]);
+
+    const { capturedHandler } = renderHook({
+      updateDateRangeAction,
+      updateListStateActionType: 'UPDATE_LIST_STATE',
+      dataDogLabel: 'Test label',
+    });
+
+    await waitFor(() => {
+      expect(capturedHandler()).to.not.be.null;
+    });
+
+    // Use a value that won't be found in the list
+    const mockEvent = { detail: { value: 'unknown-value' } };
+    capturedHandler()(mockEvent);
+
+    await waitFor(() => {
+      expect(sendDataDogActionStub.calledWith('Test label - Unknown')).to.be
+        .true;
+    });
+  });
+
+  it('should handle year-based date range selection', async () => {
+    const updateDateRangeAction = sinon
+      .stub()
+      .returns({ type: 'SET_DATE_RANGE' });
+
+    calculateDateRangeStub.returns({
+      fromDate: '2023-01-01',
+      toDate: '2023-12-31',
+    });
+    getDateRangeListStub.returns([
+      { value: '3', label: 'Last 3 months' },
+      { value: '2023', label: 'All of 2023' },
+    ]);
+
+    const { capturedHandler, store } = renderHook({
+      updateDateRangeAction,
+      updateListStateActionType: 'UPDATE_LIST_STATE',
+      dataDogLabel: 'Date range option',
+    });
+
+    await waitFor(() => {
+      expect(capturedHandler()).to.not.be.null;
+    });
+
+    const mockEvent = { detail: { value: '2023' } };
+    capturedHandler()(mockEvent);
+
+    await waitFor(() => {
+      expect(calculateDateRangeStub.calledWith('2023')).to.be.true;
+      expect(
+        updateDateRangeAction.calledWith('2023', '2023-01-01', '2023-12-31'),
+      ).to.be.true;
+      expect(
+        sendDataDogActionStub.calledWith('Date range option - All of 2023'),
+      ).to.be.true;
+      expect(store.dispatch.called).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- **What changed**: Created a new custom hook `useDateRangeSelector` that consolidates duplicated date range selection logic from `LabsAndTests.jsx` and `CareSummariesAndNotes.jsx`. This reduces code duplication and improves maintainability.

- **Solution**: Extracted the shared `handleDateRangeSelect` callback into a reusable hook that accepts configuration for the Redux action, action type, and DataDog label. Both container components now use this hook instead of duplicating ~20 lines of identical logic.

- **Team**: MHV Medical Records team. We own the maintenance of this component.

- **No flipper required**: This is a refactoring change with no user-facing impact.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#129057

- Parent ticket: department-of-veterans-affairs/va.gov-team#124565

## Testing done

- **Old behavior**: `LabsAndTests.jsx` and `CareSummariesAndNotes.jsx` each had their own `handleDateRangeSelect` callback with nearly identical logic (~20 lines each).

- **Steps to verify**:
  1. Navigate to Labs & Tests page (`/my-health/medical-records/labs-and-tests`)
  2. Change the date range dropdown (e.g., from "Last 3 months" to "Last 6 months")
  3. Verify the loading spinner appears and records refresh
  4. Navigate to Care Summaries & Notes page (`/my-health/medical-records/summaries-and-notes`)
  5. Repeat step 2-3

## Screenshots

N/A - No UI changes. This is a code refactoring that consolidates duplicate logic into a shared hook.

## What areas of the site does it impact?

- Medical Records > Labs and Tests (list page)
- Medical Records > Care Summaries and Notes (list page)

Both pages use the date range selector when the accelerated data feature flag is enabled.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (JSDoc comments added to the new hook)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (DataDog actions preserved)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - existing monitoring unchanged)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user