### PR TITLE
10-7959c | Fix MBI title customization

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/mbiNumber.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/mbiNumber.js
@@ -2,8 +2,10 @@ import { textUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { titleWithNameUI } from '../../utils/titles';
 import content from '../../locales/en/content.json';
 
-const TITLE_TEXT = content['medicare--mbi-label'];
+const TITLE_TEXT = content['medicare--mbi-title'];
 const DESC_TEXT = content['medicare--mbi-description'];
+
+const INPUT_LABEL = content['medicare--mbi-label'];
 const HINT_TEXT = content['medicare--mbi-hint'];
 
 const ERR_MSG_PATTERN = content['validation--mbi-invalid'];
@@ -20,7 +22,7 @@ export default {
   uiSchema: {
     ...titleWithNameUI(TITLE_TEXT, DESC_TEXT),
     medicareNumber: textUI({
-      title: TITLE_TEXT,
+      title: INPUT_LABEL,
       hint: HINT_TEXT,
       errorMessages: {
         pattern: ERR_MSG_PATTERN,

--- a/src/applications/ivc-champva/10-7959C/locales/en/content.json
+++ b/src/applications/ivc-champva/10-7959C/locales/en/content.json
@@ -85,6 +85,7 @@
   "medicare--general-pharmacy-label": "Does the beneficiary’s Medicare plan provide pharmacy benefits?",
   "medicare--general-pharmacy-hint": "You can find this information on the front of the Medicare card.",
   "medicare--intro-title": "Report Medicare",
+  "medicare--mbi-title": "%s MBI",
   "medicare--mbi-description": "Every Medicare recipient has an 11-character Medicare Beneficiary Identifier (MBI) code. You can find this code on the front of Medicare cards or on medicare.gov accounts.",
   "medicare--mbi-label": "MBI",
   "medicare--mbi-hint": "You can enter an HICN if that’s what’s shown on the Medicare card.",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the Medicare Beneficiary Identifier (MBI) field in the CHAMPVA application to clarify field labels and improve accessibility by distinguishing between the field's title and input label. The main changes involve updating the content source and how labels are displayed in the UI schema.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#128013

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Content meets C/IA standards

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
