### PR TITLE
21P-534ez truncate middle initials for veteran and claimant

### DIFF
--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -8,6 +8,7 @@ import {
   transformCareExpenses,
   combineTreatmentFacility,
   updateChildOfVeteran,
+  truncateMiddleInitials,
 } from '../utils/transformers';
 
 export const transform = (formConfig, form) => {
@@ -19,6 +20,7 @@ export const transform = (formConfig, form) => {
   transformedData = transformCareExpenses(transformedData);
   transformedData = combineTreatmentFacility(transformedData);
   transformedData = updateChildOfVeteran(transformedData);
+  transformedData = truncateMiddleInitials(transformedData);
   return JSON.stringify({
     survivorsBenefitsClaim: {
       form: transformedData,

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -60,6 +60,7 @@
   "claimantSocialSecurityNumber": "332213313",
   "claimantFullName": {
     "first": "Jane",
+    "middle": "Middle",
     "last": "Doe"
   },
   "claimantDateOfBirth": "1955-05-05",
@@ -75,6 +76,7 @@
   "view:warningAlert": {},
   "veteranFullName": {
     "first": "Jonathan",
+    "middle": "Kevin",
     "last": "Testerson"
   },
   "veteranDateOfBirth": "1954-01-11",
@@ -83,7 +85,7 @@
   "view:medicalExpensesList": false,
   "files": [],
   "view:uploadMessage": {},
-  "statementOfTruthSignature": "Jane Doe",
+  "statementOfTruthSignature": "Jane Middle Doe",
   "statementOfTruthCertified": true,
   "expectingChild": false,
   "hadChildWithVeteran": false,

--- a/src/applications/survivors-benefits/tests/unit/submit-transformer.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/submit-transformer.unit.spec.jsx
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as transformHelpers from 'platform/forms-system/src/js/helpers';
+import { transform } from '../../config/submit-transformer';
+import completedForm from '../fixtures/mocks/completed-form.json';
+
+describe('Survivors Benefits submit transformer', () => {
+  let transformForSubmitStub;
+  beforeEach(() => {
+    transformForSubmitStub = sinon
+      .stub(transformHelpers, 'transformForSubmit')
+      .callsFake((formConfig, form) => {
+        return JSON.stringify({
+          ...form,
+        });
+      });
+  });
+
+  afterEach(() => {
+    transformForSubmitStub.restore();
+  });
+  it('should truncate middle names to initials in veteran and claimant full names', () => {
+    const formConfig = {}; // Mock or import your formConfig as needed
+    const transformed = JSON.parse(transform(formConfig, completedForm));
+    const form = JSON.parse(transformed.survivorsBenefitsClaim.form);
+
+    expect(form.veteranFullName.middle).to.equal('K');
+    expect(form.claimantFullName.middle).to.equal('M');
+  });
+  it('should split SSN field correctly', () => {
+    const formConfig = {}; // Mock or import your formConfig as needed
+    const transformed = JSON.parse(transform(formConfig, completedForm));
+    const form = JSON.parse(transformed.survivorsBenefitsClaim.form);
+
+    expect(form.veteranSocialSecurityNumber).to.equal('321313311');
+  });
+});

--- a/src/applications/survivors-benefits/utils/transformers/index.js
+++ b/src/applications/survivors-benefits/utils/transformers/index.js
@@ -3,5 +3,6 @@ export * from './combineTreatmentFacility';
 export * from './splitSsn';
 export * from './switchToInternationalPhone';
 export * from './transformCareExpenses';
+export * from './truncateMiddleInitials';
 export * from './updateBankValues';
 export * from './updateChildOfVeteran';

--- a/src/applications/survivors-benefits/utils/transformers/truncateMiddleInitials.js
+++ b/src/applications/survivors-benefits/utils/transformers/truncateMiddleInitials.js
@@ -1,5 +1,15 @@
-export function splitVaSsnField(formData) {
+export function truncateMiddleInitials(formData) {
   const parsedFormData = JSON.parse(formData);
   const transformedValue = parsedFormData;
+  if (parsedFormData?.veteranFullName?.middle) {
+    transformedValue.veteranFullName.middle = parsedFormData?.veteranFullName?.middle.charAt(
+      0,
+    );
+  }
+  if (parsedFormData?.claimantFullName?.middle) {
+    transformedValue.claimantFullName.middle = parsedFormData?.claimantFullName?.middle.charAt(
+      0,
+    );
+  }
   return JSON.stringify(transformedValue);
 }

--- a/src/applications/survivors-benefits/utils/transformers/truncateMiddleInitials.js
+++ b/src/applications/survivors-benefits/utils/transformers/truncateMiddleInitials.js
@@ -1,0 +1,5 @@
+export function splitVaSsnField(formData) {
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = parsedFormData;
+  return JSON.stringify(transformedValue);
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Truncate the middle name of veteran and claimant on submit to one character to fill in pdf correctly.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128497

## Testing done

- Before this update, the whole middle name was sent to the pdf_filler in vets-api
- Manual testing could be submitting and checking the pdf for just one character in the box or inspecting payload sent to vets-api endpoint at submission and making sure the json looks correct for the two fullname fields. 

## Screenshots

N/A

## What areas of the site does it impact?

Just the submit transform for the 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A
