### PR TITLE
Add data-dd-privacy mask to array builder

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCancelButton.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCancelButton.jsx
@@ -164,6 +164,7 @@ const ArrayBuilderCancelButton = ({
       >
         <div
           className="dd-privacy-mask"
+          data-dd-privacy="mask"
           data-dd-action-name="Cancel Confirmation"
         >
           {getText(modalDescriptionKey, currentItem, formData, arrayIndex)}

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
@@ -343,12 +343,14 @@ const ArrayBuilderCards = ({
                       {label}
                       <CardTitle
                         className={`vads-u-margin-top--0${cardHeadingStyling} dd-privacy-mask`}
+                        data-dd-privacy="mask"
                         data-dd-action-name="Item Name"
                       >
                         {itemName}
                       </CardTitle>
                       <div
                         className="dd-privacy-mask"
+                        data-dd-privacy="mask"
                         data-dd-action-name="Item Description"
                       >
                         {itemDescription}
@@ -421,6 +423,7 @@ const ArrayBuilderCards = ({
       >
         <div
           className="dd-privacy-mask"
+          data-dd-privacy="mask"
           data-dd-action-name="Delete Confirmation"
         >
           {required(formData) && arrayData?.length === 1

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -38,7 +38,11 @@ const SuccessAlert = ({ nounSingular, index, onDismiss, text }) => (
       closeBtnAriaLabel="Close notification"
       uswds
     >
-      <div className="dd-privacy-mask" data-dd-action-name="Success Alert">
+      <div
+        className="dd-privacy-mask"
+        data-dd-privacy="mask"
+        data-dd-action-name="Success Alert"
+      >
         {text}
       </div>
     </VaAlert>


### PR DESCRIPTION
## Summary

Datadog is still not always masking data despite using `className="dd-privacy-mask"`
So trying to also add `data-dd-privacy="mask"` in addition to this to see if it helps filter out components in addition to strings.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5399

## Testing done

- unit, browser, regression

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
