### PR TITLE
128979: fix flakiness for medications-need-help-section-list-page-api-call-failure.cypress.spec.js

### DIFF
--- a/src/applications/mhv-medications/tests/e2e/medications-need-help-section-list-page-api-call-failure.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-need-help-section-list-page-api-call-failure.cypress.spec.js
@@ -7,14 +7,31 @@ describe('Medications List Page Need Help Section API Call Failure', () => {
     const listPage = new MedicationsListPage();
     const site = new MedicationsSite();
     site.login();
+
+    cy.intercept('GET', '/my_health/v1/prescriptions?*', {
+      statusCode: 500,
+      body: {
+        errors: [
+          {
+            title: 'Internal Server Error',
+            detail: 'An error occurred while processing your request.',
+            status: '500',
+          },
+        ],
+      },
+    }).as('prescriptionsError');
+
     cy.visit('/my-health/medications');
-    cy.injectAxe();
-    cy.axeCheck('main');
+    cy.wait('@prescriptionsError');
+
     listPage.verifyNeedHelpSectionOnListPage(Data.HELP_TEXT);
     listPage.verifyGoToUseMedicationLinkOnListPage();
     listPage.verifyStartANewMessageLinkOnListPage();
-    listPage.verifyErroMessageforFailedAPICallListPage(
+    listPage.verifyErrorMessageforFailedAPICallListPage(
       Alerts.NO_ACCESS_TO_MEDICATIONS_ERROR,
     );
+
+    cy.injectAxe();
+    cy.axeCheck('main');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -965,17 +965,17 @@ class MedicationsListPage {
   };
 
   verifyNeedHelpSectionOnListPage = text => {
-    cy.get('[data-testid="rx-need-help-container"]')
+    cy.findByTestId('rx-need-help-container')
       .should('contain', text)
       .and('be.visible');
   };
 
   verifyGoToUseMedicationLinkOnListPage = () => {
-    cy.get('[data-testid="go-to-use-medications-link"]').should('be.visible');
+    cy.findByTestId('go-to-use-medications-link').should('be.visible');
   };
 
   verifyStartANewMessageLinkOnListPage = () => {
-    cy.get('[data-testid="start-a-new-message-link"]').should('be.visible');
+    cy.findByTestId('start-a-new-message-link').should('be.visible');
   };
 
   verifyTitleNotesOnListPage = text => {
@@ -1038,8 +1038,8 @@ class MedicationsListPage {
       });
   };
 
-  verifyErroMessageforFailedAPICallListPage = text => {
-    cy.get('[data-testid="no-medications-list"]').should('contain', text);
+  verifyErrorMessageforFailedAPICallListPage = text => {
+    cy.findByTestId('no-medications-list').should('contain', text);
   };
 
   loadListPageWithoutToolTip = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This fixes an e2e test fail deterministically.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128979

## Testing done

`Medications List Page Need Help Section API Call Failure` passes in pipeline.

Verified locally:

https://github.com/user-attachments/assets/2bd9beee-dcec-4f2d-b8a4-2f2b04d4a6da

## What areas of the site does it impact?

This only impacts an e2e test in medications.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
