### PR TITLE
Micahalconcel/128942 530a change full name label

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/burial-benefits-recipient.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/burial-benefits-recipient.js
@@ -13,7 +13,7 @@ export const burialBenefitsRecipientPage = {
       'This is the organization who will be receiving compensation.',
     burialInformation: {
       recipientOrganization: {
-        name: textUI('Name of State Cemetery of Tribal Organization'),
+        name: textUI('Name of State Cemetery or Tribal Organization'),
         phoneNumber: phoneUI('Phone number'),
       },
     },

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/burial-benefits-recipient.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/burial-benefits-recipient.js
@@ -13,7 +13,7 @@ export const burialBenefitsRecipientPage = {
       'This is the organization who will be receiving compensation.',
     burialInformation: {
       recipientOrganization: {
-        name: textUI('Full name'),
+        name: textUI('Name of State Cemetery of Tribal Organization'),
         phoneNumber: phoneUI('Phone number'),
       },
     },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing "**Full name**" label on "**Burial Benefits Recipient"** page to "**Name of State Cemetery or Tribal Organization**" to match paper form.

### Issue
The label for the field that maps to the "Name of State Cemetery or Tribal Organization" field on the paper form is labeled "Full Name" on the online form. This label is currently just hardcoded into the schema.

### Solution
Changed the label being set in the schema to what is on the paper form.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21p-530a form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 128942](https://github.com/department-of-veterans-affairs/va.gov-team/issues/128942)

## Testing done

### Old behavior
* The label was being set to "Full Name"

### New behavior
* The label is now being set to "Name of State Cemetery or Tribal Organization"

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the new label is being displayed (navigate to "/burial-benefits-recipient" page and verify that the label is changed)
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="428" height="574" alt="before mobile" src="https://github.com/user-attachments/assets/ecbb4113-b01a-46b3-a99d-3de4abaf4a90" /> | <img width="337" height="388" alt="after mobile" src="https://github.com/user-attachments/assets/4d14b548-4b91-4be3-9345-a27268e9ff02" /> |
| Desktop |  <img width="786" height="642" alt="before" src="https://github.com/user-attachments/assets/aa1cb69c-b065-4e43-a9ec-a295ebf49d31" /> | <img width="583" height="464" alt="after" src="https://github.com/user-attachments/assets/cd609361-bb3c-4aee-8cde-6d82bc41c5c2" /> |

## What areas of the site does it impact?

This change affects form 21p-530a, specifically on the Burial Benefits Recipient page at /submit-state-interment-allowance-form-21p-530a/burial-benefits-recipient

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

