### PR TITLE
[22830] fix(facility-locator): correct lat/lon swap in getBoxCenter calculation

### DIFF
--- a/src/applications/facility-locator/tests/utils/mapHelpers.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/utils/mapHelpers.unit.spec.jsx
@@ -3,12 +3,20 @@ import { getBoxCenter, getPlaceName } from '../../utils/mapHelpers';
 
 describe('mapHelpers utils', () => {
   describe('getBoxCenter', () => {
-    it('should properly calculate the box center when given bounds', () => {
+    it('should properly calculate the box center when given square bounds', () => {
       expect(
         getBoxCenter([-77.955898, 38.380263, -76.955898, 39.380263]),
       ).to.deep.equal({
         lat: 38.880263,
         lon: -77.455898,
+      });
+    });
+
+    it('should properly calculate the box center when given non-square bounds', () => {
+      // Non-square box ensures lonDiff !== latDiff to catch swap bugs
+      expect(getBoxCenter([-123.0, 36.0, -121.0, 37.0])).to.deep.equal({
+        lon: -122.0,
+        lat: 36.5,
       });
     });
 

--- a/src/applications/facility-locator/utils/mapHelpers.js
+++ b/src/applications/facility-locator/utils/mapHelpers.js
@@ -36,7 +36,7 @@ export const getBoxCenter = bounds => {
     const lonDiff = (bounds[2] - bounds[0]) / 2;
     const latDiff = (bounds[3] - bounds[1]) / 2;
 
-    return { lon: bounds[0] + latDiff, lat: bounds[1] + lonDiff };
+    return { lon: bounds[0] + lonDiff, lat: bounds[1] + latDiff };
   }
 
   return {};


### PR DESCRIPTION



## Summary

The getBoxCenter function was incorrectly swapping lonDiff and latDiff when calculating the center point of a bounding box. This caused reverse geocoding to fail for non-square bounding boxes (like coastal areas) because the calculated center would be in an incorrect location.

For Monterey, CA searches, this placed the center point in the Pacific Ocean, causing Mapbox reverse geocode to return no results and triggering the 'Find VA locations isn't working right now' error.

- Swap LatDiff and LongDiff used when calculating map's center point
- Facilities owned and maintained

## Related issue(s)

- Fixes: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22730

## Testing done

- Tested against bug and various other searches
- Use RI, and search for Urgent Care Facilities in Monterey, CA using /find-locations

## What areas of the site does it impact?

Facility Locator and the associated Mapbox

## Acceptance criteria

Monterey, CA no longer errors when searching for UC

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

