### PR TITLE
fix(avs): fix failing E2E tests

### DIFF
--- a/src/applications/avs/tests/e2e/avs.cypress.spec.js
+++ b/src/applications/avs/tests/e2e/avs.cypress.spec.js
@@ -82,15 +82,24 @@ describe('After-visit Summary - Happy Path', () => {
     cy.get('h1').contains('After-visit summary');
 
     cy.contains('Consultations').should('not.be.visible');
-    cy.get("[header='Your treatment plan from this appointment']").click();
+    cy.get("[header='Your treatment plan from this appointment']")
+      .shadow()
+      .find('button')
+      .click({ force: true });
     cy.contains('Consultations').should('be.visible');
 
     cy.contains('Primary care team').should('not.be.visible');
-    cy.get("[header='Your health information as of this appointment']").click();
+    cy.get("[header='Your health information as of this appointment']")
+      .shadow()
+      .find('button')
+      .click({ force: true });
     cy.contains('Primary care team').should('be.visible');
 
     cy.contains('More help and information').should('not.be.visible');
-    cy.get("[header='More information']").click();
+    cy.get("[header='More information']")
+      .shadow()
+      .find('button')
+      .click({ force: true });
     cy.contains('More help and information').should('be.visible');
 
     cy.injectAxeThenAxeCheck();
@@ -137,7 +146,7 @@ describe('After-visit Summary - Authentication', () => {
     setup({ login: false });
     cy.visit(testUrl);
     cy.injectAxeThenAxeCheck();
-    const urlPattern = `\\/\\?next=%2Fmy-health%2Fmedical-records%2Fsummaries-and-notes%2Fvisit-summary%2F${avsId}$`;
+    const urlPattern = `\\/\\?next=%2Fmy-health%2Fmedical-records%2Fsummaries-and-notes%2Fvisit-summary%2F${avsId}(&oauth=true)?$`;
     cy.url().should('match', new RegExp(urlPattern));
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed two failing E2E tests in the AVS (After-visit Summary) application
- **Accordion click test**: The `va-accordion-item` web component has its clickable button inside a shadow DOM. The test was clicking the outer element directly, but the button's center was hidden from view. Fixed by targeting the `button` inside the shadow DOM and using `{ force: true }`.
- **Authentication redirect test**: The redirect URL now includes an `&oauth=true` parameter. Updated the regex pattern to make this parameter optional.
- Team: N/A - Test fix only

## Related issue(s)

- N/A - Test maintenance

## Testing done

- Ran the AVS E2E tests locally before fix: 2 tests failing
- Ran the AVS E2E tests locally after fix: All 13 tests passing
- Command: `xvfb-run --auto-servernum yarn cy:run --spec "src/applications/avs/tests/e2e/avs.cypress.spec.js"`

## Screenshots

N/A - No UI changes, test fix only

## What areas of the site does it impact?

Only affects the AVS application E2E tests. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A - test fix only)
- [x] Accessibility testing has been performed (N/A - test fix only)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

N/A