### PR TITLE
updates employer information address schema to limit characters to wh…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employer-information.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employer-information.js
@@ -29,6 +29,33 @@ export const employerInformationUiSchema = {
   },
 };
 
+const customAddressSchema = {
+  ...addressNoMilitarySchema(),
+  properties: {
+    ...addressNoMilitarySchema().properties,
+    street: {
+      type: 'string',
+      maxLength: 30,
+    },
+    street2: {
+      type: 'string',
+      maxLength: 30,
+    },
+    city: {
+      type: 'string',
+      maxLength: 18,
+    },
+    state: {
+      type: 'string',
+      maxLength: 2,
+    },
+    postalCode: {
+      type: 'string',
+      maxLength: 9,
+    },
+  },
+};
+
 /**
  * JSON Schema for Employer Information page
  * Validates employer name and address fields
@@ -45,7 +72,7 @@ export const employerInformationSchema = {
           type: 'string',
           maxLength: 100,
         },
-        employerAddress: addressNoMilitarySchema(),
+        employerAddress: customAddressSchema,
       },
     },
   },

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employer-information.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employer-information.js
@@ -29,10 +29,12 @@ export const employerInformationUiSchema = {
   },
 };
 
+const baseAddressSchema = addressNoMilitarySchema();
+
 const customAddressSchema = {
-  ...addressNoMilitarySchema(),
+  ...baseAddressSchema,
   properties: {
-    ...addressNoMilitarySchema().properties,
+    ...baseAddressSchema.properties,
     street: {
       type: 'string',
       maxLength: 30,


### PR DESCRIPTION
…at's allowed on the backend

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Restricting address fields input lengths on the Employer Information page to match what the backend expects

### Issue
On the Employer Information page, the allowed length for the address fields on the front end were larger than what was allowed on the backend, causing submission failures without helpful error messages.

### Solution
Overrode the default length restrictions on the address fields with what the backend expects them to be

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-4192 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129677](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129677)

## Testing done

### Old behavior
* The address fields on the "Employer Information" page were allowing up to 100 characters to be input (zip code was allowing even more)

### New behavior
* The address fields should be restricted to what the backend expects (30 for street 1 and street 2, 18 for city, 2 for state, 9 for postal code)

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the fields are being restricted to the appropriate lengths, and the form submits successfully when these lengths are maxed out
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

Not applicable, there were no UI changes so the form appears identical


## What areas of the site does it impact?

This change affects form 21-4192, specifically on the Employment Information page at /disability/eligibility/special-claims/unemployability/submit-employment-information-form-21-4192/employer-information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user