### PR TITLE
Add list semantics to medical records card lists for accessibility

### DIFF
--- a/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
@@ -106,23 +106,26 @@ const RecordList = props => {
         hidePagination={hidePagination}
         perPage={perPage}
       />
-      <div className="no-print">
+      <ul className="record-list-items no-print vads-u-margin--0 vads-u-padding--0">
         {currentRecords?.length > 0 &&
           currentRecords.map((record, idx) => (
-            <RecordListItem
-              key={idx}
-              record={record}
-              type={type}
-              domainOptions={domainOptions}
-            />
+            <li key={idx} className="vads-u-list-style--none">
+              <RecordListItem
+                record={record}
+                type={type}
+                domainOptions={domainOptions}
+              />
+            </li>
           ))}
-      </div>
-      <div className="print-only">
+      </ul>
+      <ul className="record-list-items print-only vads-u-margin--0 vads-u-padding--0">
         {records?.length > 0 &&
           records.map((record, idx) => (
-            <RecordListItem key={idx} record={record} type={type} />
+            <li key={idx} className="vads-u-list-style--none">
+              <RecordListItem record={record} type={type} />
+            </li>
           ))}
-      </div>
+      </ul>
       {currentRecords &&
         (paginatedRecords.current.length > 1 ? (
           <div className="vads-u-margin-bottom--2 no-print">

--- a/src/applications/mhv-medical-records/components/RecordList/RecordListNew.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/RecordListNew.jsx
@@ -61,21 +61,24 @@ const RecordListNew = ({
       </p>
 
       {/* The list itself */}
-      <div className="no-print">
+      <ul className="record-list-items no-print vads-u-margin--0 vads-u-padding--0">
         {records.map((record, idx) => (
-          <RecordListItem
-            key={idx}
-            record={record}
-            type={type}
-            domainOptions={domainOptions}
-          />
+          <li key={idx} className="vads-u-list-style--none">
+            <RecordListItem
+              record={record}
+              type={type}
+              domainOptions={domainOptions}
+            />
+          </li>
         ))}
-      </div>
-      <div className="print-only">
+      </ul>
+      <ul className="record-list-items print-only vads-u-margin--0 vads-u-padding--0">
         {records.map((record, idx) => (
-          <RecordListItem key={idx} record={record} type={type} />
+          <li key={idx} className="vads-u-list-style--none">
+            <RecordListItem record={record} type={type} />
+          </li>
         ))}
-      </div>
+      </ul>
 
       {/* Pagination footer */}
       {totalPages > 1 ? (

--- a/src/applications/mhv-medical-records/tests/components/RecordList.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/RecordList.unit.spec.jsx
@@ -59,4 +59,18 @@ describe('Record list component', () => {
       expect(screen.getAllByTestId('record-list-item')).to.have.length(4);
     });
   });
+
+  it('renders records in semantic list elements for accessibility', async () => {
+    await waitFor(() => {
+      const lists = screen.container.querySelectorAll('ul.record-list-items');
+      // 2 lists: one for no-print view and one for print-only view
+      expect(lists).to.have.length(2);
+
+      // Each list should contain li elements
+      lists.forEach(list => {
+        const listItems = list.querySelectorAll('li');
+        expect(listItems.length).to.be.greaterThan(0);
+      });
+    });
+  });
 });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.discharge-detail.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.discharge-detail.cypress.spec.js
@@ -27,10 +27,9 @@ describe('Medical Records View Care Summary and Notes', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 6;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     const DISCHARGE_INDEX = 1;
     CareSummaryAndNotes.checkDischargeListItem({ index: DISCHARGE_INDEX });
     CareSummaryAndNotes.selectCareSummaryOrNote({ index: DISCHARGE_INDEX });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.list.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.list.cypress.spec.js
@@ -27,10 +27,9 @@ describe('Medical Records View Care Summary and Notes', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 6;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
 
     CareSummaryAndNotes.checkInfoAlert();
     CareSummaryAndNotes.checkDischargeListItem();

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.note-detail.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.note-detail.cypress.spec.js
@@ -27,10 +27,9 @@ describe('Medical Records View Care Summary and Notes', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 6;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     const NOTE_INDEX = 2;
     CareSummaryAndNotes.checkNoteListItem({ index: NOTE_INDEX });
     CareSummaryAndNotes.selectCareSummaryOrNote({ index: NOTE_INDEX });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.update-timeframe.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/care-notes-and-summary/view-care-notes.update-timeframe.cypress.spec.js
@@ -39,10 +39,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 6;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
 

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/conditions/view-conditions-list.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/conditions/view-conditions-list.cypress.spec.js
@@ -29,9 +29,8 @@ describe('Medical Records View Conditions', () => {
       .should('not.exist');
 
     const CARDS_PER_PAGE = 10;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
   });
 });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.back-button.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.back-button.cypress.spec.js
@@ -43,10 +43,9 @@ describe('Medical Records View Lab and Tests', () => {
 
     LabsAndTests.loadVAPaginationNext();
     const CARDS_PER_PAGE = 1;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
 
@@ -63,9 +62,8 @@ describe('Medical Records View Lab and Tests', () => {
     cy.get('[data-testid="mr-breadcrumbs"] > a').click({
       waitForAnimations: true,
     });
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
   });
 });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.cypress.spec.js
@@ -42,10 +42,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 3;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
   });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.full-sample.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.full-sample.cypress.spec.js
@@ -42,10 +42,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 3;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
     // go to a specific lab

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.no-observations.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.no-observations.cypress.spec.js
@@ -42,10 +42,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 3;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     LabsAndTests.selectLabAndTest({
       labName: 'Surgical Pathology',

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.non-oracle-user.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.non-oracle-user.cypress.spec.js
@@ -41,10 +41,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 3;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
   });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.observations.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.observations.cypress.spec.js
@@ -42,10 +42,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 3;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
     // go to a specific lab

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.update-timeframe.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.update-timeframe.cypress.spec.js
@@ -41,10 +41,9 @@ describe('Medical Records View Lab and Tests', () => {
     cy.injectAxeThenAxeCheck();
 
     const CARDS_PER_PAGE = 3;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
     cy.get("[data-testid='filter-display-message']").should('be.visible');
     cy.get("[data-testid='filter-display-message']").should('not.be.empty');
 

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/CareSummaryAndNotes.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/CareSummaryAndNotes.js
@@ -96,8 +96,10 @@ class CareSummaryAndNotes {
 
   selectCareSummaryOrNote = ({ index = 1 } = {}) => {
     cy.get(
-      `:nth-child(4) > :nth-child(${index}) > .vads-u-font-weight--bold > [data-testid="note-name"]`,
-    ).click({ waitForAnimations: true });
+      `ul.record-list-items.no-print > :nth-child(${index}) [data-testid="note-name"]`,
+    )
+      .first()
+      .click({ waitForAnimations: true });
   };
 
   loadVAPaginationNext = () => {
@@ -109,10 +111,10 @@ class CareSummaryAndNotes {
 
   checkDischargeListItem = ({ index = 1, title = 'Clinical Summary' } = {}) => {
     cy.get(
-      `:nth-child(4) > :nth-child(${index}) > :nth-child(5) > :nth-child(1)`,
+      `ul.record-list-items.no-print > :nth-child(${index}) [data-testid="record-list-item"]`,
     ).should('contain.text', 'Discharged');
     cy.get(
-      `:nth-child(4) > :nth-child(${index}) > .vads-u-font-weight--bold`,
+      `ul.record-list-items.no-print > :nth-child(${index}) .vads-u-font-weight--bold`,
     ).should('contain.text', title);
   };
 
@@ -121,10 +123,10 @@ class CareSummaryAndNotes {
     title = 'Inpatient Discharge Instructions - VA',
   } = {}) => {
     cy.get(
-      `:nth-child(4) > :nth-child(${index}) > :nth-child(5) > :nth-child(1)`,
+      `ul.record-list-items.no-print > :nth-child(${index}) [data-testid="record-list-item"]`,
     ).should('contain.text', 'Written by');
     cy.get(
-      `:nth-child(4) > :nth-child(${index}) > .vads-u-font-weight--bold`,
+      `ul.record-list-items.no-print > :nth-child(${index}) .vads-u-font-weight--bold`,
     ).should('contain.text', title);
   };
 

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/view-vaccines-list.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/view-vaccines-list.cypress.spec.js
@@ -24,9 +24,8 @@ describe('Medical Records View Vaccines', () => {
 
     // fix this
     const CARDS_PER_PAGE = 10;
-    cy.get(':nth-child(4) > [data-testid="record-list-item"]').should(
-      'have.length',
-      CARDS_PER_PAGE,
-    );
+    cy.get(
+      'ul.record-list-items.no-print [data-testid="record-list-item"]',
+    ).should('have.length', CARDS_PER_PAGE);
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added semantic list elements (`<ul>` and `<li>`) to the `RecordList` and `RecordListNew` components in MHV Medical Records to improve accessibility for screen reader users
- Previously, card lists were rendered using non-semantic `<div>` elements, which went against WCAG 1.3.1 (Info and Relationships)
- Screen readers will now properly announce "list, X items" and allow users to navigate between list items using standard list navigation shortcuts
- Updated E2E test selectors to use the new semantic list structure instead of brittle `:nth-child` positional selectors
- MHV Medical Records team owns this component
- No flipper required - this is a straightforward accessibility fix

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128666

## Testing done

- **Old behavior**: Cards in the Labs and Tests list (and other record lists) were rendered inside `<div>` elements. Screen readers could not identify the content as a list or announce the number of items.
- **Steps to verify**:
  1. Navigate to any Medical Records list page (e.g., Labs and Tests, Vaccines, Allergies, Care Summaries and Notes)
  2. Use a screen reader (VoiceOver, NVDA) or browser dev tools to inspect the DOM
  3. Verify the record cards are now wrapped in `<ul>` and `<li>` elements
  4. Screen reader should announce "list, X items" when entering the list
- **Tests completed**:
  - Ran `yarn test:unit src/applications/mhv-medical-records/tests/components/RecordList.unit.spec.jsx` - 3 tests passing
  - Added new unit test to verify `<ul>` and `<li>` elements are rendered correctly
  - Ran all 28 accelerated E2E tests - all passing
  - Visually verified no styling changes (list bullets are hidden via utility classes)

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile |        |       |
| Desktop |        |       |

*Note: There is no visual difference. This is a semantic/accessibility change only. The DOM structure changes from `<div>` to `<ul>`/`<li>` but styling remains identical.*

## What areas of the site does it impact?

All Medical Records list pages that use the `RecordList` or `RecordListNew` components:
- Labs and Tests
- Vaccines
- Allergies
- Health Conditions
- Vitals
- Care Summaries and Notes

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation changes needed)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - no new events)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A - no new monitoring needed)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user