### PR TITLE
10-10dx | Allow future date value for Medicare effective dates

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -32,7 +32,7 @@ import {
   validateMedicarePartDDates,
   validateMedicarePlan,
 } from '../helpers';
-
+import { futureDateUI, futureDateSchema } from '../definitions';
 import medicareParticipant from './medicareInformation/participants';
 import {
   MedicarePartADescription,
@@ -212,7 +212,7 @@ const medicarePartAPartBEffectiveDatesPage = {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      medicarePartAEffectiveDate: currentOrPastDateUI({
+      medicarePartAEffectiveDate: futureDateUI({
         title: 'Effective date',
         hint:
           'This will be on the front of the Medicare card near “Coverage starts.”',
@@ -225,7 +225,7 @@ const medicarePartAPartBEffectiveDatesPage = {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      medicarePartBEffectiveDate: currentOrPastDateUI({
+      medicarePartBEffectiveDate: futureDateUI({
         title: 'Effective date',
         hint:
           'This will be on the front of the Medicare card near “Coverage starts.”',
@@ -243,14 +243,14 @@ const medicarePartAPartBEffectiveDatesPage = {
         type: 'object',
         required: ['medicarePartAEffectiveDate'],
         properties: {
-          medicarePartAEffectiveDate: currentOrPastDateSchema,
+          medicarePartAEffectiveDate: futureDateSchema,
         },
       },
       'view:medicarePartBEffectiveDate': {
         type: 'object',
         required: ['medicarePartBEffectiveDate'],
         properties: {
-          medicarePartBEffectiveDate: currentOrPastDateSchema,
+          medicarePartBEffectiveDate: futureDateSchema,
         },
       },
       'view:medicarePartCDescription': blankSchema,
@@ -297,7 +297,7 @@ const medicarePartAEffectiveDatePage = {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      medicarePartAEffectiveDate: currentOrPastDateUI({
+      medicarePartAEffectiveDate: futureDateUI({
         title: 'Effective date',
         hint:
           'You may find the effective date on the front of the Medicare card near “Coverage starts” or “Effective date.”',
@@ -312,7 +312,7 @@ const medicarePartAEffectiveDatePage = {
         type: 'object',
         required: ['medicarePartAEffectiveDate'],
         properties: {
-          medicarePartAEffectiveDate: currentOrPastDateSchema,
+          medicarePartAEffectiveDate: futureDateSchema,
         },
       },
     },
@@ -356,7 +356,7 @@ const medicarePartBEffectiveDatePage = {
         headerLevel: 2,
         headerStyleLevel: 3,
       }),
-      medicarePartBEffectiveDate: currentOrPastDateUI({
+      medicarePartBEffectiveDate: futureDateUI({
         title: 'Effective date',
         hint:
           'This will be on the front of the Medicare card near “Coverage starts.”',
@@ -371,7 +371,7 @@ const medicarePartBEffectiveDatePage = {
         type: 'object',
         required: ['medicarePartBEffectiveDate'],
         properties: {
-          medicarePartBEffectiveDate: currentOrPastDateSchema,
+          medicarePartBEffectiveDate: futureDateSchema,
         },
       },
     },
@@ -503,7 +503,7 @@ const medicarePartCCarrierEffectiveDatePage = {
       title: 'Name of insurance carrier',
       hint: 'This is the name of the insurance company.',
     }),
-    medicarePartCEffectiveDate: currentOrPastDateUI({
+    medicarePartCEffectiveDate: futureDateUI({
       title: 'Medicare Part C effective date',
       hint:
         'This information is on the front of the Medicare card near “Effective date” or “Issue date.” If it’s not there, it may be on the plan’s online portal or enrollment documents.',
@@ -514,7 +514,7 @@ const medicarePartCCarrierEffectiveDatePage = {
     required: ['medicarePartCCarrier', 'medicarePartCEffectiveDate'],
     properties: {
       medicarePartCCarrier: textSchema,
-      medicarePartCEffectiveDate: currentOrPastDateSchema,
+      medicarePartCEffectiveDate: futureDateSchema,
     },
   },
 };
@@ -611,7 +611,7 @@ const medicarePartDStatusPage = {
 const medicarePartDCarrierEffectiveDatePage = {
   uiSchema: {
     ...medicarePageTitleUI('Medicare Part D effective date'),
-    medicarePartDEffectiveDate: currentOrPastDateUI({
+    medicarePartDEffectiveDate: futureDateUI({
       title: 'Medicare Part D effective date',
       hint: 'This information is at the top of the card.',
     }),
@@ -625,7 +625,7 @@ const medicarePartDCarrierEffectiveDatePage = {
     type: 'object',
     required: ['medicarePartDEffectiveDate'],
     properties: {
-      medicarePartDEffectiveDate: currentOrPastDateSchema,
+      medicarePartDEffectiveDate: futureDateSchema,
       medicarePartDTerminationDate: currentOrPastDateSchema,
     },
   },

--- a/src/applications/ivc-champva/10-10d-extended/components/FormDescriptions/ReportMedicareDescription.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormDescriptions/ReportMedicareDescription.jsx
@@ -13,8 +13,8 @@ const ReportMedicareDescription = (
       </li>
       <li>
         <strong>If you’re pre-enrolled in Medicare</strong> with a future
-        effective date, you need to submit using the Other Health Insurance
-        Certification (VA Form 10-7959c) before you file your first claim.
+        effective date, you’ll need to upload a copy of the front and back of
+        your Medicare card with this form.
       </li>
     </ul>
   </>

--- a/src/applications/ivc-champva/10-10d-extended/components/FormReview/DateReviewField.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormReview/DateReviewField.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { format } from 'date-fns';
+
+const DateReviewField = ({ children }) => {
+  const { formData, uiSchema } = children.props;
+  const formattedDate = format(formData, 'MM/dd/yyyy');
+  return (
+    <div className="review-row">
+      <dt>{uiSchema['ui:title']}</dt>
+      <dd
+        className="dd-privacy-hidden"
+        data-dd-action-name={uiSchema['ui:title']}
+      >
+        {formattedDate}
+      </dd>
+    </div>
+  );
+};
+
+DateReviewField.propTypes = {
+  children: PropTypes.shape({
+    props: PropTypes.shape({
+      formData: PropTypes.string,
+      uiSchema: PropTypes.object,
+    }),
+  }),
+};
+
+export default DateReviewField;

--- a/src/applications/ivc-champva/10-10d-extended/components/FormReview/DateReviewField.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/components/FormReview/DateReviewField.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
 
 const DateReviewField = ({ children }) => {
   const { formData, uiSchema } = children.props;
-  const formattedDate = format(formData, 'MM/dd/yyyy');
+  const localeOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+  const formattedDate =
+    formData &&
+    new Date(`${formData}T00:00:00`).toLocaleDateString('en-us', localeOptions);
   return (
     <div className="review-row">
       <dt>{uiSchema['ui:title']}</dt>

--- a/src/applications/ivc-champva/10-10d-extended/definitions/dates.js
+++ b/src/applications/ivc-champva/10-10d-extended/definitions/dates.js
@@ -6,7 +6,7 @@ import content from '../locales/en/content.json';
 
 const INPUT_LABEL = content['dates--default-label'];
 const ERR_MSG_PATTERN = content['validation--date-pattern'];
-const ERR_MES_REQUIRED = content['validation--required'];
+const ERR_MSG_REQUIRED = content['validation--required'];
 
 export const futureDateUI = options => {
   const { title, errorMessages, required, validations, ...uiOptions } =
@@ -18,7 +18,7 @@ export const futureDateUI = options => {
     'ui:validations': validations ?? [validateFutureDate],
     'ui:errorMessages': {
       pattern: errorMessages?.pattern || ERR_MSG_PATTERN,
-      required: errorMessages?.required || ERR_MES_REQUIRED,
+      required: errorMessages?.required || ERR_MSG_REQUIRED,
     },
     'ui:options': { ...uiOptions },
     'ui:reviewField': DateReviewField,

--- a/src/applications/ivc-champva/10-10d-extended/definitions/dates.js
+++ b/src/applications/ivc-champva/10-10d-extended/definitions/dates.js
@@ -1,0 +1,27 @@
+import VaMemorableDateField from 'platform/forms-system/src/js/web-component-fields/VaMemorableDateField';
+import DateReviewField from '../components/FormReview/DateReviewField';
+import { validateFutureDate } from '../helpers/validations';
+import { commonDefinitions } from '../imports';
+import content from '../locales/en/content.json';
+
+const INPUT_LABEL = content['dates--default-label'];
+const ERR_MSG_PATTERN = content['validation--date-pattern'];
+const ERR_MES_REQUIRED = content['validation--required'];
+
+export const futureDateUI = options => {
+  const { title, errorMessages, required, validations, ...uiOptions } =
+    typeof options === 'object' ? options : { title: options };
+  return {
+    'ui:title': title ?? INPUT_LABEL,
+    'ui:webComponentField': VaMemorableDateField,
+    'ui:required': required,
+    'ui:validations': validations ?? [validateFutureDate],
+    'ui:errorMessages': {
+      pattern: errorMessages?.pattern || ERR_MSG_PATTERN,
+      required: errorMessages?.required || ERR_MES_REQUIRED,
+    },
+    'ui:options': { ...uiOptions },
+    'ui:reviewField': DateReviewField,
+  };
+};
+export const futureDateSchema = commonDefinitions.date;

--- a/src/applications/ivc-champva/10-10d-extended/definitions/index.js
+++ b/src/applications/ivc-champva/10-10d-extended/definitions/index.js
@@ -7,6 +7,8 @@ import content from '../locales/en/content.json';
 
 const MIDDLE_NAME_SCHEMA = { type: 'string', maxLength: 1 };
 
+export * from './dates';
+
 export const blankSchema = { type: 'object', properties: {} };
 
 export const fileUploadSchema = {

--- a/src/applications/ivc-champva/10-10d-extended/helpers/validations.js
+++ b/src/applications/ivc-champva/10-10d-extended/helpers/validations.js
@@ -542,7 +542,7 @@ export const validateApplicant = (item = {}) => {
  * Validates that a date is not more than one year in the future.
  *
  * Ensures the date is valid, within the allowed year range (minYear to current year + 1),
- * and not more than 365 days from today. Used for dates that should be current or near-future.
+ * and not more than one calendar year from today. Used for dates that should be current or near-future.
  *
  * @param {Object} errors - The errors object to add validation errors to
  * @param {string} dateString - The date string to validate (format: 'YYYY-MM-DD')
@@ -572,7 +572,8 @@ export const validateFutureDate = (
     maxYear,
   );
 
-  if (isAfter(new Date(dateString), yearFromToday)) {
+  const date = dateString ? new Date(dateString) : null;
+  if (date && isValid(date) && isAfter(date, yearFromToday)) {
     errors.addError(ERR_FUTURE_DATE);
   }
 };

--- a/src/applications/ivc-champva/10-10d-extended/helpers/validations.js
+++ b/src/applications/ivc-champva/10-10d-extended/helpers/validations.js
@@ -1,9 +1,14 @@
-import { isAfter, isBefore, isValid } from 'date-fns';
+import { add, isAfter, isBefore, isValid } from 'date-fns';
 import { isValidSSN } from 'platform/forms-system/src/js/utilities/validations';
-import { convertToDateField } from 'platform/forms-system/src/js/validation';
+import { minYear } from 'platform/forms-system/src/js/helpers';
+import {
+  convertToDateField,
+  validateDate,
+} from 'platform/forms-system/src/js/validation';
 import { isValidDateRange } from 'platform/forms/validations';
 import content from '../locales/en/content.json';
 
+const ERR_FUTURE_DATE = content['validation--date-range--future'];
 const ERR_SSN_UNIQUE = content['validation--ssn-unique'];
 const ERR_SSN_INVALID = content['validation--ssn-invalid'];
 
@@ -531,4 +536,43 @@ export const validateApplicant = (item = {}) => {
   }
 
   return false;
+};
+
+/**
+ * Validates that a date is not more than one year in the future.
+ *
+ * Ensures the date is valid, within the allowed year range (minYear to current year + 1),
+ * and not more than 365 days from today. Used for dates that should be current or near-future.
+ *
+ * @param {Object} errors - The errors object to add validation errors to
+ * @param {string} dateString - The date string to validate (format: 'YYYY-MM-DD')
+ * @param {Object} formData - The complete form data object
+ * @param {Object} schema - The JSON schema for the date field
+ * @param {Object} [errorMessages={}] - Optional custom error messages to override defaults
+ */
+export const validateFutureDate = (
+  errors,
+  dateString,
+  formData,
+  schema,
+  errorMessages = {},
+) => {
+  const yearFromToday = add(new Date(), { years: 1 });
+  const maxYear = new Date().getFullYear() + 1;
+
+  validateDate(
+    errors,
+    dateString,
+    formData,
+    schema,
+    errorMessages,
+    undefined,
+    undefined,
+    minYear,
+    maxYear,
+  );
+
+  if (isAfter(new Date(dateString), yearFromToday)) {
+    errors.addError(ERR_FUTURE_DATE);
+  }
 };

--- a/src/applications/ivc-champva/10-10d-extended/imports.js
+++ b/src/applications/ivc-champva/10-10d-extended/imports.js
@@ -3,6 +3,10 @@ export {
 } from '@department-of-veterans-affairs/component-library/contacts';
 
 export {
+  default as commonDefinitions,
+} from 'vets-json-schema/dist/definitions.json';
+
+export {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';

--- a/src/applications/ivc-champva/10-10d-extended/locales/en/content.json
+++ b/src/applications/ivc-champva/10-10d-extended/locales/en/content.json
@@ -23,6 +23,7 @@
   "arraybuilder--button-delete-yes": "Yes, delete",
   "button--edit": "Edit",
   "button--update-page": "Update page",
+  "dates--default-label": "Date",
   "form-label--middle-initial": "Middle initial",
   "form-title": "Apply for CHAMPVA benefits",
   "form-subtitle": "Application for CHAMPVA benefits (VA Form 10-10d)",
@@ -75,6 +76,8 @@
   "noun--veteran-possessive": "Veteran\u2019s",
   "ohi--section-title": "Submit your Other Health Insurance Certification (VA Form 10-7959c)",
   "review--no-option": "No",
+  "validation--date-pattern": "Enter a valid date",
+  "validation--date-range--future": "Date may not be more than 1 year from today",
   "validation--required": "You must provide a response",
   "validation--ssn-invalid": "Enter a valid 9-digit SSN (dashes allowed)",
   "validation--ssn-unique": "This SSN has already been used. Enter a different number."

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/components/FormReview/DateReviewField.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/components/FormReview/DateReviewField.unit.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import DateReviewField from '../../../../components/FormReview/DateReviewField';
+
+const INPUT_LABEL = 'Effective date';
+
+describe('10-10d <DateReviewField>', () => {
+  const subject = ({ title = INPUT_LABEL, formData = '1990-01-15' } = {}) => {
+    const props = { formData, uiSchema: { 'ui:title': title } };
+    const { container } = render(
+      <DateReviewField>
+        <div {...props} />
+      </DateReviewField>,
+    );
+    return () => ({
+      dt: container.querySelector('dt'),
+      dd: container.querySelector('dd'),
+    });
+  };
+
+  it('should render the title from uiSchema and format a valid date string', () => {
+    const selectors = subject();
+    const { dd, dt } = selectors();
+    expect(dt.textContent).to.equal(INPUT_LABEL);
+    expect(dd.textContent).to.equal('January 15, 1990');
+  });
+
+  it('should not render a value when formData is an empty string', () => {
+    const selectors = subject({ formData: '' });
+    expect(selectors().dd.textContent).to.equal('');
+  });
+
+  it('should populate the "data-dd-action-name" attribute from the uiSchema', () => {
+    const selectors = subject({ title: 'Test date' });
+    expect(selectors().dd).to.have.attr('data-dd-action-name', 'Test date');
+  });
+});

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/validations.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/validations.unit.spec.jsx
@@ -9,6 +9,7 @@ import {
   validateOHIDates,
   validateApplicantSsn,
   validateSponsorSsn,
+  validateFutureDate,
 } from '../../../helpers/validations';
 
 describe('1010d `validateSponsorSsn` form validation', () => {
@@ -1357,6 +1358,61 @@ describe('1010d `validateApplicant` form validation', () => {
         dateOfMarriageToSponsor: '2015-06-15',
       });
       expect(validateApplicant(applicant)).to.be.false;
+    });
+  });
+});
+
+describe('1010d `validateFutureDate` form validation', () => {
+  const NOW_ISO = '2026-01-06T12:00:00.000Z';
+  const formData = {};
+  const schema = {};
+  let errors;
+  let clock;
+
+  const run = (dateString, errorMessages) =>
+    validateFutureDate(errors, dateString, formData, schema, errorMessages);
+
+  before(() => {
+    clock = sinon.useFakeTimers(new Date(NOW_ISO));
+  });
+
+  after(() => {
+    clock.restore();
+  });
+
+  beforeEach(() => {
+    errors = { addError: sinon.spy() };
+  });
+
+  const noErrorCases = [
+    { title: 'date is today', dateString: '2026-01-06' },
+    { title: 'date is in the past', dateString: '2025-01-01' },
+    { title: 'date is within one year from today', dateString: '2026-12-31' },
+    { title: 'date is exactly one year from today', dateString: '2027-01-06' },
+    { title: 'date is empty string', dateString: '' },
+    { title: 'date is undefined', dateString: undefined },
+  ];
+
+  noErrorCases.forEach(({ title, dateString }) => {
+    it(`should not add an error when ${title}`, () => {
+      run(dateString);
+      sinon.assert.notCalled(errors.addError);
+    });
+  });
+
+  const errorCases = [
+    {
+      title: 'date is more than one year in the future',
+      dateString: '2027-01-07',
+    },
+    { title: 'date is far in the future', dateString: '2030-01-01' },
+    { title: 'date year exceeds maxYear', dateString: '2028-01-01' },
+  ];
+
+  errorCases.forEach(({ title, dateString }) => {
+    it(`should add an error when ${title}`, () => {
+      run(dateString);
+      sinon.assert.calledOnce(errors.addError);
     });
   });
 });

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/validations.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/validations.unit.spec.jsx
@@ -1407,6 +1407,8 @@ describe('1010d `validateFutureDate` form validation', () => {
     },
     { title: 'date is far in the future', dateString: '2030-01-01' },
     { title: 'date year exceeds maxYear', dateString: '2028-01-01' },
+    { title: 'date has invalid month', dateString: '2026-13-01' },
+    { title: 'date has invalid day', dateString: '2026-02-30' },
   ];
 
   errorCases.forEach(({ title, dateString }) => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds functionality to allow for future Medicare effective date values.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#128037

## Testing done

- Prior to the update, all date values were current or past dates
- After the update, dates up to 1 year from the current date are permitted

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Future dates are permitted for effective dates

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
