### PR TITLE
fix(cypress): add web-components/react-bindings to esbuild external list

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Select E2E Tests
         run: node script/github-actions/select-e2e-tests.js
         env:
-          RUN_FULL_SUITE: false
+          RUN_FULL_SUITE: true
           CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Select E2E Tests
         run: node script/github-actions/select-e2e-tests.js
         env:
-          RUN_FULL_SUITE: true
+          RUN_FULL_SUITE: false
           CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -79,6 +79,7 @@ module.exports = async (on, config) => {
     loader: { '.js': 'jsx' },
     format: 'cjs',
     external: [
+      '@department-of-veterans-affairs/web-components/react-bindings',
       'web-components/react-bindings',
       'url-search-params',
       '@@vap-svc/*',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes Cypress test compilation failures for tests that import app code which transitively imports from `@department-of-veterans-affairs/web-components/react-bindings`
- The `web-components` package path is an alias resolved by webpack/babel at build time, but esbuild (used by Cypress to bundle test specs) does not have these aliases configured
- Adding the path to the esbuild `external` list tells esbuild to skip resolving it, matching webpack's behavior
- Platform Engineering / Testing Tools Team
- No flipper involved

## Related issue(s)

- This fixes a Cypress test compilation error encountered when running `dispute-debt` E2E tests

## Testing done

- **Old behavior**: Running `yarn cy:run --spec "src/applications/dispute-debt/tests/dispute-debt.cypress.spec.js"` failed with:
  ```
  ERROR: Could not resolve "@department-of-veterans-affairs/web-components/react-bindings"
  ```
- **Steps to verify**:
  1. Run `yarn watch --env entry=dispute-debt` in background
  2. Run `yarn cy:run --spec "src/applications/dispute-debt/tests/dispute-debt.cypress.spec.js"`
  3. Verify test passes without compilation errors
- **Tests completed**: 
  - Ran dispute-debt Cypress spec locally - PASSED
  - Setting `RUN_FULL_SUITE=true` temporarily to validate no regressions across all E2E tests

## Screenshots

N/A - No UI changes

## What areas of the site does it impact?

This change only affects Cypress test infrastructure. No application code or user-facing functionality is modified.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, infrastructure change
- [ ] Screenshot of the developed feature is added - N/A, no UI changes
- [ ] Accessibility testing has been performed - N/A, no UI changes

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution - N/A
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A, test infrastructure only

## Requested Feedback

After CI passes with the full E2E suite, the `RUN_FULL_SUITE` change in `continuous-integration.yml` should be reverted back to `false` in a follow-up commit before merging.