### PR TITLE
fixes order of first,middle, last name, uses middle initial for middl…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
@@ -5,8 +5,8 @@
  */
 
 import {
-  firstNameLastNameNoSuffixUI,
-  firstNameLastNameNoSuffixSchema,
+  fullNameNoSuffixUI,
+  fullNameNoSuffixSchema,
   dateOfBirthUI,
   dateOfBirthSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -18,13 +18,26 @@ const relationshipLabels = {
   parent: "Veteran's parent's",
 };
 
+const formatFullNameTitles = name => {
+  switch (name) {
+    case 'first or given name':
+      return 'First or given name';
+    case 'middle name':
+      return 'Middle initial';
+    case 'last or family name':
+      return 'Last or family name';
+    default:
+      return name;
+  }
+};
+
 /**
  * uiSchema for Claimant Information page
  * Collects claimant's full name and date of birth
  */
 export const claimantInformationUiSchema = {
   claimantInformation: {
-    claimantFullName: firstNameLastNameNoSuffixUI(),
+    claimantFullName: fullNameNoSuffixUI(formatFullNameTitles),
     claimantDob: dateOfBirthUI(),
   },
   'ui:options': {
@@ -47,9 +60,9 @@ export const claimantInformationUiSchema = {
  */
 // Customize the name schema to add maxLength constraint for middle name
 const customNameSchema = {
-  ...firstNameLastNameNoSuffixSchema,
+  ...fullNameNoSuffixSchema,
   properties: {
-    ...firstNameLastNameNoSuffixSchema.properties,
+    ...fullNameNoSuffixSchema.properties,
     middle: {
       type: 'string',
       maxLength: 1,


### PR DESCRIPTION
…e name label

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Fixing order of first, middle, and last names, and changing "**middle**" label on "**Claimant Information"** page to "**Middle initial**" to match paper form.

### Issue
The order of the name fields didn't match the paper form - it was listed as First, Last, and then Middle. Also, the label for the field that maps to the "Middle initial" field on the paper form is labeled "middle" on the online form

### Solution
Changed the schema being used from FirstLastName to FullName so that the middle name is included in the correct spot, and overrode the label to make it Middle Initial.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129637](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129637)

## Testing done

### Old behavior
* The order of the name fields was First, Last, and Middle, and the label for the middle initial was just "middle"

### New behavior
* The order of the name fields are First, Middle, Last, and the label for the middle initial is now "Middle initial"

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the new label and field order is being displayed (navigate to "Claimant Information" page and verify that the label and field order are changed)
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="592" height="497" alt="before" src="https://github.com/user-attachments/assets/8cf213fa-0ab5-478c-b418-2dd8e8543df8" /> | <img width="594" height="494" alt="after" src="https://github.com/user-attachments/assets/a7febf8a-577a-4bb3-b9bc-01cdb0a6eb4f" /> |

## What areas of the site does it impact?

This change affects form 21-2680, specifically on the Claimant Information page at /pension/aid-attendance-housebound/apply-form-21-2680/claimant-information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user