### PR TITLE
534ez chapter 3 pdf updates

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/03-military-history/nationalGuardServicePeriod.js
+++ b/src/applications/survivors-benefits/config/chapters/03-military-history/nationalGuardServicePeriod.js
@@ -19,17 +19,17 @@ export default {
     unitName: textUI({
       title: 'Reserve or National Guard Unit name',
     }),
-    unitPhoneNumber: internationalPhoneUI({
+    unitPhone: internationalPhoneUI({
       title: 'Reserve or National Guard Unit primary phone number',
     }),
   },
   schema: {
     type: 'object',
-    required: ['nationalGuardActivationDate', 'unitPhoneNumber', 'unitName'],
+    required: ['nationalGuardActivationDate', 'unitPhone', 'unitName'],
     properties: {
       nationalGuardActivationDate: currentOrPastDateSchema,
       unitName: textSchema,
-      unitPhoneNumber: internationalPhoneSchema({ required: true }),
+      unitPhone: internationalPhoneSchema({ required: true }),
     },
   },
 };

--- a/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
+++ b/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
@@ -1,13 +1,11 @@
 import {
   titleUI,
-  checkboxGroupUI,
-  checkboxGroupSchema,
-  currentOrPastDateDigitsUI,
   currentOrPastDateSchema,
-  currentOrPastDateUI,
+  currentOrPastDateRangeUI,
   textUI,
   textSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaComboBoxField from 'platform/forms-system/src/js/web-component-fields/VaComboBoxField';
 
 import { servicesOptions } from '../../../utils/labels';
 
@@ -17,18 +15,29 @@ export default {
   path: 'veteran/service-period',
   uiSchema: {
     ...titleUI('Service period'),
-    serviceBranch: checkboxGroupUI({
-      title: 'Branch of service',
-      required: true,
-      labels: servicesOptions,
-    }),
-    dateInitiallyEnteredActiveDuty: currentOrPastDateDigitsUI({
-      title: 'Date initially entered active duty',
-    }),
-    finalReleaseDateFromActiveDuty: currentOrPastDateUI({
-      title: 'Final release date from active duty',
-      monthSelect: false,
-    }),
+    serviceBranch: {
+      'ui:webComponentField': VaComboBoxField,
+      'ui:title': 'Branch of service',
+      'ui:errorMessages': {
+        required: 'Select a branch',
+      },
+      'ui:options': {
+        labels: Object.keys(servicesOptions).map(key => ({
+          value: key,
+          label: servicesOptions[key],
+        })),
+      },
+    },
+    activeServiceDateRange: currentOrPastDateRangeUI(
+      {
+        title: 'Date initially entered active duty',
+        monthSelect: false,
+      },
+      {
+        title: 'Final release date from active duty',
+        monthSelect: false,
+      },
+    ),
     placeOfSeparation: textUI({
       title: 'Place of Veteran’s last separation',
       hint: 'City, state, or foreign country',
@@ -36,16 +45,23 @@ export default {
   },
   schema: {
     type: 'object',
-    required: [
-      'serviceBranch',
-      'dateInitiallyEnteredActiveDuty',
-      'finalReleaseDateFromActiveDuty',
-      'placeOfSeparation',
-    ],
+    required: ['serviceBranch', 'activeServiceDateRange', 'placeOfSeparation'],
     properties: {
-      serviceBranch: checkboxGroupSchema(Object.keys(servicesOptions)),
-      dateInitiallyEnteredActiveDuty: currentOrPastDateSchema,
-      finalReleaseDateFromActiveDuty: currentOrPastDateSchema,
+      serviceBranch: {
+        type: 'string',
+        enum: Object.keys(servicesOptions),
+        enumNames: Object.keys(servicesOptions).map(
+          key => servicesOptions[key],
+        ),
+      },
+      activeServiceDateRange: {
+        type: 'object',
+        required: ['from', 'to'],
+        properties: {
+          from: currentOrPastDateSchema,
+          to: currentOrPastDateSchema,
+        },
+      },
       placeOfSeparation: textSchema,
     },
   },

--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -10,6 +10,7 @@ import {
   updateChildOfVeteran,
   truncateMiddleInitials,
   unnestOtherServiceNames,
+  combineUnitNameAddress,
 } from '../utils/transformers';
 
 export const transform = (formConfig, form) => {
@@ -23,6 +24,7 @@ export const transform = (formConfig, form) => {
   transformedData = updateChildOfVeteran(transformedData);
   transformedData = truncateMiddleInitials(transformedData);
   transformedData = unnestOtherServiceNames(transformedData);
+  transformedData = combineUnitNameAddress(transformedData);
   return JSON.stringify({
     survivorsBenefitsClaim: {
       form: transformedData,

--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -9,6 +9,7 @@ import {
   combineTreatmentFacility,
   updateChildOfVeteran,
   truncateMiddleInitials,
+  unnestOtherServiceNames,
 } from '../utils/transformers';
 
 export const transform = (formConfig, form) => {
@@ -21,6 +22,7 @@ export const transform = (formConfig, form) => {
   transformedData = combineTreatmentFacility(transformedData);
   transformedData = updateChildOfVeteran(transformedData);
   transformedData = truncateMiddleInitials(transformedData);
+  transformedData = unnestOtherServiceNames(transformedData);
   return JSON.stringify({
     survivorsBenefitsClaim: {
       form: transformedData,

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -120,6 +120,13 @@
         "last": "Service",
         "middle": "Name"
       }
+    },
+    {
+      "otherServiceName": {
+        "first": "John",
+        "last": "Other",
+        "middle": "Test"
+      }
     }
   ],
   "serviceBranch": {

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -129,20 +129,11 @@
       }
     }
   ],
-  "serviceBranch": {
-    "ARMY": true,
-    "NAVY": true,
-    "AIR_FORCE": true,
-    "COAST_GUARD": true,
-    "MARINE_CORPS": true,
-    "SPACE_FORCE": true,
-    "USPHS": true,
-    "NOAA": true
-  },
+  "serviceBranch": "spaceForce",
   "nationalGuardActivated": true,
   "nationalGuardActivationDate": "2001-09-11",
   "unitName": "Unit Name",
-  "unitPhoneNumber": {
+  "unitPhone": {
     "callingCode": 1,
     "countryCode": "US",
     "contact": "5555112222",
@@ -154,13 +145,15 @@
   "unitAddress": {
     "view:militaryBaseDescription": {},
     "country": "USA",
-    "street": "2131",
-    "city": "123213",
+    "street": "999 Unit St",
+    "city": "North Unitton",
     "state": "AL",
     "postalCode": "12313"
   },
-  "dateInitiallyEnteredActiveDuty": "2000-01-01",
-  "finalReleaseDateFromActiveDuty": "2005-01-01",
+  "activeServiceDateRange": {
+    "from": "1995-01-01",
+    "to": "2000-01-01"
+  },
   "placeOfSeparation": "Some City, ST",
   "careExpenses": [
     {

--- a/src/applications/survivors-benefits/tests/unit/pages/03-military-history/servicePeriod.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/03-military-history/servicePeriod.unit.spec.jsx
@@ -7,7 +7,6 @@ import {
 } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import servicePeriod from '../../../../config/chapters/03-military-history/servicePeriod';
-import { servicesOptions } from '../../../../utils/labels';
 
 describe('Service period page', () => {
   const { schema, uiSchema } = servicePeriod;
@@ -18,15 +17,15 @@ describe('Service period page', () => {
     const formDOM = getFormDOM(form);
     expect(form.getByRole('heading')).to.have.text('Service period');
 
-    const vaCheckboxGroups = $$('va-checkbox-group', formDOM);
-    expect(vaCheckboxGroups.length).to.equal(1);
+    const vaComboBox = $$('va-combo-box', formDOM);
+    expect(vaComboBox.length).to.equal(1);
     const vaMemorableDates = $$('va-memorable-date', formDOM);
     expect(vaMemorableDates.length).to.equal(2);
     const textInputs = $$('va-text-input[type="text"]', formDOM);
     expect(textInputs.length).to.equal(1);
 
     const vaBranchOfService = $(
-      'va-checkbox-group[label="Branch of service"]',
+      'va-combo-box[label="Branch of service"]',
       formDOM,
     );
     expect(vaBranchOfService.getAttribute('required')).to.equal('true');
@@ -48,13 +47,5 @@ describe('Service period page', () => {
     expect(vaLastSeparationPlace.getAttribute('hint')).to.equal(
       'City, state, or foreign country',
     );
-
-    const vaCheckboxes = $$('va-checkbox[name^="root_serviceBranch"]', formDOM);
-    expect(vaCheckboxes.length).to.equal(Object.keys(servicesOptions).length);
-    vaCheckboxes.forEach(checkbox => {
-      const key = checkbox.getAttribute('data-key');
-      const label = checkbox.getAttribute('label');
-      expect(label).to.equal(servicesOptions[key]);
-    });
   });
 });

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -10,14 +10,14 @@ export const dicOptions = {
 };
 
 export const servicesOptions = {
-  ARMY: 'Army',
-  NAVY: 'Navy',
-  AIR_FORCE: 'Air Force',
-  COAST_GUARD: 'Coast Guard',
-  MARINE_CORPS: 'Marine Corps',
-  SPACE_FORCE: 'Space Force',
-  USPHS: 'USPHS',
-  NOAA: 'NOAA',
+  army: 'Army',
+  navy: 'Navy',
+  airForce: 'Air Force',
+  coastGuard: 'Coast Guard',
+  marineCorps: 'Marine Corps',
+  spaceForce: 'Space Force',
+  usphs: 'USPHS',
+  noaa: 'NOAA',
 };
 
 export const claimantRelationshipOptions = {

--- a/src/applications/survivors-benefits/utils/transformers/combineUnitNameAddress.js
+++ b/src/applications/survivors-benefits/utils/transformers/combineUnitNameAddress.js
@@ -1,0 +1,18 @@
+export function combineUnitNameAddress(formData) {
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = parsedFormData;
+  let unitName = '';
+  if (parsedFormData?.unitName) {
+    unitName = parsedFormData.unitName;
+    transformedValue.unitNameAndAddress = unitName;
+  }
+  if (parsedFormData?.unitAddress) {
+    const { street, city, state, postalCode } = parsedFormData.unitAddress;
+    transformedValue.unitNameAndAddress += unitName
+      ? `, ${street}, ${city}, ${state} ${postalCode}`
+      : `${street}, ${city}, ${state} ${postalCode}`;
+  }
+  delete transformedValue.unitName;
+  delete transformedValue.unitAddress;
+  return JSON.stringify(transformedValue);
+}

--- a/src/applications/survivors-benefits/utils/transformers/index.js
+++ b/src/applications/survivors-benefits/utils/transformers/index.js
@@ -4,5 +4,6 @@ export * from './splitSsn';
 export * from './switchToInternationalPhone';
 export * from './transformCareExpenses';
 export * from './truncateMiddleInitials';
+export * from './unnestOtherServiceNames';
 export * from './updateBankValues';
 export * from './updateChildOfVeteran';

--- a/src/applications/survivors-benefits/utils/transformers/index.js
+++ b/src/applications/survivors-benefits/utils/transformers/index.js
@@ -1,5 +1,6 @@
 export * from './calculateSeparationDuration';
 export * from './combineTreatmentFacility';
+export * from './combineUnitNameAddress';
 export * from './splitSsn';
 export * from './switchToInternationalPhone';
 export * from './transformCareExpenses';

--- a/src/applications/survivors-benefits/utils/transformers/truncateMiddleInitials.js
+++ b/src/applications/survivors-benefits/utils/transformers/truncateMiddleInitials.js
@@ -2,13 +2,25 @@ export function truncateMiddleInitials(formData) {
   const parsedFormData = JSON.parse(formData);
   const transformedValue = parsedFormData;
   if (parsedFormData?.veteranFullName?.middle) {
-    transformedValue.veteranFullName.middle = parsedFormData?.veteranFullName?.middle.charAt(
-      0,
-    );
+    transformedValue.veteranFullName.middle = parsedFormData?.veteranFullName?.middle.charAt();
   }
   if (parsedFormData?.claimantFullName?.middle) {
-    transformedValue.claimantFullName.middle = parsedFormData?.claimantFullName?.middle.charAt(
-      0,
+    transformedValue.claimantFullName.middle = parsedFormData?.claimantFullName?.middle.charAt();
+  }
+  if (parsedFormData?.veteranPreviousNames?.length) {
+    transformedValue.veteranPreviousNames = parsedFormData.veteranPreviousNames.map(
+      name => {
+        if (name?.otherServiceName?.middle) {
+          return {
+            ...name,
+            otherServiceName: {
+              ...name.otherServiceName,
+              middle: name.otherServiceName.middle.charAt(),
+            },
+          };
+        }
+        return name;
+      },
     );
   }
   return JSON.stringify(transformedValue);

--- a/src/applications/survivors-benefits/utils/transformers/unnestOtherServiceNames.js
+++ b/src/applications/survivors-benefits/utils/transformers/unnestOtherServiceNames.js
@@ -1,0 +1,14 @@
+export function unnestOtherServiceNames(formData) {
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = parsedFormData;
+  if (parsedFormData?.veteranPreviousNames?.length) {
+    transformedValue.veteranPreviousNames = parsedFormData.veteranPreviousNames.map(
+      name => {
+        return {
+          ...name.otherServiceName,
+        };
+      },
+    );
+  }
+  return JSON.stringify(transformedValue);
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated field names in chapter 3 to match vets-api pdf_fill
- Switch service branch from list of checkboxes to a combo box
- Combine unit name and unit address to one line for pdf_fill
- unnest other service names from their otherServiceName key in the array items
- Truncate the middle initial of each other service name
- update service branch labels to match vets-api


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129010
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127891

## Testing done

- Manually tested with local vets-api pdf fill
- Updated automated tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="535" height="673" alt="Screenshot 2026-01-12 at 9 58 24 AM" src="https://github.com/user-attachments/assets/35b4c656-30af-4538-9f99-1b1c7fd84380" /> | <img width="535" height="673" alt="Screenshot 2026-01-12 at 9 58 24 AM" src="https://github.com/user-attachments/assets/540b7868-896f-4e3e-8845-3355f20aa216" /> |

## What areas of the site does it impact?

Chapter 3 of 534ez and submit transformer

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
