### PR TITLE
ci: add Trivy-based library SBOM generation workflow

### DIFF
--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -2,7 +2,9 @@ name: Library SBOM Generation
 
 on:
   push:
-    branches: [main, eb-library-sbom-workflow]
+    branches: [main]
+    paths:
+      - 'yarn.lock'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -1,0 +1,17 @@
+name: Library SBOM Generation
+
+on:
+  push:
+    branches: [main, eb-library-sbom-workflow]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-sbom:
+    uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/library-sbom-generation.yml@main
+    with:
+      artifact_name: sbom
+      output_bucket: s3://vagov-infra-sbom-bucket/library/vets-website

--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -14,4 +14,4 @@ jobs:
     uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/library-sbom-generation.yml@main
     with:
       artifact_name: sbom
-      output_bucket: s3://vagov-infra-sbom-bucket/library/vets-website
+      output_bucket: s3://vagov-infra-sbom-bucket/software/vets-website


### PR DESCRIPTION
## Summary
- Adds Trivy-based SBOM generation workflow for vets-website
- Sister PR to [vets-api#25870](https://github.com/department-of-veterans-affairs/vets-api/pull/25870)
- Uploads CycloneDX JSON and CSV to S3 for PSEC/CSOC security teams

## Test plan
- [x] Workflow syntax validates
- [x] Manual trigger via workflow_dispatch succeeds
- [x] SBOM files uploaded to s3://vagov-infra-sbom-bucket/library/vets-website/

## Related
- vets-api PR: https://github.com/department-of-veterans-affairs/vets-api/pull/25870

---

**Note:** Branch filter temporarily expanded and paths filter removed for testing. Will revert in follow-up commit before merge.