### PR TITLE
[ARC/127812] - clean up spacing across forms

### DIFF
--- a/src/applications/representative-form-upload/containers/App.jsx
+++ b/src/applications/representative-form-upload/containers/App.jsx
@@ -45,8 +45,10 @@ const App = ({ children }) => {
         'va-file-input-multiple',
         'va-checkbox-group',
         'va-radio',
+        'va-text-input[name="root_veteranFullName_first"]',
+        'va-text-input[name="root_claimantFullName_first"]',
       ],
-      '#dateHint {display: none} .usa-form-group--month-select {width: 159px} .usa-accordion, .usa-accordion-bordered, .usa-accordion--bordered {margin: 24px 0 !important;} .usa-accordion__content.usa-prose {border:1px solid #f0f0f0;} .usa-hint {white-space: pre-line; margin-bottom: 16px} .usa-label {margin: 8px 0} .label-header {display:none} .input-wrap .usa-fieldset .usa-legend h3 {display:block}',
+      '.usa-label{margin-top: 16px} #dateHint {display: none} .usa-form-group--month-select {width: 159px} .usa-accordion, .usa-accordion-bordered, .usa-accordion--bordered {margin: 24px 0 !important;} .usa-accordion__content.usa-prose {border:1px solid #f0f0f0;} .usa-hint {white-space: pre-line; margin-bottom: 16px} .label-header {display:none} .input-wrap .usa-fieldset .usa-legend h3 {display:block}',
     );
   });
 

--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -39,8 +39,7 @@
 //overriding default classes set at the forms level to match figma
 .form-21-0966,
 .form-21-686c,
-.form-21-526EZ,
-.form-21-0966 {
+.form-21-526EZ {
   -webkit-font-smoothing: antialiased;
   [for="root_vaFileNumber"] {
     margin-top: 1.5rem;


### PR DESCRIPTION
Updating spacing to 16px under the veteran/claimant headers in forms, see ticket:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/127812

<img width="400" height="300" alt="Screenshot 2026-01-09 at 2 00 03 PM" src="https://github.com/user-attachments/assets/e8458ec9-a5b7-4367-b0f8-ff66ee0e0868" />
<img width="522" height="325" alt="Screenshot 2026-01-09 at 1 59 20 PM" src="https://github.com/user-attachments/assets/df8255b8-a301-4b94-8a10-e0a113e4d1d1" />
<img width="944" height="832" alt="image" src="https://github.com/user-attachments/assets/d16735c8-b49d-48e9-89f0-85f149321ff7" />
