### PR TITLE
#128115 - fix(mhv-secure-messaging): Validate partial dates in custom filter

### DIFF
--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -16,6 +16,7 @@ import moment from 'moment';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { DateRangeOptions, SelectCategories } from '../../util/inputContants';
 import { ErrorMessages } from '../../util/constants';
+import { isValidDateValue } from '../../util/helpers';
 
 const FilterBox = forwardRef((props, ref) => {
   const {
@@ -55,16 +56,15 @@ const FilterBox = forwardRef((props, ref) => {
 
   const checkFormValidity = () => {
     const today = new Date();
-    // TODO: add validation for ALL blank fields
     let formInvalid;
     const invalidInputs = [];
     if (dateRange === 'custom') {
-      if (!fromDate) {
+      if (!isValidDateValue(fromDate)) {
         formInvalid = true;
         setFromDateError(ErrorMessages.SearchForm.START_DATE_REQUIRED);
         invalidInputs.push(fromDateRef);
       }
-      if (!toDate) {
+      if (!isValidDateValue(toDate)) {
         formInvalid = true;
         setToDateError(ErrorMessages.SearchForm.END_DATE_REQUIRED);
         invalidInputs.push(toDateRef);

--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -59,6 +59,10 @@ const FilterBox = forwardRef((props, ref) => {
     let formInvalid;
     const invalidInputs = [];
     if (dateRange === 'custom') {
+      // Clear error states first, then set only for invalid fields
+      setFromDateError('');
+      setToDateError('');
+
       if (!isValidDateValue(fromDate)) {
         formInvalid = true;
         setFromDateError(ErrorMessages.SearchForm.START_DATE_REQUIRED);
@@ -79,16 +83,7 @@ const FilterBox = forwardRef((props, ref) => {
         setToDateError(ErrorMessages.SearchForm.END_DATE_BEFORE_START_DATE);
         invalidInputs.push(fromDateRef);
       }
-      if (
-        isValidDateValue(fromDate) &&
-        isValidDateValue(toDate) &&
-        moment(fromDate).isBefore(toDate)
-      ) {
-        formInvalid = false;
-        setFromDateError('');
-        setToDateError('');
-      }
-      if (parseInt(toDate.substring(0, 4), 10) > today.getFullYear()) {
+      if (parseInt(toDate?.substring(0, 4), 10) > today.getFullYear()) {
         formInvalid = true;
         setToDateError(
           ErrorMessages.SearchForm.END_YEAR_GREATER_THAN_CURRENT_YEAR,

--- a/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/FilterBox.jsx
@@ -69,13 +69,21 @@ const FilterBox = forwardRef((props, ref) => {
         setToDateError(ErrorMessages.SearchForm.END_DATE_REQUIRED);
         invalidInputs.push(toDateRef);
       }
-      if (fromDate && toDate && moment(toDate).isBefore(fromDate)) {
+      if (
+        isValidDateValue(fromDate) &&
+        isValidDateValue(toDate) &&
+        moment(toDate).isBefore(fromDate)
+      ) {
         formInvalid = true;
         setFromDateError(ErrorMessages.SearchForm.START_DATE_AFTER_END_DATE);
         setToDateError(ErrorMessages.SearchForm.END_DATE_BEFORE_START_DATE);
         invalidInputs.push(fromDateRef);
       }
-      if (fromDate && toDate && moment(fromDate).isBefore(toDate)) {
+      if (
+        isValidDateValue(fromDate) &&
+        isValidDateValue(toDate) &&
+        moment(fromDate).isBefore(toDate)
+      ) {
         formInvalid = false;
         setFromDateError('');
         setToDateError('');

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderManagementPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderManagementPage.js
@@ -95,11 +95,13 @@ class FolderManagementPage {
   };
 
   selectFolderFromModal = (folderName = `Trash`) => {
-    cy.findByTestId('move-button-text')
+    // Wait for folders to load before interacting with the move button
+    cy.wait('@folders');
+    cy.findByTestId(Locators.BUTTONS.MOVE_BUTTON_TEST_ID)
       .should('be.visible')
       .click();
     // Wait for the modal to fully render and radio options to be available
-    cy.get(Locators.ALERTS.MOVE_MODAL)
+    cy.findByTestId(Locators.BUTTONS.MOVE_MODAL_TEST_ID)
       .should('be.visible')
       .within(() => {
         cy.findByLabelText(folderName, { timeout: 10000 })

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js
@@ -66,8 +66,13 @@ describe('SM CUSTOM FOLDER ADD FILTER CUSTOM DATE RANGE', () => {
       .find('[name="discharge-dateMonth"]')
       .should('not.be.disabled');
 
+    // Must provide complete dates (month, day, year) to test date range validation
     PatientFilterPage.selectStartMonth('April');
+    PatientFilterPage.selectStartDay('15');
+    PatientFilterPage.getStartYear('2025');
     PatientFilterPage.selectEndMonth('February');
+    PatientFilterPage.selectEndDay('10');
+    PatientFilterPage.getEndYear('2025');
     cy.get(Locators.BUTTONS.FILTER).click();
 
     PatientFilterPage.getRequiredFieldError(

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-drafts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-drafts.cypress.spec.js
@@ -65,8 +65,13 @@ describe('SM DRAFTS ADD FILTER CUSTOM DATE RANGE', () => {
       .find('[name="discharge-dateMonth"]')
       .should('not.be.disabled');
 
+    // Must provide complete dates (month, day, year) to test date range validation
     PatientFilterPage.selectStartMonth('April');
+    PatientFilterPage.selectStartDay('15');
+    PatientFilterPage.getStartYear('2025');
     PatientFilterPage.selectEndMonth('February');
+    PatientFilterPage.selectEndDay('10');
+    PatientFilterPage.getEndYear('2025');
     cy.get(Locators.BUTTONS.FILTER).click();
 
     PatientFilterPage.getRequiredFieldError(

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
@@ -62,8 +62,13 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
       .find('[name="discharge-dateMonth"]')
       .should('not.be.disabled');
 
+    // Must provide complete dates (month, day, year) to test date range validation
     PatientFilterPage.selectStartMonth('April');
+    PatientFilterPage.selectStartDay('15');
+    PatientFilterPage.getStartYear('2025');
     PatientFilterPage.selectEndMonth('February');
+    PatientFilterPage.selectEndDay('10');
+    PatientFilterPage.getEndYear('2025');
     cy.get(Locators.BUTTONS.FILTER).click();
 
     PatientFilterPage.getRequiredFieldError(

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-inbox.cypress.spec.js
@@ -93,6 +93,31 @@ describe('SM INBOX ADD FILTER CUSTOM DATE RANGE', () => {
     cy.axeCheck(AXE_CONTEXT);
   });
 
+  it('verify error when date fields are partially filled (day only)', () => {
+    // Fill only the day for start date (leaving month and year empty)
+    PatientFilterPage.selectStartDay('4');
+    // Fill only the day for end date (leaving month and year empty)
+    PatientFilterPage.selectEndDay('30');
+
+    cy.findByTestId('filter-messages-button').click();
+
+    // Verify start date error appears
+    PatientFilterPage.getRequiredFieldError(
+      Locators.BLOCKS.FILTER_START_DATE,
+    ).should('have.text', Alerts.DATE_FILTER.EMPTY_START_DATE);
+
+    // Verify end date error appears
+    PatientFilterPage.getRequiredFieldError(
+      Locators.BLOCKS.FILTER_END_DATE,
+    ).should('have.text', Alerts.DATE_FILTER.EMPTY_END_DATE);
+
+    // Verify focus is on first error field
+    cy.findByTestId('date-start').should('be.focused');
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
   it('clears start and end date errors on filter clear', () => {
     cy.get(Locators.BUTTONS.FILTER).click();
     cy.get(Locators.CLEAR_FILTERS).click();

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-sent.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-sent.cypress.spec.js
@@ -66,8 +66,13 @@ describe('SM SENT ADD FILTER CUSTOM DATE RANGE', () => {
       .find('[name="discharge-dateMonth"]')
       .should('not.be.disabled');
 
+    // Must provide complete dates (month, day, year) to test date range validation
     PatientFilterPage.selectStartMonth('April');
+    PatientFilterPage.selectStartDay('15');
+    PatientFilterPage.getStartYear('2025');
     PatientFilterPage.selectEndMonth('February');
+    PatientFilterPage.selectEndDay('10');
+    PatientFilterPage.getEndYear('2025');
     cy.get(Locators.BUTTONS.FILTER).click();
 
     PatientFilterPage.getRequiredFieldError(

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-trash.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-add-filter-custom-date-trash.cypress.spec.js
@@ -65,8 +65,13 @@ describe('SM TRASH ADD FILTER CUSTOM DATE RANGE', () => {
       .find('[name="discharge-dateMonth"]')
       .should('not.be.disabled');
 
+    // Must provide complete dates (month, day, year) to test date range validation
     PatientFilterPage.selectStartMonth('April');
+    PatientFilterPage.selectStartDay('15');
+    PatientFilterPage.getStartYear('2025');
     PatientFilterPage.selectEndMonth('February');
+    PatientFilterPage.selectEndDay('10');
+    PatientFilterPage.getEndYear('2025');
     cy.get(Locators.BUTTONS.FILTER).click();
 
     PatientFilterPage.getRequiredFieldError(

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -146,6 +146,7 @@ export const Locators = {
     TRASH: `#trash-button`,
     BUTTON_TEXT: '[data-testid="trash-button-text"]',
     MOVE_BUTTON_TEST_ID: 'move-button-text',
+    MOVE_MODAL_TEST_ID: 'move-to-modal',
     FILTER: '[data-testid="filter-messages-button"]',
     SEND: '[data-testid="send-button"]',
     SEND_TEST_ID: 'send-button',

--- a/src/applications/mhv-secure-messaging/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/util/helpers.unit.spec.jsx
@@ -24,6 +24,7 @@ import {
   sortRecipients,
   decodeHtmlEntities,
   isOlderThan,
+  isValidDateValue,
   isCustomFolder,
   handleHeader,
   getPageTitle,
@@ -1282,6 +1283,52 @@ describe('MHV Secure Messaging helpers', () => {
       const result = buildRxRenewalMessageBody(rxWithoutSig, false);
 
       expect(result).to.include('Instructions: Instructions not available');
+    });
+  });
+
+  describe('isValidDateValue', () => {
+    it('should return false for empty string', () => {
+      expect(isValidDateValue('')).to.be.false;
+    });
+
+    it('should return false for null', () => {
+      expect(isValidDateValue(null)).to.be.false;
+    });
+
+    it('should return false for undefined', () => {
+      expect(isValidDateValue(undefined)).to.be.false;
+    });
+
+    it('should return false for day only ("--04")', () => {
+      expect(isValidDateValue('--04')).to.be.false;
+    });
+
+    it('should return false for month and day only ("-01-04")', () => {
+      expect(isValidDateValue('-01-04')).to.be.false;
+    });
+
+    it('should return false for year and day only ("2026--04")', () => {
+      expect(isValidDateValue('2026--04')).to.be.false;
+    });
+
+    it('should return false for year and month only ("2026-01-")', () => {
+      expect(isValidDateValue('2026-01-')).to.be.false;
+    });
+
+    it('should return true for valid complete date', () => {
+      expect(isValidDateValue('2026-01-13')).to.be.true;
+    });
+
+    it('should return true for valid date at year boundary', () => {
+      expect(isValidDateValue('2025-12-31')).to.be.true;
+    });
+
+    it('should return false for invalid date (Feb 31st)', () => {
+      expect(isValidDateValue('2026-02-31')).to.be.false;
+    });
+
+    it('should return false for invalid month (13)', () => {
+      expect(isValidDateValue('2026-13-01')).to.be.false;
     });
   });
 });

--- a/src/applications/mhv-secure-messaging/util/helpers.js
+++ b/src/applications/mhv-secure-messaging/util/helpers.js
@@ -157,6 +157,25 @@ export const decodeHtmlEntities = str => {
 };
 
 /**
+ * Validates if a date string from VaDate is complete and valid.
+ * VaDate returns strings like "2026-01-04" for complete dates,
+ * or "--04", "2026--04", "-01-04" for partial dates.
+ * @param {string} dateValue - The date value from VaDate component
+ * @returns {boolean} - true if date is valid and complete, false otherwise
+ */
+export const isValidDateValue = dateValue => {
+  if (!dateValue) return false;
+  // Check for invalid date patterns (missing year, month, or day)
+  if (dateValue.includes('--') || dateValue.startsWith('-')) return false;
+  // Validate format: YYYY-MM-DD
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(dateValue)) return false;
+  // Parse and validate actual date
+  const date = moment(dateValue, 'YYYY-MM-DD', true);
+  return date.isValid();
+};
+
+/**
  * Comparing a timestamp to current date and time, if older than days return true
  * @param {*} timestamp
  * @param {*} days


### PR DESCRIPTION
'Introduced `isValidDateValue()` helper to validate complete date strings from VaDate. Updated FilterBox to use this helper for more robust custom date range validation, ensuring incomplete or malformed dates are flagged.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'\''m not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug**: When users select "Custom" date range in the filter and only partially fill in the date fields (e.g., entering day only while leaving month/year blank), the filter does not show an error. Instead, it appears to "apply" the filter with "Invalid Date" displayed.
- **Root Cause**: The `VaDate` component returns partial date strings like `"--04"` when fields are incomplete. The previous validation only checked `!fromDate` and `!toDate`, which are truthy for these partial strings.
- **Solution**: Added `isValidDateValue()` helper function that properly validates:
  - Non-empty values
  - No missing segments (detects `--` patterns)
  - Correct YYYY-MM-DD format
  - Valid calendar dates (no Feb 31st, etc.)
- **Team**: MHV Secure Messaging team owns this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128115
- Related defect review: department-of-veterans-affairs/va.gov-team#121972

## Testing done

- **Old behavior**: Entering partial dates (e.g., day "4" only for start, day "30" only for end) would silently "apply" the filter with "Invalid Date" shown in the applied filter summary
- **New behavior**: Entering partial dates now shows proper error messages ("Please enter a start date." / "Please enter an end date.") and focuses on the first error field

### Test verification:
1. Unit tests for `isValidDateValue()` helper - **10 test cases covering all edge cases**
   - Empty string, null, undefined → returns false
   - Partial dates (`"--04"`, `"-01-04"`, `"2026--04"`) → returns false
   - Valid dates (`"2026-01-13"`) → returns true
   - Invalid calendar dates (`"2026-02-31"`) → returns false
2. Existing SearchForm unit tests - **16 tests passing**
3. Cypress E2E test for partial date validation - **New test added and passing**
4. Full Cypress test suite for custom date filter - **41 tests passing across 5 spec files**

### E2E Test Fixes

The following E2E tests in `tests/e2e/sort-filter-test/` were updated to fix the "verify errors" test case:

| Test File | Issue | Fix |
|-----------|-------|-----|
| `secure-messaging-add-filter-custom-date-inbox.cypress.spec.js` | Only selected months without day/year | Added complete dates (day + year) |
| `secure-messaging-add-filter-custom-date-sent.cypress.spec.js` | Only selected months without day/year | Added complete dates (day + year) |
| `secure-messaging-add-filter-custom-date-drafts.cypress.spec.js` | Only selected months without day/year | Added complete dates (day + year) |
| `secure-messaging-add-filter-custom-date-trash.cypress.spec.js` | Only selected months without day/year | Added complete dates (day + year) |
| `secure-messaging-add-filter-custom-date-custom-folder.cypress.spec.js` | Only selected months without day/year | Added complete dates (day + year) |

**Root cause**: The tests were only calling `selectStartMonth('\''April'\'')` and `selectEndMonth('\''February'\'')` without filling in day/year values. With the new `isValidDateValue()` validation, incomplete dates correctly trigger the "required field" error instead of the "date range" error. The fix provides complete dates (April 15, 2025 → February 10, 2025) to properly test the date range validation logic.

### Flaky Test Fix

Fixed `secure-messaging-move-message-from-folder-to-new-folder.cypress.spec.js` by adding `cy.wait('\''@folders'\'')` in `FolderManagementPage.selectFolderFromModal()` to ensure folders are loaded before interacting with the move button modal. Also updated to use `cy.findByTestId()` per VA Cypress best practices.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="960" height="1066" alt="Screenshot 2026-01-13 at 12 03 47 PM" src="https://github.com/user-attachments/assets/b663fdb1-fad8-46dd-9d19-c2e566c17013" /> | <img width="933" height="1207" alt="Screenshot 2026-01-13 at 12 00 49 PM" src="https://github.com/user-attachments/assets/c46b8a19-706f-4256-9715-f539aca90cd6" /> |
| Mobile  | <img width="414" height="896" alt="Screenshot 2026-01-13 at 12 04 00 PM" src="https://github.com/user-attachments/assets/e7aea4e0-0e5a-4236-8a1e-778f9e98506a" /> | <img width="387" height="835" alt="Screenshot 2026-01-13 at 12 01 16 PM" src="https://github.com/user-attachments/assets/cf0ed4bb-3b3f-497a-b37e-a866096e7cf8" /> |

## What areas of the site does it impact?

- MHV Secure Messaging filter functionality in Inbox, Sent, Drafts, Trash, and Custom folders
- Only affects custom date range validation when applying filters

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (JSDoc added to new helper function)
- [ ] Screenshot of the developed feature is added
- [x] Accessibility testing has been performed (axeCheck included in Cypress tests)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (existing Datadog actions unchanged)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A - uses existing filter monitoring)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a focused bug fix that enhances date validation without changing the UI or user flow. The main change is replacing simple truthy checks (`!fromDate`) with proper date format validation (`!isValidDateValue(fromDate)`).'