### PR TITLE
fix(check-in): fix E2E tests for validation error alert

### DIFF
--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -197,7 +197,7 @@ class ValidateVeteran {
       'We’re sorry. We couldn’t find an account that matches that last name or date of birth. Please try again.';
     cy.get('[data-testid=validate-error-alert]')
       .should('be.visible')
-      .and('have.text', messageText);
+      .and('contain.text', messageText);
   };
 }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed failing E2E tests in the Check-In Experience applications (day-of, pre-check-in, travel-claim)
- The `va-alert` component now includes "Error Alert" as a visible heading within its text content
- Changed the assertion in `validateErrorAlert` from `.and('have.text', messageText)` to `.and('contain.text', messageText)`
- This allows the test to verify the expected message is present without requiring an exact match of the entire element's text
- Team: Check-In Experience

## Related issue(s)

- N/A - Test maintenance

## Testing done

- Ran the following E2E tests locally before fix: 3 tests failing
- Ran the following E2E tests locally after fix: All 6 tests passing
- Test specs:
  - `src/applications/check-in/day-of/tests/e2e/authentication.failure.cypress.spec.js`
  - `src/applications/check-in/pre-check-in/tests/e2e/authentication.failure.cypress.spec.js`
  - `src/applications/check-in/travel-claim/tests/e2e/errors-validation.cypress.spec.js`

## Screenshots

N/A - No UI changes, test fix only

## What areas of the site does it impact?

Only affects the Check-In Experience E2E tests. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A - test fix only)
- [x] Accessibility testing has been performed (N/A - test fix only)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

N/A