### PR TITLE
Burial | PDF form alignment - Update getItemName function 

### DIFF
--- a/src/applications/burials-ez/config/chapters/03-military-history/powPages.js
+++ b/src/applications/burials-ez/config/chapters/03-military-history/powPages.js
@@ -18,9 +18,9 @@ export const options = {
   isItemIncomplete: item => !item?.powDateRange?.from || !item.powDateRange?.to, // include all required fields here
   text: {
     getItemName: item =>
-      item?.powDateRange
-        ? `${formatDateLong(item.powDateRange?.from)} - ${formatDateLong(
-            item.powDateRange?.to,
+      item?.powDateRange?.from && item?.powDateRange?.to
+        ? `${formatDateLong(item.powDateRange.from)} - ${formatDateLong(
+            item.powDateRange.to,
           )}`
         : undefined,
     summaryTitleWithoutItems: 'Prisoner of war status',

--- a/src/applications/burials-ez/tests/config/chapters/03-military-history/powPages.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/config/chapters/03-military-history/powPages.unit.spec.jsx
@@ -46,9 +46,19 @@ describe('prisoner of war confinement period list and loop pages', () => {
   });
 
   describe('text getItemName function', () => {
-    expect(options.text.getItemName(testData.powPeriods[0])).to.equal(
-      'February 26, 1971 - March 2, 1973',
-    );
+    it('returns undefined when dates are missing', () => {
+      expect(options.text.getItemName({ powDateRange: {} })).to.be.undefined;
+      expect(options.text.getItemName({ powDateRange: { from: '1971-02-26' } }))
+        .to.be.undefined;
+      expect(options.text.getItemName({ powDateRange: { to: '1973-03-02' } }))
+        .to.be.undefined;
+    });
+
+    it('returns formatted range when dates are present', () => {
+      expect(options.text.getItemName(testData.powPeriods[0])).to.equal(
+        'February 26, 1971 - March 2, 1973',
+      );
+    });
   });
 
   describe('summaryTitle function', () => {


### PR DESCRIPTION
### Summary of Changes
This PR fixes an error on the **Prisoner of war confinement periods** pages in the **Burial Benefits form (VA Form 21P-530EZ)** related to the `getItemName` function used in the array builder options.  

The update makes `getItemName` more resilient by safely handling cases where a confinement period date range is incomplete or undefined, preventing attempts to format dates that do not exist and avoiding runtime errors.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122793

### How to Set Up in Local Environment
1. Run the local environment
2. Enable the required feature toggles:
   - `burial_form_enabled`  
     http://localhost:3000/flipper/features/burial_form_enabled
   - `burial_pdf_form_alignment`  
     http://localhost:3000/flipper/features/burial_pdf_form_alignment
3. Navigate to the Burial Benefits form:  
  http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/

### How to Test
1. Start a new **21P-530EZ** application and navigate to the **Military history** chapter.
2. With `burial_pdf_form_alignment` enabled, add a **Prisoner of war confinement period**.
3. Verify:
   - The summary card renders without errors when dates are present.
   - No errors occur if a confinement period is partially completed or missing dates.
4. Edit and remove confinement period entries to confirm stable behavior.
5. Confirm there are no console errors.

### Feature Flag Note
- The POW confinement periods pages are available only when `burial_pdf_form_alignment` is enabled.

### Acceptance Criteria
- [x] `getItemName` no longer attempts to format undefined or missing dates.
- [x] No runtime errors occur on POW confinement period pages.
- [x] Summary cards render safely for incomplete data.
- [x] No regressions in list-and-loop behavior.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggles enabled.
- [ ] No console errors.
- [ ] Tests passing.