### PR TITLE
Add plain language override for ASB specific disability evidence request

### DIFF
--- a/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
@@ -233,9 +233,11 @@ export default function DefaultPage({
             </h3>
             <p className="vads-u-margin-y--2">
               On {dateFormatter(item.requestedDate)}, we mailed you a letter
-              titled “Request for Specific Evidence or Information,” which may
-              include more details about this request. You can access this and
-              all your claim letters online.
+              titled "Request for Specific Evidence or Information," which may
+              include more details about this request.
+            </p>
+            <p className="vads-u-margin-top--2 vads-u-margin-bottom--0">
+              You can access this and all your claim letters online.
             </p>
             <VaLink
               text="Access your claim letters"

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/DefaultPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/DefaultPage.unit.spec.jsx
@@ -537,6 +537,29 @@ describe('<DefaultPage>', () => {
         showsThirdPartyNotice: false,
       },
       {
+        id: 15,
+        name: 'ASB - tell us specific disability (isSensitive: true)',
+        item: {
+          id: 15,
+          displayName: 'ASB-tell us specific disability fm asbestos exposure',
+          status: 'NEEDED_FROM_YOU',
+          requestedDate: '2025-10-23',
+          suspenseDate: futureSuspenseDate,
+          friendlyName: 'asbestos exposure information',
+          canUploadFile: true,
+        },
+        dictionaryEntry: getDictEntry(
+          'ASB-tell us specific disability fm asbestos exposure',
+        ),
+        expectedHeader: 'Request for evidence',
+        expectedSubheaderPattern: /Respond by .* for: asbestos exposure information/i,
+        expectedDescriptionText:
+          'To process your disability claim for asbestos exposure, we need information about your asbestos-related disease or disability:',
+        showsAddFilesForm: true,
+        showsPastDueAlert: false,
+        showsThirdPartyNotice: false,
+      },
+      {
         id: 4,
         name: 'Frontend override with longDescription but NO nextSteps',
         item: {

--- a/src/applications/claims-status/tests/local-dev-mock-api/common.js
+++ b/src/applications/claims-status/tests/local-dev-mock-api/common.js
@@ -576,6 +576,25 @@ const baseClaims = [
           canUploadFile: true,
         }),
 
+        // ASB - tell us specific disability (isSensitive: true)
+        // Shows "Request for evidence" header with specific disability content
+        createTrackedItem(
+          15,
+          'ASB-tell us specific disability fm asbestos exposure',
+          true,
+          {
+            requestedDate: '2025-10-23',
+            suspenseDate: '2026-01-23',
+            friendlyName: 'asbestos exposure information',
+            shortDescription:
+              'To process your disability claim, we need to know the disease or disability caused by the asbestos exposure.',
+            supportAliases: [
+              'ASB-tell us specific disability fm asbestos exposure',
+            ],
+            canUploadFile: true,
+          },
+        ),
+
         // Path 4: Frontend override with longDescription but NO nextSteps
         // Shows generic "Next steps" section
         createTrackedItem(4, 'Employer (21-4192)', true, {

--- a/src/applications/claims-status/utils/evidenceDictionary.jsx
+++ b/src/applications/claims-status/utils/evidenceDictionary.jsx
@@ -425,6 +425,44 @@ export const evidenceDictionary = {
     ),
     isSensitive: true,
   },
+  'ASB-tell us specific disability fm asbestos exposure': {
+    longDescription: (
+      <>
+        <p>
+          To process your disability claim for asbestos exposure, we need
+          information about your asbestos-related disease or disability:
+        </p>
+        <ol>
+          <li>
+            The specific disease or disability caused by asbestos exposure
+          </li>
+          <li>Why you believe asbestos caused your disease or disability</li>
+          <li>
+            Evidence of this connection, like a medical opinion from your doctor
+          </li>
+        </ol>
+      </>
+    ),
+    nextSteps: (
+      <>
+        <p>
+          Use Statement in Support of Claim (VA Form 21-4138) to answer the
+          questions listed under "what we need from you."
+        </p>
+        <p>
+          After completing and signing the form, you can upload or mail it.
+          <br />
+          <va-link
+            active
+            data-testid="VA Form 21-4138"
+            text="VA Form 21-4138"
+            href="/find-forms/about-form-21-4138/"
+          />
+        </p>
+      </>
+    ),
+    isSensitive: true,
+  },
   'HAIMS STR Request': {
     longDescription: (
       <p>


### PR DESCRIPTION
## Summary

This PR adds a plain language content override for the ASB (Asbestos) evidence request type: **"ASB - tell us specific disability fm asbestos exposure"**
### Changes

- **New evidenceDictionary entry:** Added plain language `longDescription` with numbered list and `nextSteps` with VA Form 21-4138 link
- **Privacy:** Set `isSensitive: true` to show generic "Request for evidence" header
- **DefaultPage.jsx:** Split claim letter section into two paragraphs for better readability
- **Mock data:** Added tracked item for local testing with `friendlyName`, `shortDescription`, and `supportAliases`
- **Testing:** Added unit test case for the new ASB entry

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#128630

## How to Test Locally

1. **Start the mock API server:**
   `yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js`

2. **Start the development server:**
   `yarn watch --env entry=claims-status`

3. **Test Status Tab Alert:**
   - Navigate to: `http://localhost:3001/track-claims/your-claims/3/status`
   - Scroll to "What you need to do" section
   - Find the alert with "Respond by January 23, 2026"
   - Verify title shows "Request for evidence" and description shows asbestos-related text

4. **Test Evidence Request Page:**
   - Click "About this request" OR navigate to: `http://localhost:3001/track-claims/your-claims/3/needed-from-you/15`
   - Verify "What we need from you" shows numbered list with 3 items
   - Verify "Next steps" shows VA Form 21-4138 instructions
   - Verify "Need help?" shows display name alias

## Testing Done

- **Unit Tests:** Added parameterized test case for the new ASB entry
- **Manual Testing:** Verified Status tab alert and Evidence Request page display correctly

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Evidence Request Page |
| ------- | --------------------- |
| Desktop | <img width="490" height="920" alt="Screenshot 2026-01-12 at 6 01 42 PM" src="https://github.com/user-attachments/assets/1006877d-2632-4d10-baa5-bd1046d413db" />|

## What areas of the site does it impact?

- Claims Status application - Evidence Request pages
- Status tab alerts for claims with this evidence request type

## Acceptance Criteria

- [x] New `evidenceDictionary` entry for "ASB - tell us specific disability fm asbestos exposure"
- [x] `longDescription` displays intro paragraph and numbered list with 3 items
- [x] `nextSteps` displays VA Form 21-4138 instructions with link
- [x] `isSensitive: true` shows generic "Request for evidence" header for privacy
- [x] Status tab alert shows appropriate short description
- [x] "Need help?" section shows display name alias
- [x] Claim letter section split into two paragraphs for readability
- [x] Unit test added for new entry

## Quality Assurance & Testing

- [x] I updated unit tests to verify the new dictionary entry
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the changes is added
- [x] Content matches Figma design specifications

### Error Handling

- [x] Browser console contains no warnings or errors
- [x] Existing functionality remains unchanged
- [x] New entry follows existing evidenceDictionary patterns

### Authentication

- [x] Did you log in to a local build and verify all authenticated routes work as expected with a test user?