### PR TITLE
129280 Reset page to "1" when updating date range filter

### DIFF
--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
@@ -39,6 +40,7 @@ import { getTimeFrame, getDisplayTimeFrame } from '../util/helpers';
 
 const CareSummariesAndNotes = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const updatedRecordList = useSelector(
     state => state.mr.careSummariesAndNotes.updatedList,
   );
@@ -111,6 +113,7 @@ const CareSummariesAndNotes = () => {
     updateDateRangeAction: updateNotesDateRange,
     updateListStateActionType: Actions.CareSummariesAndNotes.UPDATE_LIST_STATE,
     dataDogLabel: 'Notes date option',
+    history,
   });
 
   return (

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
@@ -48,6 +49,7 @@ import AdditionalReportsInfo from '../components/shared/AdditionalReportsInfo';
 
 const LabsAndTests = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const dateRange = useSelector(state => state.mr.labsAndTests.dateRange);
   const updatedRecordList = useSelector(
     state => state.mr.labsAndTests.updatedList,
@@ -140,6 +142,7 @@ const LabsAndTests = () => {
     updateDateRangeAction: updateLabsAndTestDateRange,
     updateListStateActionType: Actions.LabsAndTests.UPDATE_LIST_STATE,
     dataDogLabel: 'Date range option',
+    history,
   });
 
   return (

--- a/src/applications/mhv-medical-records/hooks/useDateRangeSelector.js
+++ b/src/applications/mhv-medical-records/hooks/useDateRangeSelector.js
@@ -13,6 +13,7 @@ import { loadStates } from '../util/constants';
  * @param {Function} options.updateDateRangeAction - Redux action creator to update date range
  * @param {string} options.updateListStateActionType - Action type for updating list state
  * @param {string} options.dataDogLabel - Label for DataDog tracking
+ * @param {Object} options.history - React Router history object (optional, for resetting pagination)
  * @returns {Function} handleDateRangeSelect callback
  *
  * @example
@@ -20,12 +21,14 @@ import { loadStates } from '../util/constants';
  *   updateDateRangeAction: updateNotesDateRange,
  *   updateListStateActionType: Actions.CareSummariesAndNotes.UPDATE_LIST_STATE,
  *   dataDogLabel: 'Notes date option',
+ *   history,
  * });
  */
 const useDateRangeSelector = ({
   updateDateRangeAction,
   updateListStateActionType,
   dataDogLabel,
+  history,
 }) => {
   const dispatch = useDispatch();
 
@@ -33,6 +36,11 @@ const useDateRangeSelector = ({
     event => {
       const { value } = event.detail;
       const { fromDate, toDate } = calculateDateRange(value);
+
+      // Reset to page 1 when changing date range to avoid pagination issues
+      if (history) {
+        history.push(`${history.location.pathname}?page=1`);
+      }
 
       // Update Redux with new range
       dispatch(updateDateRangeAction(value, fromDate, toDate));
@@ -50,7 +58,13 @@ const useDateRangeSelector = ({
       const label = selectedOption ? selectedOption.label : 'Unknown';
       sendDataDogAction(`${dataDogLabel} - ${label}`);
     },
-    [dispatch, updateDateRangeAction, updateListStateActionType, dataDogLabel],
+    [
+      dispatch,
+      updateDateRangeAction,
+      updateListStateActionType,
+      dataDogLabel,
+      history,
+    ],
   );
 };
 

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.pagination-reset.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.pagination-reset.cypress.spec.js
@@ -1,0 +1,147 @@
+import { format, subMonths } from 'date-fns';
+import MedicalRecordsSite from '../../mr_site/MedicalRecordsSite';
+import LabsAndTests from '../pages/LabsAndTests';
+import oracleHealthUser from '../fixtures/user/oracle-health.json';
+import labsAndTestData from '../fixtures/labsAndTests/multiple-pages.json';
+
+describe('Medical Records Labs And Tests - Pagination Reset on Date Range Change', () => {
+  const site = new MedicalRecordsSite();
+  const mockDate = new Date(2024, 0, 25); // January 25, 2024
+
+  beforeEach(() => {
+    cy.clock(mockDate, ['Date']);
+
+    site.login(oracleHealthUser, false);
+    site.mockFeatureToggles({
+      isAcceleratingEnabled: true,
+      isAcceleratingVitals: false,
+      isAcceleratingLabsAndTests: true,
+    });
+    LabsAndTests.setIntercepts({ labsAndTestData });
+  });
+
+  afterEach(() => {
+    cy.clock().invoke('restore');
+  });
+
+  it('resets pagination to page 1 when date range changes', () => {
+    site.loadPage();
+    LabsAndTests.goToLabAndTestPage();
+
+    // Verify initial load shows default date range
+    const today = mockDate;
+    const fromDisplay = format(subMonths(today, 3), 'MMMM d, yyyy');
+    const toDisplay = format(today, 'MMMM d, yyyy');
+    LabsAndTests.checkTimeFrameDisplay({
+      fromDate: fromDisplay,
+      toDate: toDisplay,
+    });
+
+    // Wait for initial data to load
+    cy.wait('@labs-and-test-list');
+
+    // Verify records are visible
+    cy.get('[data-testid="record-list-item"]').should(
+      'have.length.at.least',
+      1,
+    );
+
+    // Verify pagination exists (fixture has 11 records, 3 per page = 4 pages)
+    cy.get('va-pagination').should('exist');
+
+    // Navigate to page 2 using pagination
+    cy.get('va-pagination')
+      .shadow()
+      .find('.usa-pagination__button')
+      .contains('2')
+      .click({ waitForAnimations: true });
+
+    // Verify URL shows page 2
+    cy.url().should('include', 'page=2');
+
+    // Verify we're on page 2 by checking the pagination display
+    cy.get('va-pagination')
+      .shadow()
+      .find('.usa-current')
+      .should('contain', '2');
+
+    // Change the date range filter to a different year
+    LabsAndTests.selectDateRange({
+      option: '2023',
+    });
+
+    // Wait for API call with new date range
+    cy.wait('@labs-and-test-list');
+
+    // Verify URL has been reset to page 1 (or no page param)
+    cy.url().should('not.include', 'page=2');
+    cy.url().then(url => {
+      // URL should either have page=1 or no page param at all
+      expect(url).to.satisfy(
+        currentUrl =>
+          currentUrl.includes('page=1') || !currentUrl.includes('page='),
+      );
+    });
+
+    // Verify the date range was updated
+    LabsAndTests.checkTimeFrameDisplayForYear({ year: '2023' });
+
+    // Accessibility check
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('resets pagination when switching between multiple date ranges', () => {
+    site.loadPage();
+    LabsAndTests.goToLabAndTestPage();
+
+    // Wait for initial load
+    cy.wait('@labs-and-test-list');
+
+    // Verify pagination exists
+    cy.get('va-pagination').should('exist');
+
+    // Navigate to page 2
+    cy.get('va-pagination')
+      .shadow()
+      .find('.usa-pagination__button')
+      .contains('2')
+      .click({ waitForAnimations: true });
+
+    cy.url().should('include', 'page=2');
+
+    // Change to 2023
+    LabsAndTests.selectDateRange({ option: '2023' });
+    cy.wait('@labs-and-test-list');
+
+    // Should not be on page 2 anymore
+    cy.url().should('not.include', 'page=2');
+
+    // Verify year changed
+    LabsAndTests.checkTimeFrameDisplayForYear({ year: '2023' });
+  });
+
+  it('maintains page 1 when date range changes on page 1', () => {
+    site.loadPage();
+    LabsAndTests.goToLabAndTestPage();
+
+    // Wait for initial load
+    cy.wait('@labs-and-test-list');
+
+    // User is already on page 1 (URL may or may not have page=1)
+    cy.url().should('not.include', 'page=2');
+
+    // Change date range
+    LabsAndTests.selectDateRange({ option: '2023' });
+    cy.wait('@labs-and-test-list');
+
+    // Should still be on page 1 (not on page 2 or higher)
+    cy.url().should('not.include', 'page=2');
+    cy.url().should('not.include', 'page=3');
+
+    // Verify date range changed
+    LabsAndTests.checkTimeFrameDisplayForYear({ year: '2023' });
+
+    // Verify records are shown
+    cy.get('[data-testid="record-list-item"]').should('exist');
+  });
+});

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.pagination-reset.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.pagination-reset.cypress.spec.js
@@ -118,6 +118,9 @@ describe('Medical Records Labs And Tests - Pagination Reset on Date Range Change
 
     // Verify year changed
     LabsAndTests.checkTimeFrameDisplayForYear({ year: '2023' });
+
+    // Accessibility check
+    cy.injectAxeThenAxeCheck();
   });
 
   it('maintains page 1 when date range changes on page 1', () => {
@@ -143,5 +146,8 @@ describe('Medical Records Labs And Tests - Pagination Reset on Date Range Change
 
     // Verify records are shown
     cy.get('[data-testid="record-list-item"]').should('exist');
+
+    // Accessibility check
+    cy.injectAxeThenAxeCheck();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When a user changes the date-range filter on Labs & Tests or Care Summaries & Notes, we now reset the page to "1". This prevents pages showing without any records, and with invalid headers (e.g. "Showing 11 to 9 of 9 records")

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129280

## Testing done

- Added a unit test for the updated hook
- Added an e2e test to check for the specific bug case

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Before, list stays on page 3 in bad state. After, list reverts to page 1 on filter change.

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="300" height="214" alt="image" src="https://github.com/user-attachments/assets/7a44b25c-30d5-42a0-aa90-ae2441f6201a" /> | <img width="300" height="450" alt="image" src="https://github.com/user-attachments/assets/3ee92c9f-63bc-4db2-a535-b076e4cde5fa" /> |

## What areas of the site does it impact?

MHV Medical Records list views for labs and notes

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
