### PR TITLE
Update e2e test to use class selectors instead of aria-label

### DIFF
--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-validate-record-list-pagination-focus.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-validate-record-list-pagination-focus.cypress.spec.js
@@ -24,20 +24,24 @@ describe('Medical Records View Vaccines', () => {
     // With no page specified, default is page 1 but focus should be on <h1>
     cy.get('h1').should('be.focused');
 
-    // Click page 2 in the pagination
+    // Wait for records to render before interacting with pagination
+    cy.get('#showingRecords').should('be.visible');
+
+    // Click next page using class selector (more stable than aria-label after component-library updates)
     cy.get('va-pagination')
+      .should('be.visible')
       .shadow()
-      .find('a[aria-label="page 2, last page"]')
-      .click();
+      .find('[class="usa-pagination__link usa-pagination__next-page"]')
+      .click({ waitForAnimations: true });
 
     // After page change, focus should be on "Showing..."
     cy.get('#showingRecords').should('be.focused');
 
-    // Click page 1 in the pagination
+    // Click previous page
     cy.get('va-pagination')
       .shadow()
-      .find('a[aria-label="page 1, first page"]')
-      .click();
+      .find('[class="usa-pagination__link usa-pagination__previous-page"]')
+      .click({ waitForAnimations: true });
 
     // After page change back to page 1, focus should remain on "Showing..."
     cy.get('#showingRecords').should('be.focused');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- **What changed**: Fixed a flaky E2E test (`medical-records-validate-record-list-pagination-focus.cypress.spec.js`) that was failing consistently in CI but passing locally.

- **How to reproduce the bug**: The test was timing out in CI with error: `Expected to find element: a[aria-label="page 2, last page"], but never found it`. This started occurring after the component-library was updated to v54.4.1 (PR #40976, merged January 5, 2026).

- **Solution**: Updated the test to use stable class selectors (`usa-pagination__next-page`, `usa-pagination__previous-page`) instead of brittle aria-label selectors. Also added proper waits for elements to be visible before interacting with them. This pattern is already used by other passing pagination tests in the codebase.

- **Team**: MHV Medical Records team. We own the maintenance of this test.

- **No flipper required**: This is a test-only fix with no application code changes.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129087
## Testing done

- **Old behavior**: Test used `aria-label` selectors (`a[aria-label="page 2, last page"]`) which became unreliable after the component-library update. Test passed locally but failed consistently in CI (10+ consecutive failures).

- **Steps to verify**:
  1. Run the E2E test locally: `yarn cy:run --spec "src/applications/mhv-medical-records/tests/e2e/medical-records-validate-record-list-pagination-focus.cypress.spec.js"`
  2. Verify test passes locally
  3. Push to CI and verify test passes in CI environment

## Screenshots

N/A - No UI changes. This is a test-only fix that updates element selectors.

## What areas of the site does it impact?

No application code is impacted. This PR only modifies an E2E test file:
- `src/applications/mhv-medical-records/tests/e2e/medical-records-validate-record-list-pagination-focus.cypress.spec.js`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test-only change)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - test still includes axeCheck)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - test-only change)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - test-only change)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test-only change, no application code modified)