### PR TITLE
129176 bug form 21p 530a name length

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-personal-information.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-personal-information.js
@@ -36,9 +36,17 @@ export const veteranPersonalInformationPage = {
             ...fullNameNoSuffixSchema,
             properties: {
               ...fullNameNoSuffixSchema.properties,
+              first: {
+                ...fullNameNoSuffixSchema.properties.first,
+                maxLength: 12,
+              },
               middle: {
                 ...fullNameNoSuffixSchema.properties.middle,
                 maxLength: 1,
+              },
+              last: {
+                ...fullNameNoSuffixSchema.properties.last,
+                maxLength: 18,
               },
             },
           },

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/pages/veteran-personal-information.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/pages/veteran-personal-information.unit.spec.jsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.veteranInformationChapter.pages.veteranPersonalInformation;
+
+describe('21p-530a veteran personal information', () => {
+  const getData = () => ({
+    veteranInformation: {
+      fullName: {
+        first: 'John',
+        middle: 'A',
+        last: 'Doe',
+      },
+    },
+  });
+
+  const mockStore = {
+    getState: () => ({
+      form: {
+        data: getData(),
+      },
+      formContext: {
+        onReviewPage: false,
+        reviewMode: false,
+        touched: {},
+        submitted: false,
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  };
+
+  it('should render veteran name fields', () => {
+    const { container } = render(
+      <Provider store={mockStore}>
+        <DefinitionTester
+          definitions={{}}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={{}}
+          formData={{}}
+        />
+      </Provider>,
+    );
+
+    expect(container.querySelector('button[type="submit"]')).to.exist;
+  });
+
+  it('should have proper max lengths for name fields', () => {
+    const nameProps =
+      schema.properties.veteranInformation.properties.fullName.properties;
+
+    expect(nameProps.first.maxLength).to.equal(12);
+    expect(nameProps.middle.maxLength).to.equal(1);
+    expect(nameProps.last.maxLength).to.equal(18);
+  });
+
+  it('should validate first name does not exceed max length', async () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteranInformation: {
+        fullName: {
+          first: 'VeryLongFirstName', // 17 characters, exceeds limit of 12
+          middle: 'A',
+          last: 'Doe',
+        },
+      },
+    };
+
+    const { container } = render(
+      <Provider store={mockStore}>
+        <DefinitionTester
+          definitions={{}}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={formData}
+          formData={formData}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+
+    const form = container.querySelector('form');
+    form.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await waitFor(() => {
+      expect(onSubmit.called).to.be.false;
+    });
+  });
+
+  it('should validate middle name does not exceed max length', async () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteranInformation: {
+        fullName: {
+          first: 'John',
+          middle: 'AB', // 2 characters, exceeds limit of 1
+          last: 'Doe',
+        },
+      },
+    };
+
+    const { container } = render(
+      <Provider store={mockStore}>
+        <DefinitionTester
+          definitions={{}}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={formData}
+          formData={formData}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+
+    const form = container.querySelector('form');
+    form.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await waitFor(() => {
+      expect(onSubmit.called).to.be.false;
+    });
+  });
+
+  it('should validate last name does not exceed max length', async () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteranInformation: {
+        fullName: {
+          first: 'John',
+          middle: 'A',
+          last: 'VeryLongLastNameThatExceedsLimit', // 33 characters, exceeds limit of 18
+        },
+      },
+    };
+
+    const { container } = render(
+      <Provider store={mockStore}>
+        <DefinitionTester
+          definitions={{}}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={formData}
+          formData={formData}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+
+    const form = container.querySelector('form');
+    form.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await waitFor(() => {
+      expect(onSubmit.called).to.be.false;
+    });
+  });
+
+  it('should accept valid names within max length limits', () => {
+    const nameProps =
+      schema.properties.veteranInformation.properties.fullName.properties;
+
+    // Test that names at the limit are acceptable
+    const validFirst = 'a'.repeat(12);
+    const validMiddle = 'a'.repeat(1);
+    const validLast = 'a'.repeat(18);
+
+    expect(validFirst.length).to.equal(nameProps.first.maxLength);
+    expect(validMiddle.length).to.equal(nameProps.middle.maxLength);
+    expect(validLast.length).to.equal(nameProps.last.maxLength);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
First name should have a maximum length of 12 and last name should have a maximum length of 18 to conform to vets-api validation.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/129176

## Testing done

added tests
tested max allowable length manually (see screenshot)

## Screenshots
Maximum number of characters I'm allowed to type:
<img width="799" height="637" alt="image" src="https://github.com/user-attachments/assets/624c7ea1-4b03-4fbe-87dd-374aa590baca" />
## What areas of the site does it impact?

form 21p-530a veteran's name
## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- n/a [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- n/a Did you login to a local build and verify all authenticated routes work as expected with a test user
