### PR TITLE
eselkin/128340-CAIA fix - add noun (an appointment) to Start scheduling links

### DIFF
--- a/src/applications/vaos/appointment-list/components/ScheduleNewAppointment.jsx
+++ b/src/applications/vaos/appointment-list/components/ScheduleNewAppointment.jsx
@@ -47,7 +47,7 @@ function ScheduleNewAppointmentButton() {
       href="/"
       onClick={handleClick(history, dispatch, typeOfCare)}
     >
-      Start scheduling
+      Start scheduling an appointment
     </a>
   );
 }

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -128,9 +128,11 @@ describe('VAOS Page: AppointmentsPage', () => {
       },
     });
 
-    expect(screen.getByText(/Start scheduling/)).to.be.ok;
+    expect(screen.getByText(/Start scheduling an appointment/)).to.be.ok;
     userEvent.click(
-      await screen.findByRole('link', { name: /Start scheduling/i }),
+      await screen.findByRole('link', {
+        name: /Start scheduling an appointment/i,
+      }),
     );
 
     await waitFor(() =>
@@ -171,7 +173,9 @@ describe('VAOS Page: AppointmentsPage', () => {
     ).not.to.exist;
 
     // and scheduling link should be displayed
-    expect(screen.getByRole('link', { name: 'Start scheduling' })).to.be.ok;
+    expect(
+      screen.getByRole('link', { name: 'Start scheduling an appointment' }),
+    ).to.be.ok;
 
     // and appointment list navigation should be displayed
     expect(screen.getByRole('navigation', { name: 'Appointment list' })).to.be

--- a/src/applications/vaos/new-appointment/components/UrgentCareInformationPage.jsx
+++ b/src/applications/vaos/new-appointment/components/UrgentCareInformationPage.jsx
@@ -51,7 +51,7 @@ export default function UrgentCareInformationPage() {
         href="/"
         onClick={handleClick(history, dispatch)}
       >
-        Start scheduling
+        Start scheduling an appointment
       </a>
       <h2 className="vads-u-font-size--h3 vads-u-margin--0">
         If you need help sooner, use one of these urgent communications options:

--- a/src/applications/vaos/new-appointment/components/UrgentCareInformationPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/UrgentCareInformationPage.unit.spec.jsx
@@ -31,7 +31,9 @@ describe('VAOS Page: UrgentCareInformationPage', () => {
         /You can schedule or request non-urgent appointments for future dates./i,
       ),
     );
-    expect(screen.getByRole('link', { name: /Start scheduling/i }));
+    expect(
+      screen.getByRole('link', { name: /Start scheduling an appointment/i }),
+    );
     expect(
       screen.getByRole('heading', {
         level: 2,
@@ -55,7 +57,9 @@ describe('VAOS Page: UrgentCareInformationPage', () => {
       store,
     });
 
-    const link = screen.getByRole('link', { name: 'Start scheduling' });
+    const link = screen.getByRole('link', {
+      name: 'Start scheduling an appointment',
+    });
     link.click();
 
     // Assert

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -25,7 +25,7 @@ module.exports = [
   },
   { name: 'vaOnlineSchedulingListViewClinicInfo', value: true },
   { name: 'vaOnlineSchedulingAddOhAvs', value: true },
-  { name: 'vaOnlineSchedulingImmediateCareAlert', value: true },
+  { name: 'vaOnlineSchedulingImmediateCareAlert', value: false },
   { name: 'vaOnlineSchedulingRemoveFacilityConfigCheck', value: true },
   { name: 'vaOnlineSchedulingUseBrowserTimezone', value: true },
 ];

--- a/src/applications/vaos/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PageObject.js
@@ -248,7 +248,7 @@ export default class PageObject {
     return this.clickButton({ label });
   }
 
-  scheduleAppointment(text = 'Start scheduling') {
+  scheduleAppointment(text = 'Start scheduling an appointment') {
     cy.findByText(text).click({ waitForAnimations: true });
     return this;
   }

--- a/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/scheduling.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/scheduling.cypress.spec.js
@@ -37,7 +37,7 @@ describe('VAOS schedule flow', () => {
       })
       .assertCrisisModal()
       .clickButton({ ariaLabel: 'Close this modal' })
-      .clickLink({ name: /Start scheduling/i });
+      .clickLink({ name: /Start scheduling an appointment/i });
 
     TypeOfCarePageObject.assertUrl();
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds "an appointment" to links that used to just say "Start scheduling"
- UAE/Appointments/Orion

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128340

## Testing done

- Tested locally and updated cypress tests

## Screenshots

<details><summary>Current (main) - </summary>
<img width="1134" height="780" alt="Screenshot 2026-01-12 at 2 43 17 PM" src="https://github.com/user-attachments/assets/7fe92f58-2277-40a5-9ee8-0b106fcaf248" />
</details>

<details><summary>PR</summary>
<img width="1728" height="1117" alt="Screenshot 2026-01-12 at 2 41 32 PM" src="https://github.com/user-attachments/assets/b0c625f8-cca9-4bc3-a4b4-fb70974c29a1" />
</details>


## What areas of the site does it impact?

Appointment scheduling flow initial page

## Acceptance criteria

1. Text says "Start scheduling and appointment" for action link

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check message about non-urgent immediate care when starting to schedule an appointment