### PR TITLE
Changed the stop recieving date to use MemorableDateUI field to accept past, present, future dates.

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js
@@ -11,7 +11,9 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import { getVeteranName } from './helpers';
+import { MemorableDateUI } from '../components/memorable-date-ui';
 
 /**
  * Generate title for start receiving date field
@@ -75,7 +77,7 @@ export const benefitsDetailsUiSchema = {
         required: 'First payment date is required',
       },
     }),
-    stopReceivingDate: currentOrPastDateUI({
+    stopReceivingDate: MemorableDateUI({
       title: 'Stop receiving date', // Default title, will be updated by updateUiSchema
       hint: 'Enter an approximate date if the exact date is unknown',
       required: false,
@@ -135,7 +137,7 @@ export const benefitsDetailsSchema = {
         grossMonthlyAmount: currencySchema,
         startReceivingDate: currentOrPastDateSchema,
         firstPaymentDate: currentOrPastDateSchema,
-        stopReceivingDate: currentOrPastDateSchema,
+        stopReceivingDate: commonDefinitions.date,
       },
     },
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


## Summary

- Updated the "Stop receiving date" field in Form 21-4192 Benefits Details page to use MemorableDateUI instead of currentOrPastDateUI
- This change allows users to enter past, present, or future dates for the stop receiving date field, removing the previous restriction that limited entries to current or past dates only
- The stopReceivingDate field was changed from currentOrPastDateUI to the new MemorableDateUI component, which uses VaMemorableDateField and validates date format only without temporal restrictions
- The JSON schema for stopReceivingDate was updated to use commonDefinitions.date instead of currentOrPastDateSchema
- Benefits Optimization (Aquia) team maintains this form
- This change improves user flexibility when indicating when a veteran will stop receiving benefits, accommodating cases where the exact future stop date is known

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#129469

## Testing done

- Old behavior: The "Stop receiving date" field used currentOrPastDateUI which enforced validation that only allowed current or past dates to be entered
- New behavior: The "Stop receiving date" field now uses MemorableDateUI which accepts any valid date (past, present, or future) with only format validation applied
- Steps to verify:
  1. Navigate to Form 21-4192 (Employment Information for Veterans' Entitlement to Non-Service-Connected Disability Pension)
  2. Complete the form and reach the Benefits Details page
  3. Enter a benefit type and payment details
  4. Attempt to enter a future date in the "Stop receiving date" field (e.g., a date 6 months from today)
  5. Verify the form accepts the future date without validation errors
  6. Submit the form and verify the date is properly saved and displayed in the confirmation and PDF output
- Manual testing confirms no console errors or validation warnings appear when using future dates in the stop receiving date field
- All existing unit tests continue to pass, confirming no regression in other form functionality

## Screenshots
Field now accept past, present, and future dates

<img width="447" height="220" alt="image" src="https://github.com/user-attachments/assets/dc9f9e37-f149-4ae5-9724-3b9696319114" />

<img width="453" height="213" alt="image" src="https://github.com/user-attachments/assets/6fa74b08-b842-4705-8b25-896d5a34eeda" />

<img width="471" height="206" alt="image" src="https://github.com/user-attachments/assets/9e1b82bf-30cd-45e6-8a49-4bc0cd0f6335" />

## What areas of the site does it impact?

This change impacts Form 21-4192 (Employment Information for Veterans' Entitlement to Non-Service-Connected Disability Pension) specifically:
- Benefits Details page: The "Stop receiving date" field in the Benefit entitlement and/or payments section
- The form validation behavior for the stop receiving date input
- The generated PDF form output which now properly handles future dates for the stop receiving date field

No other forms or applications are affected by this change.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a focused change to the date field validation logic. Reviewer attention should be directed to: (1) confirming the MemorableDateUI component properly handles the date formatting and validation as intended, (2) verifying that removing the temporal restriction on the stop receiving date does not conflict with downstream PDF generation or VA backend processing, and (3) ensuring the change aligns with the business requirements for Form 21-4192 benefits information collection.
