### PR TITLE
Address payload transformation bug

### DIFF
--- a/src/applications/dependents/686c-674/tests/config/utilities.data.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/utilities.data.unit.spec.jsx
@@ -618,6 +618,58 @@ describe('customTransformForSubmit - integration tests', () => {
     pages: [],
   };
 
+  it('should not include data property wrapper in final payload (regression test for payload structure bug)', () => {
+    // This test verifies that the final payload sent to backend does NOT have
+    // a nested 'data' property, and that view:selectable686Options and
+    // view:removeDependentOptions are present at the top level
+    const form = {
+      data: {
+        'view:addOrRemoveDependents': { add: false, remove: true },
+        'view:removeDependentOptions': {
+          reportDivorce: true,
+        },
+        reportDivorce: {
+          fullName: { first: 'Ex', last: 'Spouse' },
+          birthDate: '1980-01-01',
+          date: '2024-01-01',
+          reasonMarriageEnded: 'Divorce',
+          divorceLocation: {
+            outsideUsa: false,
+            location: { city: 'City', state: 'CA' },
+          },
+          spouseIncome: 'N',
+        },
+        veteranInformation: { fullName: { first: 'Test', last: 'Veteran' } },
+        veteranContactInformation: { phoneNumber: '555-1234' },
+        statementOfTruthSignature: 'Test Signature',
+        statementOfTruthCertified: true,
+        metadata: { version: 1 },
+      },
+    };
+
+    const result = customTransformForSubmit(mockFormConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    // Critical assertions for the bug:
+    // 1. Should NOT have a 'data' property at the top level
+    expect(submittedData.data).to.be.undefined;
+
+    // 2. Should have view:selectable686Options at the top level
+    expect(submittedData['view:selectable686Options']).to.not.be.undefined;
+    expect(submittedData['view:selectable686Options'].reportDivorce).to.be.true;
+
+    // 3. Should have view:removeDependentOptions at the top level
+    expect(submittedData['view:removeDependentOptions']).to.not.be.undefined;
+    expect(submittedData['view:removeDependentOptions'].reportDivorce).to.be
+      .true;
+
+    // 4. Data fields should be at the top level (not nested under 'data')
+    expect(submittedData.useV2).to.be.true;
+    expect(submittedData.daysTillExpires).to.equal(365);
+    expect(submittedData.reportDivorce).to.not.be.undefined;
+    expect(submittedData.veteranInformation).to.not.be.undefined;
+  });
+
   it('should correctly handle V2 flow with empty stepChildren through full transformation pipeline', () => {
     // This integration test verifies the full data flow from form submission
     // through filterInactivePageData, type extraction, and buildSubmissionData
@@ -710,6 +762,68 @@ describe('customTransformForSubmit - integration tests', () => {
           .reportStepchildNotInHousehold,
       ).to.be.true;
     }
+  });
+
+  it('should set flags based on data presence in V3 picklist flow (regression test)', () => {
+    // Regression test for V3 picklist where view:removeDependentOptions is EMPTY
+    // but data arrays exist after transformation. Flags should be set based on
+    // data presence, not checkbox selection.
+    const form = {
+      data: {
+        vaDependentsV3: true,
+        'view:addOrRemoveDependents': { add: false, remove: true },
+        'view:removeDependentOptions': {}, // EMPTY - typical V3 picklist state
+        [PICKLIST_DATA]: [
+          {
+            fullName: { first: 'Ex', last: 'Spouse' },
+            dateOfBirth: '1980-01-01',
+            relationshipToVeteran: 'Spouse',
+            selected: true,
+            removalReason: 'marriageEnded',
+            endType: 'Divorce',
+            endDate: '2024-01-01',
+            endOutsideUs: false,
+            endCity: 'City',
+            endState: 'CA',
+            spouseIncome: 'N',
+          },
+          {
+            fullName: { first: 'Deceased', last: 'Child' },
+            dateOfBirth: '2010-01-01',
+            relationshipToVeteran: 'Child',
+            selected: true,
+            removalReason: 'childDied',
+            endDate: '2024-06-01',
+            endOutsideUs: false,
+            endCity: 'City',
+            endState: 'CA',
+          },
+        ],
+        veteranInformation: { fullName: { first: 'Test', last: 'Veteran' } },
+        veteranContactInformation: { phoneNumber: '555-1234' },
+        statementOfTruthSignature: 'Test Signature',
+        statementOfTruthCertified: true,
+        metadata: { version: 1 },
+      },
+    };
+
+    const result = customTransformForSubmit(mockFormConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    // Critical assertions: flags should be set even though view:removeDependentOptions is empty
+    expect(submittedData['view:selectable686Options']).to.not.be.undefined;
+    expect(submittedData['view:selectable686Options'].reportDivorce).to.be.true;
+    expect(submittedData['view:selectable686Options'].reportDeath).to.be.true;
+
+    expect(submittedData['view:removeDependentOptions']).to.not.be.undefined;
+    expect(submittedData['view:removeDependentOptions'].reportDivorce).to.be
+      .true;
+    expect(submittedData['view:removeDependentOptions'].reportDeath).to.be.true;
+
+    // Data should be present
+    expect(submittedData.reportDivorce).to.not.be.undefined;
+    expect(submittedData.deaths).to.be.an('array');
+    expect(submittedData.deaths).to.have.lengthOf(1);
   });
 });
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes a bug where we are sending a malformed as the code does not handle v3 correctly.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129357

## Testing done

- Unit tests added
- payload examined before and after change.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
