### PR TITLE
Add "To" to Appointments CernerFacilityAlert title, make VAOS mocks work for alerts

### DIFF
--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -89,6 +89,11 @@ const MockReferralSubmitAppointmentResponse = require('../../tests/fixtures/Mock
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
 const features = require('./featureFlags');
+const {
+  // defaultUser,
+  // acceleratedCernerUser,
+  cernerUser,
+} = require('../../../../platform/mhv/api/mocks/user');
 
 const mockAppts = [];
 let currentMockId = 1;
@@ -681,32 +686,7 @@ const responses = {
           'rx',
           'messaging',
         ],
-        va_profile: {
-          status: 'OK',
-          birth_date: '19511118',
-          family_name: 'Hunter',
-          gender: 'M',
-          given_names: ['Julio', 'E'],
-          active_status: 'active',
-          facilities: [
-            {
-              facility_id: '556',
-              is_cerner: false,
-            },
-            {
-              facility_id: '984',
-              is_cerner: false,
-            },
-            {
-              facility_id: '983',
-              is_cerner: false,
-            },
-            {
-              facility_id: '692',
-              is_cerner: true,
-            },
-          ],
-        },
+        vaProfile: cernerUser.data.attributes.vaProfile,
         vet360ContactInformation: {
           email: {
             createdAt: '2018-04-20T17:24:13.000Z',

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -686,7 +686,27 @@ const responses = {
           'rx',
           'messaging',
         ],
-        vaProfile: cernerUser.data.attributes.vaProfile,
+        vaProfile: {
+          ...cernerUser.data.attributes.vaProfile,
+          facilities: [
+            {
+              facility_id: '556',
+              is_cerner: false,
+            },
+            {
+              facility_id: '984',
+              is_cerner: false,
+            },
+            {
+              facility_id: '983',
+              is_cerner: false,
+            },
+            {
+              facility_id: '692',
+              is_cerner: true,
+            },
+          ],
+        },
         vet360ContactInformation: {
           email: {
             createdAt: '2018-04-20T17:24:13.000Z',

--- a/src/platform/mhv/components/CernerFacilityAlert/constants.js
+++ b/src/platform/mhv/components/CernerFacilityAlert/constants.js
@@ -2,7 +2,7 @@ export const CernerAlertContent = {
   APPOINTMENTS: {
     linkPath: '/pages/scheduling/upcoming',
     pageName: 'appointments',
-    headline: 'Manage your appointments at',
+    headline: 'To manage your appointments at',
     domain: 'appointments',
     infoAlertActionPhrase: 'manage most of your appointments',
     infoAlertText: 'You can manage most of your appointments here.',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds word "To" to start of title for CernerFacilityAlert, adds vaProfile object from MHV user to VAOS mock user to show alerts
- Appointments/Orion/UAE

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127877

## Testing done

- Checked wording of alert and user content locally (since mocks changed)

## Screenshots

Only difference from Staging/Prod is work "To" and capitalization of Manage.
<img width="1728" height="1117" alt="Screenshot 2026-01-06 at 12 02 32 PM" src="https://github.com/user-attachments/assets/ea503bb3-9c2a-415b-b84e-8e54de27900b" />


## What areas of the site does it impact?

Alert for Cerner pretransitioned users

## Acceptance criteria

Alert now says "To manage" instead of "Manage" in alert title for Cerner users.

Alert shows for mock users on vaos app/api mocks on local dev.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
