### PR TITLE
Invalid switch case syntax in ExtraDetails

### DIFF
--- a/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
+++ b/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
@@ -37,7 +37,7 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
             <va-icon icon="warning" size={4} aria-hidden="true" />
             <div className="vads-u-padding-left--2" data-testid="unknown-rx">
               <p className="vads-u-margin-y--0">
-                We’re sorry. There’s a problem with our system. You can’t manage
+                We’re sorry. There’s a problem with our system. You can't manage
                 this prescription online right now.
               </p>
               <p className="vads-u-margin-y--0">
@@ -299,7 +299,7 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
         return (
           <div>
             <p className="vads-u-margin-y--0" data-testid="discontinued">
-              You can’t refill this prescription. If you need more, send a
+              You can't refill this prescription. If you need more, send a
               message to your care team.
             </p>
             <va-link

--- a/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
+++ b/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
@@ -37,7 +37,7 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
             <va-icon icon="warning" size={4} aria-hidden="true" />
             <div className="vads-u-padding-left--2" data-testid="unknown-rx">
               <p className="vads-u-margin-y--0">
-                We’re sorry. There’s a problem with our system. You can't manage
+                We’re sorry. There’s a problem with our system. You can’t manage
                 this prescription online right now.
               </p>
               <p className="vads-u-margin-y--0">
@@ -299,7 +299,7 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
         return (
           <div>
             <p className="vads-u-margin-y--0" data-testid="discontinued">
-              You can't refill this prescription. If you need more, send a
+              You can’t refill this prescription. If you need more, send a
               message to your care team.
             </p>
             <va-link
@@ -329,7 +329,7 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
           </div>
         );
 
-      case dispStatusObj.nonVA || rxSourceIsNonVA(rx):
+      case dispStatusObj.nonVA:
         return (
           <p className="vads-u-margin-y--0" data-testid="non-VA-prescription">
             You can’t manage this medication in this online tool.


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Delete unnecessary || operator that was never hit. Logic explained in [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/128626). Make sure nonVA logic still works as intended.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128626

## Testing done

- _Describe what the old behavior was prior to the change_

Behavior is the same

## Screenshots

<img width="760" height="201" alt="Screenshot 2026-01-06 at 5 00 28 PM" src="https://github.com/user-attachments/assets/be0af308-aa09-4ab5-8713-5c41c7f1dc06" />

## What areas of the site does it impact? 

No areas impacted

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

