### PR TITLE
Updated /find-forms url references to /forms

### DIFF
--- a/src/applications/search/components/MoreVASearchTools.jsx
+++ b/src/applications/search/components/MoreVASearchTools.jsx
@@ -9,7 +9,7 @@ const MoreVASearchTools = () => (
       />
     </li>
     <li>
-      <va-link href="/find-forms/" text="Find a VA form" />
+      <va-link href="/forms/" text="Find a VA form" />
     </li>
     <li>
       <va-link

--- a/src/applications/search/constants/stub-new-term.json
+++ b/src/applications/search/constants/stub-new-term.json
@@ -40,7 +40,7 @@
             },
             {
               "title": "About VA Form SF180 | Veterans Affairs",
-              "url": "https://www.va.gov/forms/about-form-sf180/",
+              "url": "https://www.va.gov/forms/sf180/",
               "snippet": "Use GSA Form SF180 to request your military service records, like your DD214 or...orders and endorsements, and your military medical records....Form name: Request Pertaining to Military Records Related to: A non-VA form...Use GSA Form SF180 to request your military service records, like your DD214 or",
               "publicationDate": "2022-12-06",
               "thumbnailUrl": null

--- a/src/applications/search/constants/stub-new-term.json
+++ b/src/applications/search/constants/stub-new-term.json
@@ -40,7 +40,7 @@
             },
             {
               "title": "About VA Form SF180 | Veterans Affairs",
-              "url": "https://www.va.gov/find-forms/about-form-sf180/",
+              "url": "https://www.va.gov/forms/about-form-sf180/",
               "snippet": "Use GSA Form SF180 to request your military service records, like your DD214 or...orders and endorsements, and your military medical records....Form name: Request Pertaining to Military Records Related to: A non-VA form...Use GSA Form SF180 to request your military service records, like your DD214 or",
               "publicationDate": "2022-12-06",
               "thumbnailUrl": null

--- a/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
+++ b/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
@@ -223,7 +223,7 @@ describe('Global search', () => {
         '/health-care/health-needs-conditions/military-sexual-trauma/',
       );
 
-      verifyResultsLink('About VA Form SF180', '/find-forms/about-form-sf180/');
+      verifyResultsLink('About VA Form SF180', '/forms/about-form-sf180/');
     });
 
     cy.axeCheck();

--- a/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
+++ b/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
@@ -223,7 +223,7 @@ describe('Global search', () => {
         '/health-care/health-needs-conditions/military-sexual-trauma/',
       );
 
-      verifyResultsLink('About VA Form SF180', '/forms/about-form-sf180/');
+      verifyResultsLink('About VA Form SF180', '/forms/sf180/');
     });
 
     cy.axeCheck();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updated `/find-forms/` to `/forms/` in Search results links. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/unified-search/issues/125

