### PR TITLE
#127191 [WIP - for test observation] Add field key mappings to addressPattern Platform component

### DIFF
--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-v3-removal.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-v3-removal.cypress.spec.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-
 import formConfig from '../../config/form';
 import { PICKLIST_DATA } from '../../config/constants';
 import manifest from '../../manifest.json';

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,6 +1,17 @@
-import React from 'react';
-import merge from 'lodash/merge';
-import omit from 'platform/utilities/data/omit';
+// import React from 'react';
+// import merge from 'lodash/merge';
+// import omit from 'platform/utilities/data/omit';
+// import {
+//   addressSchema,
+//   addressUI,
+//   updateFormDataAddress,
+// } from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  mappedAddressUI,
+  mappedAddressSchema,
+  updateMappedFormDataAddress,
+} from 'platform/forms-system/src/js/web-component-patterns/addressPattern';
+
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
@@ -13,62 +24,76 @@ import {
   phoneEmailViewField,
 } from '../content/contactInformation';
 
-import { addressUISchema } from '../utils/schemas';
+// import { addressUISchema } from '../utils/schemas';
 
-import {
-  ADDRESS_PATHS,
-  USA,
-  MILITARY_STATE_LABELS,
-  MILITARY_STATE_VALUES,
-  MILITARY_CITIES,
-  STATE_LABELS,
-  STATE_VALUES,
-} from '../constants';
+// import {
+//   ADDRESS_PATHS,
+//   USA,
+//   MILITARY_STATE_LABELS,
+//   MILITARY_STATE_VALUES,
+//   MILITARY_CITIES,
+//   STATE_LABELS,
+//   STATE_VALUES,
+// } from '../constants';
 
-import {
-  validateMilitaryCity,
-  validateMilitaryState,
-  validateZIP,
-} from '../validations';
+// import {
+//   validateMilitaryCity,
+//   validateMilitaryState,
+//   validateZIP,
+// } from '../validations';
 
 const {
   // forwardingAddress,
   phoneAndEmail,
 } = fullSchema.properties;
 
-const mailingAddress = merge(
-  {
-    properties: {
-      'view:livesOnMilitaryBase': {
-        type: 'boolean',
-      },
-      'view:livesOnMilitaryBaseInfo': {
-        type: 'object',
-        properties: {},
-      },
-    },
-  },
-  fullSchema.definitions.address,
-);
+// const mailingAddress = merge(
+//   {
+//     properties: {
+//       'view:livesOnMilitaryBase': {
+//         type: 'boolean',
+//       },
+//       'view:livesOnMilitaryBaseInfo': {
+//         type: 'object',
+//         properties: {},
+//       },
+//     },
+//   },
+//   fullSchema.definitions.address,
+// );
 
-const countryEnum = fullSchema.definitions.country.enum;
-const citySchema = fullSchema.definitions.address.properties.city;
+// const countryEnum = fullSchema.definitions.country.enum;
+// const citySchema = fullSchema.definitions.address.properties.city;
 
 /**
  * Return state of mailing address military base checkbox
  * @param {object} data - Complete form data
  * @returns {boolean} - military base checkbox state
  */
-const getMilitaryValue = data =>
-  data.mailingAddress?.['view:livesOnMilitaryBase'];
+// const getMilitaryValue = data =>
+//   data.mailingAddress?.['view:livesOnMilitaryBase'];
 
-// Temporary storage for city & state if military base checkbox is toggled more
-// than once
-const savedAddress = {
-  city: '',
-  state: '',
+// // Temporary storage for city & state if military base checkbox is toggled more
+// // than once
+// const savedAddress = {
+//   city: '',
+//   state: '',
+// };
+
+export const updateFormData = (oldFormData, formData) => {
+  return updateMappedFormDataAddress(
+    oldFormData,
+    formData,
+    ['mailingAddress'],
+    null,
+    {
+      street: 'addressLine1',
+      street2: 'addressLine2',
+      street3: 'addressLine3',
+      postalCode: 'zipCode',
+    },
+  );
 };
-
 /**
  * Update form data to remove selected military city & state and restore any
  * previously set city & state when the "I live on a U.S. military base"
@@ -78,33 +103,35 @@ const savedAddress = {
  * @returns {object} - updated Form data with manipulated mailing address if the
  * military base checkbox state changes
  */
-export const updateFormData = (oldFormData, formData) => {
-  let { city, state } = formData.mailingAddress;
-  const onMilitaryBase = getMilitaryValue(formData);
-  if (getMilitaryValue(oldFormData) !== onMilitaryBase) {
-    if (onMilitaryBase) {
-      savedAddress.city = oldFormData.mailingAddress.city || '';
-      savedAddress.state = oldFormData.mailingAddress.state || '';
-      city = '';
-      state = '';
-    } else {
-      city = MILITARY_CITIES.includes(oldFormData.mailingAddress.city)
-        ? savedAddress.city
-        : city || savedAddress.city;
-      state = MILITARY_STATE_VALUES.includes(oldFormData.mailingAddress.state)
-        ? savedAddress.state
-        : state || savedAddress.state;
-    }
-  }
-  return {
-    ...formData,
-    mailingAddress: {
-      ...formData.mailingAddress,
-      city,
-      state,
-    },
-  };
-};
+// export const updateFormData = (oldFormData, formData) => {
+//   updateFormDataAddress(oldFormData, formData, ['mailingAddress']);
+//   return formData;
+// let { city, state } = formData.mailingAddress;
+// const onMilitaryBase = getMilitaryValue(formData);
+// if (getMilitaryValue(oldFormData) !== onMilitaryBase) {
+//   if (onMilitaryBase) {
+//     savedAddress.city = oldFormData.mailingAddress.city || '';
+//     savedAddress.state = oldFormData.mailingAddress.state || '';
+//     city = '';
+//     state = '';
+//   } else {
+//     city = MILITARY_CITIES.includes(oldFormData.mailingAddress.city)
+//       ? savedAddress.city
+//       : city || savedAddress.city;
+//     state = MILITARY_STATE_VALUES.includes(oldFormData.mailingAddress.state)
+//       ? savedAddress.state
+//       : state || savedAddress.state;
+//   }
+// }
+// return {
+//   ...formData,
+//   mailingAddress: {
+//     ...formData.mailingAddress,
+//     city,
+//     state,
+//   },
+// };
+// };
 
 export const uiSchema = {
   'ui:title': 'Contact information',
@@ -118,161 +145,172 @@ export const uiSchema = {
     primaryPhone: phoneUI('Phone number'),
     emailAddress: emailUI(),
   },
-  mailingAddress: {
-    ...omit(
-      ['ui:order'],
-      addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
-    ),
-    'view:livesOnMilitaryBase': {
-      'ui:title':
-        'I live on a United States military base outside of the United States',
+  mailingAddress: mappedAddressUI({
+    keyMap: {
+      street: 'addressLine1',
+      street2: 'addressLine2',
+      street3: 'addressLine3',
+      postalCode: 'zipCode',
     },
-    'view:livesOnMilitaryBaseInfo': {
-      'ui:description': () => (
-        <div className="vads-u-padding-x--2p5">
-          <va-additional-info trigger="Learn more about military base addresses">
-            <span>
-              The United States is automatically chosen as your country if you
-              live on a military base outside of the country.
-            </span>
-          </va-additional-info>
-        </div>
-      ),
-    },
-    country: {
-      'ui:title': 'Country',
-      'ui:autocomplete': 'country',
-      'ui:options': {
-        updateSchema: (formData, schema, uiSchemaCountry) => {
-          const uiSchemaDisabled = uiSchemaCountry;
+  }),
+  // mailingAddress: {
+  //   ...addressUI(),
+  // },
+  // mailingAddress: {
+  //   ...omit(
+  //     ['ui:order'],
+  //     addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
+  //   ),
+  //   'view:livesOnMilitaryBase': {
+  //     'ui:title':
+  //       'I live on a United States military base outside of the United States',
+  //   },
+  //   'view:livesOnMilitaryBaseInfo': {
+  //     'ui:description': () => (
+  //       <div className="vads-u-padding-x--2p5">
+  //         <va-additional-info trigger="Learn more about military base addresses">
+  //           <span>
+  //             The United States is automatically chosen as your country if you
+  //             live on a military base outside of the country.
+  //           </span>
+  //         </va-additional-info>
+  //       </div>
+  //     ),
+  //   },
+  //   country: {
+  //     'ui:title': 'Country',
+  //     'ui:autocomplete': 'country',
+  //     'ui:options': {
+  //       updateSchema: (formData, schema, uiSchemaCountry) => {
+  //         const uiSchemaDisabled = uiSchemaCountry;
 
-          if (formData.mailingAddress?.['view:livesOnMilitaryBase']) {
-            const formDataMailingAddress = formData.mailingAddress;
-            formDataMailingAddress.country = USA;
+  //         if (formData.mailingAddress?.['view:livesOnMilitaryBase']) {
+  //           const formDataMailingAddress = formData.mailingAddress;
+  //           formDataMailingAddress.country = USA;
 
-            uiSchemaDisabled['ui:disabled'] = true;
+  //           uiSchemaDisabled['ui:disabled'] = true;
 
-            return {
-              enum: [USA],
-            };
-          }
-          uiSchemaDisabled['ui:disabled'] = false;
-          return {
-            enum: countryEnum,
-          };
-        },
-      },
-    },
-    addressLine1: {
-      'ui:title': 'Street address (20 characters maximum)',
-      'ui:autocomplete': 'address-line1',
-      'ui:errorMessages': {
-        required: 'Please enter a street address',
-      },
-    },
-    addressLine2: {
-      'ui:title': 'Street address line 2 (20 characters maximum)',
-      'ui:autocomplete': 'address-line2',
-      'ui:errorMessages': {
-        pattern: 'Please enter a valid street address',
-      },
-    },
-    addressLine3: {
-      'ui:title': 'Street address line 3 (20 characters maximum)',
-      'ui:autocomplete': 'address-line3',
-      'ui:errorMessages': {
-        pattern: 'Please enter a valid street address',
-      },
-    },
-    city: {
-      'ui:autocomplete': 'address-level2',
-      'ui:errorMessages': {
-        pattern: 'Please enter a valid city',
-        required: 'Please enter a city',
-      },
-      'ui:options': {
-        replaceSchema: formData => {
-          if (formData.mailingAddress?.['view:livesOnMilitaryBase'] === true) {
-            return {
-              type: 'string',
-              title: 'APO/FPO/DPO',
-              enum: MILITARY_CITIES,
-            };
-          }
-          return merge(
-            {
-              title: 'City',
-            },
-            citySchema,
-          );
-        },
-      },
-      'ui:validations': [
-        {
-          options: { addressPath: 'mailingAddress' },
-          // pathWithIndex is called in validateMilitaryCity
-          validator: validateMilitaryCity,
-        },
-      ],
-    },
-    state: {
-      'ui:title': 'State',
-      'ui:autocomplete': 'address-level1',
-      'ui:options': {
-        hideIf: formData =>
-          !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
-          formData.mailingAddress.country !== USA,
-        updateSchema: formData => {
-          if (
-            formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
-            MILITARY_CITIES.includes(formData.mailingAddress.city)
-          ) {
-            return {
-              enum: MILITARY_STATE_VALUES,
-              enumNames: MILITARY_STATE_LABELS,
-            };
-          }
-          return {
-            enum: STATE_VALUES,
-            enumNames: STATE_LABELS,
-          };
-        },
-      },
-      'ui:required': formData =>
-        formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
-        formData.mailingAddress.country === USA,
-      'ui:validations': [
-        {
-          options: { addressPath: 'mailingAddress' },
-          // pathWithIndex is called in validateMilitaryState
-          validator: validateMilitaryState,
-        },
-      ],
-      'ui:errorMessages': {
-        pattern: 'Please enter a valid state',
-        required: 'Please enter a state',
-      },
-    },
-    zipCode: {
-      'ui:title': 'Postal code',
-      'ui:autocomplete': 'postal-code',
-      'ui:validations': [validateZIP],
-      'ui:required': formData =>
-        formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
-        formData.mailingAddress.country === USA,
-      'ui:errorMessages': {
-        required: 'Please enter a postal code',
-        pattern:
-          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
-      },
-      'ui:options': {
-        widgetClassNames: 'va-input-medium-large',
-        hideIf: formData =>
-          !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
-          formData.mailingAddress.country !== USA,
-      },
-    },
-  },
+  //           return {
+  //             enum: [USA],
+  //           };
+  //         }
+  //         uiSchemaDisabled['ui:disabled'] = false;
+  //         return {
+  //           enum: countryEnum,
+  //         };
+  //       },
+  //     },
+  //   },
+  //   addressLine1: {
+  //     'ui:title': 'Street address (20 characters maximum)',
+  //     'ui:autocomplete': 'address-line1',
+  //     'ui:errorMessages': {
+  //       required: 'Please enter a street address',
+  //     },
+  //   },
+  //   addressLine2: {
+  //     'ui:title': 'Street address line 2 (20 characters maximum)',
+  //     'ui:autocomplete': 'address-line2',
+  //     'ui:errorMessages': {
+  //       pattern: 'Please enter a valid street address',
+  //     },
+  //   },
+  //   addressLine3: {
+  //     'ui:title': 'Street address line 3 (20 characters maximum)',
+  //     'ui:autocomplete': 'address-line3',
+  //     'ui:errorMessages': {
+  //       pattern: 'Please enter a valid street address',
+  //     },
+  //   },
+  //   city: {
+  //     'ui:autocomplete': 'address-level2',
+  //     'ui:errorMessages': {
+  //       pattern: 'Please enter a valid city',
+  //       required: 'Please enter a city',
+  //     },
+  //     'ui:options': {
+  //       replaceSchema: formData => {
+  //         if (formData.mailingAddress?.['view:livesOnMilitaryBase'] === true) {
+  //           return {
+  //             type: 'string',
+  //             title: 'APO/FPO/DPO',
+  //             enum: MILITARY_CITIES,
+  //           };
+  //         }
+  //         return merge(
+  //           {
+  //             title: 'City',
+  //           },
+  //           citySchema,
+  //         );
+  //       },
+  //     },
+  //     'ui:validations': [
+  //       {
+  //         options: { addressPath: 'mailingAddress' },
+  //         // pathWithIndex is called in validateMilitaryCity
+  //         validator: validateMilitaryCity,
+  //       },
+  //     ],
+  //   },
+  //   state: {
+  //     'ui:title': 'State',
+  //     'ui:autocomplete': 'address-level1',
+  //     'ui:options': {
+  //       hideIf: formData =>
+  //         !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
+  //         formData.mailingAddress.country !== USA,
+  //       updateSchema: formData => {
+  //         if (
+  //           formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
+  //           MILITARY_CITIES.includes(formData.mailingAddress.city)
+  //         ) {
+  //           return {
+  //             enum: MILITARY_STATE_VALUES,
+  //             enumNames: MILITARY_STATE_LABELS,
+  //           };
+  //         }
+  //         return {
+  //           enum: STATE_VALUES,
+  //           enumNames: STATE_LABELS,
+  //         };
+  //       },
+  //     },
+  //     'ui:required': formData =>
+  //       formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
+  //       formData.mailingAddress.country === USA,
+  //     'ui:validations': [
+  //       {
+  //         options: { addressPath: 'mailingAddress' },
+  //         // pathWithIndex is called in validateMilitaryState
+  //         validator: validateMilitaryState,
+  //       },
+  //     ],
+  //     'ui:errorMessages': {
+  //       pattern: 'Please enter a valid state',
+  //       required: 'Please enter a state',
+  //     },
+  //   },
+  //   zipCode: {
+  //     'ui:title': 'Postal code',
+  //     'ui:autocomplete': 'postal-code',
+  //     'ui:validations': [validateZIP],
+  //     'ui:required': formData =>
+  //       formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
+  //       formData.mailingAddress.country === USA,
+  //     'ui:errorMessages': {
+  //       required: 'Please enter a postal code',
+  //       pattern:
+  //         'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+  //     },
+  //     'ui:options': {
+  //       widgetClassNames: 'va-input-medium-large',
+  //       hideIf: formData =>
+  //         !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
+  //         formData.mailingAddress.country !== USA,
+  //     },
+  //   },
+  // },
   'view:contactInfoDescription': {
     'ui:description': contactInfoUpdateHelpDescription,
   },
@@ -282,7 +320,18 @@ export const schema = {
   type: 'object',
   properties: {
     phoneAndEmail,
-    mailingAddress,
+    // mailingAddress,
+    // mailingAddress: addressUISchema,
+    // mailingAddress: addressSchema(),
+    mailingAddress: mappedAddressSchema({
+      keyMap: {
+        street: 'addressLine1',
+        street2: 'addressLine2',
+        street3: 'addressLine3',
+        postalCode: 'zipCode',
+      },
+      // omit: ['street3'],
+    }),
     'view:contactInfoDescription': {
       type: 'object',
       properties: {},

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,17 +1,6 @@
-// import React from 'react';
-// import merge from 'lodash/merge';
-// import omit from 'platform/utilities/data/omit';
-// import {
-//   addressSchema,
-//   addressUI,
-//   updateFormDataAddress,
-// } from 'platform/forms-system/src/js/web-component-patterns';
-import {
-  mappedAddressUI,
-  mappedAddressSchema,
-  updateMappedFormDataAddress,
-} from 'platform/forms-system/src/js/web-component-patterns/addressPattern';
-
+import React from 'react';
+import merge from 'lodash/merge';
+import omit from 'platform/utilities/data/omit';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
@@ -24,76 +13,62 @@ import {
   phoneEmailViewField,
 } from '../content/contactInformation';
 
-// import { addressUISchema } from '../utils/schemas';
+import { addressUISchema } from '../utils/schemas';
 
-// import {
-//   ADDRESS_PATHS,
-//   USA,
-//   MILITARY_STATE_LABELS,
-//   MILITARY_STATE_VALUES,
-//   MILITARY_CITIES,
-//   STATE_LABELS,
-//   STATE_VALUES,
-// } from '../constants';
+import {
+  ADDRESS_PATHS,
+  USA,
+  MILITARY_STATE_LABELS,
+  MILITARY_STATE_VALUES,
+  MILITARY_CITIES,
+  STATE_LABELS,
+  STATE_VALUES,
+} from '../constants';
 
-// import {
-//   validateMilitaryCity,
-//   validateMilitaryState,
-//   validateZIP,
-// } from '../validations';
+import {
+  validateMilitaryCity,
+  validateMilitaryState,
+  validateZIP,
+} from '../validations';
 
 const {
   // forwardingAddress,
   phoneAndEmail,
 } = fullSchema.properties;
 
-// const mailingAddress = merge(
-//   {
-//     properties: {
-//       'view:livesOnMilitaryBase': {
-//         type: 'boolean',
-//       },
-//       'view:livesOnMilitaryBaseInfo': {
-//         type: 'object',
-//         properties: {},
-//       },
-//     },
-//   },
-//   fullSchema.definitions.address,
-// );
+const mailingAddress = merge(
+  {
+    properties: {
+      'view:livesOnMilitaryBase': {
+        type: 'boolean',
+      },
+      'view:livesOnMilitaryBaseInfo': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+  fullSchema.definitions.address,
+);
 
-// const countryEnum = fullSchema.definitions.country.enum;
-// const citySchema = fullSchema.definitions.address.properties.city;
+const countryEnum = fullSchema.definitions.country.enum;
+const citySchema = fullSchema.definitions.address.properties.city;
 
 /**
  * Return state of mailing address military base checkbox
  * @param {object} data - Complete form data
  * @returns {boolean} - military base checkbox state
  */
-// const getMilitaryValue = data =>
-//   data.mailingAddress?.['view:livesOnMilitaryBase'];
+const getMilitaryValue = data =>
+  data.mailingAddress?.['view:livesOnMilitaryBase'];
 
-// // Temporary storage for city & state if military base checkbox is toggled more
-// // than once
-// const savedAddress = {
-//   city: '',
-//   state: '',
-// };
-
-export const updateFormData = (oldFormData, formData) => {
-  return updateMappedFormDataAddress(
-    oldFormData,
-    formData,
-    ['mailingAddress'],
-    null,
-    {
-      street: 'addressLine1',
-      street2: 'addressLine2',
-      street3: 'addressLine3',
-      postalCode: 'zipCode',
-    },
-  );
+// Temporary storage for city & state if military base checkbox is toggled more
+// than once
+const savedAddress = {
+  city: '',
+  state: '',
 };
+
 /**
  * Update form data to remove selected military city & state and restore any
  * previously set city & state when the "I live on a U.S. military base"
@@ -103,35 +78,33 @@ export const updateFormData = (oldFormData, formData) => {
  * @returns {object} - updated Form data with manipulated mailing address if the
  * military base checkbox state changes
  */
-// export const updateFormData = (oldFormData, formData) => {
-//   updateFormDataAddress(oldFormData, formData, ['mailingAddress']);
-//   return formData;
-// let { city, state } = formData.mailingAddress;
-// const onMilitaryBase = getMilitaryValue(formData);
-// if (getMilitaryValue(oldFormData) !== onMilitaryBase) {
-//   if (onMilitaryBase) {
-//     savedAddress.city = oldFormData.mailingAddress.city || '';
-//     savedAddress.state = oldFormData.mailingAddress.state || '';
-//     city = '';
-//     state = '';
-//   } else {
-//     city = MILITARY_CITIES.includes(oldFormData.mailingAddress.city)
-//       ? savedAddress.city
-//       : city || savedAddress.city;
-//     state = MILITARY_STATE_VALUES.includes(oldFormData.mailingAddress.state)
-//       ? savedAddress.state
-//       : state || savedAddress.state;
-//   }
-// }
-// return {
-//   ...formData,
-//   mailingAddress: {
-//     ...formData.mailingAddress,
-//     city,
-//     state,
-//   },
-// };
-// };
+export const updateFormData = (oldFormData, formData) => {
+  let { city, state } = formData.mailingAddress;
+  const onMilitaryBase = getMilitaryValue(formData);
+  if (getMilitaryValue(oldFormData) !== onMilitaryBase) {
+    if (onMilitaryBase) {
+      savedAddress.city = oldFormData.mailingAddress.city || '';
+      savedAddress.state = oldFormData.mailingAddress.state || '';
+      city = '';
+      state = '';
+    } else {
+      city = MILITARY_CITIES.includes(oldFormData.mailingAddress.city)
+        ? savedAddress.city
+        : city || savedAddress.city;
+      state = MILITARY_STATE_VALUES.includes(oldFormData.mailingAddress.state)
+        ? savedAddress.state
+        : state || savedAddress.state;
+    }
+  }
+  return {
+    ...formData,
+    mailingAddress: {
+      ...formData.mailingAddress,
+      city,
+      state,
+    },
+  };
+};
 
 export const uiSchema = {
   'ui:title': 'Contact information',
@@ -145,172 +118,161 @@ export const uiSchema = {
     primaryPhone: phoneUI('Phone number'),
     emailAddress: emailUI(),
   },
-  mailingAddress: mappedAddressUI({
-    keyMap: {
-      street: 'addressLine1',
-      street2: 'addressLine2',
-      street3: 'addressLine3',
-      postalCode: 'zipCode',
+  mailingAddress: {
+    ...omit(
+      ['ui:order'],
+      addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
+    ),
+    'view:livesOnMilitaryBase': {
+      'ui:title':
+        'I live on a United States military base outside of the United States',
     },
-  }),
-  // mailingAddress: {
-  //   ...addressUI(),
-  // },
-  // mailingAddress: {
-  //   ...omit(
-  //     ['ui:order'],
-  //     addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
-  //   ),
-  //   'view:livesOnMilitaryBase': {
-  //     'ui:title':
-  //       'I live on a United States military base outside of the United States',
-  //   },
-  //   'view:livesOnMilitaryBaseInfo': {
-  //     'ui:description': () => (
-  //       <div className="vads-u-padding-x--2p5">
-  //         <va-additional-info trigger="Learn more about military base addresses">
-  //           <span>
-  //             The United States is automatically chosen as your country if you
-  //             live on a military base outside of the country.
-  //           </span>
-  //         </va-additional-info>
-  //       </div>
-  //     ),
-  //   },
-  //   country: {
-  //     'ui:title': 'Country',
-  //     'ui:autocomplete': 'country',
-  //     'ui:options': {
-  //       updateSchema: (formData, schema, uiSchemaCountry) => {
-  //         const uiSchemaDisabled = uiSchemaCountry;
+    'view:livesOnMilitaryBaseInfo': {
+      'ui:description': () => (
+        <div className="vads-u-padding-x--2p5">
+          <va-additional-info trigger="Learn more about military base addresses">
+            <span>
+              The United States is automatically chosen as your country if you
+              live on a military base outside of the country.
+            </span>
+          </va-additional-info>
+        </div>
+      ),
+    },
+    country: {
+      'ui:title': 'Country',
+      'ui:autocomplete': 'country',
+      'ui:options': {
+        updateSchema: (formData, schema, uiSchemaCountry) => {
+          const uiSchemaDisabled = uiSchemaCountry;
 
-  //         if (formData.mailingAddress?.['view:livesOnMilitaryBase']) {
-  //           const formDataMailingAddress = formData.mailingAddress;
-  //           formDataMailingAddress.country = USA;
+          if (formData.mailingAddress?.['view:livesOnMilitaryBase']) {
+            const formDataMailingAddress = formData.mailingAddress;
+            formDataMailingAddress.country = USA;
 
-  //           uiSchemaDisabled['ui:disabled'] = true;
+            uiSchemaDisabled['ui:disabled'] = true;
 
-  //           return {
-  //             enum: [USA],
-  //           };
-  //         }
-  //         uiSchemaDisabled['ui:disabled'] = false;
-  //         return {
-  //           enum: countryEnum,
-  //         };
-  //       },
-  //     },
-  //   },
-  //   addressLine1: {
-  //     'ui:title': 'Street address (20 characters maximum)',
-  //     'ui:autocomplete': 'address-line1',
-  //     'ui:errorMessages': {
-  //       required: 'Please enter a street address',
-  //     },
-  //   },
-  //   addressLine2: {
-  //     'ui:title': 'Street address line 2 (20 characters maximum)',
-  //     'ui:autocomplete': 'address-line2',
-  //     'ui:errorMessages': {
-  //       pattern: 'Please enter a valid street address',
-  //     },
-  //   },
-  //   addressLine3: {
-  //     'ui:title': 'Street address line 3 (20 characters maximum)',
-  //     'ui:autocomplete': 'address-line3',
-  //     'ui:errorMessages': {
-  //       pattern: 'Please enter a valid street address',
-  //     },
-  //   },
-  //   city: {
-  //     'ui:autocomplete': 'address-level2',
-  //     'ui:errorMessages': {
-  //       pattern: 'Please enter a valid city',
-  //       required: 'Please enter a city',
-  //     },
-  //     'ui:options': {
-  //       replaceSchema: formData => {
-  //         if (formData.mailingAddress?.['view:livesOnMilitaryBase'] === true) {
-  //           return {
-  //             type: 'string',
-  //             title: 'APO/FPO/DPO',
-  //             enum: MILITARY_CITIES,
-  //           };
-  //         }
-  //         return merge(
-  //           {
-  //             title: 'City',
-  //           },
-  //           citySchema,
-  //         );
-  //       },
-  //     },
-  //     'ui:validations': [
-  //       {
-  //         options: { addressPath: 'mailingAddress' },
-  //         // pathWithIndex is called in validateMilitaryCity
-  //         validator: validateMilitaryCity,
-  //       },
-  //     ],
-  //   },
-  //   state: {
-  //     'ui:title': 'State',
-  //     'ui:autocomplete': 'address-level1',
-  //     'ui:options': {
-  //       hideIf: formData =>
-  //         !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
-  //         formData.mailingAddress.country !== USA,
-  //       updateSchema: formData => {
-  //         if (
-  //           formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
-  //           MILITARY_CITIES.includes(formData.mailingAddress.city)
-  //         ) {
-  //           return {
-  //             enum: MILITARY_STATE_VALUES,
-  //             enumNames: MILITARY_STATE_LABELS,
-  //           };
-  //         }
-  //         return {
-  //           enum: STATE_VALUES,
-  //           enumNames: STATE_LABELS,
-  //         };
-  //       },
-  //     },
-  //     'ui:required': formData =>
-  //       formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
-  //       formData.mailingAddress.country === USA,
-  //     'ui:validations': [
-  //       {
-  //         options: { addressPath: 'mailingAddress' },
-  //         // pathWithIndex is called in validateMilitaryState
-  //         validator: validateMilitaryState,
-  //       },
-  //     ],
-  //     'ui:errorMessages': {
-  //       pattern: 'Please enter a valid state',
-  //       required: 'Please enter a state',
-  //     },
-  //   },
-  //   zipCode: {
-  //     'ui:title': 'Postal code',
-  //     'ui:autocomplete': 'postal-code',
-  //     'ui:validations': [validateZIP],
-  //     'ui:required': formData =>
-  //       formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
-  //       formData.mailingAddress.country === USA,
-  //     'ui:errorMessages': {
-  //       required: 'Please enter a postal code',
-  //       pattern:
-  //         'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
-  //     },
-  //     'ui:options': {
-  //       widgetClassNames: 'va-input-medium-large',
-  //       hideIf: formData =>
-  //         !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
-  //         formData.mailingAddress.country !== USA,
-  //     },
-  //   },
-  // },
+            return {
+              enum: [USA],
+            };
+          }
+          uiSchemaDisabled['ui:disabled'] = false;
+          return {
+            enum: countryEnum,
+          };
+        },
+      },
+    },
+    addressLine1: {
+      'ui:title': 'Street address (20 characters maximum)',
+      'ui:autocomplete': 'address-line1',
+      'ui:errorMessages': {
+        required: 'Please enter a street address',
+      },
+    },
+    addressLine2: {
+      'ui:title': 'Street address line 2 (20 characters maximum)',
+      'ui:autocomplete': 'address-line2',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid street address',
+      },
+    },
+    addressLine3: {
+      'ui:title': 'Street address line 3 (20 characters maximum)',
+      'ui:autocomplete': 'address-line3',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid street address',
+      },
+    },
+    city: {
+      'ui:autocomplete': 'address-level2',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid city',
+        required: 'Please enter a city',
+      },
+      'ui:options': {
+        replaceSchema: formData => {
+          if (formData.mailingAddress?.['view:livesOnMilitaryBase'] === true) {
+            return {
+              type: 'string',
+              title: 'APO/FPO/DPO',
+              enum: MILITARY_CITIES,
+            };
+          }
+          return merge(
+            {
+              title: 'City',
+            },
+            citySchema,
+          );
+        },
+      },
+      'ui:validations': [
+        {
+          options: { addressPath: 'mailingAddress' },
+          // pathWithIndex is called in validateMilitaryCity
+          validator: validateMilitaryCity,
+        },
+      ],
+    },
+    state: {
+      'ui:title': 'State',
+      'ui:autocomplete': 'address-level1',
+      'ui:options': {
+        hideIf: formData =>
+          !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
+          formData.mailingAddress.country !== USA,
+        updateSchema: formData => {
+          if (
+            formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
+            MILITARY_CITIES.includes(formData.mailingAddress.city)
+          ) {
+            return {
+              enum: MILITARY_STATE_VALUES,
+              enumNames: MILITARY_STATE_LABELS,
+            };
+          }
+          return {
+            enum: STATE_VALUES,
+            enumNames: STATE_LABELS,
+          };
+        },
+      },
+      'ui:required': formData =>
+        formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
+        formData.mailingAddress.country === USA,
+      'ui:validations': [
+        {
+          options: { addressPath: 'mailingAddress' },
+          // pathWithIndex is called in validateMilitaryState
+          validator: validateMilitaryState,
+        },
+      ],
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid state',
+        required: 'Please enter a state',
+      },
+    },
+    zipCode: {
+      'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
+      'ui:validations': [validateZIP],
+      'ui:required': formData =>
+        formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
+        formData.mailingAddress.country === USA,
+      'ui:errorMessages': {
+        required: 'Please enter a postal code',
+        pattern:
+          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+      },
+      'ui:options': {
+        widgetClassNames: 'va-input-medium-large',
+        hideIf: formData =>
+          !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
+          formData.mailingAddress.country !== USA,
+      },
+    },
+  },
   'view:contactInfoDescription': {
     'ui:description': contactInfoUpdateHelpDescription,
   },
@@ -320,18 +282,7 @@ export const schema = {
   type: 'object',
   properties: {
     phoneAndEmail,
-    // mailingAddress,
-    // mailingAddress: addressUISchema,
-    // mailingAddress: addressSchema(),
-    mailingAddress: mappedAddressSchema({
-      keyMap: {
-        street: 'addressLine1',
-        street2: 'addressLine2',
-        street3: 'addressLine3',
-        postalCode: 'zipCode',
-      },
-      // omit: ['street3'],
-    }),
+    mailingAddress,
     'view:contactInfoDescription': {
       type: 'object',
       properties: {},

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -1,10 +1,8 @@
 import path from 'path';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-
 import mockUser from './fixtures/mocks/user.json';
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
-
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { setup, pageHooks } from './cypress.helpers';

--- a/src/applications/lgy/coe/form/config/chapters/contact-information/mailing-address.js
+++ b/src/applications/lgy/coe/form/config/chapters/contact-information/mailing-address.js
@@ -2,7 +2,6 @@ import React from 'react';
 import addressUiSchema, {
   updateFormDataAddress,
 } from 'platform/forms-system/src/js/definitions/profileAddress';
-
 import { contactInformation } from '../../schemaImports';
 
 const description = () => (

--- a/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
@@ -3,6 +3,7 @@ import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+
 // pages
 import chapterSelect from '../pages/chapterSelect';
 import textInput from '../pages/mockTextInput';

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -268,7 +268,7 @@ function detectKeyCollisions(schema, newSchemaKeys = {}) {
 
   if (collisions.length > 0) {
     throw new Error(
-      `WARNING: Field mapping would cause key collisions: ${collisions.join(
+      `ERROR: Field mapping would cause key collisions: ${collisions.join(
         ', ',
       )}. Cannot map to field names that already exist in the schema.`,
     );

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -446,7 +446,19 @@ export const updateFormDataAddress = (
  * @returns {UISchemaOptions}
  */
 export function addressUI(options = {}) {
-  const { keys = {} } = options;
+  // Centralized default keys
+  const DEFAULT_KEYS = {
+    country: 'country',
+    street: 'street',
+    street2: 'street2',
+    street3: 'street3',
+    city: 'city',
+    state: 'state',
+    postalCode: 'postalCode',
+    isMilitary: 'isMilitary',
+  };
+  const keys = { ...DEFAULT_KEYS, ...options.keys };
+
   let cityMaxLength = 100;
   let stateMaxLength = 100;
 
@@ -466,13 +478,13 @@ export function addressUI(options = {}) {
   };
 
   function validateMilitaryBaseZipCode(errors, addr, mappedKeys = {}) {
-    const militaryKey = mappedKeys.isMilitary || 'isMilitary';
+    const militaryKey = mappedKeys.isMilitary;
 
     if (!(addr[militaryKey] && addr.state)) return;
 
     if (addr[militaryKey] && MILITARY_STATE_VALUES.includes(addr.state)) {
       const postalCode = getFieldValue('postalCode', addr, mappedKeys);
-      const postalCodeKey = mappedKeys.postalCode || 'postalCode';
+      const postalCodeKey = mappedKeys.postalCode;
 
       const state = getFieldValue('state', addr, mappedKeys);
 
@@ -534,7 +546,7 @@ export function addressUI(options = {}) {
         const addressPath = getAddressPath(path);
         if (addressPath) {
           const addressData = get(addressPath, formData) ?? {};
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           return !addressData[militaryKey];
         }
         return true;
@@ -558,7 +570,7 @@ export function addressUI(options = {}) {
           const addressFormData = get(addressPath, formData) ?? {};
           /* Set isMilitary to either `true` or `undefined` (not `false`) so that
           `hideEmptyValueInReview` works as expected. See docs: https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-about-schema-and-uischema#VAFormsLibrary-AboutschemaanduiSchema-ui:options */
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           addressFormData[militaryKey] =
             addressFormData[militaryKey] || undefined;
           const isMilitary = addressFormData[militaryKey];
@@ -619,7 +631,7 @@ export function addressUI(options = {}) {
         updateSchema: (formData, schema, _uiSchema, index, path) => {
           const addressPath = getAddressPath(path);
           const addressFormData = get(addressPath, formData) ?? {};
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           const isMilitary = addressFormData[militaryKey];
 
           const titleIfMilitary =
@@ -647,7 +659,7 @@ export function addressUI(options = {}) {
         updateSchema: (formData, schema, _uiSchema, _index, path) => {
           const addressPath = getAddressPath(path);
           const addressFormData = get(addressPath, formData) ?? {};
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           const isMilitary = addressFormData[militaryKey];
 
           const titleIfMilitary =
@@ -688,7 +700,7 @@ export function addressUI(options = {}) {
           const addressPath = getAddressPath(path); // path is ['address', 'currentField']
           const ui = _uiSchema;
           const addressFormData = get(addressPath, formData) ?? {};
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           const isMilitary = addressFormData[militaryKey];
           if (isMilitary) {
             ui['ui:webComponentField'] = VaRadioField;
@@ -725,7 +737,7 @@ export function addressUI(options = {}) {
         const addressPath = getAddressPath(path);
         if (addressPath) {
           const { country } = get(addressPath, formData) ?? {};
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           const isMilitary = get(addressPath, formData)?.[militaryKey];
           return (
             isMilitary || (country && ['USA', 'CAN', 'MEX'].includes(country))
@@ -765,7 +777,7 @@ export function addressUI(options = {}) {
           const addressPath = getAddressPath(path); // path is ['address', 'currentField']
           const data = get(addressPath, formData) ?? {};
           const { country } = data;
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           const isMilitary = data[militaryKey];
           const ui = _uiSchema;
 
@@ -836,7 +848,7 @@ export function addressUI(options = {}) {
           const addressPath = getAddressPath(path); // path is ['address', 'currentField']
           const data = get(addressPath, formData) ?? {};
           const { country } = data;
-          const militaryKey = keys.isMilitary || 'isMilitary';
+          const militaryKey = keys.isMilitary;
           const isMilitary = data[militaryKey];
 
           const addressSchema = _schema;

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -730,7 +730,7 @@ export function addressUI(options = {}) {
         const addressPath = getAddressPath(path);
         if (addressPath) {
           const countryKey = keys.country;
-          const country = get(addressPath, formData)?.[countryKey] ?? {};
+          const country = get(addressPath, formData)?.[countryKey] ?? '';
           const militaryKey = keys.isMilitary;
           const isMilitary = get(addressPath, formData)?.[militaryKey];
           return (

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -284,7 +284,7 @@ function detectKeyCollisions(schema, keys = {}) {
  * Applies field key mapping to a schema object
  * @param {Object} schema - The original schema object
  * @param {Object} keys - Mapping of standard keys to custom keys
- * @returns {Object} - Mapped schema object with transformed keys and omitted fields
+ * @returns {Object} - Mapped schema object with transformed keys
  *
  * @throws {Error} If key mapping would cause field collisions (e.g., mapping 'street' to 'addressLine1'
  * when 'addressLine1' already exists in the original schema)
@@ -293,8 +293,7 @@ function detectKeyCollisions(schema, keys = {}) {
  * const originalSchema = { street: {}, postalCode: {} };
  * const mapped = applyKeyMapping(
  *   originalSchema,
- *   { street: 'addressLine1', postalCode: 'zipCode' },
- *   ['street2']
+ *   { street: 'addressLine1', postalCode: 'zipCode' }
  * );
  * // Returns: { addressLine1: {}, zipCode: {} }
  */

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -243,7 +243,7 @@ function getFieldValue(fieldName, addressData, newSchemaKeys = {}) {
  * );
  * // Returns: { addressLine1: {}, zipCode: {} }
  */
-function applyKeyMapping(schema, newSchemaKeys = {}, omit = []) {
+export function applyKeyMapping(schema, newSchemaKeys = {}, omit = []) {
   if (Object.keys(newSchemaKeys).length === 0) {
     return schema;
   }

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -805,3 +805,137 @@ export const addressNoMilitarySchema = options =>
     ...options,
     omit: ['isMilitary', ...(options?.omit || [])],
   });
+
+/**
+ * Creates a mapping wrapper for addressUI that allows field keys to be renamed
+ * in the schema. Useful for forms that have multiple address fields
+ * with different key names.
+ * ```js
+ * schema: {
+ *   mailingAddress: mappedAddressUI({
+ *     keyMap: {
+ *       street: 'addressLine1',
+ *       street2: 'addressLine2',
+ *       street3: 'addressLine3',
+ *       postalCode: 'zipCode'
+ *     }
+ *   })
+ *   legacyAddress: mappedAddressUI({
+ *     keyMap: {
+ *       postalCode: 'zipCode'
+ *     },
+ *     omit: ['street2', 'street3']
+ *   })
+ * }
+ * ```
+ * @param {Object} options
+ * @param {Object} options.keyMap - Mapping of standard keys to custom keys
+ * @param {Object} [options.labels] - Custom field labels
+ * @param {Array<string>} [options.omit] - Fields to omit (use standard keys)
+ * @param {boolean | Object} [options.required] - Required field configuration
+ * @returns {UISchemaOptions}
+ */
+export const mappedAddressUI = (options = {}) => {
+  const { keyMap = {}, ...addressOptions } = options;
+
+  // Get the base address UI schema using standard keys
+  const baseSchema = addressUI(addressOptions);
+  const mappedSchema = {};
+
+  // Create reverse key map for easier lookup
+  Object.entries(baseSchema).forEach(([standardKey, fieldConfig]) => {
+    const customKey = keyMap[standardKey] || standardKey;
+
+    // Skip if omitted
+    if (addressOptions.omit?.includes(standardKey)) {
+      return;
+    }
+
+    mappedSchema[customKey] = fieldConfig;
+  });
+
+  return mappedSchema;
+};
+
+/**
+ * Creates a mapping wrapper for addressSchema that renames field keys
+ *
+ * ```js
+ * schema: {
+ *   mailingAddress: mappedAddressSchema({
+ *     keyMap: {
+ *       street: 'addressLine1',
+ *       street2: 'addressLine2',
+ *       street3: 'addressLine3',
+ *       postalCode: 'zipCode'
+ *     }
+ *   })
+ * }
+ * ```
+ * @param {Object} options
+ * @param {Object} options.keyMap - Mapping of standard keys to custom keys
+ * @param {Array<string>} [options.omit] - Fields to omit (use standard keys)
+ * @returns {SchemaOptions}
+ */
+export const mappedAddressSchema = (options = {}) => {
+  const { keyMap = {}, ...schemaOptions } = options;
+
+  // Get the base address schema
+  const baseSchema = addressSchema(schemaOptions);
+  const mappedProperties = {};
+
+  // Map each property to its custom key
+  Object.entries(baseSchema.properties).forEach(
+    ([standardKey, propertyConfig]) => {
+      const customKey = keyMap[standardKey] || standardKey;
+      // Skip if this field is omitted
+      if (
+        schemaOptions.omit?.includes(standardKey) ||
+        schemaOptions.omit?.includes(customKey)
+      ) {
+        return;
+      }
+
+      mappedProperties[customKey] = propertyConfig;
+    },
+  );
+
+  return {
+    ...baseSchema,
+    properties: mappedProperties,
+  };
+};
+
+/**
+ * Helper function to update form data for mapped addresses
+ * Use this in place of updateFormDataAddress when using mapped keys
+ */
+export const updateMappedFormDataAddress = (
+  oldFormData,
+  formData,
+  path,
+  index = null,
+  keyMap = {},
+) => {
+  // Create schema keys mapping that includes the custom key mappings
+  const mappedSchemaKeys = { ...schemaCrossXRef };
+
+  // Override with custom key mappings
+  Object.entries(keyMap).forEach(([standardKey, customKey]) => {
+    // Find the schema cross reference for this standard key
+    const schemaKey = Object.keys(schemaCrossXRef).find(
+      key => schemaCrossXRef[key] === standardKey,
+    );
+    if (schemaKey) {
+      mappedSchemaKeys[schemaKey] = customKey;
+    }
+  });
+
+  return updateFormDataAddress(
+    oldFormData,
+    formData,
+    path,
+    index,
+    mappedSchemaKeys,
+  );
+};

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -39,7 +39,7 @@ const POSTAL_CODE_PATTERN_ERROR_MESSAGES = {
   },
   USA: {
     required: 'Enter a zip code',
-    pattern: 'Enter a valid 5- digit zip code',
+    pattern: 'Enter a valid 5-digit zip code',
   },
   NONE: {
     required: 'Enter a postal code',

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -25,7 +25,7 @@ const POSTAL_CODE_PATTERNS = {
   CAN:
     '^(?=[^DdFfIiOoQqUu\\d\\s])[A-Za-z]\\d(?=[^DdFfIiOoQqUu\\d\\s])[A-Za-z]\\s{0,1}\\d(?=[^DdFfIiOoQqUu\\d\\s])[A-Za-z]\\d$',
   MEX: '^\\d{5}$',
-  USA: '^\\d{5}(-?\\d{4})?$',
+  USA: '^\\d{5}$',
 };
 
 const POSTAL_CODE_PATTERN_ERROR_MESSAGES = {
@@ -39,7 +39,7 @@ const POSTAL_CODE_PATTERN_ERROR_MESSAGES = {
   },
   USA: {
     required: 'Enter a zip code',
-    pattern: 'Enter a valid 5- or 9-digit zip code',
+    pattern: 'Enter a valid 5- digit zip code',
   },
   NONE: {
     required: 'Enter a postal code',

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -25,7 +25,7 @@ const POSTAL_CODE_PATTERNS = {
   CAN:
     '^(?=[^DdFfIiOoQqUu\\d\\s])[A-Za-z]\\d(?=[^DdFfIiOoQqUu\\d\\s])[A-Za-z]\\s{0,1}\\d(?=[^DdFfIiOoQqUu\\d\\s])[A-Za-z]\\d$',
   MEX: '^\\d{5}$',
-  USA: '^\\d{5}$',
+  USA: '^\\d{5}(-?\\d{4})?$',
 };
 
 const POSTAL_CODE_PATTERN_ERROR_MESSAGES = {
@@ -39,7 +39,7 @@ const POSTAL_CODE_PATTERN_ERROR_MESSAGES = {
   },
   USA: {
     required: 'Enter a zip code',
-    pattern: 'Enter a valid 5-digit zip code',
+    pattern: 'Enter a valid 5- or 9-digit zip code',
   },
   NONE: {
     required: 'Enter a postal code',

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -729,7 +729,8 @@ export function addressUI(options = {}) {
 
         const addressPath = getAddressPath(path);
         if (addressPath) {
-          const { country } = get(addressPath, formData) ?? {};
+          const countryKey = keys.country;
+          const country = get(addressPath, formData)?.[countryKey] ?? {};
           const militaryKey = keys.isMilitary;
           const isMilitary = get(addressPath, formData)?.[militaryKey];
           return (
@@ -769,7 +770,8 @@ export function addressUI(options = {}) {
 
           const addressPath = getAddressPath(path); // path is ['address', 'currentField']
           const data = get(addressPath, formData) ?? {};
-          const { country } = data;
+          const countryKey = keys.country;
+          const country = data[countryKey];
           const militaryKey = keys.isMilitary;
           const isMilitary = data[militaryKey];
           const ui = _uiSchema;
@@ -840,7 +842,8 @@ export function addressUI(options = {}) {
         replaceSchema: (formData, _schema, _uiSchema, index, path) => {
           const addressPath = getAddressPath(path); // path is ['address', 'currentField']
           const data = get(addressPath, formData) ?? {};
-          const { country } = data;
+          const countryKey = keys.country;
+          const country = data[countryKey];
           const militaryKey = keys.isMilitary;
           const isMilitary = data[militaryKey];
 
@@ -895,21 +898,30 @@ export function addressUI(options = {}) {
  * }
  * ```
  * @param {Object} [options]
- * @param {Array<string>} [options.omit] - Field names to omit from schema
- * @param {Object} [options.keys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}). Uses applyKeyMapping utility internally.
+ * @param {Array<AddressSchemaKey>} [options.omit] - Field names to omit from schema
+ * @param {Record<AddressSchemaKey, string>} [options.keys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}). Uses applyKeyMapping utility internally.
  * @returns {SchemaOptions}
  */
 export const addressSchema = (options = {}) => {
   const { keys = {}, omit = [] } = options;
   const schema = commonDefinitions.profileAddress;
+
+  // Only modify properties if needed
+  const needsOmit = omit.length > 0;
+  const needsKeyMapping = Object.keys(keys).length > 0;
+
+  if (!needsOmit && !needsKeyMapping) {
+    return schema;
+  }
+
   let { properties } = schema;
 
-  if (omit.length > 0) {
+  if (needsOmit) {
     validateKeys(omit, 'omit', MAPPABLE_KEYS);
     properties = utilsOmit(omit, properties);
   }
 
-  if (Object.keys(keys).length > 0) {
+  if (needsKeyMapping) {
     properties = applyKeyMapping(properties, keys);
   }
 

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -904,6 +904,11 @@ export const addressSchema = (options = {}) => {
   const schema = commonDefinitions.profileAddress;
   let { properties } = schema;
 
+  // Only create a new object if we need to modify properties
+  if (omit.length === 0 && Object.keys(keys).length === 0) {
+    return schema;
+  }
+
   if (omit.length > 0) {
     validateKeys(omit, 'omit', MAPPABLE_KEYS);
     properties = utilsOmit(omit, properties);

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -215,7 +215,7 @@ const getAddressPath = path => {
 };
 
 // This is a helper function for getting a field value from address data, taking into account any mapped schema keys
-function getFieldValue(fieldName, addressData, keys = {}) {
+export function getFieldValue(fieldName, addressData, keys = {}) {
   const mappedKey = keys[fieldName] || fieldName;
   return addressData?.[mappedKey];
 }
@@ -232,7 +232,7 @@ const UNSAFE_FIELDS = ['country', 'city', 'state'];
 /**
  * Validates mappable fields and provides warnings for unsafe mappings
  */
-function validateMappableFields(keys = {}) {
+function warnAboutUnsafeMappings(keys = {}) {
   const attemptedMappings = Object.keys(keys);
   const unsafeMappings = attemptedMappings.filter(field =>
     UNSAFE_FIELDS.includes(field),
@@ -309,7 +309,7 @@ export function applyKeyMapping(schema, keys = {}, omit = []) {
     return utilsOmit(schema, omit);
   }
   // Validate that only safe fields are being mapped by logging warnings
-  validateMappableFields(keys);
+  warnAboutUnsafeMappings(keys);
   detectKeyCollisions(schema, keys);
 
   const mappedSchema = {};

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -475,9 +475,11 @@ export function addressUI(options = {}) {
       const postalCode = getFieldValue('postalCode', addr, mappedKeys);
       const postalCodeKey = mappedKeys.postalCode || 'postalCode';
 
-      const isAA = addr.state === 'AA' && /^340\d*/.test(postalCode);
-      const isAE = addr.state === 'AE' && /^09[0-9]\d*/.test(postalCode);
-      const isAP = addr.state === 'AP' && /^96[2-6]\d*/.test(postalCode);
+      const state = getFieldValue('state', addr, mappedKeys);
+
+      const isAA = state === 'AA' && /^340\d*/.test(postalCode);
+      const isAE = state === 'AE' && /^09[0-9]\d*/.test(postalCode);
+      const isAP = state === 'AP' && /^96[2-6]\d*/.test(postalCode);
       if (!(isAA || isAE || isAP)) {
         const militaryTitle =
           options.labels?.militaryCheckbox ??

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -844,7 +844,8 @@ export function addressUI(options = {}) {
           const militaryKey = keys.isMilitary;
           const isMilitary = data[militaryKey];
 
-          const addressSchema = _schema;
+          // Create a copy of the schema to avoid mutating the original
+          const addressSchema = { ..._schema };
           const addressUiSchema = _uiSchema;
 
           // country-specific error messages

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -281,7 +281,7 @@ export const updateFormDataAddress = (
  */
 
 /**
- * uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted.
+ * uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted or mapped to alternative key names.
  *
  * ```js
  * schema: {
@@ -302,7 +302,7 @@ export const updateFormDataAddress = (
  * }
  * ```
  * @param {Object} [options]
- * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
+ * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}) Only street, street2, street3, and postalCode should be mapped, or update replaceSchema and updateSchema functions to account for mapped field names
  * @param {Object} [options.labels]
  * @param {string} [options.labels.militaryCheckbox]
  * @param {string} [options.labels.street]
@@ -753,7 +753,7 @@ export function addressUI(options = {}) {
  * @param {{
  *  omit: string[]
  * }} [options]
- * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
+ * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}). Only street, street2, street3, and postalCode should be mapped, or update replaceSchema and updateSchema functions to account for mapped field names.
  * @returns {SchemaOptions}
  */
 export const addressSchema = (options = {}) => {

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -214,6 +214,54 @@ const getAddressPath = path => {
   return path.slice(0, -1);
 };
 
+// This is a helper function for getting a field value from address data, taking into account any mapped schema keys
+function getFieldValue(fieldName, addressData, newSchemaKeys = {}) {
+  const mappedKey = newSchemaKeys[fieldName] || fieldName;
+  return addressData?.[mappedKey];
+}
+
+// This is a currently unused helper function to get mapped field values from address form data
+// function getAddressFieldValue(fieldName, formData, path, newSchemaKeys = {}) {
+//   const addressPath = getAddressPath(path);
+//   const addressFormData = get(addressPath, formData) ?? {};
+//   return getFieldValue(fieldName, addressFormData, newSchemaKeys);
+// }
+
+/**
+ * Applies field key mapping to a schema object
+ * @param {Object} schema - The original schema object
+ * @param {Object} newSchemaKeys - Mapping of standard keys to custom keys
+ * @param {Array} omit - Fields to omit from the final schema
+ * @returns {Object} - Mapped schema object with transformed keys and omitted fields
+ *
+ * @example
+ * const originalSchema = { street: {}, postalCode: {} };
+ * const mapped = applyKeyMapping(
+ *   originalSchema,
+ *   { street: 'addressLine1', postalCode: 'zipCode' },
+ *   ['street2']
+ * );
+ * // Returns: { addressLine1: {}, zipCode: {} }
+ */
+function applyKeyMapping(schema, newSchemaKeys = {}, omit = []) {
+  if (Object.keys(newSchemaKeys).length === 0) {
+    return schema;
+  }
+
+  const mappedSchema = {};
+  Object.entries(schema).forEach(([standardKey, fieldConfig]) => {
+    const mappedKey = newSchemaKeys[standardKey] || standardKey;
+
+    if (omit.includes(standardKey) || omit.includes(mappedKey)) {
+      return; // Skip omitted fields
+    }
+
+    mappedSchema[mappedKey] = fieldConfig;
+  });
+
+  return mappedSchema;
+}
+
 /**
  * Update form data to remove selected military city & state and restore any
  * previously set city & state when the "I live on a U.S. military base"
@@ -287,6 +335,9 @@ export const updateFormDataAddress = (
  * schema: {
  *   address: addressUI()
  *   simpleAddress: addressUI({ omit: ['street2', 'street3'] })
+ *   mappedAddress: addressUI({
+ *     newSchemaKeys: { street: 'addressLine1', postalCode: 'zipCode' }
+ *   })
  *   futureAddress: addressUI({
  *     labels: {
  *      militaryCheckbox: 'I will live on a United States military base outside of the U.S.'
@@ -302,7 +353,7 @@ export const updateFormDataAddress = (
  * }
  * ```
  * @param {Object} [options]
- * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}) Only street, street2, street3, and postalCode should be mapped, or update replaceSchema and updateSchema functions to account for mapped field names
+ * @param {Object} [options.newSchemaKeys] - Maps `street` and `postalCode` keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}) Only street, street2, street3, and postalCode should be mapped, or update replaceSchema and updateSchema functions to account for mapped field names
  * @param {Object} [options.labels]
  * @param {string} [options.labels.militaryCheckbox]
  * @param {string} [options.labels.street]
@@ -316,13 +367,13 @@ export const updateFormDataAddress = (
  * @returns {UISchemaOptions}
  */
 export function addressUI(options = {}) {
-  const { newSchemaKeys = {} } = options;
+  const { newSchemaKeys = {} } = options || {};
   let cityMaxLength = 100;
   let stateMaxLength = 100;
 
-  const omit = key => options.omit?.includes(key);
-  let customRequired = key => options.required?.[key];
-  if (options.required === false) {
+  const omit = key => options?.omit?.includes(key);
+  let customRequired = key => options?.required?.[key];
+  if (options?.required === false) {
     customRequired = () => () => false;
   }
 
@@ -335,15 +386,18 @@ export function addressUI(options = {}) {
     },
   };
 
-  function validateMilitaryBaseZipCode(errors, addr) {
+  function validateMilitaryBaseZipCode(errors, addr, mappedKeys = {}) {
     if (!(addr.isMilitary && addr.state)) return;
 
     if (addr.isMilitary && MILITARY_STATE_VALUES.includes(addr.state)) {
-      const isAA = addr.state === 'AA' && /^340\d*/.test(addr.postalCode);
-      const isAE = addr.state === 'AE' && /^09[0-9]\d*/.test(addr.postalCode);
-      const isAP = addr.state === 'AP' && /^96[2-6]\d*/.test(addr.postalCode);
+      const postalCode = getFieldValue('postalCode', addr, mappedKeys);
+      const postalCodeKey = mappedKeys.postalCode || 'postalCode';
+
+      const isAA = addr.state === 'AA' && /^340\d*/.test(postalCode);
+      const isAE = addr.state === 'AE' && /^09[0-9]\d*/.test(postalCode);
+      const isAP = addr.state === 'AP' && /^96[2-6]\d*/.test(postalCode);
       if (!(isAA || isAE || isAP)) {
-        errors.postalCode.addError(
+        errors[postalCodeKey].addError(
           `This postal code is within the United States. If your mailing address is in the United States, uncheck the checkbox "${
             uiSchema.isMilitary['ui:title']
           }". If your mailing address is an APO/FPO/DPO address, enter the postal code for the military base.`,
@@ -376,7 +430,9 @@ export function addressUI(options = {}) {
       },
     };
 
-    uiSchema['ui:validations'].push(validateMilitaryBaseZipCode);
+    uiSchema['ui:validations'].push((errors, addr) =>
+      validateMilitaryBaseZipCode(errors, addr, newSchemaKeys),
+    );
   }
 
   if (!omit('isMilitary') && !omit('view:militaryBaseDescription')) {
@@ -455,6 +511,9 @@ export function addressUI(options = {}) {
         classNames:
           'vads-web-component-pattern-field vads-web-component-pattern-address',
         replaceSchema: (_, schema) => {
+          // Example if you ever need to access mapped fields:
+          // replaceSchema: (formData, schema, _uiSchema, index, path) => {
+          //  const streetValue = getAddressFieldValue('street', formData, path, newSchemaKeys);
           return {
             ...schema,
             pattern: NONBLANK_PATTERN,
@@ -688,6 +747,11 @@ export function addressUI(options = {}) {
           const data = get(addressPath, formData) ?? {};
           const { country } = data;
           const { isMilitary } = data;
+          // Note: This function is safe with mapped keys because it only accesses
+          // 'country' and 'isMilitary' which are not mappable fields
+          // Example if you ever need to access mapped fields:
+          // const postalCode = getAddressFieldValue('postalCode', formData, path, newSchemaKeys);
+
           const addressSchema = _schema;
           const addressUiSchema = _uiSchema;
 
@@ -723,37 +787,24 @@ export function addressUI(options = {}) {
       },
     };
   }
-  // If no newSchemaKeys, return as-is (backward compatibility)
-  if (Object.keys(newSchemaKeys).length === 0) {
-    return uiSchema;
-  }
-  // Apply key mapping
-  const mappedSchema = {};
-  Object.entries(uiSchema).forEach(([standardKey, fieldConfig]) => {
-    const mappedKey = newSchemaKeys[standardKey] || standardKey;
-    if (omit(standardKey) || omit(mappedKey)) {
-      return; // Skip omitted fields entirely
-    }
-
-    // Use mapped key name, preserve field configuration
-    mappedSchema[mappedKey] = fieldConfig;
-  });
-  return mappedSchema;
+  return applyKeyMapping(uiSchema, newSchemaKeys, options?.omit || []);
 }
 
 /**
- * Schema for addressUI. Fields may be omitted.
+ * Schema for addressUI. Fields may be omitted or mapped to alternative key names.
  *
  * ```js
  * schema: {
  *   address: addressSchema()
  *   simpleAddress: addressSchema({ omit: ['street2', 'street3'] })
+ *   mappedAddress: addressSchema({
+ *     newSchemaKeys: { street: 'addressLine1', postalCode: 'zipCode' }
+ *   })
  * }
  * ```
- * @param {{
- *  omit: string[]
- * }} [options]
- * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}). Only street, street2, street3, and postalCode should be mapped, or update replaceSchema and updateSchema functions to account for mapped field names.
+ * @param {Object} [options]
+ * @param {Array<string>} [options.omit] - Field names to omit from schema
+ * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'}). Uses applyKeyMapping utility internally.
  * @returns {SchemaOptions}
  */
 export const addressSchema = (options = {}) => {
@@ -773,23 +824,10 @@ export const addressSchema = (options = {}) => {
     return schema;
   }
 
-  // Apply key mapping and omit filtering to properties
-  const mappedProperties = {};
-
-  Object.entries(schema.properties).forEach(([standardKey, propertyConfig]) => {
-    // Skip if field should be omitted
-    const mappedKey = newSchemaKeys[standardKey] || standardKey;
-    if (omit.includes(standardKey) || omit.includes(mappedKey)) {
-      return;
-    }
-
-    // Use mapped key name, preserve property configuration
-    mappedProperties[mappedKey] = propertyConfig;
-  });
-
+  // Apply mapping to properties
   return {
     ...schema,
-    properties: mappedProperties,
+    properties: applyKeyMapping(schema.properties, newSchemaKeys, omit),
   };
 };
 

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -274,7 +274,7 @@ function detectKeyCollisions(schema, keys = {}) {
 
   if (collisions.length > 0) {
     throw new Error(
-      `ERROR: Field mapping would cause key collisions: ${collisions.join(
+      `Field mapping would cause key collisions: ${collisions.join(
         ', ',
       )}. Cannot map to field names that already exist in the schema.`,
     );
@@ -308,7 +308,7 @@ export function applyKeyMapping(schema, keys = {}, omit = []) {
     }
     return utilsOmit(schema, omit);
   }
-  // Validate that only safe fields are being mapped
+  // Validate that only safe fields are being mapped by logging warnings
   validateMappableFields(keys);
   detectKeyCollisions(schema, keys);
 
@@ -447,12 +447,12 @@ export const updateFormDataAddress = (
  * @returns {UISchemaOptions}
  */
 export function addressUI(options = {}) {
-  const { keys = {} } = options || {};
+  const { keys = {} } = options;
   let cityMaxLength = 100;
   let stateMaxLength = 100;
 
-  const omit = key => options?.omit?.includes(key);
-  let customRequired = key => options?.required?.[key];
+  const omit = key => options.omit?.includes(key);
+  let customRequired = key => options.required?.[key];
   if (options?.required === false) {
     customRequired = () => () => false;
   }
@@ -481,7 +481,7 @@ export function addressUI(options = {}) {
       if (!(isAA || isAE || isAP)) {
         errors[postalCodeKey].addError(
           `This postal code is within the United States. If your mailing address is in the United States, uncheck the checkbox "${
-            uiSchema.isMilitary['ui:title']
+            uiSchema[militaryKey]['ui:title']
           }". If your mailing address is an APO/FPO/DPO address, enter the postal code for the military base.`,
         );
       }
@@ -596,9 +596,6 @@ export function addressUI(options = {}) {
         classNames:
           'vads-web-component-pattern-field vads-web-component-pattern-address',
         replaceSchema: (_, schema) => {
-          // Example if you ever need to access mapped fields:
-          // replaceSchema: (formData, schema, _uiSchema, index, path) => {
-          //  const streetValue = getAddressFieldValue('street', formData, path, keys);
           return {
             ...schema,
             pattern: NONBLANK_PATTERN,
@@ -875,7 +872,7 @@ export function addressUI(options = {}) {
       },
     };
   }
-  return applyKeyMapping(uiSchema, keys, options?.omit || []);
+  return applyKeyMapping(uiSchema, keys, options.omit || []);
 }
 
 /**

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -232,10 +232,10 @@ export const updateFormDataAddress = (
   formData,
   path,
   index = null, // this is included in the path, but added as
-  newSchemaKeys = {},
+  keyMap = {},
 ) => {
   let updatedData = formData;
-  const schemaKeys = { ...schemaCrossXRef, ...newSchemaKeys };
+  const schemaKeys = { ...schemaCrossXRef, ...keyMap };
 
   /*
    * formData and oldFormData are not guaranteed to have the same shape; formData
@@ -302,6 +302,7 @@ export const updateFormDataAddress = (
  * }
  * ```
  * @param {Object} [options]
+ * @param {Object} [options.keyMap] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
  * @param {Object} [options.labels]
  * @param {string} [options.labels.militaryCheckbox]
  * @param {string} [options.labels.street]
@@ -315,6 +316,7 @@ export const updateFormDataAddress = (
  * @returns {UISchemaOptions}
  */
 export function addressUI(options = {}) {
+  const { keyMap = {} } = options;
   let cityMaxLength = 100;
   let stateMaxLength = 100;
 
@@ -721,8 +723,21 @@ export function addressUI(options = {}) {
       },
     };
   }
-
-  return uiSchema;
+  // If no keyMap, return as-is (backward compatibility)
+  if (Object.keys(keyMap).length === 0) {
+    return uiSchema;
+  }
+  // Apply key mapping
+  const mappedSchema = {};
+  Object.entries(uiSchema).forEach(([standardKey, fieldConfig]) => {
+    const mappedKey = keyMap[standardKey] || standardKey;
+    if (!omit(standardKey) && !omit(mappedKey)) {
+      mappedSchema[mappedKey] = fieldConfig;
+    } else {
+      mappedSchema[standardKey] = fieldConfig;
+    }
+  });
+  return mappedSchema;
 }
 
 /**
@@ -737,9 +752,11 @@ export function addressUI(options = {}) {
  * @param {{
  *  omit: string[]
  * }} [options]
+ * @param {Object} [options.keyMap] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
  * @returns {SchemaOptions}
  */
 export const addressSchema = options => {
+  const { keyMap = {}, omit = [] } = options;
   let schema = commonDefinitions.profileAddress;
 
   if (options?.omit) {
@@ -751,7 +768,29 @@ export const addressSchema = options => {
     };
   }
 
-  return schema;
+  // If no keyMap provided, return standard schema
+  if (Object.keys(keyMap).length === 0) {
+    return schema;
+  }
+
+  // Apply key mapping and omit filtering to properties
+  const mappedProperties = {};
+
+  Object.entries(schema.properties).forEach(([standardKey, propertyConfig]) => {
+    // Skip if field should be omitted
+    const mappedKey = keyMap[standardKey] || standardKey;
+    if (omit.includes(standardKey) || omit.includes(mappedKey)) {
+      return;
+    }
+
+    // Use mapped key name, preserve property configuration
+    mappedProperties[mappedKey] = propertyConfig;
+  });
+
+  return {
+    ...schema,
+    properties: mappedProperties,
+  };
 };
 
 /**
@@ -805,137 +844,3 @@ export const addressNoMilitarySchema = options =>
     ...options,
     omit: ['isMilitary', ...(options?.omit || [])],
   });
-
-/**
- * Creates a mapping wrapper for addressUI that allows field keys to be renamed
- * in the schema. Useful for forms that have multiple address fields
- * with different key names.
- * ```js
- * schema: {
- *   mailingAddress: mappedAddressUI({
- *     keyMap: {
- *       street: 'addressLine1',
- *       street2: 'addressLine2',
- *       street3: 'addressLine3',
- *       postalCode: 'zipCode'
- *     }
- *   })
- *   legacyAddress: mappedAddressUI({
- *     keyMap: {
- *       postalCode: 'zipCode'
- *     },
- *     omit: ['street2', 'street3']
- *   })
- * }
- * ```
- * @param {Object} options
- * @param {Object} options.keyMap - Mapping of standard keys to custom keys
- * @param {Object} [options.labels] - Custom field labels
- * @param {Array<string>} [options.omit] - Fields to omit (use standard keys)
- * @param {boolean | Object} [options.required] - Required field configuration
- * @returns {UISchemaOptions}
- */
-export const mappedAddressUI = (options = {}) => {
-  const { keyMap = {}, ...addressOptions } = options;
-
-  // Get the base address UI schema using standard keys
-  const baseSchema = addressUI(addressOptions);
-  const mappedSchema = {};
-
-  // Create reverse key map for easier lookup
-  Object.entries(baseSchema).forEach(([standardKey, fieldConfig]) => {
-    const customKey = keyMap[standardKey] || standardKey;
-
-    // Skip if omitted
-    if (addressOptions.omit?.includes(standardKey)) {
-      return;
-    }
-
-    mappedSchema[customKey] = fieldConfig;
-  });
-
-  return mappedSchema;
-};
-
-/**
- * Creates a mapping wrapper for addressSchema that renames field keys
- *
- * ```js
- * schema: {
- *   mailingAddress: mappedAddressSchema({
- *     keyMap: {
- *       street: 'addressLine1',
- *       street2: 'addressLine2',
- *       street3: 'addressLine3',
- *       postalCode: 'zipCode'
- *     }
- *   })
- * }
- * ```
- * @param {Object} options
- * @param {Object} options.keyMap - Mapping of standard keys to custom keys
- * @param {Array<string>} [options.omit] - Fields to omit (use standard keys)
- * @returns {SchemaOptions}
- */
-export const mappedAddressSchema = (options = {}) => {
-  const { keyMap = {}, ...schemaOptions } = options;
-
-  // Get the base address schema
-  const baseSchema = addressSchema(schemaOptions);
-  const mappedProperties = {};
-
-  // Map each property to its custom key
-  Object.entries(baseSchema.properties).forEach(
-    ([standardKey, propertyConfig]) => {
-      const customKey = keyMap[standardKey] || standardKey;
-      // Skip if this field is omitted
-      if (
-        schemaOptions.omit?.includes(standardKey) ||
-        schemaOptions.omit?.includes(customKey)
-      ) {
-        return;
-      }
-
-      mappedProperties[customKey] = propertyConfig;
-    },
-  );
-
-  return {
-    ...baseSchema,
-    properties: mappedProperties,
-  };
-};
-
-/**
- * Helper function to update form data for mapped addresses
- * Use this in place of updateFormDataAddress when using mapped keys
- */
-export const updateMappedFormDataAddress = (
-  oldFormData,
-  formData,
-  path,
-  index = null,
-  keyMap = {},
-) => {
-  // Create schema keys mapping that includes the custom key mappings
-  const mappedSchemaKeys = { ...schemaCrossXRef };
-
-  // Override with custom key mappings
-  Object.entries(keyMap).forEach(([standardKey, customKey]) => {
-    // Find the schema cross reference for this standard key
-    const schemaKey = Object.keys(schemaCrossXRef).find(
-      key => schemaCrossXRef[key] === standardKey,
-    );
-    if (schemaKey) {
-      mappedSchemaKeys[schemaKey] = customKey;
-    }
-  });
-
-  return updateFormDataAddress(
-    oldFormData,
-    formData,
-    path,
-    index,
-    mappedSchemaKeys,
-  );
-};

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -755,7 +755,7 @@ export function addressUI(options = {}) {
  * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
  * @returns {SchemaOptions}
  */
-export const addressSchema = options => {
+export const addressSchema = (options = {}) => {
   const { newSchemaKeys = {}, omit = [] } = options;
   let schema = commonDefinitions.profileAddress;
 

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -479,10 +479,11 @@ export function addressUI(options = {}) {
       const isAE = addr.state === 'AE' && /^09[0-9]\d*/.test(postalCode);
       const isAP = addr.state === 'AP' && /^96[2-6]\d*/.test(postalCode);
       if (!(isAA || isAE || isAP)) {
+        const militaryTitle =
+          options.labels?.militaryCheckbox ??
+          'I live on a U.S. military base outside of the United States.';
         errors[postalCodeKey].addError(
-          `This postal code is within the United States. If your mailing address is in the United States, uncheck the checkbox "${
-            uiSchema[militaryKey]['ui:title']
-          }". If your mailing address is an APO/FPO/DPO address, enter the postal code for the military base.`,
+          `This postal code is within the United States. If your mailing address is in the United States, uncheck the checkbox "${militaryTitle}". If your mailing address is an APO/FPO/DPO address, enter the postal code for the military base.`,
         );
       }
     }

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -731,11 +731,12 @@ export function addressUI(options = {}) {
   const mappedSchema = {};
   Object.entries(uiSchema).forEach(([standardKey, fieldConfig]) => {
     const mappedKey = newSchemaKeys[standardKey] || standardKey;
-    if (!omit(standardKey) && !omit(mappedKey)) {
-      mappedSchema[mappedKey] = fieldConfig;
-    } else {
-      mappedSchema[standardKey] = fieldConfig;
+    if (omit(standardKey) || omit(mappedKey)) {
+      return; // Skip omitted fields entirely
     }
+
+    // Use mapped key name, preserve field configuration
+    mappedSchema[mappedKey] = fieldConfig;
   });
   return mappedSchema;
 }
@@ -759,17 +760,16 @@ export const addressSchema = (options = {}) => {
   const { newSchemaKeys = {}, omit = [] } = options;
   let schema = commonDefinitions.profileAddress;
 
-  if (options?.omit) {
-    schema = {
-      ...schema,
-      properties: {
-        ...utilsOmit(options.omit, schema.properties),
-      },
-    };
-  }
-
-  // If no newSchemaKeys provided, return standard schema
+  // If no key mapping is needed, use the existing omit logic and return early
   if (Object.keys(newSchemaKeys).length === 0) {
+    if (omit.length > 0) {
+      schema = {
+        ...schema,
+        properties: {
+          ...utilsOmit(omit, schema.properties),
+        },
+      };
+    }
     return schema;
   }
 

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -1,6 +1,7 @@
 /**
  * Web component version of address
  */
+import environment from 'platform/utilities/environment';
 import React from 'react';
 import constants from 'vets-json-schema/dist/constants.json';
 
@@ -241,7 +242,7 @@ export function getFieldValue(fieldName, addressData, keys = {}) {
 function validateKeys(keys = [], methodName = '', fields = MAPPABLE_KEYS) {
   const invalidKeys = keys.filter(field => !fields.includes(field));
 
-  if (invalidKeys.length > 0) {
+  if (!environment.isProduction() && invalidKeys.length > 0) {
     throw new Error(
       `${
         methodName ? `${methodName}: ` : ''

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -420,12 +420,11 @@ export const updateFormDataAddress = (
  * @param {Object} [options]
  * @param {Object} [options.keys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
  *
- * **IMPORTANT**: Only street, street2, street3, and postalCode should be mapped without code modifications.
+ * **IMPORTANT**: Only street, street2, street3, postalCode, and isMilitary should be mapped without code modifications.
  *
  * Other fields (country, city, state) have dynamic schema functions (updateSchema/replaceSchema)
  * that access form data using hardcoded field names. Mapping these fields will cause runtime errors because:
  * - State field's replaceSchema accesses `data.country`
- * - Military validation function accesses `addr.state`
  *
  * To map other fields, you must:
  * 1. Update all dynamic schema functions to use getFieldValue() helper

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -232,10 +232,10 @@ export const updateFormDataAddress = (
   formData,
   path,
   index = null, // this is included in the path, but added as
-  keyMap = {},
+  newSchemaKeys = {},
 ) => {
   let updatedData = formData;
-  const schemaKeys = { ...schemaCrossXRef, ...keyMap };
+  const schemaKeys = { ...schemaCrossXRef, ...newSchemaKeys };
 
   /*
    * formData and oldFormData are not guaranteed to have the same shape; formData
@@ -302,7 +302,7 @@ export const updateFormDataAddress = (
  * }
  * ```
  * @param {Object} [options]
- * @param {Object} [options.keyMap] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
+ * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
  * @param {Object} [options.labels]
  * @param {string} [options.labels.militaryCheckbox]
  * @param {string} [options.labels.street]
@@ -316,7 +316,7 @@ export const updateFormDataAddress = (
  * @returns {UISchemaOptions}
  */
 export function addressUI(options = {}) {
-  const { keyMap = {} } = options;
+  const { newSchemaKeys = {} } = options;
   let cityMaxLength = 100;
   let stateMaxLength = 100;
 
@@ -723,14 +723,14 @@ export function addressUI(options = {}) {
       },
     };
   }
-  // If no keyMap, return as-is (backward compatibility)
-  if (Object.keys(keyMap).length === 0) {
+  // If no newSchemaKeys, return as-is (backward compatibility)
+  if (Object.keys(newSchemaKeys).length === 0) {
     return uiSchema;
   }
   // Apply key mapping
   const mappedSchema = {};
   Object.entries(uiSchema).forEach(([standardKey, fieldConfig]) => {
-    const mappedKey = keyMap[standardKey] || standardKey;
+    const mappedKey = newSchemaKeys[standardKey] || standardKey;
     if (!omit(standardKey) && !omit(mappedKey)) {
       mappedSchema[mappedKey] = fieldConfig;
     } else {
@@ -752,11 +752,11 @@ export function addressUI(options = {}) {
  * @param {{
  *  omit: string[]
  * }} [options]
- * @param {Object} [options.keyMap] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
+ * @param {Object} [options.newSchemaKeys] - Maps standard keys to custom keys (e.g., {street: 'addressLine1', postalCode: 'zipCode'})
  * @returns {SchemaOptions}
  */
 export const addressSchema = options => {
-  const { keyMap = {}, omit = [] } = options;
+  const { newSchemaKeys = {}, omit = [] } = options;
   let schema = commonDefinitions.profileAddress;
 
   if (options?.omit) {
@@ -768,8 +768,8 @@ export const addressSchema = options => {
     };
   }
 
-  // If no keyMap provided, return standard schema
-  if (Object.keys(keyMap).length === 0) {
+  // If no newSchemaKeys provided, return standard schema
+  if (Object.keys(newSchemaKeys).length === 0) {
     return schema;
   }
 
@@ -778,7 +778,7 @@ export const addressSchema = options => {
 
   Object.entries(schema.properties).forEach(([standardKey, propertyConfig]) => {
     // Skip if field should be omitted
-    const mappedKey = keyMap[standardKey] || standardKey;
+    const mappedKey = newSchemaKeys[standardKey] || standardKey;
     if (omit.includes(standardKey) || omit.includes(mappedKey)) {
       return;
     }

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -2,7 +2,7 @@
   "title": "VA.gov Web Component Form Field Patterns Catalog (RJSF)",
   "description": "Catalog of all acceptable web component uiSchema and schema patterns for form fields in VA.gov applications. These patterns are used in pairs to define form field behavior and validation in RJSF (React JSON Schema Form) implementations using the VA design system web components.",
   "importPath": "platform/forms-system/src/js/web-component-patterns",
-  "totalPatterns": 54,
+  "totalPatterns": 53,
   "patterns": [
     {
       "category": "Address",
@@ -21,15 +21,6 @@
       "schema": "addressSchema",
       "schemaType": "function",
       "schemaDescription": "Schema for addressUI. Fields may be omitted."
-    },
-    {
-      "category": "Address",
-      "uiSchema": "mappedAddressUI",
-      "uiSchemaType": "function",
-      "uiSchemaDescription": "Creates a mapping wrapper for addressUI that allows field keys to be renamed",
-      "schema": "mappedAddressSchema",
-      "schemaType": "function",
-      "schemaDescription": "Creates a mapping wrapper for addressSchema that renames field keys"
     },
     {
       "category": "AddressDeprecated",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -2,7 +2,7 @@
   "title": "VA.gov Web Component Form Field Patterns Catalog (RJSF)",
   "description": "Catalog of all acceptable web component uiSchema and schema patterns for form fields in VA.gov applications. These patterns are used in pairs to define form field behavior and validation in RJSF (React JSON Schema Form) implementations using the VA design system web components.",
   "importPath": "platform/forms-system/src/js/web-component-patterns",
-  "totalPatterns": 53,
+  "totalPatterns": 54,
   "patterns": [
     {
       "category": "Address",
@@ -21,6 +21,15 @@
       "schema": "addressSchema",
       "schemaType": "function",
       "schemaDescription": "Schema for addressUI. Fields may be omitted."
+    },
+    {
+      "category": "Address",
+      "uiSchema": "mappedAddressUI",
+      "uiSchemaType": "function",
+      "uiSchemaDescription": "Creates a mapping wrapper for addressUI that allows field keys to be renamed",
+      "schema": "mappedAddressSchema",
+      "schemaType": "function",
+      "schemaDescription": "Creates a mapping wrapper for addressSchema that renames field keys"
     },
     {
       "category": "AddressDeprecated",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -2,7 +2,7 @@
   "title": "VA.gov Web Component Form Field Patterns Catalog (RJSF)",
   "description": "Catalog of all acceptable web component uiSchema and schema patterns for form fields in VA.gov applications. These patterns are used in pairs to define form field behavior and validation in RJSF (React JSON Schema Form) implementations using the VA design system web components.",
   "importPath": "platform/forms-system/src/js/web-component-patterns",
-  "totalPatterns": 53,
+  "totalPatterns": 54,
   "patterns": [
     {
       "category": "Address",
@@ -39,6 +39,15 @@
       "schema": "addressNoMilitaryDeprecatedSchema",
       "schemaType": "function",
       "schemaDescription": "Web component schema for address"
+    },
+    {
+      "category": "AddressPattern centralized keys.jsx",
+      "uiSchema": "addressUI",
+      "uiSchemaType": "function",
+      "uiSchemaDescription": "Example of how to centralize the defaults in addressUI function",
+      "schema": null,
+      "schemaType": null,
+      "schemaDescription": null
     },
     {
       "category": "Arn",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -2,8 +2,26 @@
   "title": "VA.gov Web Component Form Field Patterns Catalog (RJSF)",
   "description": "Catalog of all acceptable web component uiSchema and schema patterns for form fields in VA.gov applications. These patterns are used in pairs to define form field behavior and validation in RJSF (React JSON Schema Form) implementations using the VA design system web components.",
   "importPath": "platform/forms-system/src/js/web-component-patterns",
-  "totalPatterns": 51,
+  "totalPatterns": 53,
   "patterns": [
+    {
+      "category": "Address",
+      "uiSchema": "addressNoMilitaryUI",
+      "uiSchemaType": "function",
+      "uiSchemaDescription": "uiSchema for address - Same as addressUI, but without the military checkbox. Includes fields for country, street, street2, street3, city, state, postal code. Fields may be omitted.",
+      "schema": "addressNoMilitarySchema",
+      "schemaType": "function",
+      "schemaDescription": "Schema for addressNoMilitaryUI. Fields may be omitted."
+    },
+    {
+      "category": "Address",
+      "uiSchema": "addressUI",
+      "uiSchemaType": "function",
+      "uiSchemaDescription": "uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted or mapped to alternative key names.",
+      "schema": "addressSchema",
+      "schemaType": "function",
+      "schemaDescription": "Schema for addressUI. Fields may be omitted or mapped to alternative key names."
+    },
     {
       "category": "AddressDeprecated",
       "uiSchema": "addressDeprecatedUI",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -20,7 +20,7 @@
       "uiSchemaDescription": "uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted or mapped to alternative key names.",
       "schema": "addressSchema",
       "schemaType": "function",
-      "schemaDescription": "Schema for addressUI. Fields may be omitted."
+      "schemaDescription": "Schema for addressUI. Fields may be omitted or mapped to alternative key names."
     },
     {
       "category": "AddressDeprecated",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -2,7 +2,7 @@
   "title": "VA.gov Web Component Form Field Patterns Catalog (RJSF)",
   "description": "Catalog of all acceptable web component uiSchema and schema patterns for form fields in VA.gov applications. These patterns are used in pairs to define form field behavior and validation in RJSF (React JSON Schema Form) implementations using the VA design system web components.",
   "importPath": "platform/forms-system/src/js/web-component-patterns",
-  "totalPatterns": 54,
+  "totalPatterns": 53,
   "patterns": [
     {
       "category": "Address",
@@ -39,15 +39,6 @@
       "schema": "addressNoMilitaryDeprecatedSchema",
       "schemaType": "function",
       "schemaDescription": "Web component schema for address"
-    },
-    {
-      "category": "AddressPattern centralized keys.jsx",
-      "uiSchema": "addressUI",
-      "uiSchemaType": "function",
-      "uiSchemaDescription": "Example of how to centralize the defaults in addressUI function",
-      "schema": null,
-      "schemaType": null,
-      "schemaDescription": null
     },
     {
       "category": "Arn",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -2,26 +2,8 @@
   "title": "VA.gov Web Component Form Field Patterns Catalog (RJSF)",
   "description": "Catalog of all acceptable web component uiSchema and schema patterns for form fields in VA.gov applications. These patterns are used in pairs to define form field behavior and validation in RJSF (React JSON Schema Form) implementations using the VA design system web components.",
   "importPath": "platform/forms-system/src/js/web-component-patterns",
-  "totalPatterns": 53,
+  "totalPatterns": 51,
   "patterns": [
-    {
-      "category": "Address",
-      "uiSchema": "addressNoMilitaryUI",
-      "uiSchemaType": "function",
-      "uiSchemaDescription": "uiSchema for address - Same as addressUI, but without the military checkbox. Includes fields for country, street, street2, street3, city, state, postal code. Fields may be omitted.",
-      "schema": "addressNoMilitarySchema",
-      "schemaType": "function",
-      "schemaDescription": "Schema for addressNoMilitaryUI. Fields may be omitted."
-    },
-    {
-      "category": "Address",
-      "uiSchema": "addressUI",
-      "uiSchemaType": "function",
-      "uiSchemaDescription": "uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted or mapped to alternative key names.",
-      "schema": "addressSchema",
-      "schemaType": "function",
-      "schemaDescription": "Schema for addressUI. Fields may be omitted or mapped to alternative key names."
-    },
     {
       "category": "AddressDeprecated",
       "uiSchema": "addressDeprecatedUI",

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.json
@@ -17,7 +17,7 @@
       "category": "Address",
       "uiSchema": "addressUI",
       "uiSchemaType": "function",
-      "uiSchemaDescription": "uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted.",
+      "uiSchemaDescription": "uiSchema for address - includes checkbox for military base, and fields for country, street, street2, street3, city, state, postal code. Fields may be omitted or mapped to alternative key names.",
       "schema": "addressSchema",
       "schemaType": "function",
       "schemaDescription": "Schema for addressUI. Fields may be omitted."

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {
-  mappedAddressUI,
-  mappedAddressSchema,
-  updateMappedFormDataAddress,
+  addressUI,
+  addressSchema,
+  updateFormDataAddress,
 } from '../../../src/js/web-component-patterns/addressPattern';
 
 describe('addressPattern mapping functions', () => {
@@ -17,7 +17,7 @@ describe('addressPattern mapping functions', () => {
     sandbox.restore();
   });
 
-  describe('mappedAddressUI', () => {
+  describe('addressUI', () => {
     it('should return UI schema with mapped field keys', () => {
       const keyMap = {
         street: 'addressLine1',
@@ -26,7 +26,7 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const result = mappedAddressUI({ keyMap });
+      const result = addressUI({ keyMap });
 
       // Should have mapped keys instead of standard keys
       expect(result).to.have.property('addressLine1');
@@ -53,7 +53,7 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const result = mappedAddressUI({ keyMap });
+      const result = addressUI({ keyMap });
 
       // Check that field configurations are preserved
       expect(result.addressLine1).to.have.property('ui:required');
@@ -70,7 +70,7 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const result = mappedAddressUI({ keyMap });
+      const result = addressUI({ keyMap });
 
       // Should have mapped key
       expect(result).to.have.property('zipCode');
@@ -89,7 +89,7 @@ describe('addressPattern mapping functions', () => {
         street2: 'addressLine2',
       };
 
-      const result = mappedAddressUI({
+      const result = addressUI({
         keyMap,
         omit: ['street3', 'isMilitary'],
       });
@@ -105,7 +105,7 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should work with no keyMap provided', () => {
-      const result = mappedAddressUI({});
+      const result = addressUI({});
 
       // Should return standard keys when no mapping provided
       expect(result).to.have.property('street');
@@ -128,7 +128,7 @@ describe('addressPattern mapping functions', () => {
         militaryCheckbox: 'Custom Military Label',
       };
 
-      const result = mappedAddressUI({ keyMap, labels });
+      const result = addressUI({ keyMap, labels });
 
       // Check that labels are applied correctly
       expect(result.addressLine1['ui:title']).to.equal('Custom Street Label');
@@ -136,7 +136,7 @@ describe('addressPattern mapping functions', () => {
     });
   });
 
-  describe('mappedAddressSchema', () => {
+  describe('addressSchema', () => {
     it('should return schema with mapped property keys', () => {
       const keyMap = {
         street: 'addressLine1',
@@ -145,7 +145,7 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const result = mappedAddressSchema({ keyMap });
+      const result = addressSchema({ keyMap });
 
       expect(result).to.have.property('type', 'object');
       expect(result).to.have.property('properties');
@@ -175,7 +175,7 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const result = mappedAddressSchema({ keyMap });
+      const result = addressSchema({ keyMap });
 
       // Check that property definitions are preserved
       expect(result.properties.addressLine1).to.have.property('type', 'string');
@@ -188,7 +188,7 @@ describe('addressPattern mapping functions', () => {
         street2: 'addressLine2',
       };
 
-      const result = mappedAddressSchema({
+      const result = addressSchema({
         keyMap,
         omit: ['street3', 'isMilitary'],
       });
@@ -204,7 +204,7 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should work with empty keyMap', () => {
-      const result = mappedAddressSchema({});
+      const result = addressSchema({});
 
       // Should return standard property names
       expect(result.properties).to.have.property('street');
@@ -214,7 +214,7 @@ describe('addressPattern mapping functions', () => {
     });
   });
 
-  describe('updateMappedFormDataAddress', () => {
+  describe('updateFormDataAddress', () => {
     it('should update form data with mapped field keys', () => {
       const keyMap = {
         street: 'addressLine1',
@@ -242,7 +242,7 @@ describe('addressPattern mapping functions', () => {
         },
       };
 
-      const result = updateMappedFormDataAddress(
+      const result = updateFormDataAddress(
         oldFormData,
         formData,
         ['mailingAddress'],
@@ -278,7 +278,7 @@ describe('addressPattern mapping functions', () => {
         },
       };
 
-      const result = updateMappedFormDataAddress(
+      const result = updateFormDataAddress(
         oldFormData,
         formData,
         ['address'],
@@ -315,7 +315,7 @@ describe('addressPattern mapping functions', () => {
       };
 
       // This should save the original city/state
-      updateMappedFormDataAddress(
+      updateFormDataAddress(
         initialOldData,
         militaryData,
         ['address'],
@@ -340,7 +340,7 @@ describe('addressPattern mapping functions', () => {
         },
       };
 
-      const result = updateMappedFormDataAddress(
+      const result = updateFormDataAddress(
         oldFormData,
         newFormData,
         ['address'],
@@ -372,7 +372,7 @@ describe('addressPattern mapping functions', () => {
         },
       };
 
-      const result = updateMappedFormDataAddress(
+      const result = updateFormDataAddress(
         oldFormData,
         formData,
         ['address'],
@@ -393,8 +393,8 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const uiSchema = mappedAddressUI({ keyMap });
-      const schema = mappedAddressSchema({ keyMap });
+      const uiSchema = addressUI({ keyMap });
+      const schema = addressSchema({ keyMap });
 
       // Should have mapped keys
       expect(schema.properties).to.have.property('addressLine1');
@@ -414,7 +414,7 @@ describe('addressPattern mapping functions', () => {
         postalCode: 'zipCode',
       };
 
-      const uiSchema = mappedAddressUI({ keyMap });
+      const uiSchema = addressUI({ keyMap });
 
       // Should have military checkbox functionality
       expect(uiSchema.isMilitary).to.exist;

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -19,14 +19,14 @@ describe('addressPattern mapping functions', () => {
 
   describe('addressUI', () => {
     it('should return UI schema with mapped field keys', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         street3: 'addressLine3',
         postalCode: 'zipCode',
       };
 
-      const result = addressUI({ keyMap });
+      const result = addressUI({ newSchemaKeys });
 
       // Should have mapped keys instead of standard keys
       expect(result).to.have.property('addressLine1');
@@ -48,12 +48,12 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should preserve field configurations when mapping keys', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const result = addressUI({ keyMap });
+      const result = addressUI({ newSchemaKeys });
 
       // Check that field configurations are preserved
       expect(result.addressLine1).to.have.property('ui:required');
@@ -66,11 +66,11 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should handle partial key mapping correctly', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         postalCode: 'zipCode',
       };
 
-      const result = addressUI({ keyMap });
+      const result = addressUI({ newSchemaKeys });
 
       // Should have mapped key
       expect(result).to.have.property('zipCode');
@@ -84,13 +84,13 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should respect omit option with standard keys', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         street2: 'addressLine2',
       };
 
       const result = addressUI({
-        keyMap,
+        newSchemaKeys,
         omit: ['street3', 'isMilitary'],
       });
 
@@ -104,7 +104,7 @@ describe('addressPattern mapping functions', () => {
       expect(result).to.not.have.property('isMilitary');
     });
 
-    it('should work with no keyMap provided', () => {
+    it('should work with no newSchemaKeys provided', () => {
       const result = addressUI({});
 
       // Should return standard keys when no mapping provided
@@ -119,7 +119,7 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should pass through other options to base addressUI', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
       };
 
@@ -128,7 +128,7 @@ describe('addressPattern mapping functions', () => {
         militaryCheckbox: 'Custom Military Label',
       };
 
-      const result = addressUI({ keyMap, labels });
+      const result = addressUI({ newSchemaKeys, labels });
 
       // Check that labels are applied correctly
       expect(result.addressLine1['ui:title']).to.equal('Custom Street Label');
@@ -138,14 +138,14 @@ describe('addressPattern mapping functions', () => {
 
   describe('addressSchema', () => {
     it('should return schema with mapped property keys', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         street3: 'addressLine3',
         postalCode: 'zipCode',
       };
 
-      const result = addressSchema({ keyMap });
+      const result = addressSchema({ newSchemaKeys });
 
       expect(result).to.have.property('type', 'object');
       expect(result).to.have.property('properties');
@@ -170,12 +170,12 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should preserve property definitions when mapping', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const result = addressSchema({ keyMap });
+      const result = addressSchema({ newSchemaKeys });
 
       // Check that property definitions are preserved
       expect(result.properties.addressLine1).to.have.property('type', 'string');
@@ -183,13 +183,13 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should handle omit option correctly', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         street2: 'addressLine2',
       };
 
       const result = addressSchema({
-        keyMap,
+        newSchemaKeys,
         omit: ['street3', 'isMilitary'],
       });
 
@@ -203,7 +203,7 @@ describe('addressPattern mapping functions', () => {
       expect(result.properties).to.not.have.property('isMilitary');
     });
 
-    it('should work with empty keyMap', () => {
+    it('should work with empty newSchemaKeys', () => {
       const result = addressSchema({});
 
       // Should return standard property names
@@ -216,7 +216,7 @@ describe('addressPattern mapping functions', () => {
 
   describe('updateFormDataAddress', () => {
     it('should update form data with mapped field keys', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         postalCode: 'zipCode',
@@ -247,14 +247,14 @@ describe('addressPattern mapping functions', () => {
         formData,
         ['mailingAddress'],
         null,
-        keyMap,
+        newSchemaKeys,
       );
 
       expect(result).to.deep.equal(formData);
     });
 
     it('should handle military base checkbox toggle correctly', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         city: 'cityName',
         state: 'stateCode',
@@ -283,7 +283,7 @@ describe('addressPattern mapping functions', () => {
         formData,
         ['address'],
         null,
-        keyMap,
+        newSchemaKeys,
       );
 
       // Should clear city and state when switching to military
@@ -292,7 +292,7 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should restore saved address when unchecking military base', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         city: 'cityName',
         state: 'stateCode',
       };
@@ -320,7 +320,7 @@ describe('addressPattern mapping functions', () => {
         militaryData,
         ['address'],
         null,
-        keyMap,
+        newSchemaKeys,
       );
 
       // Now simulate unchecking military base
@@ -345,7 +345,7 @@ describe('addressPattern mapping functions', () => {
         newFormData,
         ['address'],
         null,
-        keyMap,
+        newSchemaKeys,
       );
 
       // Should restore the previously saved city and state
@@ -353,7 +353,7 @@ describe('addressPattern mapping functions', () => {
       expect(result.address.stateCode).to.equal('NY');
     });
 
-    it('should work with no keyMap provided', () => {
+    it('should work with no newSchemaKeys provided', () => {
       const oldFormData = {
         address: {
           isMilitary: false,
@@ -388,13 +388,13 @@ describe('addressPattern mapping functions', () => {
 
   describe('integration with existing patterns', () => {
     it('should work seamlessly with existing address validation', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const uiSchema = addressUI({ keyMap });
-      const schema = addressSchema({ keyMap });
+      const uiSchema = addressUI({ newSchemaKeys });
+      const schema = addressSchema({ newSchemaKeys });
 
       // Should have mapped keys
       expect(schema.properties).to.have.property('addressLine1');
@@ -407,14 +407,14 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should preserve all address functionality with mapped keys', () => {
-      const keyMap = {
+      const newSchemaKeys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         street3: 'addressLine3',
         postalCode: 'zipCode',
       };
 
-      const uiSchema = addressUI({ keyMap });
+      const uiSchema = addressUI({ newSchemaKeys });
 
       // Should have military checkbox functionality
       expect(uiSchema.isMilitary).to.exist;

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -780,9 +780,9 @@ describe('addressPattern mapping functions', () => {
       };
 
       // Even though addressLine1 would be omitted, the collision should be detected first
-      expect(() =>
-        applyKeyMapping(originalSchema, keys, ['addressLine1']),
-      ).to.throw(/Field mapping would cause key collisions/);
+      expect(() => applyKeyMapping(originalSchema, keys)).to.throw(
+        /Field mapping would cause key collisions/,
+      );
     });
 
     it('should handle complex collision scenarios with multiple mappings', () => {

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -9,14 +9,14 @@ import {
 describe('addressPattern mapping functions', () => {
   describe('addressUI', () => {
     it('should return UI schema with mapped field keys', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         street3: 'addressLine3',
         postalCode: 'zipCode',
       };
 
-      const result = addressUI({ newSchemaKeys });
+      const result = addressUI({ keys });
 
       // Should have mapped keys instead of standard keys
       expect(result).to.have.property('addressLine1');
@@ -38,12 +38,12 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should preserve field configurations when mapping keys', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const result = addressUI({ newSchemaKeys });
+      const result = addressUI({ keys });
 
       // Check that field configurations are preserved
       expect(result.addressLine1).to.have.property('ui:required');
@@ -56,11 +56,11 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should handle partial key mapping correctly', () => {
-      const newSchemaKeys = {
+      const keys = {
         postalCode: 'zipCode',
       };
 
-      const result = addressUI({ newSchemaKeys });
+      const result = addressUI({ keys });
 
       // Should have mapped key
       expect(result).to.have.property('zipCode');
@@ -74,13 +74,13 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should respect omit option with standard keys', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         street2: 'addressLine2',
       };
 
       const result = addressUI({
-        newSchemaKeys,
+        keys,
         omit: ['street3', 'isMilitary'],
       });
 
@@ -94,7 +94,7 @@ describe('addressPattern mapping functions', () => {
       expect(result).to.not.have.property('isMilitary');
     });
 
-    it('should work with no newSchemaKeys provided', () => {
+    it('should work with no keys provided', () => {
       const result = addressUI({});
 
       // Should return standard keys when no mapping provided
@@ -108,12 +108,12 @@ describe('addressPattern mapping functions', () => {
       expect(result).to.have.property('isMilitary');
     });
     it('should omit using mapped field names in omit array', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
       };
 
       const result = addressUI({
-        newSchemaKeys,
+        keys,
         omit: ['addressLine1'], // Omit using the mapped name
       });
 
@@ -123,7 +123,7 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should pass through other options to base addressUI', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
       };
 
@@ -132,7 +132,7 @@ describe('addressPattern mapping functions', () => {
         militaryCheckbox: 'Custom Military Label',
       };
 
-      const result = addressUI({ newSchemaKeys, labels });
+      const result = addressUI({ keys, labels });
 
       // Check that labels are applied correctly
       expect(result.addressLine1['ui:title']).to.equal('Custom Street Label');
@@ -141,8 +141,8 @@ describe('addressPattern mapping functions', () => {
   });
 
   describe('addressSchema with key mapping', () => {
-    describe('without key mapping (newSchemaKeys empty)', () => {
-      it('should return standard schema when no newSchemaKeys provided', () => {
+    describe('without key mapping (keys empty)', () => {
+      it('should return standard schema when no keys provided', () => {
         const result = addressSchema();
 
         expect(result).to.have.property('type', 'object');
@@ -156,7 +156,7 @@ describe('addressPattern mapping functions', () => {
         expect(result.properties).to.have.property('country');
         expect(result.properties).to.have.property('isMilitary');
       });
-      it('should omit specified fields when omit array provided and no newSchemaKeys', () => {
+      it('should omit specified fields when omit array provided and no keys', () => {
         const result = addressSchema({ omit: ['street2', 'street3'] });
 
         // Should have standard fields except omitted ones
@@ -182,16 +182,16 @@ describe('addressPattern mapping functions', () => {
       });
     });
 
-    describe('with key mapping (newSchemaKeys provided)', () => {
-      it('should map field keys when newSchemaKeys provided', () => {
-        const newSchemaKeys = {
+    describe('with key mapping (keys provided)', () => {
+      it('should map field keys when keys provided', () => {
+        const keys = {
           street: 'addressLine1',
           street2: 'addressLine2',
           street3: 'addressLine3',
           postalCode: 'zipCode',
         };
 
-        const result = addressSchema({ newSchemaKeys });
+        const result = addressSchema({ keys });
 
         // Should have mapped keys
         expect(result.properties).to.have.property('addressLine1');
@@ -213,12 +213,12 @@ describe('addressPattern mapping functions', () => {
       });
 
       it('should preserve property configurations when mapping keys', () => {
-        const newSchemaKeys = {
+        const keys = {
           street: 'addressLine1',
           postalCode: 'zipCode',
         };
 
-        const result = addressSchema({ newSchemaKeys });
+        const result = addressSchema({ keys });
 
         // Check that property definitions are preserved
         expect(result.properties.addressLine1).to.have.property(
@@ -235,7 +235,7 @@ describe('addressPattern mapping functions', () => {
       });
 
       it('should apply omit filtering with mapped keys', () => {
-        const newSchemaKeys = {
+        const keys = {
           street: 'addressLine1',
           street2: 'addressLine2',
           street3: 'addressLine3',
@@ -243,7 +243,7 @@ describe('addressPattern mapping functions', () => {
         };
 
         const result = addressSchema({
-          newSchemaKeys,
+          keys,
           omit: ['street3', 'isMilitary'],
         });
 
@@ -263,13 +263,13 @@ describe('addressPattern mapping functions', () => {
         expect(result.properties).to.have.property('country');
       });
       it('should omit using mapped key names in omit array', () => {
-        const newSchemaKeys = {
+        const keys = {
           street: 'addressLine1',
           postalCode: 'zipCode',
         };
 
         const result = addressSchema({
-          newSchemaKeys,
+          keys,
           omit: ['addressLine1', 'zipCode'], // Using mapped names in omit
         });
 
@@ -287,11 +287,11 @@ describe('addressPattern mapping functions', () => {
       });
 
       it('should handle partial key mapping correctly', () => {
-        const newSchemaKeys = {
+        const keys = {
           postalCode: 'zipCode',
         };
 
-        const result = addressSchema({ newSchemaKeys });
+        const result = addressSchema({ keys });
 
         // Should have mapped key
         expect(result.properties).to.have.property('zipCode');
@@ -306,10 +306,10 @@ describe('addressPattern mapping functions', () => {
     });
 
     describe('edge cases', () => {
-      it('should handle empty newSchemaKeys object', () => {
-        const result = addressSchema({ newSchemaKeys: {} });
+      it('should handle empty keys object', () => {
+        const result = addressSchema({ keys: {} });
 
-        // Should behave like no newSchemaKeys provided
+        // Should behave like no keys provided
         expect(result.properties).to.have.property('street');
         expect(result.properties).to.have.property('postalCode');
       });
@@ -322,20 +322,20 @@ describe('addressPattern mapping functions', () => {
         expect(result.properties).to.have.property('street');
       });
 
-      it('should handle options with undefined newSchemaKeys', () => {
-        const result = addressSchema({ newSchemaKeys: undefined });
+      it('should handle options with undefined keys', () => {
+        const result = addressSchema({ keys: undefined });
 
         expect(result.properties).to.have.property('street');
         expect(result.properties).to.have.property('postalCode');
       });
 
       it('should handle mapping keys that do not exist in original schema', () => {
-        const newSchemaKeys = {
+        const keys = {
           street: 'addressLine1',
           nonExistentField: 'mappedNonExistent',
         };
 
-        const result = addressSchema({ newSchemaKeys });
+        const result = addressSchema({ keys });
 
         // Should map existing fields
         expect(result.properties).to.have.property('addressLine1');
@@ -350,7 +350,7 @@ describe('addressPattern mapping functions', () => {
 
   describe('updateFormDataAddress', () => {
     it('should update form data with mapped field keys', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         postalCode: 'zipCode',
@@ -381,14 +381,14 @@ describe('addressPattern mapping functions', () => {
         formData,
         ['mailingAddress'],
         null,
-        newSchemaKeys,
+        keys,
       );
 
       expect(result).to.deep.equal(formData);
     });
 
     it('should handle military base checkbox toggle correctly', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         city: 'cityName',
         state: 'stateCode',
@@ -417,7 +417,7 @@ describe('addressPattern mapping functions', () => {
         formData,
         ['address'],
         null,
-        newSchemaKeys,
+        keys,
       );
 
       // Should clear city and state when switching to military
@@ -426,7 +426,7 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should restore saved address when unchecking military base', () => {
-      const newSchemaKeys = {
+      const keys = {
         city: 'cityName',
         state: 'stateCode',
       };
@@ -454,7 +454,7 @@ describe('addressPattern mapping functions', () => {
         militaryData,
         ['address'],
         null,
-        newSchemaKeys,
+        keys,
       );
 
       // Now simulate unchecking military base
@@ -479,7 +479,7 @@ describe('addressPattern mapping functions', () => {
         newFormData,
         ['address'],
         null,
-        newSchemaKeys,
+        keys,
       );
 
       // Should restore the previously saved city and state
@@ -487,7 +487,7 @@ describe('addressPattern mapping functions', () => {
       expect(result.address.stateCode).to.equal('NY');
     });
 
-    it('should work with no newSchemaKeys provided', () => {
+    it('should work with no keys provided', () => {
       const oldFormData = {
         address: {
           isMilitary: false,
@@ -522,13 +522,13 @@ describe('addressPattern mapping functions', () => {
 
   describe('integration with existing patterns', () => {
     it('should work seamlessly with existing address validation', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const uiSchema = addressUI({ newSchemaKeys });
-      const schema = addressSchema({ newSchemaKeys });
+      const uiSchema = addressUI({ keys });
+      const schema = addressSchema({ keys });
 
       // Should have mapped keys
       expect(schema.properties).to.have.property('addressLine1');
@@ -541,14 +541,14 @@ describe('addressPattern mapping functions', () => {
     });
 
     it('should preserve all address functionality with mapped keys', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         street3: 'addressLine3',
         postalCode: 'zipCode',
       };
 
-      const uiSchema = addressUI({ newSchemaKeys });
+      const uiSchema = addressUI({ keys });
 
       // Should have military checkbox functionality
       expect(uiSchema.isMilitary).to.exist;
@@ -570,12 +570,12 @@ describe('addressPattern mapping functions', () => {
         city: { type: 'string', title: 'City' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const result = applyKeyMapping(originalSchema, newSchemaKeys);
+      const result = applyKeyMapping(originalSchema, keys);
 
       // Should have mapped keys
       expect(result).to.have.property('addressLine1');
@@ -605,12 +605,12 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const result = applyKeyMapping(originalSchema, newSchemaKeys, [
+      const result = applyKeyMapping(originalSchema, keys, [
         'street2',
         'street3',
       ]);
@@ -631,11 +631,11 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
-      const result = applyKeyMapping(originalSchema, newSchemaKeys, [
+      const result = applyKeyMapping(originalSchema, keys, [
         'addressLine1',
         'zipCode',
       ]);
@@ -660,7 +660,7 @@ describe('addressPattern mapping functions', () => {
 
       expect(result).to.deep.equal(originalSchema);
     });
-    it('should return original schema when newSchemaKeys is empty', () => {
+    it('should return original schema when keys is empty', () => {
       const originalSchema = {
         street: { type: 'string' },
         postalCode: { type: 'string' },
@@ -688,12 +688,12 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         postalCode: 'zipCode',
       };
 
-      const result = applyKeyMapping(originalSchema, newSchemaKeys, [
+      const result = applyKeyMapping(originalSchema, keys, [
         'street', // Omit by source name
         'zipCode', // Omit by target name
         'street2', // Omit unmapped field
@@ -718,11 +718,11 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string', title: 'Postal Code' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1', // Collision: addressLine1 already exists
       };
 
-      expect(() => applyKeyMapping(originalSchema, newSchemaKeys)).to.throw(
+      expect(() => applyKeyMapping(originalSchema, keys)).to.throw(
         /Field mapping would cause key collisions.*'street' -> 'addressLine1'/,
       );
     });
@@ -736,12 +736,12 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1', // Collision
         postalCode: 'zipCode', // Collision
       };
 
-      expect(() => applyKeyMapping(originalSchema, newSchemaKeys)).to.throw(
+      expect(() => applyKeyMapping(originalSchema, keys)).to.throw(
         /Field mapping would cause key collisions.*'street' -> 'addressLine1'.*'postalCode' -> 'zipCode'/,
       );
     });
@@ -751,13 +751,11 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'street', // Same name, should be fine
       };
 
-      expect(() =>
-        applyKeyMapping(originalSchema, newSchemaKeys),
-      ).to.not.throw();
+      expect(() => applyKeyMapping(originalSchema, keys)).to.not.throw();
     });
 
     it('should detect collision with case sensitivity', () => {
@@ -766,11 +764,11 @@ describe('addressPattern mapping functions', () => {
         Street: { type: 'string' }, // Different case
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'Street', // Collision due to case
       };
 
-      expect(() => applyKeyMapping(originalSchema, newSchemaKeys)).to.throw(
+      expect(() => applyKeyMapping(originalSchema, keys)).to.throw(
         /Field mapping would cause key collisions.*'street' -> 'Street'/,
       );
     });
@@ -780,11 +778,11 @@ describe('addressPattern mapping functions', () => {
         postalCode: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1', // addressLine1 doesn't exist in original
         postalCode: 'zipCode', // zipCode doesn't exist in original
       };
-      const result = applyKeyMapping(originalSchema, newSchemaKeys);
+      const result = applyKeyMapping(originalSchema, keys);
 
       expect(result).to.have.property('addressLine1');
       expect(result).to.have.property('zipCode');
@@ -798,13 +796,13 @@ describe('addressPattern mapping functions', () => {
         addressLine1: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
       };
 
       // Even though addressLine1 would be omitted, the collision should be detected first
       expect(() =>
-        applyKeyMapping(originalSchema, newSchemaKeys, ['addressLine1']),
+        applyKeyMapping(originalSchema, keys, ['addressLine1']),
       ).to.throw(/Field mapping would cause key collisions/);
     });
 
@@ -817,48 +815,48 @@ describe('addressPattern mapping functions', () => {
         targetY: { type: 'string' },
       };
 
-      const newSchemaKeys = {
+      const keys = {
         fieldA: 'targetX', // Collision
         fieldB: 'targetY', // Collision
         fieldC: 'newField', // No collision
       };
 
-      expect(() => applyKeyMapping(originalSchema, newSchemaKeys)).to.throw(
+      expect(() => applyKeyMapping(originalSchema, keys)).to.throw(
         /Field mapping would cause key collisions.*'fieldA' -> 'targetX'.*'fieldB' -> 'targetY'/,
       );
     });
   });
   describe('integration with collision detection', () => {
     it('should prevent addressUI from creating schemas with collisions', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'country', // This would collide with existing country field
       };
 
-      expect(() => addressUI({ newSchemaKeys })).to.throw(
+      expect(() => addressUI({ keys })).to.throw(
         /Field mapping would cause key collisions.*'street' -> 'country'/,
       );
     });
 
     it('should prevent addressSchema from creating schemas with collisions', () => {
-      const newSchemaKeys = {
+      const keys = {
         postalCode: 'city', // This would collide with existing city field
       };
 
-      expect(() => addressSchema({ newSchemaKeys })).to.throw(
+      expect(() => addressSchema({ keys })).to.throw(
         /Field mapping would cause key collisions.*'postalCode' -> 'city'/,
       );
     });
 
     it('should allow safe mappings that do not cause collisions', () => {
-      const newSchemaKeys = {
+      const keys = {
         street: 'addressLine1',
         street2: 'addressLine2',
         postalCode: 'zipCode',
       };
 
       // These should work fine as they don't collide with existing fields
-      expect(() => addressUI({ newSchemaKeys })).to.not.throw();
-      expect(() => addressSchema({ newSchemaKeys })).to.not.throw();
+      expect(() => addressUI({ keys })).to.not.throw();
+      expect(() => addressSchema({ keys })).to.not.throw();
     });
   });
 });

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -110,17 +110,17 @@ describe('addressPattern mapping functions', () => {
       expect(result).to.have.property('isMilitary');
     });
 
-    it('should omit using mapped field names in omit array', () => {
+    it('should omit mapped field when standard key is in omit array', () => {
       const keys = {
         street: 'addressLine1',
       };
 
       const result = addressUI({
         keys,
-        omit: ['street'], // Omit using the mapped name
+        omit: ['street'], // Omit using the standard name; mapped field should also be omitted
       });
 
-      // Should NOT have the mapped field (omitted by mapped name)
+      // Should NOT have the mapped field (omitted by standard key)
       expect(result).to.not.have.property('addressLine1');
       expect(result).to.not.have.property('street');
     });
@@ -130,18 +130,11 @@ describe('addressPattern mapping functions', () => {
         street: 'addressLine1',
       };
 
-      try {
-        addressUI({
-          keys,
-          omit: ['addressLine1'], // Omit using the mapped name
-        });
-        expect.fail('Expected error was not thrown');
-      } catch (e) {
-        // expect error: omit: Invalid key mappings: addressLine1. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary
-        expect(e.message).to.match(
-          /omit: Invalid key mappings: addressLine1. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary/,
-        );
-      }
+      expect(
+        () => addressUI({ keys, omit: ['addressLine1'] }), // Omit using mapped name
+      ).to.throw(
+        /omit: Invalid key mappings: addressLine1. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary/,
+      );
     });
 
     it('should pass through other options to base addressUI', () => {
@@ -284,22 +277,21 @@ describe('addressPattern mapping functions', () => {
         expect(result.properties).to.have.property('state');
         expect(result.properties).to.have.property('country');
       });
+
       it('should validate if using wrong keys in omit', () => {
         const keys = {
           street: 'addressLine1',
           postalCode: 'zipCode',
         };
 
-        try {
+        expect(() =>
           addressSchema({
             keys,
             omit: ['addressLine1', 'zipCode'], // Using mapped names in omit
-          });
-        } catch (e) {
-          expect(e.message).to.match(
-            /omit: Invalid key mappings: addressLine1, zipCode. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary/,
-          );
-        }
+          }),
+        ).to.throw(
+          /omit: Invalid key mappings: addressLine1, zipCode. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary/,
+        );
       });
 
       it('should handle partial key mapping correctly', () => {
@@ -351,13 +343,9 @@ describe('addressPattern mapping functions', () => {
           nonExistentField: 'mappedNonExistent',
         };
 
-        try {
-          addressSchema({ keys });
-        } catch (e) {
-          expect(e.message).to.match(
-            /keys: Invalid key mappings: nonExistentField. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary/,
-          );
-        }
+        expect(() => addressSchema({ keys })).to.throw(
+          /keys: Invalid key mappings: nonExistentField. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary./,
+        );
       });
     });
   });
@@ -1094,13 +1082,9 @@ describe('addressPattern mapping functions', () => {
         unsafeField: 'customField',
       };
 
-      try {
-        applyKeyMapping(schema, keys);
-      } catch (e) {
-        expect(e.message).to.match(
-          /keys: Invalid key mappings: unsafeField. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary./,
-        );
-      }
+      expect(() => applyKeyMapping(schema, keys)).to.throw(
+        /keys: Invalid key mappings: unsafeField. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary./,
+      );
     });
 
     it('should handle multiple separate unsafe field mappings', () => {
@@ -1115,13 +1099,9 @@ describe('addressPattern mapping functions', () => {
         unsafeField2: 'customField2',
       };
 
-      try {
-        applyKeyMapping(schema, keys);
-      } catch (e) {
-        expect(e.message).to.match(
-          /keys: Invalid key mappings: unsafeField1, unsafeField2. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary./,
-        );
-      }
+      expect(() => applyKeyMapping(schema, keys)).to.throw(
+        /keys: Invalid key mappings: unsafeField1, unsafeField2. Valid mappable fields are: country, city, state, street, street2, street3, postalCode, isMilitary./,
+      );
     });
 
     it('should not log warnings when no mapping keys are provided', () => {

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
 import {
   addressUI,
   addressSchema,
@@ -7,16 +6,6 @@ import {
 } from '../../../src/js/web-component-patterns/addressPattern';
 
 describe('addressPattern mapping functions', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('addressUI', () => {
     it('should return UI schema with mapped field keys', () => {
       const newSchemaKeys = {

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -107,6 +107,20 @@ describe('addressPattern mapping functions', () => {
       expect(result).to.have.property('country');
       expect(result).to.have.property('isMilitary');
     });
+    it('should omit using mapped field names in omit array', () => {
+      const newSchemaKeys = {
+        street: 'addressLine1',
+      };
+
+      const result = addressUI({
+        newSchemaKeys,
+        omit: ['addressLine1'], // Omit using the mapped name
+      });
+
+      // Should NOT have the mapped field (omitted by mapped name)
+      expect(result).to.not.have.property('addressLine1');
+      expect(result).to.not.have.property('street');
+    });
 
     it('should pass through other options to base addressUI', () => {
       const newSchemaKeys = {
@@ -332,71 +346,6 @@ describe('addressPattern mapping functions', () => {
         expect(result.properties).to.not.have.property('nonExistentField');
       });
     });
-    it('should return schema with mapped property keys', () => {
-      const newSchemaKeys = {
-        street: 'addressLine1',
-        street2: 'addressLine2',
-        street3: 'addressLine3',
-        postalCode: 'zipCode',
-      };
-
-      const result = addressSchema({ newSchemaKeys });
-
-      expect(result).to.have.property('type', 'object');
-      expect(result).to.have.property('properties');
-
-      // Should have mapped keys
-      expect(result.properties).to.have.property('addressLine1');
-      expect(result.properties).to.have.property('addressLine2');
-      expect(result.properties).to.have.property('addressLine3');
-      expect(result.properties).to.have.property('zipCode');
-
-      // Should not have original keys
-      expect(result.properties).to.not.have.property('street');
-      expect(result.properties).to.not.have.property('street2');
-      expect(result.properties).to.not.have.property('street3');
-      expect(result.properties).to.not.have.property('postalCode');
-
-      // Should still have unmapped keys
-      expect(result.properties).to.have.property('isMilitary');
-      expect(result.properties).to.have.property('country');
-      expect(result.properties).to.have.property('city');
-      expect(result.properties).to.have.property('state');
-    });
-
-    it('should preserve property definitions when mapping', () => {
-      const newSchemaKeys = {
-        street: 'addressLine1',
-        postalCode: 'zipCode',
-      };
-
-      const result = addressSchema({ newSchemaKeys });
-
-      // Check that property definitions are preserved
-      expect(result.properties.addressLine1).to.have.property('type', 'string');
-      expect(result.properties.zipCode).to.have.property('type', 'string');
-    });
-
-    it('should handle omit option correctly', () => {
-      const newSchemaKeys = {
-        street: 'addressLine1',
-        street2: 'addressLine2',
-      };
-
-      const result = addressSchema({
-        newSchemaKeys,
-        omit: ['street3', 'isMilitary'],
-      });
-
-      // Should have mapped keys
-      expect(result.properties).to.have.property('addressLine1');
-      expect(result.properties).to.have.property('addressLine2');
-
-      // Should omit specified fields
-      expect(result.properties).to.not.have.property('street3');
-      expect(result.properties).to.not.have.property('addressLine3');
-      expect(result.properties).to.not.have.property('isMilitary');
-    });
   });
 
   describe('updateFormDataAddress', () => {
@@ -568,45 +517,6 @@ describe('addressPattern mapping functions', () => {
       // Should work like regular updateFormDataAddress
       expect(result.address.city).to.equal('');
       expect(result.address.state).to.equal('');
-    });
-
-    it('should omit fields when both keyMap and omit are provided', () => {
-      const newSchemaKeys = {
-        street: 'addressLine1',
-        postalCode: 'zipCode',
-      };
-
-      const result = addressUI({
-        newSchemaKeys,
-        omit: ['street2', 'street3'],
-      });
-
-      // Should have mapped keys
-      expect(result).to.have.property('addressLine1');
-      expect(result).to.have.property('zipCode');
-
-      // Should NOT have omitted fields
-      expect(result).to.not.have.property('street2');
-      expect(result).to.not.have.property('street3');
-
-      // Should still have other unmapped, non-omitted fields
-      expect(result).to.have.property('city');
-      expect(result).to.have.property('state');
-    });
-
-    it('should omit using mapped field names in omit array', () => {
-      const newSchemaKeys = {
-        street: 'addressLine1',
-      };
-
-      const result = addressUI({
-        newSchemaKeys,
-        omit: ['addressLine1'], // Omit using the mapped name
-      });
-
-      // Should NOT have the mapped field (omitted by mapped name)
-      expect(result).to.not.have.property('addressLine1');
-      expect(result).to.not.have.property('street');
     });
   });
 

--- a/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/addressPattern.unit.spec.jsx
@@ -234,28 +234,6 @@ describe('addressPattern mapping functions', () => {
         expect(result.properties).to.have.property('isMilitary');
       });
 
-      it('should preserve property configurations when mapping keys', () => {
-        const keys = {
-          street: 'addressLine1',
-          postalCode: 'zipCode',
-        };
-
-        const result = addressSchema({ keys });
-
-        // Check that property definitions are preserved
-        expect(result.properties.addressLine1).to.have.property(
-          'type',
-          'string',
-        );
-        expect(result.properties.addressLine1).to.have.property('minLength', 1);
-        expect(result.properties.addressLine1).to.have.property(
-          'maxLength',
-          100,
-        );
-
-        expect(result.properties.zipCode).to.have.property('type', 'string');
-      });
-
       it('should apply omit filtering with mapped keys', () => {
         const keys = {
           street: 'addressLine1',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] 
Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR adds field key mapping functionality to the Platform's addressPattern component, enabling legacy field keys like addressLine1, addressLine2, addressLine3, zipCode to be mapped to the standard Platform keys street, street2, street3, postalCode. All field keys are eligible for mapping. This solution avoids the need for consumers of addressUI pattern to make data transformation updates across multiple systems (vets-website, vets-api, and vets-json-schema).

   - Added `applyKeyMapping` utility function with key collision detection and validation
   - Extended `addressUI` and `addressSchema` functions to support the `newSchemaKeys` mapping parameter
   - Updated `validateMilitaryBaseZipCode` to work with mapped field keys

- I'm on Disability Benefits Crew Core Form team, and got the approval from Platform in [this slack thread](https://dsva.slack.com/archives/C053U7BUT27/p1765215836572839)
- No flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127191

## Testing Steps

- To test, you can pull down this branch `125872-upgrade-address-component` which is built off this PR's branch. For reference see corresponding PR: https://github.com/department-of-veterans-affairs/vets-website/pull/40741
- Log in using mocked-auth, go to Disability Benefits and start a new or use an existing application
- Step through the application to the contact-info page (second page, http://localhost:3001/disability/file-disability-claim-form-21-526ez/contact-information)
- If you're starting a new application, you should be able to fill out a new address and in the browser's dev tools, check that the PUT request to vets-api includes the details in the request form data under `mailingAddress`
- If existing application, you should be able to see all address fields prefilled in the appropriate lines, and any changes are similarly observed in the PUT request to vets-api 
- You should be able to navigate to the Review and Submit page, observe the address again in the accordion, and then submit successfully. 
- The Copy of Submission accordion on the confirmation page should also have all address details. 

- With the old addressUI, any existing in progress form data would get ignored and not get rendered in the UI. This new functionality will map old keys to the expected new keys.
- I've added unit tests and tested in DBC code (which is pushed up in a separate still in progress PR)

## Screenshots
This doesn't affect our application yet but here's an up-to-date proof of submission:
<img width="696" height="474" alt="image" src="https://github.com/user-attachments/assets/d2547483-78f2-4f66-9c65-1192b092d865" />


## What areas of the site does it impact?

Platform's addressPattern code (added newSchemaKeys key mapping functionality)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

- Previously this code was in a different PR so for history and comments, see https://github.com/department-of-veterans-affairs/vets-website/pull/40688 which was closed due to excessive reviewers added by accident.