### PR TITLE
Bio/127780/accessibility issues incorrect heading structure

### DIFF
--- a/src/applications/simple-forms/21P-601/pages/expensesList.js
+++ b/src/applications/simple-forms/21P-601/pages/expensesList.js
@@ -48,7 +48,10 @@ const yesNoOptions = {
 const summaryPage = {
   uiSchema: {
     ...titleUI('Expenses you paid'),
-    'view:hasExpenses': arrayBuilderYesNoUI(options, yesNoOptions),
+...titleUI('Expenses you paid'),
+'view:hasExpenses': arrayBuilderYesNoUI(options, yesNoOptions, {
+  labelHeaderLevel: '3',
+}),
     'view:expenseInfo': {
       'ui:description': (
         <va-alert status="info" uswds>

--- a/src/applications/simple-forms/21P-601/pages/expensesList.js
+++ b/src/applications/simple-forms/21P-601/pages/expensesList.js
@@ -37,6 +37,7 @@ const options = {
 const yesNoOptions = {
   title: 'Do you have an expense to add?',
   hint: `You can add up to ${options.maxItems}`,
+  labelHeaderLevel: '3',
 };
 
 /**


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Expense Heading Hierarchy Fix: Correct Legend Heading Level**

Fixed the heading hierarchy on the "Review your expenses" page by changing the radio button legend from H4 to H3. Previously, when expenses were present, the alert used an H3 and the radio button legend used an H4, which incorrectly implied that the legend "belongs to" the alert or is a subsection of it. This created a misleading semantic structure that didn't accurately represent the page's content organization.

**Changes Made:**
- Added `labelHeaderLevel: '3'` to `yesNoOptions` in `expensesList.js` to ensure the radio button legend uses H3 instead of the default H4 when items are present

## How to Reproduce (Bug)

1. Fill out the form until you reach the expenses list-and-loop section
2. Add at least one expense to get to the "Review your expenses" page
3. View the source code or use the HeadingsMap browser extension to view the semantic headings
4. Observe that the alert headline uses H3: "You can only request reimbursement for expenses you've already paid"
5. Observe that the radio button legend uses H4: "Do you have an expense to add?"
6. Notice that the H4 appears as a subsection of the H3 alert in the heading hierarchy, which is semantically incorrect
7. The legend should be a sibling of the alert, not a child/subsection

**Affected Pages:**
- `/expenses-list` (Expenses you paid / Review your expenses) - when items are present

**Issue Severity:**
- Expected WCAG failure: n/a (not a WCAG issue)
- Expected 508 audit severity: n/a
- Expected CC severity level: possibly a11y-defect-2 (HTML should have properly nested headings) - there isn't a skipped heading level so it might be a11y-defect-4
- Expected experience standard: User encounters content that meets best practices

## Solution and Why

**Solution:** Added `labelHeaderLevel: '3'` to the `yesNoOptions` object passed to `arrayBuilderYesNoUI`, ensuring the radio button legend uses H3 instead of the default H4 when items are present on the page.

**Why This Solution:**
1. **Correct Semantic Structure:** By making the legend H3, it becomes a sibling of the alert's H3 rather than appearing as a subsection, accurately reflecting that they are separate, independent sections on the page
2. **Proper Heading Hierarchy:** The page now has a consistent structure: H3 (page title), H3 (alert headline), H3 (radio button legend) - all as siblings, which is semantically correct
3. **Accessibility Best Practice:** Screen readers and assistive technologies rely on proper heading hierarchy to help users understand page structure. The incorrect H3→H4 relationship was misleading
4. **User Experience:** Users navigating by headings will now see the correct relationship between page sections, making the content structure clearer
5. **Follows Recommendation:** Implements the short-term fix recommended in the issue report
