### PR TITLE
Pensions | Restore disability rating alert & add logging

### DIFF
--- a/src/applications/pensions/components/DisabilityRatingAlert.jsx
+++ b/src/applications/pensions/components/DisabilityRatingAlert.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
+import { dataDogLogger } from 'platform/monitoring/Datadog/utilities';
 
 const VaLink = () => (
   <va-link
@@ -50,6 +51,14 @@ const DisabilityRatingAlert = () => {
   }
 
   if (error) {
+    dataDogLogger({
+      message: 'Pension disability rating fetch error',
+      attributes: {
+        error: error?.message || 'unknown error',
+        state: 'visible',
+        alertType: 'info',
+      },
+    });
     return (
       <va-alert visible>
         <h2 slot="headline">
@@ -69,8 +78,26 @@ const DisabilityRatingAlert = () => {
   }
 
   if (rating !== 100) {
+    dataDogLogger({
+      message:
+        'Pension disability rating alert hidden for ratings less than 100',
+      attributes: {
+        error: null,
+        state: 'hidden',
+        alertType: null,
+      },
+    });
     return null;
   }
+
+  dataDogLogger({
+    message: 'Pension disability rating alert visible for 100 rating',
+    attributes: {
+      error: null,
+      state: 'visible',
+      alertType: 'warning',
+    },
+  });
 
   return (
     <va-alert status="warning" visible>

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -9,6 +9,7 @@ import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
 
 import { FormReactivationAlert } from './FormAlerts';
+import DisabilityRatingAlert from './DisabilityRatingAlert';
 
 const IntroductionPage = props => {
   const { route } = props;
@@ -16,6 +17,9 @@ const IntroductionPage = props => {
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const pbbFormsRequireLoa3 = useToggleValue(TOGGLE_NAMES.pbbFormsRequireLoa3);
+  const pensionRatingAlertLoggingEnabled = useToggleValue(
+    TOGGLE_NAMES.pensionRatingAlertLoggingEnabled,
+  );
 
   const loggedIn = useSelector(isLoggedIn);
   // LOA3 Verified?
@@ -34,6 +38,8 @@ const IntroductionPage = props => {
         title="Apply for Veterans Pension benefits"
         subTitle="Application for Veterans Pension (VA Form 21P-527EZ)"
       />
+      {loggedIn &&
+        pensionRatingAlertLoggingEnabled && <DisabilityRatingAlert />}
       <p className="va-introtext">
         Use our online tool to fill out and submit your application for Veterans
         Pension benefits. If you’re a wartime Veteran and you’re at least 65

--- a/src/applications/pensions/tests/mock-api-full-data.js
+++ b/src/applications/pensions/tests/mock-api-full-data.js
@@ -1,0 +1,154 @@
+/**
+ * Run mock Pensions server with max data using
+ * > yarn mock-api --responses ./src/applications/pensions/tests/mock-api-full-data.js
+ * Run this in browser console
+ * > localStorage.setItem('hasSession', true)
+ */
+const dateFns = require('date-fns');
+const delay = require('mocker-api/lib/delay');
+
+const mockUser = require('./fixtures/mocks/user.json');
+const mockMaxData = require('./e2e/fixtures/data/maximal-test.json');
+
+const returnUrl = '/applicant/information';
+
+const submission = {
+  data: {
+    id: '8',
+    type: 'saved_claim_pensions',
+    attributes: {
+      submittedAt: new Date().toISOString(),
+      regionalOffice: [
+        'Attention:  Philadelphia Pension Center',
+        'P.O. Box 5206',
+        'Janesville, WI 53547-5206',
+      ],
+      confirmationNumber: '01e77e8d-79bf-4991-a899-4e2defff11e0',
+      guid: '01e77e8d-79bf-4991-a899-4e2defff11e0',
+      form: '21P-527EZ',
+    },
+  },
+};
+
+const itf = {
+  data: {
+    id: '',
+    type: 'intent_to_file',
+    attributes: {
+      intentToFile: [
+        {
+          id: '1',
+          creationDate: '2026-01-11T19:53:45.810+00:00',
+          expirationDate: dateFns.formatISO(
+            dateFns.add(new Date(), { months: 1 }),
+          ),
+          participantId: 1,
+          source: '',
+          status: 'active',
+          type: 'pension',
+        },
+      ],
+    },
+  },
+};
+
+const mockSipGet = {
+  formData: mockMaxData.data,
+  metadata: {
+    version: 0,
+    prefill: false,
+    returnUrl,
+  },
+};
+
+const mockSipPut = {
+  data: {
+    id: '1234',
+    type: 'in_progress_forms',
+    attributes: {
+      formId: '21P-527EZ',
+      createdAt: '2021-06-03T00:00:00.000Z',
+      updatedAt: '2021-06-03T00:00:00.000Z',
+      metadata: {
+        version: 1,
+        returnUrl,
+        savedAt: 1593500000000,
+        lastUpdated: 1593500000000,
+        expiresAt: 99999999999,
+        inProgressFormId: 1234,
+      },
+    },
+  },
+};
+
+/**
+ * @returns {Object} mock user data with inProgressForms
+ */
+const userData = () => {
+  const twoMonthsAgo = dateFns.getUnixTime(
+    dateFns.add(new Date(), { months: -2 }),
+  );
+
+  const sipData = {
+    form: '21P-527EZ',
+    metadata: {
+      version: 1,
+      returnUrl,
+      savedAt: new Date().getTime(),
+      submission: {
+        status: false,
+        errorMessage: false,
+        id: false,
+        timestamp: false,
+        hasAttemptedSubmit: false,
+      },
+      createdAt: twoMonthsAgo,
+      expiresAt: dateFns.getUnixTime(dateFns.add(new Date(), { years: 1 })),
+      lastUpdated: twoMonthsAgo,
+      inProgressFormId: 1234,
+    },
+    lastUpdated: twoMonthsAgo,
+  };
+
+  return {
+    data: {
+      ...mockUser.data,
+      attributes: {
+        ...mockUser.data.attributes,
+        inProgressForms: [sipData],
+      },
+    },
+  };
+};
+
+const responses = {
+  'GET /v0/user': userData(),
+  'GET /v0/feature_toggles': {
+    data: {
+      type: 'feature_toggles',
+      features: [
+        { name: 'pensionFormEnabled', value: true },
+        { name: 'pension_form_enabled', value: true },
+        { name: 'pensionRatingAlertLoggingEnabled', value: true },
+        { name: 'pension_rating_alert_logging_enabled', value: true },
+      ],
+    },
+  },
+  'OPTIONS /v0/maintenance_windows': 'OK',
+  'GET /v0/maintenance_windows': { data: [] },
+  'GET /data/cms/vamc-ehr.json': {},
+
+  'GET /v0/in_progress_forms/21P-527EZ': mockSipGet,
+  'PUT /v0/in_progress_forms/21P-527EZ': mockSipPut,
+  'GET /v0/intent_to_file/pension': itf,
+  'GET /v0/rated_disabilities': {
+    data: {
+      type: 'disability_ratings',
+      attributes: { combinedDisabilityRating: 100 },
+    },
+  },
+
+  'POST /pensions/v0/claims': submission,
+};
+
+module.exports = delay(responses, 200);

--- a/src/applications/pensions/tests/unit/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/components/IntroductionPage.unit.spec.jsx
@@ -11,6 +11,7 @@ const getData = ({
   toggle = false,
   verified = false,
   savedForm = false,
+  ratingToggle = false,
 } = {}) => ({
   props: {
     loggedIn,
@@ -51,6 +52,7 @@ const getData = ({
       featureToggles: {
         loading: false,
         [`pbb_forms_require_loa3`]: toggle,
+        [`pension_rating_alert_logging_enabled`]: ratingToggle,
       },
     }),
     subscribe: () => {},
@@ -158,5 +160,33 @@ describe('<IntroductionPage />', () => {
       </Provider>,
     );
     expect($('va-link-action, .vads-c-action-link--green', container)).to.exist;
+  });
+
+  it('renders rating info alert when logged in, and the endpoint has an error', () => {
+    // logged in true, ratingToggle true
+    const { props, mockStore } = getData({
+      loggedIn: true,
+      ratingToggle: true,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-alert[status="info"]', container)).to.exist;
+  });
+
+  it('renders rating info alert when logged in, no saved form & toggle off', () => {
+    // logged in false, ratingToggle true
+    const { props, mockStore } = getData({
+      loggedIn: false,
+      ratingToggle: true,
+    });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect($('va-alert[status="info"]', container)).to.not.exist;
   });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -227,6 +227,7 @@
   "pensionMultiplePageResponse": "pension_multiple_page_response",
   "pensionPdfFormAlignment": "pension_pdf_form_alignment",
   "pensionsBrowserMonitoringEnabled": "pension_browser_monitoring_enabled",
+  "pensionRatingAlertLoggingEnabled": "pension_rating_alert_logging_enabled",
   "pbbFormsRequireLoa3": "pbb_forms_require_loa3",
   "preEntryCovid19Screener": "pre_entry_covid19_screener",
   "profileDoNotRequireInternationalZipCode": "profile_do_not_require_international_zip_code",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Restoring the disability rating alert, but visible behind a feature toggle
  > - Added Datadog logging for the disability rating alert - either visible or hidden
  > - Updated unit tests
  > - Added mock server for local testing
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127083

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| rating error  | <img width="765" height="404" alt="pension intro page with no alert showing" src="https://github.com/user-attachments/assets/ecb8b5c6-f854-4b53-97ca-108a7359359b" /> | <img width="769" height="636" alt="info alert showing when the endpoint has an error showing stating that a rating of 100 would pay more than any pension payments" src="https://github.com/user-attachments/assets/2178a4df-5c9e-41af-a837-f97d6bbf706b" /> |
| rating = 100 | <img width="765" height="404" alt="pension intro page with no alert showing" src="https://github.com/user-attachments/assets/ecb8b5c6-f854-4b53-97ca-108a7359359b" /> | <img width="791" height="647" alt="disability rating of 100% showing a warning alert stating that the disability compensation pays more than pension " src="https://github.com/user-attachments/assets/d9f06cbb-98ca-4cb7-b823-fce7f7090c6b" /> |
| rating < 100 | <img width="765" height="404" alt="pension intro page with no alert showing" src="https://github.com/user-attachments/assets/ecb8b5c6-f854-4b53-97ca-108a7359359b" /> | <img width="765" height="404" alt="pension intro page with no alert showing" src="https://github.com/user-attachments/assets/ecb8b5c6-f854-4b53-97ca-108a7359359b" /> |

## What areas of the site does it impact?

Pensions (VA Form 21P-527EZ)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
