### PR TITLE
Added BlueButton support for v2 vaccines

### DIFF
--- a/src/applications/mhv-medical-records/actions/blueButtonReport.js
+++ b/src/applications/mhv-medical-records/actions/blueButtonReport.js
@@ -3,6 +3,7 @@ import {
   getLabsAndTests,
   getNotes,
   getVaccineList,
+  getAcceleratedImmunizations,
   getAllergies,
   getConditions,
   getVitalsList,
@@ -24,10 +25,18 @@ export const getBlueButtonReportData = (
   options = {},
   dateFilter,
 ) => async dispatch => {
+  const { isAcceleratingVaccines = false } = options;
+
+  const vaccinesActionType = isAcceleratingVaccines
+    ? Actions.Vaccines.GET_UNIFIED_LIST
+    : Actions.Vaccines.GET_LIST;
+
   const fetchMap = {
     labsAndTests: getLabsAndTests,
     notes: getNotes,
-    vaccines: getVaccineList,
+    vaccines: isAcceleratingVaccines
+      ? getAcceleratedImmunizations
+      : getVaccineList,
     allergies: getAllergies,
     conditions: getConditions,
     vitals: getVitalsList,
@@ -106,7 +115,7 @@ export const getBlueButtonReportData = (
           break;
         case 'vaccines':
           dispatch({
-            type: Actions.Vaccines.GET_LIST,
+            type: vaccinesActionType,
             response,
           });
           break;

--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -16,6 +16,7 @@ import {
   makePdf,
   formatUserDob,
   formatNameFirstLast,
+  useAcceleratedData,
 } from '@department-of-veterans-affairs/mhv/exports';
 import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { isBefore, isAfter } from 'date-fns';
@@ -57,6 +58,7 @@ const DownloadFileType = props => {
   const [fileTypeError, setFileTypeError] = useState('');
 
   const dispatch = useDispatch();
+  const { isAcceleratingVaccines } = useAcceleratedData();
 
   const fileTypeFilter = useSelector(
     state => state.mr.downloads?.fileTypeFilter,
@@ -234,13 +236,14 @@ const DownloadFileType = props => {
         demographics: recordFilter?.includes('demographics'),
         militaryService: recordFilter?.includes('militaryService'),
         patient: true,
+        isAcceleratingVaccines,
       };
 
       if (!isDataFetched) {
         dispatch(getBlueButtonReportData(options, dateFilter));
       }
     },
-    [isDataFetched, recordFilter, dispatch, dateFilter],
+    [isDataFetched, recordFilter, dispatch, dateFilter, isAcceleratingVaccines],
   );
 
   const recordData = useMemo(

--- a/src/applications/mhv-medical-records/tests/actions/blueButtonReport.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/blueButtonReport.unit.spec.jsx
@@ -93,6 +93,67 @@ describe('Blue Button Actions', () => {
         );
       });
 
+      describe('vaccines with accelerating toggle', () => {
+        let getVaccineListStub;
+        let getAcceleratedImmunizationsStub;
+
+        beforeEach(() => {
+          getVaccineListStub = sinon
+            .stub(MrApi, 'getVaccineList')
+            .resolves({ mockData: 'v1VaccinesData' });
+          getAcceleratedImmunizationsStub = sinon
+            .stub(MrApi, 'getAcceleratedImmunizations')
+            .resolves({ mockData: 'v2ImmunizationsData' });
+        });
+
+        afterEach(() => {
+          getVaccineListStub.restore();
+          getAcceleratedImmunizationsStub.restore();
+        });
+
+        it('should call v1 getVaccineList and dispatch GET_LIST when isAcceleratingVaccines is false', async () => {
+          const dispatch = sinon.spy();
+          const action = getBlueButtonReportData(
+            { vaccines: true, isAcceleratingVaccines: false },
+            {},
+          );
+          await action(dispatch);
+
+          expect(getVaccineListStub.calledOnce).to.be.true;
+          expect(getAcceleratedImmunizationsStub.called).to.be.false;
+          expect(dispatch.firstCall.args[0].type).to.equal(
+            Actions.Vaccines.GET_LIST,
+          );
+        });
+
+        it('should call v2 getAcceleratedImmunizations and dispatch GET_UNIFIED_LIST when isAcceleratingVaccines is true', async () => {
+          const dispatch = sinon.spy();
+          const action = getBlueButtonReportData(
+            { vaccines: true, isAcceleratingVaccines: true },
+            {},
+          );
+          await action(dispatch);
+
+          expect(getAcceleratedImmunizationsStub.calledOnce).to.be.true;
+          expect(getVaccineListStub.called).to.be.false;
+          expect(dispatch.firstCall.args[0].type).to.equal(
+            Actions.Vaccines.GET_UNIFIED_LIST,
+          );
+        });
+
+        it('should call v1 getVaccineList and dispatch GET_LIST when isAcceleratingVaccines is not provided (default)', async () => {
+          const dispatch = sinon.spy();
+          const action = getBlueButtonReportData({ vaccines: true }, {});
+          await action(dispatch);
+
+          expect(getVaccineListStub.calledOnce).to.be.true;
+          expect(getAcceleratedImmunizationsStub.called).to.be.false;
+          expect(dispatch.firstCall.args[0].type).to.equal(
+            Actions.Vaccines.GET_LIST,
+          );
+        });
+      });
+
       it('should get conditions', async () => {
         const mockData = { mockData: 'mockData' };
         mockApiRequest(mockData);

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/blue-button-download-vaccines.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/blue-button-download-vaccines.cypress.spec.js
@@ -1,0 +1,119 @@
+import MedicalRecordsSite from '../../mr_site/MedicalRecordsSite';
+import DownloadReportsPage from '../../pages/DownloadReportsPage';
+import DownloadAllPage from '../../pages/DownloadAllPage';
+import oracleHealthUser from '../fixtures/user/oracle-health.json';
+import vaccinesData from '../fixtures/vaccines/sample-lighthouse.json';
+
+describe('Medical Records - Blue Button Download with Accelerated Vaccines', () => {
+  const site = new MedicalRecordsSite();
+
+  describe('when accelerating vaccines is enabled', () => {
+    beforeEach(() => {
+      site.login(oracleHealthUser, false);
+      site.mockFeatureToggles({
+        isAcceleratingEnabled: true,
+        isAcceleratingVaccines: true,
+      });
+    });
+
+    it('calls v2 immunizations endpoint when downloading vaccines in Blue Button report', () => {
+      // Intercept v2 endpoint - this SHOULD be called
+      cy.intercept('GET', '/my_health/v2/medical_records/immunizations*', {
+        statusCode: 200,
+        body: vaccinesData,
+      }).as('v2Immunizations');
+
+      // Track v1 endpoint - this should NOT be called
+      let v1Called = false;
+      cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', req => {
+        v1Called = true;
+        req.reply({ statusCode: 200, body: vaccinesData });
+      }).as('v1Vaccines');
+
+      // Intercept patient endpoint (required for Blue Button)
+      cy.intercept('GET', '/my_health/v1/medical_records/patient*', {
+        statusCode: 200,
+        body: { data: { attributes: {} } },
+      }).as('patient');
+
+      site.loadPage();
+      DownloadReportsPage.goToReportsPage();
+      DownloadReportsPage.goToDownloadAllPage();
+
+      // Select date range
+      DownloadAllPage.selectDateRangeDropdown('any');
+      DownloadAllPage.clickContinueOnDownloadAllPage();
+
+      // Select vaccines checkbox on page 2
+      DownloadAllPage.selectVaccinesCheckbox();
+      DownloadAllPage.clickContinueOnDownloadAllPage();
+
+      // Wait for the v2 endpoint to be called
+      cy.wait('@v2Immunizations').then(interception => {
+        expect(interception.response.statusCode).to.equal(200);
+      });
+
+      // Verify v1 was not called
+      cy.wrap(null).then(() => {
+        expect(v1Called).to.equal(false);
+      });
+
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  describe('when accelerating vaccines is disabled', () => {
+    beforeEach(() => {
+      site.login();
+      // Default feature toggles have acceleration disabled
+    });
+
+    it('calls v1 vaccines endpoint when downloading vaccines in Blue Button report', () => {
+      // Intercept v1 endpoint - this SHOULD be called
+      cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', {
+        statusCode: 200,
+        body: vaccinesData,
+      }).as('v1Vaccines');
+
+      // Track v2 endpoint - this should NOT be called
+      let v2Called = false;
+      cy.intercept(
+        'GET',
+        '/my_health/v2/medical_records/immunizations*',
+        req => {
+          v2Called = true;
+          req.reply({ statusCode: 200, body: vaccinesData });
+        },
+      ).as('v2Immunizations');
+
+      // Intercept patient endpoint (required for Blue Button)
+      cy.intercept('GET', '/my_health/v1/medical_records/patient*', {
+        statusCode: 200,
+        body: { data: { attributes: {} } },
+      }).as('patient');
+
+      cy.visit('my-health/medical-records/download');
+      DownloadReportsPage.goToDownloadAllPage();
+
+      // Select date range
+      DownloadAllPage.selectDateRangeDropdown('any');
+      DownloadAllPage.clickContinueOnDownloadAllPage();
+
+      // Select vaccines checkbox on page 2
+      DownloadAllPage.selectVaccinesCheckbox();
+      DownloadAllPage.clickContinueOnDownloadAllPage();
+
+      // Wait for the v1 endpoint to be called
+      cy.wait('@v1Vaccines').then(interception => {
+        expect(interception.response.statusCode).to.equal(200);
+      });
+
+      // Verify v2 was not called
+      cy.wrap(null).then(() => {
+        expect(v2Called).to.equal(false);
+      });
+
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Feature**: Added support for the v2 immunizations endpoint in the Blue Button download report when the accelerated vaccines feature toggle is enabled.
- **Problem**: The Blue Button report was always calling the v1 vaccines endpoint (`/my_health/v1/medical_records/vaccines`), even when users had the accelerated delivery toggle enabled. This meant users downloading their medical records via Blue Button were not benefiting from the v2 endpoint improvements.
- **Solution**: 
  - Updated `getBlueButtonReportData` action to accept `isAcceleratingVaccines` in the options parameter
  - Conditionally calls `getAcceleratedImmunizations` (v2) or `getVaccineList` (v1) based on the toggle
  - Dispatches the appropriate Redux action type (`GET_UNIFIED_LIST` for v2, `GET_LIST` for v1) to ensure the reducer properly transforms the response data
  - Updated `DownloadFileType.jsx` to use `useAcceleratedData` hook and pass the toggle value

## Related issue(s)

N/A, [slack thread](https://dsva.slack.com/archives/C03Q2UQL1AS/p1767813241834309)

## Testing done

- **Old behavior**: `getBlueButtonReportData` always called the v1 `getVaccineList()` endpoint and dispatched `Actions.Vaccines.GET_LIST`, regardless of feature toggle state.
- **New behavior**: `getBlueButtonReportData` conditionally calls the appropriate endpoint and dispatches the matching action type based on `isAcceleratingVaccines`.
- **Verification steps**:
  1. Enable both accelerated delivery toggles (`mhvAcceleratedDeliveryEnabled` and `mhvAcceleratedDeliveryVaccinesEnabled`)
  2. Navigate to Download Reports → Download All
  3. Select vaccines checkbox and continue
  4. Observe that v2 endpoint (`/my_health/v2/medical_records/immunizations`) is called
  5. Disable the vaccines-specific toggle
  6. Repeat steps 2-4
  7. Observe that v1 endpoint (`/my_health/v1/medical_records/vaccines`) is called
- **Unit tests added**: 3 new tests in `blueButtonReport.unit.spec.jsx`:
  - Verifies v1 `getVaccineList` is called and `GET_LIST` is dispatched when `isAcceleratingVaccines` is false
  - Verifies v2 `getAcceleratedImmunizations` is called and `GET_UNIFIED_LIST` is dispatched when `isAcceleratingVaccines` is true
  - Verifies default behavior (v1) when `isAcceleratingVaccines` is not provided
- **E2E tests added**: New Cypress test file `blue-button-download-vaccines.cypress.spec.js` with 2 tests verifying v1/v2 endpoint routing in the Blue Button download flow based on feature toggles.

## Screenshots

_N/A - No UI changes, this is a backend API routing fix._

## What areas of the site does it impact?

This impacts the Medical Records Blue Button download feature (`/my-health/medical-records/download`). The fix ensures that users with the accelerated delivery toggle enabled will have their vaccines data fetched from the v2 endpoint when downloading Blue Button reports, maintaining consistency with the main vaccines list view.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation changes needed)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (e2e tests include axe checks)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (existing monitors apply)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

