### PR TITLE
[128823] Fix CCD success alert timing

### DIFF
--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -267,13 +267,21 @@ const DownloadReportPage = ({ runningUnitTest }) => {
       return (
         <div>
           <VistaAndOHIntroText
-            ohFacilityNames={ohFacilityNames}
-            vistaFacilityNames={vistaFacilityNames}
+            ohFacilityNames={
+              ohFacilityNames.length ? ohFacilityNames : ['unknown']
+            }
+            vistaFacilityNames={
+              vistaFacilityNames.length ? vistaFacilityNames : ['unknown']
+            }
             holdTimeMessagingUpdate={holdTimeMessagingUpdate}
           />
           <VistaAndOHContent
-            vistaFacilityNames={vistaFacilityNames}
-            ohFacilityNames={ohFacilityNames}
+            vistaFacilityNames={
+              vistaFacilityNames.length ? vistaFacilityNames : ['unknown']
+            }
+            ohFacilityNames={
+              ohFacilityNames.length ? ohFacilityNames : ['unknown']
+            }
             handleDownloadCCDV2={handleDownloadCCDV2}
             ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}
             failedSeiDomains={failedSeiDomains}

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -93,25 +93,27 @@ const DownloadReportPage = ({ runningUnitTest }) => {
     state => state.drupalStaticData?.vamcEhrData?.data?.ehrDataByVhaId,
   );
 
-  // Map facility IDs to facility names
+  // Map facility IDs to facility names, fallback to 'Unknown' if empty
   const vistaFacilityNames = useMemo(
     () => {
-      if (!ehrDataByVhaId) return [];
+      if (!ehrDataByVhaId) return ['Unknown'];
       const vistaFacilities = facilities.filter(f => !f.isCerner);
-      return vistaFacilities
+      const names = vistaFacilities
         .map(f => getVamcSystemNameFromVhaId(ehrDataByVhaId, f.facilityId))
         .filter(name => name); // Filter out undefined/null names
+      return names.length ? names : ['Unknown'];
     },
     [facilities, ehrDataByVhaId],
   );
 
   const ohFacilityNames = useMemo(
     () => {
-      if (!ehrDataByVhaId) return [];
+      if (!ehrDataByVhaId) return ['Unknown'];
       const ohFacilities = facilities.filter(f => f.isCerner);
-      return ohFacilities
+      const names = ohFacilities
         .map(f => getVamcSystemNameFromVhaId(ehrDataByVhaId, f.facilityId))
         .filter(name => name); // Filter out undefined/null names
+      return names.length ? names : ['Unknown'];
     },
     [facilities, ehrDataByVhaId],
   );
@@ -267,21 +269,13 @@ const DownloadReportPage = ({ runningUnitTest }) => {
       return (
         <div>
           <VistaAndOHIntroText
-            ohFacilityNames={
-              ohFacilityNames.length ? ohFacilityNames : ['Unknown']
-            }
-            vistaFacilityNames={
-              vistaFacilityNames.length ? vistaFacilityNames : ['Unknown']
-            }
+            ohFacilityNames={ohFacilityNames}
+            vistaFacilityNames={vistaFacilityNames}
             holdTimeMessagingUpdate={holdTimeMessagingUpdate}
           />
           <VistaAndOHContent
-            vistaFacilityNames={
-              vistaFacilityNames.length ? vistaFacilityNames : ['Unknown']
-            }
-            ohFacilityNames={
-              ohFacilityNames.length ? ohFacilityNames : ['Unknown']
-            }
+            vistaFacilityNames={vistaFacilityNames}
+            ohFacilityNames={ohFacilityNames}
             handleDownloadCCDV2={handleDownloadCCDV2}
             ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}
             failedSeiDomains={failedSeiDomains}

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -268,19 +268,19 @@ const DownloadReportPage = ({ runningUnitTest }) => {
         <div>
           <VistaAndOHIntroText
             ohFacilityNames={
-              ohFacilityNames.length ? ohFacilityNames : ['unknown']
+              ohFacilityNames.length ? ohFacilityNames : ['Unknown']
             }
             vistaFacilityNames={
-              vistaFacilityNames.length ? vistaFacilityNames : ['unknown']
+              vistaFacilityNames.length ? vistaFacilityNames : ['Unknown']
             }
             holdTimeMessagingUpdate={holdTimeMessagingUpdate}
           />
           <VistaAndOHContent
             vistaFacilityNames={
-              vistaFacilityNames.length ? vistaFacilityNames : ['unknown']
+              vistaFacilityNames.length ? vistaFacilityNames : ['Unknown']
             }
             ohFacilityNames={
-              ohFacilityNames.length ? ohFacilityNames : ['unknown']
+              ohFacilityNames.length ? ohFacilityNames : ['Unknown']
             }
             handleDownloadCCDV2={handleDownloadCCDV2}
             ccdExtendedFileTypeFlag={ccdExtendedFileTypeFlag}

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -93,27 +93,27 @@ const DownloadReportPage = ({ runningUnitTest }) => {
     state => state.drupalStaticData?.vamcEhrData?.data?.ehrDataByVhaId,
   );
 
-  // Map facility IDs to facility names, fallback to 'Unknown' if empty
+  // Map facility IDs to facility names, fallback to 'None recorded' if empty
   const vistaFacilityNames = useMemo(
     () => {
-      if (!ehrDataByVhaId) return ['Unknown'];
+      if (!ehrDataByVhaId) return ['None recorded'];
       const vistaFacilities = facilities.filter(f => !f.isCerner);
       const names = vistaFacilities
         .map(f => getVamcSystemNameFromVhaId(ehrDataByVhaId, f.facilityId))
         .filter(name => name); // Filter out undefined/null names
-      return names.length ? names : ['Unknown'];
+      return names.length ? names : ['None recorded'];
     },
     [facilities, ehrDataByVhaId],
   );
 
   const ohFacilityNames = useMemo(
     () => {
-      if (!ehrDataByVhaId) return ['Unknown'];
+      if (!ehrDataByVhaId) return ['None recorded'];
       const ohFacilities = facilities.filter(f => f.isCerner);
       const names = ohFacilities
         .map(f => getVamcSystemNameFromVhaId(ehrDataByVhaId, f.facilityId))
         .filter(name => name); // Filter out undefined/null names
-      return names.length ? names : ['Unknown'];
+      return names.length ? names : ['None recorded'];
     },
     [facilities, ehrDataByVhaId],
   );

--- a/src/applications/mhv-medical-records/containers/ccdAccordionItem/ccdAccordionItemOH.jsx
+++ b/src/applications/mhv-medical-records/containers/ccdAccordionItem/ccdAccordionItemOH.jsx
@@ -13,7 +13,10 @@ const CCDAccordionItemOH = ({ generatingCCD, handleDownloadCCDV2 }) => (
     </p>
 
     {generatingCCD ? (
-      <div id="generating-ccd-oh-indicator">
+      <div
+        id="generating-ccd-oh-indicator"
+        data-testid="generating-ccd-oh-indicator"
+      >
         <TrackedSpinner
           id="download-ccd-oh-spinner"
           label="Loading"

--- a/src/applications/mhv-medical-records/containers/ccdAccordionItem/ccdAccordionItemV1.jsx
+++ b/src/applications/mhv-medical-records/containers/ccdAccordionItem/ccdAccordionItemV1.jsx
@@ -16,7 +16,7 @@ const CCDAccordionItemV1 = ({ generatingCCD, handleDownloadCCD }) => (
       works with other providers’ medical records systems.
     </p>
     {generatingCCD ? (
-      <div id="generating-ccd-indicator">
+      <div id="generating-ccd-indicator" data-testid="generating-ccd-indicator">
         <TrackedSpinner
           id="download-ccd-spinner"
           label="Loading"

--- a/src/applications/mhv-medical-records/containers/ccdAccordionItem/ccdAccordionItemV2.jsx
+++ b/src/applications/mhv-medical-records/containers/ccdAccordionItem/ccdAccordionItemV2.jsx
@@ -14,7 +14,7 @@ const CCDAccordionItemV2 = ({ generatingCCD, handleDownloadCCD }) => (
     </p>
 
     {generatingCCD ? (
-      <div id="generating-ccd-indicator">
+      <div id="generating-ccd-indicator" data-testid="generating-ccd-indicator">
         <TrackedSpinner
           id="download-ccd-spinner"
           label="Loading"

--- a/src/applications/mhv-medical-records/containers/ccdContent/OHOnlyContent.jsx
+++ b/src/applications/mhv-medical-records/containers/ccdContent/OHOnlyContent.jsx
@@ -84,7 +84,7 @@ const OHOnlyContent = ({
                 />
               </>
             )}
-          {(generatingCCD || ccdDownloadSuccess) &&
+          {ccdDownloadSuccess &&
             !ccdError &&
             !CCDRetryTimestamp && (
               <DownloadSuccessAlert

--- a/src/applications/mhv-medical-records/containers/ccdContent/VistaAndOHContent.jsx
+++ b/src/applications/mhv-medical-records/containers/ccdContent/VistaAndOHContent.jsx
@@ -120,8 +120,9 @@ const VistaAndOHContent = ({
             />
           </>
         )}
-      {(generatingCCD || ccdDownloadSuccess) &&
-        (!ccdError && !CCDRetryTimestamp) && (
+      {ccdDownloadSuccess &&
+        !ccdError &&
+        !CCDRetryTimestamp && (
           <DownloadSuccessAlert
             type="Continuity of Care Document download"
             className="vads-u-margin-bottom--1"

--- a/src/applications/mhv-medical-records/containers/ccdContent/VistaOnlyContent.jsx
+++ b/src/applications/mhv-medical-records/containers/ccdContent/VistaOnlyContent.jsx
@@ -92,7 +92,7 @@ const VistaOnlyContent = ({
 
       <h2>Other reports you can download</h2>
 
-      {(generatingCCD || ccdDownloadSuccess) &&
+      {ccdDownloadSuccess &&
         !ccdError &&
         !CCDRetryTimestamp && (
           <DownloadSuccessAlert

--- a/src/applications/mhv-medical-records/tests/containers/CCDAccordionItemOH.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/CCDAccordionItemOH.unit.spec.jsx
@@ -20,15 +20,11 @@ describe('CCDAccordionItemOH', () => {
 
   it('shows loading spinner when generatingCCD is true', () => {
     const props = { ...defaultProps, generatingCCD: true };
-    const { container, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <CCDAccordionItemOH {...props} />,
     );
 
-    const spinnerContainer = container.querySelector(
-      '#generating-ccd-oh-indicator',
-    );
-    expect(spinnerContainer).to.exist;
-    expect(spinnerContainer.querySelector('va-loading-indicator')).to.exist;
+    expect(getByTestId('generating-ccd-oh-indicator')).to.exist;
 
     expect(queryByTestId('generateCcdButtonXmlOH')).to.not.exist;
     expect(queryByTestId('generateCcdButtonPdfOH')).to.not.exist;

--- a/src/applications/mhv-medical-records/tests/containers/CCDAccordionItemV2.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/CCDAccordionItemV2.unit.spec.jsx
@@ -20,15 +20,11 @@ describe('CCDAccordionItemV2', () => {
 
   it('shows loading spinner when generatingCCD is true', () => {
     const props = { ...defaultProps, generatingCCD: true };
-    const { container, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <CCDAccordionItemV2 {...props} />,
     );
 
-    const spinnerContainer = container.querySelector(
-      '#generating-ccd-indicator',
-    );
-    expect(spinnerContainer).to.exist;
-    expect(spinnerContainer.querySelector('va-loading-indicator')).to.exist;
+    expect(getByTestId('generating-ccd-indicator')).to.exist;
 
     expect(queryByTestId('generateCcdButtonXml')).to.not.exist;
     expect(queryByTestId('generateCcdButtonPdf')).to.not.exist;

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -421,7 +421,7 @@ describe('DownloadRecordsPage with last successful update timestamp', () => {
 });
 
 describe('DownloadRecordsPage - Missing EHR data for facility names', () => {
-  const testUnknownFallback = ehrData => {
+  const testNoneRecordedFallback = ehrData => {
     const state = {
       ...getBaseState(bothFacilities, ['456']),
       drupalStaticData: {
@@ -439,15 +439,15 @@ describe('DownloadRecordsPage - Missing EHR data for facility names', () => {
       reducers: reducer,
       path: '/download-all',
     });
-    expect(screen.getAllByText('Unknown').length).to.be.greaterThan(0);
+    expect(screen.getAllByText('None recorded').length).to.be.greaterThan(0);
   };
 
-  it('renders "Unknown" when ehrDataByVhaId is missing', () => {
-    testUnknownFallback(undefined);
+  it('renders "None recorded" when ehrDataByVhaId is missing', () => {
+    testNoneRecordedFallback(undefined);
   });
 
-  it('renders "unknown" when facility IDs not found', () => {
-    testUnknownFallback({ 999: { vamcSystemName: 'Other' } });
+  it('renders "None recorded" when facility IDs not found', () => {
+    testNoneRecordedFallback({ 999: { vamcSystemName: 'Other' } });
   });
 });
 

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -102,8 +102,7 @@ describe('DownloadRecordsPage - VistA Only User', () => {
     );
 
     fireEvent.click(ccdGenerateButton);
-    expect(screen.container.querySelector('#generating-ccd-indicator')).to
-      .exist;
+    expect(screen.getByTestId('generating-ccd-indicator')).to.exist;
   });
 
   it('generates CCD (PDF) on button click', () => {
@@ -119,8 +118,7 @@ describe('DownloadRecordsPage - VistA Only User', () => {
     );
 
     fireEvent.click(ccdGenerateButton);
-    expect(screen.container.querySelector('#generating-ccd-indicator')).to
-      .exist;
+    expect(screen.getByTestId('generating-ccd-indicator')).to.exist;
   });
 
   it('generates CCD (HTML) on button click', () => {
@@ -136,8 +134,7 @@ describe('DownloadRecordsPage - VistA Only User', () => {
     );
 
     fireEvent.click(ccdGenerateButton);
-    expect(screen.container.querySelector('#generating-ccd-indicator')).to
-      .exist;
+    expect(screen.getByTestId('generating-ccd-indicator')).to.exist;
   });
 });
 

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -439,10 +439,10 @@ describe('DownloadRecordsPage - Missing EHR data for facility names', () => {
       reducers: reducer,
       path: '/download-all',
     });
-    expect(screen.getAllByText('unknown').length).to.be.greaterThan(0);
+    expect(screen.getAllByText('Unknown').length).to.be.greaterThan(0);
   };
 
-  it('renders "unknown" when ehrDataByVhaId is missing', () => {
+  it('renders "Unknown" when ehrDataByVhaId is missing', () => {
     testUnknownFallback(undefined);
   });
 

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -420,6 +420,37 @@ describe('DownloadRecordsPage with last successful update timestamp', () => {
   });
 });
 
+describe('DownloadRecordsPage - Missing EHR data for facility names', () => {
+  const testUnknownFallback = ehrData => {
+    const state = {
+      ...getBaseState(bothFacilities, ['456']),
+      drupalStaticData: {
+        vamcEhrData: {
+          data: {
+            ehrDataByVhaId: ehrData,
+            cernerFacilities: [{ vhaId: '456' }],
+          },
+          loading: false,
+        },
+      },
+    };
+    const screen = renderWithStoreAndRouter(<DownloadReportPage />, {
+      initialState: state,
+      reducers: reducer,
+      path: '/download-all',
+    });
+    expect(screen.getAllByText('unknown').length).to.be.greaterThan(0);
+  };
+
+  it('renders "unknown" when ehrDataByVhaId is missing', () => {
+    testUnknownFallback(undefined);
+  });
+
+  it('renders "unknown" when facility IDs not found', () => {
+    testUnknownFallback({ 999: { vamcSystemName: 'Other' } });
+  });
+});
+
 describe('DownloadRecordsPage - Oracle Health CCD not enabled', () => {
   it('shows VistaOnlyContent for VistA-only users when flag is false', () => {
     const state = getBaseState(vistaOnlyFacilities, []);

--- a/src/applications/mhv-medical-records/tests/containers/OHOnlyContent.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/OHOnlyContent.unit.spec.jsx
@@ -67,13 +67,11 @@ describe('OHOnlyContent', () => {
   });
 
   it('shows loading spinner when generatingCCD is true', () => {
-    const { container, queryByText } = renderComponent({ generatingCCD: true });
+    const { getByTestId, queryByText } = renderComponent({
+      generatingCCD: true,
+    });
 
-    const spinnerContainer = container.querySelector(
-      '#generating-ccd-OH-indicator',
-    );
-    expect(spinnerContainer).to.exist;
-    expect(spinnerContainer.querySelector('va-loading-indicator')).to.exist;
+    expect(getByTestId('generating-ccd-OH-indicator')).to.exist;
 
     expect(queryByText('Download your Continuity of Care Document')).to.not
       .exist;
@@ -322,6 +320,18 @@ describe('OHOnlyContent', () => {
   });
 
   describe('CCD Download Success Alert', () => {
+    it('does not render CCD download success alert when only generatingCCD is true, but shows spinner', () => {
+      const { queryByText, getByTestId } = renderComponent({
+        generatingCCD: true,
+        ccdDownloadSuccess: false,
+        ccdError: false,
+        CCDRetryTimestamp: null,
+      });
+
+      expect(queryByText(/Continuity of Care Document download/)).to.not.exist;
+      expect(getByTestId('generating-ccd-OH-indicator')).to.exist;
+    });
+
     it('renders CCD download success alert when ccdDownloadSuccess is true', () => {
       const { getByText } = renderComponent({
         ccdDownloadSuccess: true,

--- a/src/applications/mhv-medical-records/tests/containers/VistaAndOHContent.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/VistaAndOHContent.unit.spec.jsx
@@ -242,14 +242,17 @@ describe('VistaAndOHContent', () => {
   });
 
   describe('CCD Download Success Alert', () => {
-    it('renders CCD download success alert when generatingCCD is true and no error', () => {
-      const { getByText } = renderComponent({
+    it('does not render CCD download success alert when only generatingCCD is true, but shows spinner', () => {
+      const { queryByText, getByTestId } = renderComponent({
         generatingCCD: true,
+        ccdDownloadSuccess: false,
         ccdError: false,
         CCDRetryTimestamp: null,
       });
 
-      expect(getByText(/Continuity of Care Document download/)).to.exist;
+      expect(queryByText(/Continuity of Care Document download/)).to.not.exist;
+      expect(getByTestId('generating-ccd-Vista-indicator')).to.exist;
+      expect(getByTestId('generating-ccd-OH-indicator')).to.exist;
     });
 
     it('renders CCD download success alert when ccdDownloadSuccess is true and no error', () => {
@@ -476,30 +479,23 @@ describe('VistaAndOHContent', () => {
     });
 
     it('shows loading spinner when generatingCCD is true', () => {
-      const { container, queryByTestId } = renderComponent({
+      const { getByTestId, queryByTestId } = renderComponent({
         ccdExtendedFileTypeFlag: false,
         generatingCCD: true,
       });
 
-      const spinnerContainer = container.querySelector(
-        '#generating-ccd-indicator',
-      );
-      expect(spinnerContainer).to.exist;
-      expect(spinnerContainer.querySelector('va-loading-indicator')).to.exist;
+      expect(getByTestId('generating-ccd-indicator')).to.exist;
 
       expect(queryByTestId('generateCcdButtonXml')).to.not.exist;
     });
 
     it('does not show loading spinner when generatingCCD is false', () => {
-      const { container, getByTestId } = renderComponent({
+      const { queryByTestId, getByTestId } = renderComponent({
         ccdExtendedFileTypeFlag: false,
         generatingCCD: false,
       });
 
-      const spinnerContainer = container.querySelector(
-        '#generating-ccd-indicator',
-      );
-      expect(spinnerContainer).to.not.exist;
+      expect(queryByTestId('generating-ccd-indicator')).to.not.exist;
       expect(getByTestId('generateCcdButtonXml')).to.exist;
     });
   });

--- a/src/applications/mhv-medical-records/tests/containers/VistaOnlyContent.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/VistaOnlyContent.unit.spec.jsx
@@ -253,14 +253,16 @@ describe('VistaOnlyContent', () => {
   });
 
   describe('CCD Download Success Alert', () => {
-    it('renders CCD download success alert when generatingCCD is true and no error', () => {
-      const { getByText } = renderComponent({
+    it('does not render CCD download success alert when only generatingCCD is true, but shows spinner', () => {
+      const { queryByText, getByTestId } = renderComponent({
         generatingCCD: true,
+        ccdDownloadSuccess: false,
         ccdError: false,
         CCDRetryTimestamp: null,
       });
 
-      expect(getByText(/Continuity of Care Document download/)).to.exist;
+      expect(queryByText(/Continuity of Care Document download/)).to.not.exist;
+      expect(getByTestId('generating-ccd-indicator')).to.exist;
     });
 
     it('renders CCD download success alert when ccdDownloadSuccess is true and no error', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fixes the CCD download success alert timing and adds defensive fallback handling for missing facility names.

1. Fix success alert timing
The success alert was appearing before the CCD file download actually completed. Updated the CCD accordion item and content components to trigger the success alert callback only after the download finishes.

2. Show "None recorded" for missing facility names
When EHR data is missing or facility IDs are not found in `ehrDataByVhaId`, the facility name arrays could be empty, causing empty lists in the UI. Added fallback to display "None recorded" when facility names are unavailable.


## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128823


## Testing done

- Updated unit tests for all affected components
- Added new tests verifying the "Unknown" fallback behavior

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Alert timing  |   <img width="897" height="753" alt="Screenshot 2026-01-12 at 11 53 58 AM" src="https://github.com/user-attachments/assets/66855dd2-08f9-4463-8b98-747d98a52c46" />     |   <img width="897" height="835" alt="Screenshot 2026-01-12 at 11 29 34 AM" src="https://github.com/user-attachments/assets/58b98b53-10ef-496d-947a-3c6f8315a21b" />    |
| Missing facility names |   <img width="897" height="753" alt="Screenshot 2026-01-12 at 11 52 31 AM" src="https://github.com/user-attachments/assets/b0163b7f-d1a2-440e-8292-a3e55dba0bf8" />     |   <img width="897" height="753" alt="Screenshot 2026-01-12 at 11 42 57 AM" src="https://github.com/user-attachments/assets/5cc396fd-3f9d-45b4-9ebc-73575b55164b" />    |

## What areas of the site does it impact?

MHV Medical Records - Blue button download page


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
