### PR TITLE
10-7959c | Migrate additional props to view: fields

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/signerInformation/benefitStatus.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/signerInformation/benefitStatus.js
@@ -11,13 +11,13 @@ const INPUT_LABEL = content['signer--benefit-status-label'];
 export default {
   uiSchema: {
     ...titleWithRoleUI(TITLE_TEXT),
-    champvaBenefitStatus: yesNoUI(INPUT_LABEL),
+    'view:champvaBenefitStatus': yesNoUI(INPUT_LABEL),
   },
   schema: {
     type: 'object',
-    required: ['champvaBenefitStatus'],
+    required: ['view:champvaBenefitStatus'],
     properties: {
-      champvaBenefitStatus: yesNoSchema,
+      'view:champvaBenefitStatus': yesNoSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -11,7 +11,7 @@ import { nameWording, privWrapper } from '../../shared/utilities';
 import FileFieldWrapped from '../components/FileUploadWrapper';
 import { prefillTransformer } from './prefillTransformer';
 import SubmissionError from '../../shared/components/SubmissionError';
-import { migrateCardUploadKeys } from './migrations';
+import migrations from './migrations';
 import { blankSchema } from '../definitions';
 
 import { beneficiaryPages } from '../chapters/applicantInformation';
@@ -115,8 +115,8 @@ const formConfig = {
         'Your CHAMPVA other health insurance certification application has been saved.',
     },
   },
-  version: 1,
-  migrations: [migrateCardUploadKeys],
+  version: migrations.length,
+  migrations,
   prefillEnabled: true,
   prefillTransformer,
   transformForSubmit,
@@ -169,14 +169,10 @@ const formConfig = {
         benefitApp: {
           path: 'benefit-application',
           title: 'Apply for Benefits',
-          depends: formData => !get('champvaBenefitStatus', formData),
+          depends: formData => !get('view:champvaBenefitStatus', formData),
           CustomPage: NotEnrolledPage,
           CustomPageReview: null,
-          uiSchema: {
-            'ui:options': {
-              keepInPageOnReview: false,
-            },
-          },
+          uiSchema: {},
           schema: blankSchema,
         },
         signerEmail: {

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/10-7959C.cypress.spec.js
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { filterViewFields } from 'platform/forms-system/src/js/helpers';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import formConfig from '../../config/form';
@@ -140,7 +141,8 @@ const testConfig = createTestConfig(
 
       cy.intercept('POST', formConfig.submitUrl, req => {
         cy.get('@testData').then(data => {
-          verifyAllDataWasSubmitted(data, req.body);
+          const withoutViewFields = filterViewFields(data);
+          verifyAllDataWasSubmitted(withoutViewFields, req.body);
         });
         // Mock response
         req.reply({ status: 200 });

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/10-7959C.cypress.spec.js
@@ -50,15 +50,15 @@ const testConfig = createTestConfig(
       },
       // When we land on this screener page, progressing through the form is
       // blocked (by design). To successfully complete the test,
-      // once we land here, change `champvaBenefitStatus` to `true`
+      // once we land here, change `view:champvaBenefitStatus` to `true`
       // and click '<< Back' so that we can proceed past the screener
       [ALL_PAGES.benefitApp.path]: ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
             cy.injectAxeThenAxeCheck();
-            if (data.champvaBenefitStatus === false) {
+            if (data['view:champvaBenefitStatus'] === false) {
               // eslint-disable-next-line no-param-reassign
-              data.champvaBenefitStatus = true;
+              data['view:champvaBenefitStatus'] = true;
               // This targets the 'Back to previous page' button
               cy.get('va-link[back="true"]').click({ force: true });
             }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/10-7959C_uploads.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/10-7959C_uploads.cypress.spec.js
@@ -16,6 +16,7 @@ import path from 'path';
 import environment from 'platform/utilities/environment';
 
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { filterViewFields } from 'platform/forms-system/src/js/helpers';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import formConfig from '../../config/form';
@@ -147,7 +148,8 @@ const testConfig = createTestConfig(
       });
       cy.intercept('POST', formConfig.submitUrl, req => {
         cy.get('@testData').then(data => {
-          verifyAllDataWasSubmitted(data, req.body);
+          const withoutViewFields = filterViewFields(data);
+          verifyAllDataWasSubmitted(withoutViewFields, req.body);
         });
         // Mock response
         req.reply({ status: 200 });

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/maximal-test.json
@@ -1,7 +1,7 @@
 {
   "description": "Has Medicare (ABD), both OHIs (Medigap), US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "secondaryAdditionalComments": "Secondary comments",
     "secondaryMedigapPlan": "C",
     "applicantSecondaryInsuranceType": "medigap",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
@@ -1,7 +1,7 @@
 {
   "description": "No Medicare, no OHIs, US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "applicantHasPrimary": false,
     "applicantMedicareStatus": false,
     "applicantPhone": "1231231234",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-ohi.json
@@ -1,7 +1,7 @@
 {
   "description": "No Medicare, both OHIs (Medigap), US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "secondaryAdditionalComments": "Secondary comment",
     "secondaryMedigapPlan": "D",
     "applicantSecondaryInsuranceType": "medigap",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-primary.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-primary.json
@@ -1,7 +1,7 @@
 {
   "description": "No Medicare, one OHI (Medigap), US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "primaryAdditionalComments": "Primary comments",
     "primaryMedigapPlan": "D",
     "applicantPrimaryInsuranceType": "medigap",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/not-enrolled-champva.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/not-enrolled-champva.json
@@ -1,7 +1,7 @@
 {
     "description": "Not enrolled in CHAMPVA, No Medicare, no OHIs, US address (new), third party signer",
     "data": {
-      "champvaBenefitStatus": false,
+      "view:champvaBenefitStatus": false,
       "applicantHasPrimary": false,
       "applicantMedicareStatus": false,
       "applicantPhone": "1231231234",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/single-upload.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/single-upload.json
@@ -1,5 +1,5 @@
 {
-  "champvaBenefitStatus": true,
+  "view:champvaBenefitStatus": true,
   "certifierRole": "applicant",
   "certifierEmail": "certifier@email.gov",
   "primaryInsuranceCardFront": [

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/test-data.json
@@ -1,7 +1,7 @@
 {
   "description": "Medicare (ABD), has both OHIs (Medigap), US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "applicantSsn": "234234234",
     "applicantName": {
       "first": "Jimmy",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-no-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-no-ohi.json
@@ -1,7 +1,7 @@
 {
   "description": "Has Medicare (ABD), no OHI, US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "applicantHasPrimary": false,
     "applicantMedicareStatus": true,
     "applicantMedicarePartACarrier": "Test A Carrier",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-yes-primary.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-yes-primary.json
@@ -1,7 +1,7 @@
 {
   "description": "Has Medicare (ABD), one OHI (Medigap), US address (new), third party signer",
   "data": {
-    "champvaBenefitStatus": true,
+    "view:champvaBenefitStatus": true,
     "applicantSsn": "234234234",
     "applicantName": {
       "first": "Jimmy",

--- a/src/applications/ivc-champva/10-7959C/tests/unit/config/migrations.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/unit/config/migrations.unit.spec.jsx
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { migrateCardUploadKeys } from '../../../config/migrations';
+import migrations from '../../../config/migrations';
 
 const EXAMPLE_SIP_METADATA = {
   version: 0,
@@ -7,86 +7,64 @@ const EXAMPLE_SIP_METADATA = {
   returnUrl: '/form-signature',
 };
 
-describe('migrateCardUploadKeys ', () => {
-  it('should create a front and back property when `applicantMedicarePartAPartBCard` is present', () => {
-    const props = {
-      formData: {
-        applicantMedicarePartAPartBCard: [
-          {
-            name: 'front.png',
-            confirmationCode: 'a49136ca-377c-4b7e-b7ee-e7320ed2ca0b',
-            attachmentId: 'Front of insurance card',
-            isEncrypted: false,
-          },
-          {
-            name: 'back.png',
-            confirmationCode: 'b49136ca-377c-4b7e-b7ee-e7320ed2ca0b',
-            attachmentId: 'Back of insurance card',
-            isEncrypted: false,
-          },
-        ],
-      },
-      metadata: EXAMPLE_SIP_METADATA,
-      formId: '10-7959c',
-    };
-    // Deep copying since migration operates on input data
-    const propsDeepCopy = JSON.parse(JSON.stringify(props));
-    const migrated = migrateCardUploadKeys(propsDeepCopy);
-    expect(
-      migrated.formData.applicantMedicarePartAPartBCardFront,
-    ).to.exist.and.to.have.lengthOf(1);
-    expect(
-      migrated.formData.applicantMedicarePartAPartBCardBack,
-    ).to.exist.and.to.have.lengthOf(1);
-  });
-  it('should not modify form data when card uploads are not present', () => {
-    const props = {
-      formData: {
+const deepCopy = obj => JSON.parse(JSON.stringify(obj));
+
+const runMigration = (
+  migrationIndex,
+  formData,
+  metadata = EXAMPLE_SIP_METADATA,
+) => migrations[migrationIndex](deepCopy({ formData, metadata }));
+
+const upload = (side, overrides = {}) => ({
+  name: `${side}.png`,
+  confirmationCode: `${side}-confirmation-code`,
+  attachmentId: `${side.charAt(0).toUpperCase() +
+    side.slice(1)} of insurance card`,
+  isEncrypted: false,
+  ...overrides,
+});
+
+describe('10-7959c migrations', () => {
+  context('migration 0 -> 1: migrateCardUploadKeys', () => {
+    const oldKeys = [
+      'applicantMedicarePartAPartBCard',
+      'applicantMedicarePartDCard',
+      'primaryInsuranceCard',
+      'secondaryInsuranceCard',
+    ];
+
+    it('should split a card upload into front/back arrays', () => {
+      const formData = {
+        applicantMedicarePartAPartBCard: [upload('front'), upload('back')],
+      };
+      const { formData: migrated } = runMigration(0, formData);
+      expect(
+        migrated.applicantMedicarePartAPartBCardFront,
+      ).to.exist.and.to.have.lengthOf(1);
+      expect(
+        migrated.applicantMedicarePartAPartBCardBack,
+      ).to.exist.and.to.have.lengthOf(1);
+      expect(migrated.applicantMedicarePartAPartBCard).to.be.undefined;
+    });
+
+    it('should not modify form data when no legacy card upload keys exist', () => {
+      const formData = { applicantName: { first: 'John', last: 'Lastname' } };
+      const { formData: migrated } = runMigration(0, formData);
+      expect(migrated).to.deep.equal(formData);
+    });
+
+    it('should remove all legacy card upload keys when present', () => {
+      const formData = {
         applicantName: { first: 'John', last: 'Lastname' },
-      },
-      metadata: EXAMPLE_SIP_METADATA,
-      formId: '10-7959c',
-    };
-    // Deep copying since migration operates on input data
-    const propsDeepCopy = JSON.parse(JSON.stringify(props));
-    const migrated = migrateCardUploadKeys(propsDeepCopy);
-    expect(JSON.stringify(migrated.formData)).to.eq(
-      JSON.stringify(props.formData),
-    );
-  });
-  it('should remove all old keynames', () => {
-    const props = {
-      formData: {
-        applicantName: { first: 'John', last: 'Lastname' },
-        applicantMedicarePartAPartBCard: [
-          {
-            name: 'front.png',
-            confirmationCode: 'a49136ca-377c-4b7e-b7ee-e7320ed2ca0b',
-            attachmentId: 'Front of insurance card',
-            isEncrypted: false,
-          },
-        ],
-        primaryInsuranceCard: [
-          {
-            name: 'back.png',
-            confirmationCode: 'b49136ca-377c-4b7e-b7ee-e7320ed2ca0b',
-            attachmentId: 'Back of insurance card',
-            isEncrypted: false,
-          },
-        ],
-      },
-      metadata: EXAMPLE_SIP_METADATA,
-      formId: '10-7959c',
-    };
-    // Deep copying since migration operates on input data
-    const propsDeepCopy = JSON.parse(JSON.stringify(props));
-    const migrated = migrateCardUploadKeys(propsDeepCopy);
-    expect(migrated.formData.applicantMedicarePartAPartBCard).to.be.undefined;
-    expect(migrated.formData.primaryInsuranceCard).to.be.undefined;
-  });
-  it('should remove old keys from `missingUploads` array if present', () => {
-    const props = {
-      formData: {
+        applicantMedicarePartAPartBCard: [upload('front')],
+        primaryInsuranceCard: [upload('back')],
+      };
+      const { formData: migrated } = runMigration(0, formData);
+      oldKeys.forEach(k => expect(migrated[k]).to.be.undefined);
+    });
+
+    it('should remove legacy keys from `missingUploads` if present', () => {
+      const formData = {
         missingUploads: [
           {
             name: 'applicantMedicarePartAPartBCard',
@@ -94,14 +72,56 @@ describe('migrateCardUploadKeys ', () => {
             required: true,
             uploaded: false,
           },
+          {
+            name: 'someOtherField',
+            path: 'other-upload',
+            required: true,
+            uploaded: false,
+          },
         ],
-      },
-      metadata: EXAMPLE_SIP_METADATA,
-      formId: '10-7959c',
-    };
-    // Deep copying since migration operates on input data
-    const propsDeepCopy = JSON.parse(JSON.stringify(props));
-    const migrated = migrateCardUploadKeys(propsDeepCopy);
-    expect(migrated.formData.missingUploads.length).to.eq(0);
+      };
+      const { formData: migrated } = runMigration(0, formData);
+      expect(migrated.missingUploads).to.have.lengthOf(1);
+      expect(migrated.missingUploads[0].name).to.eq('someOtherField');
+    });
+  });
+
+  context('migration 1 -> 2: migrateBenefitStatusToViewField', () => {
+    it('should rename `champvaBenefitStatus` to `view:champvaBenefitStatus`', () => {
+      const formData = {
+        champvaBenefitStatus: 'enrolled',
+        applicantName: { first: 'John', last: 'Lastname' },
+      };
+      const { formData: migrated } = runMigration(1, formData);
+      expect(migrated['view:champvaBenefitStatus']).to.eq('enrolled');
+      expect(migrated.champvaBenefitStatus).to.be.undefined;
+    });
+
+    it('should not modify form data when `champvaBenefitStatus` is not present', () => {
+      const formData = { applicantName: { first: 'John', last: 'Lastname' } };
+      const { formData: migrated } = runMigration(1, formData);
+      expect(migrated).to.deep.equal(formData);
+      expect(migrated['view:champvaBenefitStatus']).to.be.undefined;
+    });
+
+    it('should preserve other form data fields', () => {
+      const formData = {
+        champvaBenefitStatus: 'enrolled',
+        applicantName: { first: 'John', last: 'Lastname' },
+        otherField: 'some value',
+      };
+      const { formData: migrated } = runMigration(1, formData);
+      expect(migrated.applicantName).to.deep.equal({
+        first: 'John',
+        last: 'Lastname',
+      });
+      expect(migrated.otherField).to.eq('some value');
+    });
+
+    it('should preserve metadata', () => {
+      const formData = { champvaBenefitStatus: 'enrolled' };
+      const { metadata } = runMigration(1, formData);
+      expect(metadata).to.deep.equal(EXAMPLE_SIP_METADATA);
+    });
   });
 });

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/index.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/index.js
@@ -1,2 +1,3 @@
 export * from './formatting';
 export * from './medicare';
+export * from './migrations';

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/migrations.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/migrations.js
@@ -1,0 +1,48 @@
+/**
+ * Returns file upload data for first item with matching attachmentId
+ *
+ * @param {Array} data - Array of file upload objects
+ * @param {string} id - String to match when checking the attachmentId property
+ * (e.g., 'Front of insurance card')
+ * @returns {Array|undefined} Array with first matching file upload object where the
+ * `attachmentId` property includes `id`, or undefined if no match found
+ */
+const getAttachment = (data, id) => {
+  const res = data?.find(a => a.attachmentId?.includes(id));
+  return res ? [res] : undefined;
+};
+
+/**
+ * Gets file upload data for back of document attachment
+ *
+ * @param {Array} data - Array of file upload objects
+ * @returns {Array|undefined} Array with first file upload object where attachmentId includes 'Back of'
+ */
+export const getBack = data => getAttachment(data, 'Back of');
+
+/**
+ * Gets file upload data for front of document attachment
+ *
+ * @param {Array} data - Array of file upload objects
+ * @returns {Array|undefined} Array with first file upload object where attachmentId includes 'Front of'
+ */
+export const getFront = data => getAttachment(data, 'Front of');
+
+/**
+ * Deletes any properties from the passed-in object that have a value of
+ * undefined.
+ *
+ * @param {Object} obj - Object from which to remove undefined properties
+ * @returns {Object} Copy of obj with undefined properties removed
+ */
+export const removeEmptyKeys = obj => {
+  const cleanObject = { ...obj };
+  const keysToRemove = [];
+  Object.keys(cleanObject).forEach(key => {
+    if (cleanObject[key] === undefined) {
+      keysToRemove.push(key);
+    }
+  });
+  keysToRemove.forEach(key => delete cleanObject[key]);
+  return cleanObject;
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the app to use a new key name for the benefit status question, migrating from `champvaBenefitStatus` to `view:champvaBenefitStatus`. It also refactors the migration logic for form data, centralizing helper functions and supporting multiple migration steps. The changes ensure that legacy form data is correctly migrated and all references throughout the codebase, tests, and fixtures are updated accordingly.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#129268

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Submission payload is free from additional properties that are not utilized for submission purposes

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
