### PR TITLE
DR 129014: Update SC 4142 and standalone 4142 status cards

### DIFF
--- a/src/applications/personalization/dashboard/tests/components/benefit-application-drafts/ApplicationsInProgress.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/benefit-application-drafts/ApplicationsInProgress.unit.spec.jsx
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import {
+  MY_VA_SIP_FORMS,
+  VA_FORM_IDS,
+} from '@department-of-veterans-affairs/platform-forms/constants';
+import { getCardHeaders } from '../../../components/benefit-application-drafts/ApplicationsInProgress';
+
+describe('ApplicationsInProgress', () => {
+  const getFormMeta = formId =>
+    MY_VA_SIP_FORMS.find(form => form.id === formId);
+
+  describe('utility: getCardHeaders', () => {
+    describe('forms defined in formArrays', () => {
+      it('should return the proper headers for form 22-10275', () => {
+        const formId = VA_FORM_IDS.FORM_22_10275;
+        const formMeta = getFormMeta(formId);
+        const hasBenefit = !!formMeta?.benefit;
+
+        expect(
+          getCardHeaders(formId, getFormMeta(formId), hasBenefit),
+        ).to.deep.equal({
+          formTitle: `VA Form ${formId} (${formMeta.title})`,
+          hasCustomPresentableFormId: false,
+          isForm: true,
+          presentableFormId: `FORM ${formId}`,
+        });
+      });
+    });
+
+    describe('forms with default header values', () => {
+      it('should return the proper headers for form 21-509-UPLOAD', () => {
+        const formId = VA_FORM_IDS.FORM_21_509_UPLOAD;
+        const formMeta = getFormMeta(formId);
+        const hasBenefit = !!formMeta?.benefit;
+
+        expect(
+          getCardHeaders(formId, getFormMeta(formId), hasBenefit),
+        ).to.deep.equal({
+          formTitle: `Application for ${formMeta.benefit.toLowerCase()}`,
+          hasCustomPresentableFormId: false,
+          isForm: false,
+          presentableFormId: 'FORM 21-509',
+        });
+      });
+
+      it('should return the proper headers for form 10-10EZ', () => {
+        const formId = VA_FORM_IDS.FORM_10_10EZ;
+        const formMeta = getFormMeta(formId);
+        const hasBenefit = !!formMeta?.benefit;
+
+        expect(
+          getCardHeaders(formId, getFormMeta(formId), hasBenefit),
+        ).to.deep.equal({
+          formTitle: `Application for ${formMeta.benefit.toLowerCase()}`,
+          hasCustomPresentableFormId: false,
+          isForm: false,
+          presentableFormId: 'FORM 10-10EZ',
+        });
+      });
+    });
+
+    describe('forms with custom configs', () => {
+      it('should return the proper headers for a form with formTitle and presentableFormId', () => {
+        const formId = 'form0995_form4142';
+        const formMeta = getFormMeta(formId);
+        const hasBenefit = !!formMeta?.benefit;
+
+        expect(
+          getCardHeaders(formId, getFormMeta(formId), hasBenefit),
+        ).to.deep.equal({
+          formTitle: 'Authorization to release medical information',
+          hasCustomPresentableFormId: true,
+          isForm: false,
+          presentableFormId:
+            'Form 21-4142 submitted with Supplemental Claim VA Form 20-0995',
+        });
+      });
+
+      it('should return the proper headers for a form with formIdLabel', () => {
+        const formId = 'form526_form4142';
+        const formMeta = getFormMeta(formId);
+        const hasBenefit = !!formMeta?.benefit;
+
+        expect(
+          getCardHeaders(formId, getFormMeta(formId), hasBenefit),
+        ).to.deep.equal({
+          formTitle: 'VA Form 21-4142 submitted with VA Form 21-526EZ',
+          hasCustomPresentableFormId: false,
+          isForm: false,
+          presentableFormId: '',
+        });
+      });
+
+      it('should return the proper headers for a form with formTitle', () => {
+        const formId = '21-4142';
+        const formMeta = getFormMeta(formId);
+        const hasBenefit = !!formMeta?.benefit;
+
+        expect(
+          getCardHeaders(formId, getFormMeta(formId), hasBenefit),
+        ).to.deep.equal({
+          formTitle: 'Authorization to release medical information',
+          hasCustomPresentableFormId: false,
+          isForm: false,
+          presentableFormId: 'FORM 21-4142',
+        });
+      });
+    });
+  });
+});

--- a/src/applications/personalization/dashboard/utils/custom-card-header-configs.js
+++ b/src/applications/personalization/dashboard/utils/custom-card-header-configs.js
@@ -1,0 +1,28 @@
+/**
+ * Define custom configuration for headers for form cards
+ * formId is required
+ *
+ * PICK ONE:
+ * Define formIdLabel to make this header: `VA Form ${formIdLabel}`
+ * Define formTitle to make a fully custom header
+ *
+ * OPTIONALLY:
+ * Define presentableFormId to make this subheader: `VA ${presentableFormId}`
+ * @param {Object} formMeta - metadata defined in platform/forms/constants/MY_VA_SIP_FORMS
+ */
+export const getCustomCardHeaderConfigs = formMeta => [
+  {
+    formId: 'form0995_form4142',
+    formTitle: 'Authorization to release medical information',
+    presentableFormId:
+      'Form 21-4142 submitted with Supplemental Claim VA Form 20-0995',
+  },
+  {
+    formId: 'form526_form4142',
+    formIdLabel: '21-4142 submitted with VA Form 21-526EZ',
+  },
+  {
+    formId: '21-4142',
+    formTitle: formMeta?.benefit,
+  },
+];


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

MyVA status card updates:
1. Update standalone 4142 card title to remove "Application for..." language
2. Update embedded 4142 (in SC) card to use "Authorization to release medical information" as the main heading and "VA Form 21-4142 submitted with Supplemental Claim VA Form 20-0995" as the subtitle

I discovered that making these changes meant diverging the code further for edge cases, which didn't seem ideal. 

**I am proposing a refactor** to:

1. Create a config file for folks to come in and add custom headers where appropriate, and the rest of the forms will still flow through the defaults
2. Move some of the form looping functionality into separate methods to lower cognitive load a bit

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/129014

## Testing done & screenshots

**Note** that we are only focused on the correct headers (and optional subheaders) rendering on these cards. Anything else that differs on these cards is likely not related to these code changes.

**Bolded** form headers were changed intentionally as part of the scope of this ticket.

| Form | Local | Staging/Current |
| --- | --- | --- |
| **Standalone 4142** | <img width="280" src="https://github.com/user-attachments/assets/ea38d752-a500-4cdc-897f-001cc14840a9" /> | <img width="280" src="https://github.com/user-attachments/assets/615f7175-8202-4d41-af31-0c9367150a99" /> |
| **4142 through 0995** | <img width="280" src="https://github.com/user-attachments/assets/58d178ab-99f3-4222-a3d7-bb77fd898b9d" /> | <img width="280" src="https://github.com/user-attachments/assets/c50607e5-396f-4814-9fd5-cd22a567552a" /> |
| 0995 | <img width="280" src="https://github.com/user-attachments/assets/5e410b04-80d5-4f6d-a59e-b9286c077a38" /> | <img width="280" src="https://github.com/user-attachments/assets/17d1a1e0-4747-410d-bcce-59d729d08c6a" /> |
| 10-10ez | <img width="280" src="https://github.com/user-attachments/assets/17ad1d60-5bf5-4473-aa28-d9e821594403" /> | <img width="280" src="https://github.com/user-attachments/assets/a9249f7f-a5bd-4ea4-9aa3-71ca4f8c390d" /> |
| 526ez | <img width="280" src="https://github.com/user-attachments/assets/8a42795d-0091-4af9-b3de-17252efc6b4e" /> | <img width="280" src="https://github.com/user-attachments/assets/1287d1a4-0949-4203-842a-1da99ef4ff02" /> |
| 4142 through 526ez (staging screenshot pulled from [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/38395)) | <img width="280" src="https://github.com/user-attachments/assets/7a11d0f1-ed54-4d02-8497-b92b75168b56" /> | <img width="280" src="https://github.com/user-attachments/assets/4306398a-f399-40e7-beba-22783b674b7c" /> |
| 22-10275 | <img width="280" src="https://github.com/user-attachments/assets/5681404e-0481-4a04-a2ca-b545b0a05d3f" /> | ❓ This one is an edge case in `formArrays`. I couldn't find a test user on staging with one of these cards. |
| 21P-0969 | <img width="280" src="https://github.com/user-attachments/assets/f0a0df97-f986-43e9-b33c-e2898dbce6ad" /> | <img width="280" src="https://github.com/user-attachments/assets/e58f601b-d94c-428a-8c25-160e1ffd0a9a" /> | 


## What areas of the site does it impact?

MyVA dashboard

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added