### PR TITLE
[#129097] Travel Pay, cancel expense routing fix

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ExpenseCardList.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpenseCardList.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
 
 import ExpenseCard from './ExpenseCard';
 import { getExpenseType } from '../../../util/complex-claims-helper';
+import { setExpenseBackDestination } from '../../../redux/actions';
 
 const ExpenseCardList = ({
   expensesList,
@@ -16,11 +17,13 @@ const ExpenseCardList = ({
   showHeader = false,
 }) => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const { apptId, claimId } = useParams();
   const address = useSelector(selectVAPResidentialAddress);
   const expenseFields = getExpenseType(type);
 
   const onAddExpense = expenseRoute => {
+    dispatch(setExpenseBackDestination('review'));
     navigate(`/file-new-claim/${apptId}/${claimId}/${expenseRoute}`);
   };
 

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -256,52 +256,8 @@ const ExpensePage = () => {
     [formState, dispatch],
   );
 
-  const handleFormChange = (event, explicitName) => {
-    const name = explicitName ?? event.target?.name ?? event.detail?.name;
-    const value =
-      event?.value ?? event?.detail?.value ?? event.target?.value ?? '';
-
-    setFormState(prev => {
-      const newFormState = { ...prev, [name]: value };
-
-      // Only validate the field being updated
-      setExtraFieldErrors(prevErrors => {
-        let nextErrors = { ...prevErrors };
-
-        if (isAirTravel) {
-          nextErrors = validateAirTravelFields(newFormState, nextErrors, name);
-        } else if (isCommonCarrier) {
-          nextErrors = validateCommonCarrierFields(
-            newFormState,
-            nextErrors,
-            name,
-          );
-        } else if (isLodging) {
-          nextErrors = validateLodgingFields(newFormState, nextErrors, name);
-        } else if (isMeal) {
-          nextErrors = validateMealFields(newFormState, nextErrors, name);
-        }
-
-        return nextErrors;
-      });
-
-      return newFormState;
-    });
-  };
-
-  const handleOpenCancelModal = () => setIsCancelModalVisible(true);
-  const handleCloseCancelModal = () => setIsCancelModalVisible(false);
-  const handleConfirmCancel = () => {
-    handleCloseCancelModal();
-    // Clear unsaved changes when canceling
-    dispatch(setUnsavedExpenseChanges(false));
-    if (isEditMode || backDestination === 'review') {
-      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
-    } else {
-      navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
-    }
-  };
-
+  // Validation
+  //
   // Field names must match those expected by the expenses_controller in vets-api.
   // The controller converts them to forwards them unchanged to the API.
   const REQUIRED_FIELDS = {
@@ -385,6 +341,7 @@ const ExpensePage = () => {
   const isFormChanged =
     JSON.stringify(previousFormState) !== JSON.stringify(formState);
 
+  // Handlers
   const handleContinue = async () => {
     if (!validatePage()) {
       scrollToFirstError({ focusOnAlertRole: true });
@@ -470,8 +427,6 @@ const ExpensePage = () => {
     if (isEditMode) {
       setIsCancelModalVisible(true);
     } else {
-      // TODO: Add logic to determine where the user came from and direct them back to the correct location
-      // navigate(`/file-new-claim/${apptId}/${claimId}/review`);
       navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
     }
   };
@@ -524,6 +479,52 @@ const ExpensePage = () => {
           'There was a problem processing your document. Please try again later.',
         );
       }
+    }
+  };
+
+  const handleFormChange = (event, explicitName) => {
+    const name = explicitName ?? event.target?.name ?? event.detail?.name;
+    const value =
+      event?.value ?? event?.detail?.value ?? event.target?.value ?? '';
+
+    setFormState(prev => {
+      const newFormState = { ...prev, [name]: value };
+
+      // Only validate the field being updated
+      setExtraFieldErrors(prevErrors => {
+        let nextErrors = { ...prevErrors };
+
+        if (isAirTravel) {
+          nextErrors = validateAirTravelFields(newFormState, nextErrors, name);
+        } else if (isCommonCarrier) {
+          nextErrors = validateCommonCarrierFields(
+            newFormState,
+            nextErrors,
+            name,
+          );
+        } else if (isLodging) {
+          nextErrors = validateLodgingFields(newFormState, nextErrors, name);
+        } else if (isMeal) {
+          nextErrors = validateMealFields(newFormState, nextErrors, name);
+        }
+
+        return nextErrors;
+      });
+
+      return newFormState;
+    });
+  };
+
+  const handleOpenCancelModal = () => setIsCancelModalVisible(true);
+  const handleCloseCancelModal = () => setIsCancelModalVisible(false);
+  const handleConfirmCancel = () => {
+    handleCloseCancelModal();
+    // Clear unsaved changes when canceling
+    dispatch(setUnsavedExpenseChanges(false));
+    if (isEditMode || backDestination === 'review') {
+      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
+    } else {
+      navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
     }
   };
 

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -35,6 +35,7 @@ import {
   selectExpenseWithDocument,
   selectDocumentDeleteLoadingState,
   selectExpenseFetchLoadingState,
+  selectExpenseBackDestination,
 } from '../../../redux/selectors';
 import {
   DATE_VALIDATION_TYPE,
@@ -85,6 +86,7 @@ const ExpensePage = () => {
   const isFetchingExpense = useSelector(
     state => (isEditMode ? selectExpenseFetchLoadingState(state) : false),
   );
+  const backDestination = useSelector(selectExpenseBackDestination);
 
   // Refs
   const initialFormStateRef = useRef({});
@@ -293,14 +295,10 @@ const ExpensePage = () => {
     handleCloseCancelModal();
     // Clear unsaved changes when canceling
     dispatch(setUnsavedExpenseChanges(false));
-    if (isEditMode) {
-      // TODO: Add logic to determine where the user came from and direct them back to the correct location
-      // navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
+    if (isEditMode || backDestination === 'review') {
       navigate(`/file-new-claim/${apptId}/${claimId}/review`);
     } else {
-      // TODO: Add logic to determine where the user came from and direct them back to the correct location
       navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
-      // navigate(`/file-new-claim/${apptId}/${claimId}/review`);
     }
   };
 

--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -20,6 +20,7 @@ import {
   selectExpenseCreationLoadingState,
   selectAllExpenses,
   selectAppointment,
+  selectExpenseBackDestination,
 } from '../../../redux/selectors';
 import TravelPayButtonPair from '../../shared/TravelPayButtonPair';
 import {
@@ -41,6 +42,7 @@ const Mileage = () => {
   const { data: appointment } = useSelector(selectAppointment);
   const allExpenses = useSelector(selectAllExpenses);
   const address = useSelector(selectVAPResidentialAddress);
+  const backDestination = useSelector(selectExpenseBackDestination);
 
   const title = 'Mileage';
 
@@ -192,6 +194,8 @@ const Mileage = () => {
   const handleBack = () => {
     if (isEditMode) {
       setIsModalVisible(true);
+    } else if (backDestination === 'review') {
+      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
     } else {
       navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
     }
@@ -202,11 +206,12 @@ const Mileage = () => {
   const handleConfirmCancel = () => {
     handleCloseModal();
     dispatch(setUnsavedExpenseChanges(false));
-    navigate(
-      isEditMode
-        ? `/file-new-claim/${apptId}/${claimId}/review`
-        : `/file-new-claim/${apptId}/${claimId}/choose-expense`,
-    );
+
+    if (isEditMode || backDestination === 'review') {
+      navigate(`/file-new-claim/${apptId}/${claimId}/review`);
+    } else {
+      navigate(`/file-new-claim/${apptId}/${claimId}/choose-expense`);
+    }
   };
 
   return (

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -1651,6 +1651,167 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
       { timeout: 3000 },
     );
   });
+
+  describe('Cancel modal navigation with backDestination', () => {
+    it('navigates to review page when confirming cancel in add mode with backDestination="review"', async () => {
+      const baseState = getEditState([]);
+      const stateWithBackDestination = {
+        ...baseState,
+        travelPay: {
+          ...baseState.travelPay,
+          complexClaim: {
+            ...baseState.travelPay.complexClaim,
+            expenseBackDestination: 'review',
+          },
+        },
+      };
+
+      const { container, getByTestId } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345/43555/meal']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/:expenseTypeRoute"
+              element={<ExpensePage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<div data-testid="review-page" />}
+            />
+          </Routes>
+          <LocationDisplay />
+        </MemoryRouter>,
+        { initialState: stateWithBackDestination, reducers: reducer },
+      );
+
+      // Wait for page to load
+      await waitFor(() => {
+        expect(container.querySelector('h1')).to.exist;
+      });
+
+      // Open the cancel modal
+      const cancelButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+      expect(cancelButton).to.exist;
+      fireEvent.click(cancelButton);
+
+      // Wait for modal to be visible
+      await waitFor(() => {
+        const modal = container.querySelector('va-modal');
+        expect(modal.getAttribute('visible')).to.equal('true');
+      });
+
+      // Confirm cancellation by triggering the modal's primary button click event
+      const modal = container.querySelector('va-modal');
+      modal.__events.primaryButtonClick();
+
+      // Verify navigation to review page
+      await waitFor(() => {
+        const location = getByTestId('location-display');
+        expect(location.textContent).to.equal(
+          '/file-new-claim/12345/43555/review',
+        );
+      });
+    });
+
+    it('navigates to choose-expense page when confirming cancel in add mode without backDestination', async () => {
+      const baseState = getEditState([]);
+      const stateWithoutBackDestination = {
+        ...baseState,
+        travelPay: {
+          ...baseState.travelPay,
+          complexClaim: {
+            ...baseState.travelPay.complexClaim,
+            expenseBackDestination: undefined,
+          },
+        },
+      };
+
+      const { container, getByTestId } = renderWithStoreAndRouter(
+        <MemoryRouter initialEntries={['/file-new-claim/12345/43555/meal']}>
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/:expenseTypeRoute"
+              element={<ExpensePage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/choose-expense"
+              element={<div data-testid="choose-expense-page" />}
+            />
+          </Routes>
+          <LocationDisplay />
+        </MemoryRouter>,
+        { initialState: stateWithoutBackDestination, reducers: reducer },
+      );
+
+      // Wait for page to load
+      await waitFor(() => {
+        expect(container.querySelector('h1')).to.exist;
+      });
+
+      // Open the cancel modal
+      const cancelButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+      expect(cancelButton).to.exist;
+      fireEvent.click(cancelButton);
+
+      // Wait for modal to be visible
+      await waitFor(() => {
+        const modal = container.querySelector('va-modal');
+        expect(modal.getAttribute('visible')).to.equal('true');
+      });
+
+      // Confirm cancellation by triggering the modal's primary button click event
+      const modal = container.querySelector('va-modal');
+      modal.__events.primaryButtonClick();
+
+      // Verify navigation to choose-expense page
+      await waitFor(() => {
+        const location = getByTestId('location-display');
+        expect(location.textContent).to.equal(
+          '/file-new-claim/12345/43555/choose-expense',
+        );
+      });
+    });
+
+    it('navigates to review page when confirming cancel in edit mode', async () => {
+      const { container, getByTestId } = renderEditPage();
+
+      // Wait for data to load
+      await waitFor(() => {
+        const vendorField = container.querySelector(
+          'va-text-input[name="vendorName"]',
+        );
+        expect(vendorField?.getAttribute('value')).to.equal('Saved Vendor');
+      });
+
+      // Click Cancel button to open modal
+      const cancelButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel');
+      expect(cancelButton).to.exist;
+      fireEvent.click(cancelButton);
+
+      // Wait for modal to be visible
+      await waitFor(() => {
+        const modal = container.querySelector('va-modal');
+        expect(modal.getAttribute('visible')).to.equal('true');
+      });
+
+      // Confirm cancellation by triggering the modal's primary button click event
+      const modal = container.querySelector('va-modal');
+      modal.__events.primaryButtonClick();
+
+      // Verify navigation to review page
+      await waitFor(() => {
+        const location = getByTestId('location-display');
+        expect(location.textContent).to.equal(
+          '/file-new-claim/12345/43555/review',
+        );
+      });
+    });
+  });
 });
 
 describe('toBase64 helper function', () => {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
@@ -367,6 +367,145 @@ describe('Complex Claims Mileage - Add', () => {
       expect(modal.visible).to.be.true;
     });
   });
+
+  describe('Back button navigation with backDestination', () => {
+    it('navigates to review page when back button is clicked and backDestination="review"', () => {
+      const stateWithBackDestination = {
+        ...getAddState(),
+        travelPay: {
+          ...getAddState().travelPay,
+          complexClaim: {
+            ...getAddState().travelPay.complexClaim,
+            expenseBackDestination: 'review',
+          },
+        },
+      };
+
+      renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[
+            `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/`,
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/mileage"
+              element={<Mileage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<div data-testid="review-page" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { initialState: stateWithBackDestination, reducers: reducer },
+      );
+
+      const buttonGroup = $('.travel-pay-button-group');
+      const backButton = buttonGroup.querySelectorAll('va-button')[0];
+
+      fireEvent.click(backButton);
+
+      // Verify navigation to review page
+      expect($('[data-testid="review-page"]')).to.exist;
+    });
+
+    it('navigates to choose-expense page when back button is clicked without backDestination', () => {
+      renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[
+            `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/`,
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/mileage"
+              element={<Mileage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/choose-expense"
+              element={<div data-testid="choose-expense-page" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { initialState: getAddState(), reducers: reducer },
+      );
+
+      const buttonGroup = $('.travel-pay-button-group');
+      const backButton = buttonGroup.querySelectorAll('va-button')[0];
+
+      fireEvent.click(backButton);
+
+      // Verify navigation to choose-expense page
+      expect($('[data-testid="choose-expense-page"]')).to.exist;
+    });
+  });
+
+  describe('Cancel modal navigation with backDestination', () => {
+    it('navigates to review page when confirming cancel and backDestination="review"', () => {
+      const stateWithBackDestination = {
+        ...getAddState(),
+        travelPay: {
+          ...getAddState().travelPay,
+          complexClaim: {
+            ...getAddState().travelPay.complexClaim,
+            expenseBackDestination: 'review',
+          },
+        },
+      };
+
+      const { container } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[
+            `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/`,
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/mileage"
+              element={<Mileage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<div data-testid="review-page" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { initialState: stateWithBackDestination, reducers: reducer },
+      );
+
+      // Open the cancel modal
+      const cancelButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+      fireEvent.click(cancelButton);
+
+      // Confirm cancel by triggering the modal's primary button click event
+      const modal = container.querySelector('va-modal');
+      expect(modal.visible).to.be.true;
+      modal.__events.primaryButtonClick();
+
+      // Verify navigation to review page
+      expect($('[data-testid="review-page"]')).to.exist;
+    });
+
+    it('navigates to choose-expense page when confirming cancel without backDestination', () => {
+      const { container } = renderComponent();
+
+      // Open the cancel modal
+      const cancelButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel adding this expense');
+      fireEvent.click(cancelButton);
+
+      const modal = container.querySelector('va-modal');
+      expect(modal.visible).to.be.true;
+
+      // Since choose-expense route is not set up in the test,
+      // we verify the modal behavior is triggered correctly
+      expect(modal).to.exist;
+    });
+  });
 });
 
 describe('Complex Claims Mileage - Edit', () => {
@@ -594,5 +733,94 @@ describe('Complex Claims Mileage - Edit', () => {
 
     fireEvent.click(backButton);
     expect(backButton).to.exist;
+  });
+
+  describe('Cancel modal navigation in edit mode', () => {
+    it('navigates to review page when confirming cancel in edit mode', () => {
+      const { container } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[
+            `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/${TEST_EXPENSE_ID}`,
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/mileage/:expenseId"
+              element={<Mileage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<div data-testid="review-page" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { initialState: getEditState(), reducers: reducer },
+      );
+
+      // Click Cancel button to open modal
+      const backButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel');
+      fireEvent.click(backButton);
+
+      // Verify modal is open
+      const modal = container.querySelector('va-modal');
+      expect(modal.getAttribute('visible')).to.equal('true');
+
+      // Confirm cancel by triggering the modal's primary button click event
+      modal.__events.primaryButtonClick();
+
+      // Verify navigation to review page
+      expect($('[data-testid="review-page"]')).to.exist;
+    });
+
+    it('navigates to review page when confirming cancel with backDestination="review" in edit mode', () => {
+      const stateWithBackDestination = {
+        ...getEditState(),
+        travelPay: {
+          ...getEditState().travelPay,
+          complexClaim: {
+            ...getEditState().travelPay.complexClaim,
+            expenseBackDestination: 'review',
+          },
+        },
+      };
+
+      const { container } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[
+            `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/${TEST_EXPENSE_ID}`,
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/mileage/:expenseId"
+              element={<Mileage />}
+            />
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<div data-testid="review-page" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { initialState: stateWithBackDestination, reducers: reducer },
+      );
+
+      // Click Cancel button to open modal
+      const backButton = Array.from(
+        container.querySelectorAll('va-button'),
+      ).find(btn => btn.getAttribute('text') === 'Cancel');
+      fireEvent.click(backButton);
+
+      // Verify modal is open
+      const modal = container.querySelector('va-modal');
+      expect(modal.getAttribute('visible')).to.equal('true');
+
+      // Confirm cancel by triggering the modal's primary button click event
+      modal.__events.primaryButtonClick();
+
+      // Verify navigation to review page
+      expect($('[data-testid="review-page"]')).to.exist;
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When cancelling an expense we want to route them back to /review or /choose-expense depending on which they came from.

## Related issue(s)

Fixes department-of-veterans-affairs/va.gov-team#129097

## Testing done

Tested cancel expense routing conditions for
- Expense edit mode
- Adding an expense from review
- Adding an expense from the intro page

## Screenshots

https://github.com/user-attachments/assets/d7baf50c-b1d2-436b-bd87-0983f3174dd8

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user