### PR TITLE
Fixed vaccines list refresh method

### DIFF
--- a/src/applications/mhv-medical-records/actions/vaccines.js
+++ b/src/applications/mhv-medical-records/actions/vaccines.js
@@ -40,11 +40,16 @@ export const getVaccinesList = (
   }
 };
 
-export const checkForVaccineUpdates = () => async dispatch => {
+export const checkForVaccineUpdates = (
+  isAccelerating = false,
+) => async dispatch => {
   try {
     // We don't need to use getListWithRetry here. By the time we are checking for list updates,
     // the list will already be loaded, by definition.
-    const response = await getVaccineList(1, false);
+    const getData = isAccelerating
+      ? getAcceleratedImmunizations
+      : getVaccineList;
+    const response = await getData();
     dispatch({ type: Actions.Vaccines.CHECK_FOR_UPDATE, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));

--- a/src/applications/mhv-medical-records/actions/vaccines.js
+++ b/src/applications/mhv-medical-records/actions/vaccines.js
@@ -46,10 +46,9 @@ export const checkForVaccineUpdates = (
   try {
     // We don't need to use getListWithRetry here. By the time we are checking for list updates,
     // the list will already be loaded, by definition.
-    const getData = isAccelerating
-      ? getAcceleratedImmunizations
-      : getVaccineList;
-    const response = await getData();
+    const response = await (isAccelerating
+      ? getAcceleratedImmunizations()
+      : getVaccineList(1, false));
     dispatch({ type: Actions.Vaccines.CHECK_FOR_UPDATE, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -120,7 +120,7 @@ const Vaccines = props => {
     dispatch,
     page: paramPage,
     useBackendPagination,
-    checkUpdatesAction: checkForVaccineUpdates,
+    checkUpdatesAction: () => checkForVaccineUpdates(isAcceleratingVaccines),
   });
 
   // On Unmount: reload any newly updated records and normalize the FETCHING state.

--- a/src/applications/mhv-medical-records/tests/actions/vaccines.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/vaccines.unit.spec.jsx
@@ -163,11 +163,12 @@ describe('Check for vaccine updates action', () => {
     getAcceleratedImmunizationsStub.restore();
   });
 
-  it('should call v1 getVaccineList when isAccelerating is false', async () => {
+  it('should call v1 getVaccineList with correct params when isAccelerating is false', async () => {
     const dispatch = sinon.spy();
     await checkForVaccineUpdates(false)(dispatch);
 
     expect(getVaccineListStub.calledOnce).to.be.true;
+    expect(getVaccineListStub.calledWith(1, false)).to.be.true;
     expect(getAcceleratedImmunizationsStub.called).to.be.false;
     expect(dispatch.firstCall.args[0].type).to.equal(
       Actions.Vaccines.CHECK_FOR_UPDATE,
@@ -185,11 +186,12 @@ describe('Check for vaccine updates action', () => {
     );
   });
 
-  it('should call v1 getVaccineList when isAccelerating is undefined (default)', async () => {
+  it('should call v1 getVaccineList with correct params when isAccelerating is undefined (default)', async () => {
     const dispatch = sinon.spy();
     await checkForVaccineUpdates()(dispatch);
 
     expect(getVaccineListStub.calledOnce).to.be.true;
+    expect(getVaccineListStub.calledWith(1, false)).to.be.true;
     expect(getAcceleratedImmunizationsStub.called).to.be.false;
     expect(dispatch.firstCall.args[0].type).to.equal(
       Actions.Vaccines.CHECK_FOR_UPDATE,

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vaccines.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vaccines.js
@@ -89,35 +89,6 @@ class Vaccines {
       'nav > ul > li.usa-pagination__item.usa-pagination__arrow > a',
     ).click();
   };
-
-  /**
-   * Set up intercepts for testing check-for-updates functionality.
-   * This is used to verify that the correct endpoint (v1 or v2) is called
-   * based on the accelerating vaccines feature toggle.
-   */
-  setCheckForUpdatesIntercepts = ({ vaccinesData, useV2 = true }) => {
-    cy.intercept('POST', '/v0/datadog_action', {}).as('datadogAction');
-    cy.intercept('POST', '/my_health/v1/medical_records/session', {}).as(
-      'session',
-    );
-    cy.intercept('GET', '/my_health/v1/medical_records/session/status', req => {
-      req.reply(sessionStatus);
-    });
-
-    if (useV2) {
-      cy.intercept(
-        'GET',
-        '/my_health/v2/medical_records/immunization*',
-        req => {
-          req.reply(vaccinesData);
-        },
-      ).as('vaccines-v2-list');
-    } else {
-      cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', req => {
-        req.reply(vaccinesData);
-      }).as('vaccines-v1-list');
-    }
-  };
 }
 
 export default new Vaccines();

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/check-for-updates.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/check-for-updates.cypress.spec.js
@@ -1,0 +1,117 @@
+import MedicalRecordsSite from '../../mr_site/MedicalRecordsSite';
+import Vaccines from '../pages/Vaccines';
+import oracleHealthUser from '../fixtures/user/oracle-health.json';
+import vaccinesData from '../fixtures/vaccines/sample-lighthouse.json';
+
+describe('Medical Records - Accelerated Vaccines Check For Updates', () => {
+  const site = new MedicalRecordsSite();
+
+  beforeEach(() => {
+    site.login(oracleHealthUser, false);
+    site.mockFeatureToggles({
+      isAcceleratingEnabled: true,
+      isAcceleratingVaccines: true,
+    });
+  });
+
+  it('calls v2 immunizations endpoint when accelerating vaccines is enabled', () => {
+    // Set up intercepts for the v2 endpoint
+    Vaccines.setIntercepts({ vaccinesData });
+
+    // Also intercept v2 endpoint to verify it's called for check updates
+    cy.intercept('GET', '/my_health/v2/medical_records/immunizations*').as(
+      'v2ImmunizationsList',
+    );
+
+    // Should NOT call v1 when accelerating
+    cy.intercept('GET', '/my_health/v1/medical_records/vaccines*').as(
+      'v1VaccinesList',
+    );
+
+    site.loadPage();
+    Vaccines.goToVaccinesPage();
+
+    // Wait for the v2 endpoint to be called
+    cy.wait('@v2ImmunizationsList').then(interception => {
+      expect(interception.response.statusCode).to.equal(200);
+    });
+
+    // Verify the vaccines list is displayed
+    cy.get('[data-testid="record-list-item"]').should(
+      'have.length.at.least',
+      1,
+    );
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('does not call v1 vaccines endpoint when accelerating vaccines is enabled', () => {
+    // Set up intercepts
+    Vaccines.setIntercepts({ vaccinesData });
+
+    // Track calls to v1 endpoint - this should NOT be called
+    let v1Called = false;
+    cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', req => {
+      v1Called = true;
+      req.reply(vaccinesData);
+    }).as('v1VaccinesList');
+
+    site.loadPage();
+    Vaccines.goToVaccinesPage();
+
+    // Wait for page to load
+    cy.get('[data-testid="record-list-item"]').should(
+      'have.length.at.least',
+      1,
+    );
+
+    // Verify v1 was not called
+    cy.wrap(null).then(() => {
+      expect(v1Called).to.equal(false);
+    });
+    cy.injectAxeThenAxeCheck();
+  });
+});
+
+describe('Medical Records - Non-Accelerated Vaccines Check For Updates', () => {
+  const site = new MedicalRecordsSite();
+
+  beforeEach(() => {
+    site.login();
+    // Default feature toggles have acceleration disabled
+  });
+
+  it('calls v1 vaccines endpoint when accelerating vaccines is disabled', () => {
+    // Set up intercepts for the v1 endpoint
+    cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', req => {
+      req.reply(vaccinesData);
+    }).as('v1VaccinesList');
+
+    // v2 should NOT be called
+    let v2Called = false;
+    cy.intercept('GET', '/my_health/v2/medical_records/immunizations*', req => {
+      v2Called = true;
+      req.reply(vaccinesData);
+    }).as('v2ImmunizationsList');
+
+    cy.visit('my-health/medical-records/vaccines');
+
+    // Wait for the v1 endpoint to be called
+    cy.wait('@v1VaccinesList').then(interception => {
+      expect(interception.response.statusCode).to.equal(200);
+    });
+
+    // Verify the vaccines list is displayed
+    cy.get('[data-testid="record-list-item"]').should(
+      'have.length.at.least',
+      1,
+    );
+
+    // Verify v2 was not called
+    cy.wrap(null).then(() => {
+      expect(v2Called).to.equal(false);
+    });
+
+    cy.injectAxeThenAxeCheck();
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug**: The `checkForVaccineUpdates` function was always calling the v1 vaccines endpoint (`/my_health/v1/medical_records/vaccines`), even when the accelerated delivery feature toggles were enabled. This caused a mismatch where users with the flipper enabled would still have their "check for updates" requests go to v1 instead of v2.
- **Solution**: Added an `isAccelerating` parameter to the `checkForVaccineUpdates` action. When `true`, it calls `getAcceleratedImmunizations` (v2 endpoint). When `false` or undefined (default), it calls `getVaccineList` (v1 endpoint). The Vaccines container now passes the `isAcceleratingVaccines` toggle value to this action.

## Related issue(s)

N/A, [slack thread](https://dsva.slack.com/archives/C03Q2UQL1AS/p1767813241834309)

## Testing done

- **Old behavior**: `checkForVaccineUpdates()` always called `getVaccineList(1, false)` regardless of feature toggle state. This meant all users update checks went to v1, even if their initial data load used v2.
- **New behavior**: `checkForVaccineUpdates(isAccelerating)` conditionally calls the appropriate API based on the feature toggle.
- **Verification steps**:
  1. Enable both accelerated delivery toggles
  2. Navigate to Vaccines page
  3. Observe that v2 endpoint (`/my_health/v2/medical_records/immunizations`) is called
  4. Disable the vaccines-specific toggle
  5. Navigate to Vaccines page
  6. Observe that v1 endpoint (`/my_health/v1/medical_records/vaccines`) is called
- **Unit tests added**: 4 new tests in `vaccines.unit.spec.jsx` that stub `MrApi.getVaccineList` and `MrApi.getAcceleratedImmunizations` to verify the correct API function is called based on the `isAccelerating` parameter.
- **E2E tests added**: New Cypress test file `check-for-updates.cypress.spec.js` with 3 tests verifying v1/v2 endpoint routing based on feature toggles.

## Screenshots

_N/A - No UI changes, this is a backend API routing fix._

## What areas of the site does it impact?

This impacts the Medical Records Vaccines page (`/my-health/medical-records/vaccines`). The fix ensures that users with the accelerated delivery toggle enabled will have their update checks routed to the v2 endpoint, maintaining consistency with their initial data fetch.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation changes needed)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (e2e tests include axe checks)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (existing monitors apply)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

