### PR TITLE
[ARC/129827] - updating confirmation to show claimant name on non vet option

### DIFF
--- a/src/applications/representative-form-upload/containers/ConfirmationPageITF.jsx
+++ b/src/applications/representative-form-upload/containers/ConfirmationPageITF.jsx
@@ -15,7 +15,10 @@ const ConfirmationPageITF = () => {
     ? new Date(submission.response.attributes.expirationDate)
     : null;
 
-  const { first, last } = form.data.veteranFullName;
+  const { first, last } =
+    form.data.isVeteran === 'no'
+      ? form.data.claimantFullName
+      : form.data.veteranFullName;
   const { city, state, postalCode } = form.data.address;
 
   const address = { city, state, postalCode };


### PR DESCRIPTION
Updating ITF confirmation card to show claimant name vs vet name if the itf type is survivor, see ticket 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/129827

vet pension/disability still shows the vet name, see screenshots below.

<img width="929" height="715" alt="Screenshot 2026-01-13 at 12 35 44 PM" src="https://github.com/user-attachments/assets/1866ef82-c88c-414d-baef-2b97a3bad5ae" />
<img width="925" height="661" alt="Screenshot 2026-01-13 at 12 36 08 PM" src="https://github.com/user-attachments/assets/7a03acb5-5073-4dfd-8a3c-c6f22c299c5e" />
