### PR TITLE
fix(fsr): use contain.text instead of have.text for va-alert assertions

### DIFF
--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
@@ -150,7 +150,7 @@ const testConfig = createTestConfig(
       'skip-questions-explainer': ({ afterHook }) => {
         afterHook(() => {
           cy.get('h3').should(
-            'have.text',
+            'contain.text',
             'You can skip questions on this formWe’re here anytime, day or night – 24/7',
           );
           cy.clickFormContinue();

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
@@ -92,7 +92,7 @@ const testConfig = createTestConfig(
       'skip-questions-explainer': ({ afterHook }) => {
         afterHook(() => {
           cy.get('h3').should(
-            'have.text',
+            'contain.text',
             'You can skip questions on this formWe’re here anytime, day or night – 24/7',
           );
           cy.clickFormContinue();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Issue:** The `va-alert` web component now includes the alert type (e.g., "Information Alert") as a prefix in the text content. This caused two Financial Status Report Cypress tests to fail when using `have.text` which requires an exact match.
- **Solution:** Changed `have.text` to `contain.text` in the assertion for the skip-questions-explainer page, allowing the test to pass regardless of the alert type prefix.
- **Team:** This fix follows the same pattern used in Check In Experience tests for similar "Error Alert" prefix issues.

## Related issue(s)

- Related to DART Sass migration testing - fixing pre-existing test failures
- Same fix pattern as Check In Experience tests

## Testing done

- Ran both affected Cypress tests locally and confirmed they pass:
  - `fsr-5655-streamlined-waiver-short.cypress.spec.js` ✓
  - `fsr-5655-streamlined-waiver-long.cypress.spec.js` ✓
- Both tests passed after the fix (previously failing with text mismatch)

## Screenshots

N/A - No UI changes, only test assertion fix

## What areas of the site does it impact?

This only affects Cypress test files - no production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (N/A - test fix only)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

This is a straightforward test fix. The `va-alert` component text now includes an alert type prefix, so changing from exact match (`have.text`) to partial match (`contain.text`) resolves the assertion failures while maintaining the test intent.