### PR TITLE
129389: Claim status detail links use appointment date info

### DIFF
--- a/src/applications/travel-pay/components/TravelClaimCard.jsx
+++ b/src/applications/travel-pay/components/TravelClaimCard.jsx
@@ -29,6 +29,8 @@ export default function TravelClaimCard(props) {
     appointmentDateTitle = `${appointmentDate} at ${appointmentTime} appointment`;
   }
 
+  const ariaLinkLabel = `Travel reimbursement claim details for ${appointmentDateTitle}`;
+
   return (
     <va-card key={id} class="travel-claim-card vads-u-margin-bottom--2">
       <h3
@@ -58,6 +60,7 @@ export default function TravelClaimCard(props) {
             pathname: `/claims/${id}`,
           }}
           className="vads-u-display--flex vads-u-align-items--center"
+          aria-label={ariaLinkLabel}
         >
           Travel reimbursement claim details <va-icon icon="chevron_right" />
         </Link>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
The links on the travel claim cards should read out distinct accessibility labels so the user can differentiate them from one another. This PR appends the card title that includes the appointment date/time info to the link text that is read.

<img width="441" height="290" alt="image" src="https://github.com/user-attachments/assets/02090370-c29b-4720-beef-a63a3fecd45c" />

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/129389#issue-3793809725

## What areas of the site does it impact?

Travel pay claims list

## Acceptance criteria
- [ ] The aria label of each link should be `Travel reimbursement claim details for <date> at <time> appointment`. Ex: `Travel reimbursement claim details for Monday, February 26, 2024 at 11:43 AM appointment`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
