### PR TITLE
apply focus to message sent alert after SM renewal request redirects

### DIFF
--- a/src/applications/mhv-medications/components/shared/RxRenewalDeleteDraftSuccessAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/RxRenewalDeleteDraftSuccessAlert.jsx
@@ -1,10 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const RxRenewalDeleteDraftSuccessAlert = () => {
   const [visible, setIsVisible] = useState(true);
+  const alertRef = useRef(null);
+
+  useEffect(() => {
+    if (alertRef.current) {
+      focusElement(alertRef.current);
+    }
+  }, []);
+
   return (
     <VaAlert
+      ref={alertRef}
       slim
       closeable
       role="status"

--- a/src/applications/mhv-medications/components/shared/RxRenewalMessageSuccessAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/RxRenewalMessageSuccessAlert.jsx
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const RxRenewalMessageSuccessAlert = () => {
+  const alertRef = useRef(null);
+
+  useEffect(() => {
+    if (alertRef.current) {
+      focusElement(alertRef.current);
+    }
+  }, []);
+
   return (
     <VaAlert
+      ref={alertRef}
       role="status"
       status="success"
       visible

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -244,12 +244,12 @@ const Prescriptions = () => {
       if (!isLoading) {
         if (prescriptionId) {
           goToPrevious();
-        } else {
+        } else if (!rxRenewalMessageSuccess && !deleteDraftSuccess) {
           focusElement(document.querySelector('h1'));
         }
       }
     },
-    [isLoading, prescriptionId],
+    [isLoading, prescriptionId, rxRenewalMessageSuccess, deleteDraftSuccess],
   );
 
   useEffect(

--- a/src/applications/mhv-medications/tests/components/shared/RxRenewalDeleteDraftSuccessAlert.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/RxRenewalDeleteDraftSuccessAlert.unit.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import RxRenewalDeleteDraftSuccessAlert from '../../../components/shared/RxRenewalDeleteDraftSuccessAlert';
+
+describe('RxRenewalDeleteDraftSuccessAlert', () => {
+  const setup = () => {
+    return render(<RxRenewalDeleteDraftSuccessAlert />);
+  };
+
+  it('should render the alert with correct content', () => {
+    const screen = setup();
+    expect(screen.getByTestId('rx-renewal-delete-draft-success-alert')).to
+      .exist;
+    expect(screen.getByText('You successfully deleted your draft.')).to.exist;
+  });
+
+  it('should render with success status, role, and slim style', () => {
+    const screen = setup();
+    const alert = screen.getByTestId('rx-renewal-delete-draft-success-alert');
+    expect(alert.getAttribute('status')).to.equal('success');
+    expect(alert.getAttribute('role')).to.equal('status');
+    expect(alert.getAttribute('slim')).to.exist;
+  });
+
+  it('should be closeable', () => {
+    const screen = setup();
+    const alert = screen.getByTestId('rx-renewal-delete-draft-success-alert');
+    expect(alert.getAttribute('closeable')).to.exist;
+  });
+
+  it('should hide when close event is triggered', async () => {
+    const screen = setup();
+    const alert = screen.getByTestId('rx-renewal-delete-draft-success-alert');
+
+    expect(alert.getAttribute('visible')).to.equal('true');
+    fireEvent(alert, new CustomEvent('closeEvent'));
+    expect(alert.getAttribute('visible')).to.equal('false');
+  });
+
+  it('should set focus on the alert when mounted', async () => {
+    const screen = setup();
+    const alert = screen.getByTestId('rx-renewal-delete-draft-success-alert');
+
+    await waitFor(() => {
+      expect(alert.getAttribute('tabindex')).to.equal('-1');
+    });
+  });
+});

--- a/src/applications/mhv-medications/tests/components/shared/RxRenewalMessageSuccessAlert.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/RxRenewalMessageSuccessAlert.unit.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+import RxRenewalMessageSuccessAlert from '../../../components/shared/RxRenewalMessageSuccessAlert';
+
+describe('RxRenewalMessageSuccessAlert', () => {
+  const setup = () => {
+    return render(<RxRenewalMessageSuccessAlert />);
+  };
+
+  it('should render the alert with correct content', () => {
+    const screen = setup();
+    expect(screen.getByTestId('rx-renewal-message-success-alert')).to.exist;
+    expect(screen.getByText('Message Sent')).to.exist;
+    expect(
+      screen.getByText(
+        'We shared your renewal request with your selected provider. It can take up to 3 days for your medication status to change.',
+      ),
+    ).to.exist;
+  });
+
+  it('should render link to sent messages', () => {
+    const screen = setup();
+    const link = screen.container.querySelector('va-link');
+    expect(link).to.exist;
+    expect(link.getAttribute('href')).to.equal(
+      '/my-health/secure-messages/sent/',
+    );
+    expect(link.getAttribute('text')).to.equal(
+      'Review message in your sent messages',
+    );
+  });
+
+  it('should render with success status and role', () => {
+    const screen = setup();
+    const alert = screen.getByTestId('rx-renewal-message-success-alert');
+    expect(alert.getAttribute('status')).to.equal('success');
+    expect(alert.getAttribute('role')).to.equal('status');
+  });
+
+  it('should set focus on the alert when mounted', async () => {
+    const screen = setup();
+    const alert = screen.getByTestId('rx-renewal-message-success-alert');
+
+    await waitFor(() => {
+      expect(alert.getAttribute('tabindex')).to.equal('-1');
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Applied focus to message sent alert after SM renewal request redirects
- Applied focus to draft deleted alert for SM renewal request

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/issues/40331

## Testing done

- Regression tested all unit and e2e tests
- Used Voiceover on Safari, Chrome, and Firefox for accessibility testing
- Ensured focus was on alerts

The following URL paths can be used for testing both alerts:
- my-health/medications/?page=1&rxRenewalMessageSuccess=true
- my-health/medications/?page=1&draftDeleteSuccess=true

## What areas of the site does it impact?

This only affects medication list page

## Acceptance criteria

-Upon being redirected to the Medication List page after a successful renewal request apply focus to the Message Sent Alert

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
