### PR TITLE
21-2680 updates content on intro page and benefits type page

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
@@ -38,11 +38,26 @@ const ProcessList = () => {
           you to apply.
         </p>
         <p>
-          <a href="https://www.va.gov/pension/aid-attendance-housebound/">
-            Find out if you’re eligible for Aid and Attendance benefits and
-            Housebound allowance
-          </a>
+          You may be eligible for either Special Monthly Compensation (SMC) or
+          Special Monthly Pension (SMP) benefits if you:
         </p>
+        <ul>
+          <li>Are a Veteran or the surviving spouse or parent of a Veteran</li>
+          <li>
+            Require help with everyday tasks, such as:
+            <ul>
+              <li>Bathing</li>
+              <li>Feeding</li>
+              <li>Dressing</li>
+              <li>Using the restroom</li>
+              <li>Adjusting prosthetic devices</li>
+              <li>
+                Protecting yourself from the hazards of the daily environment
+              </li>
+            </ul>
+          </li>
+          <li>Are housebound (because of permanent disability)</li>
+        </ul>
       </va-process-list-item>
       <va-process-list-item header="Gather your information">
         <p>You’ll need this information about the person applying:</p>

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
@@ -14,9 +14,9 @@ import { isClaimantVeteran } from '../utils';
 /**
  * Generate page title based on claimant relationship
  */
-const getPageTitle = formData => {
+const getRadioTitle = formData => {
   if (isClaimantVeteran(formData)) {
-    return 'Select which benefit you are applying for';
+    return 'Select which benefit you are applying for ';
   }
 
   // Get claimant's actual name
@@ -27,9 +27,9 @@ const getPageTitle = formData => {
 
   // If we have a name, use it; otherwise fallback to "you are"
   if (fullName) {
-    return `Select which benefit ${fullName} is applying for`;
+    return `Select which benefit ${fullName} is applying for `;
   }
-  return 'Select which benefit you are applying for';
+  return 'Select which benefit you are applying for ';
 };
 
 /**
@@ -37,18 +37,51 @@ const getPageTitle = formData => {
  * Selects between Special Monthly Compensation (SMC) and Special Monthly Pension (SMP)
  */
 export const benefitTypeUiSchema = {
-  'ui:title': 'Benefit type',
+  'ui:title': 'Which benefit should I apply for?',
   'ui:description': () => (
-    <p>
-      <a
-        href="https://www.va.gov/pension/aid-attendance-housebound/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Find out more about the difference between Special Monthly Compensation
-        (SMC) and Special Monthly Pension (SMP).
-      </a>
-    </p>
+    <>
+      <p>
+        If you are not sure which benefit you are eligible for, learn more about
+        Special Monthly Compensation and Special Monthly Pension.
+      </p>
+      <va-accordion>
+        <va-accordion-item header="Special Monthly Compensation (SMC)" id="smc">
+          <p>
+            SMC benefits are paid in addition to monthly compensation or
+            Dependency Indemnity Compensation (DIC). Apply for Special Monthly
+            Compensation (SMC) if you:
+          </p>
+          <ul>
+            <li>
+              Are a Veteran or the surviving spouse or parent of a Veteran
+            </li>
+            <li>Require help with everyday tasks</li>
+            <li>Are housebound (because of permanent disability)</li>
+            <li>
+              Are currently receiving, or are eligible for monthly compensation
+              or Dependency Indemnity Compensation (DIC). SMC benefits are not
+              paid without eligibility to compensation.
+            </li>
+          </ul>
+        </va-accordion-item>
+        <va-accordion-item header="Special Monthly Pension (SMP)" id="smp">
+          <p>
+            SMP is an increased monthly amount paid to a veteran or survivor who
+            is eligible for Veterans Pension or Survivors benefits. APply for
+            Special Monthly Compensation (SMC) if you:
+          </p>
+          <ul>
+            <li>Are a Veteran or the surviving spouse of a Veteran</li>
+            <li>Require help with everyday tasks</li>
+            <li>Are housebound (because of permanent disability)</li>
+            <li>
+              Currently receive, or are eligible for, Veteran’s Pension and/or
+              Survivors benefits
+            </li>
+          </ul>
+        </va-accordion-item>
+      </va-accordion>
+    </>
   ),
   benefitType: {
     benefitType: radioUI({
@@ -64,13 +97,18 @@ export const benefitTypeUiSchema = {
           'is an increased monthly amount paid to a Veteran or survivor who is eligible for Veterans Pension or Survivors benefits.',
       },
       tile: true,
+      labelHeaderLevel: 3,
     }),
   },
   'ui:options': {
     updateUiSchema: (formData, fullData) => {
-      const pageTitle = getPageTitle(fullData || formData);
+      const radioTitle = getRadioTitle(formData || fullData);
       return {
-        'ui:title': pageTitle,
+        benefitType: {
+          benefitType: {
+            'ui:title': radioTitle,
+          },
+        },
       };
     },
   },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
@@ -12,7 +12,7 @@ import {
 import { isClaimantVeteran } from '../utils';
 
 /**
- * Generate page title based on claimant relationship
+ * Generate radio button title based on claimant relationship
  */
 const getRadioTitle = formData => {
   if (isClaimantVeteran(formData)) {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
@@ -68,7 +68,7 @@ export const benefitTypeUiSchema = {
           <p>
             SMP is an increased monthly amount paid to a veteran or survivor who
             is eligible for Veterans Pension or Survivors benefits. Apply for
-            Special Monthly Compensation (SMC) if you:
+            Special Monthly Pension (SMP) if you:
           </p>
           <ul>
             <li>Are a Veteran or the surviving spouse of a Veteran</li>

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
@@ -67,7 +67,7 @@ export const benefitTypeUiSchema = {
         <va-accordion-item header="Special Monthly Pension (SMP)" id="smp">
           <p>
             SMP is an increased monthly amount paid to a veteran or survivor who
-            is eligible for Veterans Pension or Survivors benefits. APply for
+            is eligible for Veterans Pension or Survivors benefits. Apply for
             Special Monthly Compensation (SMC) if you:
           </p>
           <ul>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changes the content on the Introduction and Benefit Type pages to give better descriptions of what each benefit type is

### Issue
On form 21-2680, there wasn't enough info on SMP and SMC benefits to help users make a choice between the two

### Solution
Added additional info listed on [issue 127986](https://github.com/department-of-veterans-affairs/va.gov-team/issues/127986) to the introduction and benefit type pages

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required

## Related issue(s)

[Issue 127986](https://github.com/department-of-veterans-affairs/va.gov-team/issues/127986)

## Testing done

### Old behavior
* The form links to a separate page to give users info on benefits on the Intro and Benefit Type pages

### New behavior
* The form displays more helpful info directly on the form (letting users know if they're eligible to apply at all on the intro page, a description of the differences between SMC and SMP benefits on the Benefit Type page)

### Verification Steps
*  Unit tests: verified existing unit tests still pass
*  Manual testing in local environment verified that the new content shows up on the introduction and benefit type pages
* E2E tests: all existing tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="423" height="456" alt="before benefit mobile" src="https://github.com/user-attachments/assets/23f54743-7888-47f1-83cf-b4779096c36c" /> <img width="422" height="213" alt="before intro mobile" src="https://github.com/user-attachments/assets/7d3306bc-3d2f-4b40-acd6-6778535aa904" /> | <img width="318" height="588" alt="after benefit mobile" src="https://github.com/user-attachments/assets/46c265c3-7c3a-4762-be91-964e3b4d618c" /> <img width="417" height="590" alt="after intro mobile" src="https://github.com/user-attachments/assets/5d811a40-86f5-424a-bb0d-05617fe4ed0f" /> |
| Desktop |    <img width="535" height="391" alt="before benefit" src="https://github.com/user-attachments/assets/c748d865-9fe1-4fb3-86b3-781ac2332469" /><img width="653" height="206" alt="before intro" src="https://github.com/user-attachments/assets/34ea56aa-d5f0-452a-9d2a-c833db44848e" />  |  <img width="537" height="940" alt="after benefit" src="https://github.com/user-attachments/assets/2f33eb2f-eef5-4bfe-8dec-4c1c87e0eb9a" /><img width="721" height="556" alt="after intro" src="https://github.com/user-attachments/assets/ca7390f6-aaa3-41f2-a687-502779648da6" />  |


## What areas of the site does it impact?

This change affects form 21-2680. The content regarding SMP/SMC benefits are changed on the intro page (/pension/aid-attendance-housebound/apply-form-21-2680/introduction) and on the benefit type page (/pension/aid-attendance-housebound/apply-form-21-2680/benefit-type)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user