### PR TITLE
Fix international phone and limit mailing address on chapter 2

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/02-claimant-information/mailingAddress.js
+++ b/src/applications/survivors-benefits/config/chapters/02-claimant-information/mailingAddress.js
@@ -5,7 +5,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 const updatedAddressSchema = addressSchema({
-  omit: ['isMilitary', 'street3'],
+  omit: ['street3'],
 });
 updatedAddressSchema.properties.street.maxLength = 30;
 updatedAddressSchema.properties.street2.maxLength = 5;

--- a/src/applications/survivors-benefits/config/chapters/02-claimant-information/mailingAddress.js
+++ b/src/applications/survivors-benefits/config/chapters/02-claimant-information/mailingAddress.js
@@ -4,12 +4,20 @@ import {
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+const updatedAddressSchema = addressSchema({
+  omit: ['isMilitary', 'street3'],
+});
+updatedAddressSchema.properties.street.maxLength = 30;
+updatedAddressSchema.properties.street2.maxLength = 5;
+updatedAddressSchema.properties.city.maxLength = 18;
+
 /** @type {PageSchema} */
 export default {
   uiSchema: {
     ...titleUI('Mailing address'),
     claimantAddress: addressUI({
       labels: {
+        street2: 'Apartment or unit number',
         militaryCheckbox:
           'I receive mail outside of the United States on a U.S. military base',
       },
@@ -20,7 +28,7 @@ export default {
     type: 'object',
     required: ['claimantAddress'],
     properties: {
-      claimantAddress: addressSchema({ omit: ['street3'] }),
+      claimantAddress: updatedAddressSchema,
     },
   },
 };

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -51,8 +51,9 @@
   "claimantAddress": {
     "view:militaryBaseDescription": {},
     "country": "USA",
-    "street": "2131",
-    "city": "123213",
+    "street": "1234 Testing Dr",
+    "street2": "AB",
+    "city": "Testville",
     "state": "AL",
     "postalCode": "12313"
   },

--- a/src/applications/survivors-benefits/tests/unit/pages/02-claimant-information/mailingAddress.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/02-claimant-information/mailingAddress.unit.spec.jsx
@@ -32,7 +32,7 @@ describe('Mailing Address Page', () => {
       formDOM,
     );
     const vaStreetAddress2Input = $(
-      'va-text-input[label="Street address line 2"]',
+      'va-text-input[label="Apartment or unit number"]',
       formDOM,
     );
     const vaCityInput = $('va-text-input[label="City"]', formDOM);

--- a/src/applications/survivors-benefits/utils/transformers/switchToInternationalPhone.js
+++ b/src/applications/survivors-benefits/utils/transformers/switchToInternationalPhone.js
@@ -7,7 +7,8 @@ export function switchToInternationalPhone(formData) {
   if (parsedFormData?.claimantPhone?.countryCode !== 'US') {
     const callingCode = parsedFormData.claimantPhone?.callingCode || '';
     const contact = parsedFormData.claimantPhone?.contact || '';
-    transformedValue.claimantPhone.contact = `+${callingCode}-${contact}`;
+    delete transformedValue.claimantPhone;
+    transformedValue.claimantInternationalPhone = `+${callingCode}-${contact}`;
   }
   return JSON.stringify(transformedValue);
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Limit characters for claimant address to match pdf
- Copy international phone number to new key in submit transformer to match pdf
- Field renames were committed in a previous update

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129009

## Testing done

- Manually tested responses with vets-api local pdf_fill
- Updated tests as needed

## Screenshots

N/A

## What areas of the site does it impact?

Chapter 2 of the 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A