### PR TITLE
DMT | Add Datadog privacy classes to summary description

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/config.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/config.js
@@ -218,7 +218,13 @@ export const arrayBuilderOptions = {
     cardDescription: item => (
       <div>
         Date of birth:
-        <strong> {getFormatedDate(item?.birthDate)}</strong>
+        <strong
+          className="dd-privacy-mask"
+          data-dd-action-name="child date of birth"
+        >
+          {' '}
+          {getFormatedDate(item?.birthDate)}
+        </strong>
       </div>
     ),
     duplicateSummaryCardLabel: () => 'DUPLICATE CHILD',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > We noticed that an added child's date of birth would sometimes render within Datadog's RUM sessions. This PR adds an additional Datadog privacy class wrapper inside the summary card description. We hope that this fixes the problem as the masking of the child's date of birth is inconsistently masked in the RUM sessions.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/129084

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Child summary showing masks | <img width="648" height="238" alt="Screenshot 2026-01-06 at 2 03 09 PM" src="https://github.com/user-attachments/assets/f3f64902-6456-4a49-9750-9d21f0ac6636" /> | <img width="609" height="227" alt="Screenshot 2026-01-06 at 1 58 07 PM" src="https://github.com/user-attachments/assets/e779b1cc-45f2-4d36-b712-eef6d91bab6b" /> |

It's difficult to see, but the date of birth has an additional highlight around the actual date of birth

## What areas of the site does it impact?

Dependents Management Form (686C-674)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
