### PR TITLE
replace container block in e2e stress test job with private gov path …

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -956,7 +956,10 @@ jobs:
       needs.tests-prep.outputs.cypress-tests-to-stress-test == 'true' &&
       github.ref != 'refs/heads/main'
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
+      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
+      credentials:
+        username: ${{ needs.fetch-ecr-credentials.outputs.ecr_user }}
+        password: ${{ needs.fetch-ecr-credentials.outputs.ecr_password }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -946,7 +946,7 @@ jobs:
     name: E2E Test Stability Review
     runs-on: ubuntu-22.04
     timeout-minutes: 120
-    needs: [build, tests-prep]
+    needs: [build, tests-prep, fetch-ecr-credentials]
     permissions:
       id-token: write
       contents: read

--- a/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
@@ -23,7 +23,7 @@ class IntroductionPage extends React.Component {
     return (
       <article className="schemaform-intro">
         <FormTitle
-          title="Authorize VA to release your information to a third-party sources"
+          title="Authorize VA to release your information to a third-party source"
           subTitle="Authorization To Disclose Personal Information To a Third Party (VA Form 21-0845)"
         />
         <p>

--- a/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
@@ -23,7 +23,7 @@ class IntroductionPage extends React.Component {
     return (
       <article className="schemaform-intro">
         <FormTitle
-          title="Authorize VA to release your information to a third-party source"
+          title="Authorize VA to release your information to a third-party sources"
           subTitle="Authorization To Disclose Personal Information To a Third Party (VA Form 21-0845)"
         />
         <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _As a platform engineer, I want to convert our e2e stability review job in CI to use the correct ECR repo, so that we don't get rate limited in CI unexpectedly due to a volume spike._
- _Our current CI main e2e test job references an ECR repository that we own as we were getting rate limited on the public one. Our Stability review job in the CI pipeline is still referencing a public one and has just not run into the rate limiting as it's traditionally a lower volume job. We need to convert this to avoid it being a problem with escalating volume in the future._


## Related issue(s)

- [_Link to ticket created in va.gov-team repo_](https://github.com/department-of-veterans-affairs/va.gov-team/issues/126000)


## Testing done

- _The e2e stress test workflow used a public image for Cypress._
- _The base e2e test workflow had already been switched over to using a private Platform image to avoid rate limits disrupting CI._
- _A dummy change was implemented and then removed in commits once CI had proven that the stress test jobs were now using the private image successfully._
