### PR TITLE
[128649] Validation on condition name not enforced when all rated disabilities have been selected

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/AutocompleteNew.jsx
+++ b/src/applications/disability-benefits/all-claims/components/AutocompleteNew.jsx
@@ -70,16 +70,19 @@ const Autocomplete = ({
 
   const handleInputChange = useCallback(
     inputValue => {
-      setValue(inputValue);
-      onChange(inputValue);
+      const trimmed =
+        typeof inputValue === 'string' ? inputValue.trim() : inputValue;
 
-      if (!inputValue) {
+      setValue(inputValue);
+      onChange(trimmed);
+
+      if (!trimmed) {
         closeList();
         setAriaLiveText('Input is empty. Please enter a condition.');
         return;
       }
 
-      debouncedSearch(inputValue);
+      debouncedSearch(trimmed);
     },
     [onChange, closeList, debouncedSearch],
   );
@@ -112,8 +115,11 @@ const Autocomplete = ({
 
   const selectResult = useCallback(
     result => {
-      const newValue = result === createFreeTextItem(value) ? value : result;
-      setValue(newValue);
+      const initValue = result === createFreeTextItem(value) ? value : result;
+      const newValue =
+        typeof initValue === 'string' ? initValue.trim() : initValue;
+
+      setValue(initValue);
       onChange(newValue);
       setAriaLiveText(`${newValue} is selected`);
       closeList();

--- a/src/applications/disability-benefits/all-claims/pages/disabilityConditions/shared/newCondition.js
+++ b/src/applications/disability-benefits/all-claims/pages/disabilityConditions/shared/newCondition.js
@@ -108,6 +108,7 @@ const newConditionPage = {
       ),
       'ui:errorMessages': {
         required: ERR_MISSING_CONDITION,
+        minLength: ERR_MISSING_CONDITION,
       },
       'ui:validations': [validateCondition],
       'ui:options': {
@@ -122,6 +123,8 @@ const newConditionPage = {
     properties: {
       condition: {
         type: 'string',
+        minLength: 1,
+        maxLength: 255,
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/tests/pages/disabilityConditions/shared/newCondition.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/disabilityConditions/shared/newCondition.unit.spec.jsx
@@ -95,4 +95,32 @@ describe('526 new condition shared page', () => {
     );
     expect(error).to.exist;
   });
+
+  it('shows error when input is only whitespace', async () => {
+    const { getByRole, findByText, getByTestId } = mountPage();
+    const input = getByTestId('autocomplete-input');
+    input.value = '   ';
+
+    fireEvent.input(input);
+    fireEvent.click(getByRole('button', { name: /submit/i }));
+
+    const error = await findByText(
+      /Enter a condition, diagnosis, or short description/i,
+    );
+    expect(error).to.exist;
+  });
+
+  it('shows error when input exceeds 255 characters', async () => {
+    const { getByRole, findByText, getByTestId } = mountPage();
+    const input = getByTestId('autocomplete-input');
+    input.value = 'a'.repeat(256);
+
+    fireEvent.input(input);
+    fireEvent.click(getByRole('button', { name: /submit/i }));
+
+    const error = await findByText(
+      /This field should be less than 255 characters/i,
+    );
+    expect(error).to.exist;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When a veteran attempts to add a new condition after all rated disabilities have been exhausted, the required autocomplete input field allows navigation to the “Add a date” screen even though no condition has been entered (i.e., the input value is an empty string). In this scenario, the requirement to enter text in the autocomplete field effectively bypasses validation.

When rated disabilities have not been exhausted, validation behaves as expected and prevents progression without a condition name.

Additionally, on the Summary page where veterans review their conditions, any condition missing a name (i.e., an empty string) is marked as INCOMPLETE, and the veteran must correct the issue before continuing with the application.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/128649.

## Steps to Reproduce

### Pre-requisite

- Seed the application with the following set of rated disabilities from this [gist](https://gist.github.com/sdbars/baf1da55b2ba5c2ed837510c01a733b8)
- Ensure the disability_compensation_new_conditions_workflow feature flag is enabled
- Run vets-api 

1. Run the application
2. Run application
3. Navigate to Conditions section
4. Add a rated disability and proceed to Summary page
5. Select ‘Yes’ to continue adding conditions rated or new
6.  Repeat steps 4 and 5 until all rated disabilities have been added
7.  On the Summary page when all rated disabilities have been added, Select ‘Yes’
8.  On the Add new condition page, click continue without adding anything in the autocomplete input field

## Expected Behavior

The veteran should not be able to advance to the next page of the application without entering a condition. A validation error should be displayed, and progression should be blocked until a condition is provided.

## Actual Behavior

The veteran is able to advance to the next page of the application without entering a condition. No validation error is displayed, allowing progression even though the required condition field is empty.

## Issue

When you exhaust the rated disabilities list, the UI usually changes state and often auto-selects a “new condition” option / mode.

In many implementations, that transition also initializes the current array item with something like: { ratedDisability: NEW_CONDITION_OPTION, condition: '' }. The current schema required check isn’t enough on its own because it does not reject an empty string and if the form state contains { condition: ‘’ }, it will pass the schema requirement.

## Proposed Fix

File: `src/applications/disability-benefits/all-claims/pages/disabilityConditions/shared/newCondition.js`

The most robust fix is apply Add minLength: 1 and  maxLength: 255 to the schema. This guarantees empty string is invalid even if custom validation doesn’t fire. This constraint acts as the last line of defense.

File: `src/applications/disability-benefits/all-claims/components/AutocompleteNew.jsx`

The next thing is to add guards in the Autocomplete implementation to trim whitespace. There are two functions in this component where these guards could apply.

## Videos

### Before

https://github.com/user-attachments/assets/d6c97825-25a7-40a5-9864-f057ad7e932d

### After

https://github.com/user-attachments/assets/72a33cad-44f7-4017-9834-21a4c2ad9700

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Video of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

These changes only impact the new conditions workflow.
