### PR TITLE
128097 fix rx renewal not filled yet copy

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/util/helpers.unit.spec.jsx
@@ -1143,7 +1143,7 @@ describe('MHV Secure Messaging helpers', () => {
       };
       const result = buildRxRenewalMessageBody(rxWithInvalidDate, false);
 
-      expect(result).to.include('Last filled on: Date not available');
+      expect(result).to.include('Last filled on: Not filled yet');
     });
 
     it('should handle empty dispensed date and show placeholder', () => {
@@ -1153,7 +1153,7 @@ describe('MHV Secure Messaging helpers', () => {
       };
       const result = buildRxRenewalMessageBody(rxWithEmptyDate, false);
 
-      expect(result).to.include('Last filled on: Date not available');
+      expect(result).to.include('Last filled on: Not filled yet');
     });
 
     it('should handle null rx object and show all placeholders', () => {
@@ -1173,7 +1173,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include(
         'Prescription expiration date: Date not available',
       );
-      expect(result).to.include('Last filled on: Date not available');
+      expect(result).to.include('Last filled on: Not filled yet');
       expect(result).to.include('Reason for use: Reason for use not available');
       expect(result).to.include('Quantity: Quantity not available');
     });
@@ -1195,7 +1195,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include(
         'Prescription expiration date: Date not available',
       );
-      expect(result).to.include('Last filled on: Date not available');
+      expect(result).to.include('Last filled on: Not filled yet');
       expect(result).to.include('Reason for use: Reason for use not available');
       expect(result).to.include('Quantity: Quantity not available');
     });
@@ -1217,7 +1217,7 @@ describe('MHV Secure Messaging helpers', () => {
       expect(result).to.include(
         'Prescription expiration date: Date not available',
       );
-      expect(result).to.include('Last filled on: Date not available');
+      expect(result).to.include('Last filled on: Not filled yet');
       expect(result).to.include('Reason for use: Reason for use not available');
       expect(result).to.include('Quantity: Quantity not available');
     });

--- a/src/applications/mhv-secure-messaging/util/helpers.js
+++ b/src/applications/mhv-secure-messaging/util/helpers.js
@@ -517,12 +517,12 @@ export const buildRxRenewalMessageBody = (rx, rxError) => {
     return 'Number of refills left not available';
   };
 
-  const getDateValue = date => {
+  const getDateValue = (date, isDispensedDate = false) => {
     if (rxError) return '';
     if (date) {
       return dateFormat(date, 'MMMM D, YYYY');
     }
-    return 'Date not available';
+    return isDispensedDate ? 'Not filled yet' : 'Date not available';
   };
 
   return [
@@ -541,7 +541,7 @@ export const buildRxRenewalMessageBody = (rx, rxError) => {
     `Reason for use: ${
       rxError ? '' : rx?.reason || 'Reason for use not available'
     }`,
-    `Last filled on: ${getDateValue(rx?.sortedDispensedDate)}`,
+    `Last filled on: ${getDateValue(rx?.sortedDispensedDate, true)}`,
     `Quantity: ${rxError ? '' : rx?.quantity || 'Quantity not available'}`,
   ].join('\n');
 };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug fix**: Changes the prefilled Rx renewal message copy from `Last filled on: Date not available` to `Last filled on: Not filled yet` when a prescription has never been filled (`sortedDispensedDate` is null).
- **How to reproduce**: Navigate to Secure Messaging → Start Rx Renewal Request for a medication that has never been filled → observe the prefilled message body
- **Solution**: Added an `isDispensedDate` parameter to the `getDateValue()` helper function with a default value of `false` to preserve backward compatibility. When called with `true` for the dispensed date field, it returns `'Not filled yet'` instead of `'Date not available'`.
- **Team**: MHV Secure Messaging team owns this component
- **No flipper required** - this is a direct copy fix

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128097
- Related to parent ticket: department-of-veterans-affairs/va.gov-team#126058
- Previous implementation: department-of-veterans-affairs/vets-website#40651, department-of-veterans-affairs/vets-website#40706

## Testing done

- **Old behavior**: When `sortedDispensedDate` is null/empty, the prefilled renewal message showed `Last filled on: Date not available`
- **New behavior**: When `sortedDispensedDate` is null/empty, the prefilled renewal message now shows `Last filled on: Not filled yet` (matching the medications list page copy)
- **Steps to verify**:
  1. Log in as a test user with access to MHV Secure Messaging
  2. Navigate to Secure Messages
  3. Start an Rx renewal request for a medication that has never been filled (null `sortedDispensedDate`)
  4. Verify the prefilled message body shows `Last filled on: Not filled yet`
  5. Repeat for a medication WITH a filled date → verify it still shows the formatted date
- **Tests completed**:
  - ✅ Unit tests: 115/115 passing (5 test expectations updated)
  - ✅ Linting: No new errors introduced
  - ⚠️ E2E tests: 6 failures are **PRE-EXISTING** timezone issues unrelated to this PR (verified by running tests without PR changes - same failures occur)

## Screenshots

_N/A - This is a helper function change, not a UI component change. The output is text in a message body field._

## What areas of the site does it impact?

- MHV Secure Messaging → Rx Renewal Request flow
- Only affects the prefilled message body text when `sortedDispensedDate` is null/empty

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation changes needed for this copy fix)
- [x] Screenshot of the developed feature is added (N/A - helper function change, not UI)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - text content change only)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - no new events)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A - copy fix only)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a minimal, surgical fix. The `isDispensedDate` parameter defaults to `false` to preserve backward compatibility for other date fields (like `expirationDate`) that should still show `Date not available` when missing.