### PR TITLE
changes Middle name label to be Middle initial to align with paper form

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-information.js
@@ -11,6 +11,19 @@ import {
   dateOfBirthSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+const formatFullNameTitles = name => {
+  switch (name) {
+    case 'first or given name':
+      return 'First or given name';
+    case 'middle name':
+      return 'Middle initial';
+    case 'last or family name':
+      return 'Last or family name';
+    default:
+      return name;
+  }
+};
+
 /**
  * uiSchema for Veteran Information page
  * Collects veteran's full name and date of birth
@@ -20,7 +33,7 @@ export const veteranInformationUiSchema = {
   'ui:description':
     'Confirm the personal information we have on file for the Veteran.',
   veteranInformation: {
-    veteranFullName: fullNameNoSuffixUI(),
+    veteranFullName: fullNameNoSuffixUI(formatFullNameTitles),
     veteranDob: dateOfBirthUI(),
   },
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing "**Middle name**" label on "**Veteran Information"** page to "**Middle initial**" to match paper form.

### Issue
The label for the field that maps to the "Middle initial" field on the paper form is labeled "Middle name" on the online form. This label is just the default label for the full name schema. The form also expects and only allows an initial.

### Solution
Overrode the label being set in the full name schema with "Middle initial" to match the paper form. 

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129639](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129639)

## Testing done

### Old behavior
* The form was using the default label for middle name

### New behavior
* The middle name label is now being overridden to "Middle initial"

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the new label is being displayed (navigate to "Veteran Information" page and verify that the label is changed)
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="558" height="616" alt="before" src="https://github.com/user-attachments/assets/81f67b38-d116-4beb-95d6-fa08c28f49ff" /> | <img width="583" height="607" alt="after" src="https://github.com/user-attachments/assets/2064ffec-1821-4a72-9056-23ffe42ca2e1" /> |

## What areas of the site does it impact?

This change affects form 21-2680, specifically on the Veteran Information page at /pension/aid-attendance-housebound/apply-form-21-2680/veteran-information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user