### PR TITLE
changed 'date of interment' to 'date of burial' on form field to matc…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-burial-information.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-burial-information.js
@@ -15,7 +15,7 @@ export const veteranBurialInformationPage = {
       dateOfDeath: currentOrPastDateUI('Date of death'),
     },
     burialInformation: {
-      dateOfBurial: currentOrPastDateUI('Date of interment'),
+      dateOfBurial: currentOrPastDateUI('Date of burial'),
       placeOfBurial: {
         ...titleUI({
           title: 'Cemetery information',


### PR DESCRIPTION
…h paper form

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing "**Date of interment**" label on "**Veteran Burial Information"** page to "**Date of burial**" to match paper form.

### Issue
The label for the field that maps to the "Date of burial" field on the paper form is labeled "Date of interment" on the online form. This label is currently just hardcoded into the schema.

### Solution
Changed the label being set in the schema to what is on the paper form.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21p-530a form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 128941](https://github.com/department-of-veterans-affairs/va.gov-team/issues/128941)

## Testing done

### Old behavior
* The label was being set to "Date of interment"

### New behavior
* The label is now being set to "Date of burial"

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the new label is being displayed (navigate to "/veteran-burial-information" page and verify that the label is changed)
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="329" height="448" alt="before mobile" src="https://github.com/user-attachments/assets/c220f519-5637-4162-b22a-d353800268a1" /> | <img width="412" height="547" alt="after mobile" src="https://github.com/user-attachments/assets/1094fe68-b406-4872-aa4c-58722c570757" /> |
| Desktop | <img width="482" height="595" alt="before" src="https://github.com/user-attachments/assets/ceec2e0c-2abb-4b72-b79e-ed5afd9310ec" /> | <img width="582" height="621" alt="after" src="https://github.com/user-attachments/assets/3a48b84d-3859-4703-9d55-bd3917d04d60" /> |

## What areas of the site does it impact?

This change affects form 21p-530a, specifically on the Veteran Burial Information page at /submit-state-interment-allowance-form-21p-530a/veteran-burial-information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

