### PR TITLE
Ensure OH AVS is displayed for appointments with fulfilled status

### DIFF
--- a/src/applications/vaos/components/layouts/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layouts/DetailPageLayout.jsx
@@ -227,7 +227,8 @@ export default function DetailPageLayout({
             <AppointmentTasksSection appointment={appointment} />
           )}
         {isPastAppointment &&
-          APPOINTMENT_STATUS.booked === appointment.status && (
+          (APPOINTMENT_STATUS.booked === appointment.status ||
+            APPOINTMENT_STATUS.fulfilled === appointment.status) && (
             <AfterVisitSummary data={appointment} />
           )}
         {children}

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -414,7 +414,7 @@
           "eCheckinAllowed": true
         },
         "localStartTime": "2025-10-13T09:00:00.000-06:00",
-        "avsPdf": [{ 
+        "avsPdf": [{
             "id": "20875041789",
             "apptId": "172646526",
             "name": "Ambulatory Visit Summary",
@@ -426,7 +426,7 @@
             "contentType": "application/pdf",
             "binary": "JVBERi0xLjQKMSAwIG9iago8PC9UeXBlIC9DYXRhbG9nCi9QYWdlcyAyIDAgUgo+PgplbmRvYmoKMiAwIG9iago8PC9UeXBlIC9QYWdlcwovS2lkcyBbMyAwIFJdCi9Db3VudCAxCj4+CmVuZG9iagozIDAgb2JqCjw8L1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovTWVkaWFCb3ggWzAgMCA1OTUgODQyXQovQ29udGVudHMgNSAwIFIKL1Jlc291cmNlcyA8PC9Qcm9jU2V0IFsvUERGIC9UZXh0XQovRm9udCA8PC9GMSA0IDAgUj4+Cj4+Cj4+CmVuZG9iago0IDAgb2JqCjw8L1R5cGUgL0ZvbnQKL1N1YnR5cGUgL1R5cGUxCi9OYW1lIC9GMQovQmFzZUZvbnQgL0hlbHZldGljYQovRW5jb2RpbmcgL01hY1Jv bWFuRW5jb2RpbmcKPj4KZW5kb2JqCjUgMCBvYmoKPDwvTGVuZ3RoIDUzCj4+CnN0cmVhbQpCVAovRjEgMjAgVGYKMjIwIDQwMCBUZAooRHVtbXkgUERGKSBUagpFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZgowMDAwMDAwMDA5IDAwMDAwIG4KMDAwMDAwMDA2MyAwMDAwMCBuCjAwMDAwMDAxMjQgMDAwMDAgbgowMDAwMDAwMjc3IDAwMDAwIG4KMDAwMDAwMDM5MiAwMDAwMCBuCnRyYWlsZXIKPDwvU2l6ZSA2Ci9Sb290IDEgMCBSCj4+CnN0YXJ0eHJlZgo0OTUKJSVFQ0VPRg=="
         },
-        { 
+        {
             "id": "20875041789",
             "apptId": "172646526",
             "name": "Ambulatory Visit Summary",
@@ -553,7 +553,7 @@
           "eCheckinAllowed": true
         },
         "localStartTime": "2025-10-14T09:00:00.000-06:00",
-        "avsPdf": [{ 
+        "avsPdf": [{
             "id": "20875041789",
             "apptId": "172646526",
             "name": "Ambulatory Visit Summary",
@@ -680,7 +680,7 @@
           "eCheckinAllowed": true
         },
         "localStartTime": "2025-10-15T09:00:00.000-06:00",
-        "avsPdf": [{ 
+        "avsPdf": [{
             "id": "20875041789",
             "apptId": "AVS_PDF_Test_3",
             "name": "Ambulatory Visit Summary",
@@ -807,7 +807,7 @@
           "eCheckinAllowed": true
         },
         "localStartTime": "2025-10-16T09:00:00.000-06:00",
-        "avsPdf": [{ 
+        "avsPdf": [{
             "id": "20875041789",
             "apptId": "AVS_PDF_Test_4",
             "name": "Pharmacology Discharge summary",
@@ -899,7 +899,7 @@
         "kind": "clinic",
         "type": "VA",
         "modality": "vaInPerson",
-        "status": "booked",
+        "status": "fulfilled",
         "serviceCategory": [
           {
             "coding": [
@@ -934,7 +934,7 @@
           "eCheckinAllowed": true
         },
         "localStartTime": "2025-10-17T09:00:00.000-06:00",
-        "avsPdf": [{ 
+        "avsPdf": [{
             "id": "20875041789",
             "apptId": "AVS_PDF_Test_5",
             "name": "Pharmacology Discharge summary",
@@ -946,7 +946,7 @@
             "contentType": "application/pdf",
             "binary": "JVBERi0xLjQKJeLjz9M#INVALID-DATA$$%%123=="
         },
-        { 
+        {
             "id": "20875041789",
             "apptId": "AVS_PDF_Test_5",
             "name": "Ambulatory Visit Summary",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Past OH appointments have the "fulfilled" status but our current details page logic only tries to display AVS for "booked" appointments.
- This PR adds AVS section to appointments with the "fulfilled" status 
- United Appointments Experience
- This is behind the `va_online_scheduling_add_OH_avs`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128234

## Testing done

- Tested locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| appt with "fulfilled" status |    <img width="690" height="572" alt="image" src="https://github.com/user-attachments/assets/8fec9b74-90ca-492b-bc7e-7ab7bc41669b" />   |   <img width="686" height="647" alt="image" src="https://github.com/user-attachments/assets/e3ebf5aa-c752-46ff-b50e-c4f43fbbb9d8" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
