### PR TITLE
Fixed runAxeCheck

### DIFF
--- a/src/platform/startup/axe-check.js
+++ b/src/platform/startup/axe-check.js
@@ -2,6 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 export default function runAxeCheck() {
-  const axe = require('@axe-core/react');
+  const axe = require('@axe-core/react').default;
   axe(React, ReactDOM, 1000);
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed `runAxeCheck` so that it actually utilizes the `reactAxe` function.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/634)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by opening the Cypress UI (`yarn cy:open`), running the following test: `src/applications/_mock-form-ae-design-patterns/tests/e2e/pattern1/taskGreen.cypress.spec.js`, and keeping an eye on the browser console for `New axe issues`.

## What areas of the site does it impact?
This only impacts the `runAxeCheck` function.

## Acceptance criteria
- [x] Fix `runAxeCheck` so that it works properly