### PR TITLE
fix(0779): Strip phone number dashes

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/transform.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/transform.js
@@ -1,3 +1,15 @@
+/**
+ * Strips all non-digit characters from a phone number
+ * @param {string} phone - Phone number that may contain dashes, spaces, or other characters
+ * @returns {string} Phone number with only digits
+ */
+// TODO: Quick fix to strip dashes from phone numbers to match backend schema expectations.
+// The vets-json-schema (21-0779) needs updating to properly reflect the data structure:
+// - veteranId should be a nested object containing ssn/vaFileNumber
+// - phone format should be `^\d{10}$`
+// See: https://github.com/department-of-veterans-affairs/va.gov-team/issues/125559
+const stripNonDigits = phone => phone?.replace(/\D/g, '');
+
 export const transform = (formConfig, form) => {
   const {
     veteranPersonalInfo,
@@ -75,7 +87,9 @@ export const transform = (formConfig, form) => {
       certificationLevelOfCare: certificationLevelOfCare?.levelOfCare,
       nursingOfficialName,
       nursingOfficialTitle: nursingOfficialInformation?.jobTitle,
-      nursingOfficialPhoneNumber: nursingOfficialInformation?.phoneNumber,
+      nursingOfficialPhoneNumber: stripNonDigits(
+        nursingOfficialInformation?.phoneNumber,
+      ),
       signature,
       signatureDate: new Date().toISOString().split('T')[0],
     },

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/transform.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/config/transform.js
@@ -3,11 +3,6 @@
  * @param {string} phone - Phone number that may contain dashes, spaces, or other characters
  * @returns {string} Phone number with only digits
  */
-// TODO: Quick fix to strip dashes from phone numbers to match backend schema expectations.
-// The vets-json-schema (21-0779) needs updating to properly reflect the data structure:
-// - veteranId should be a nested object containing ssn/vaFileNumber
-// - phone format should be `^\d{10}$`
-// See: https://github.com/department-of-veterans-affairs/va.gov-team/issues/125559
 const stripNonDigits = phone => phone?.replace(/\D/g, '');
 
 export const transform = (formConfig, form) => {

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx
@@ -143,6 +143,25 @@ describe('Transform Function', () => {
     );
   });
 
+  it('should strip dashes from phone numbers', () => {
+    const mockForm = createMockFormData({
+      nursingOfficialInformation: {
+        fullName: {
+          first: 'Beru',
+          last: 'Lars',
+        },
+        jobTitle: 'Nursing Home Administrator',
+        phoneNumber: '505-555-1977',
+      },
+    });
+    const result = transform({}, mockForm);
+    const parsedResult = parseResult(result);
+
+    expect(parsedResult.generalInformation.nursingOfficialPhoneNumber).to.equal(
+      '5055551977',
+    );
+  });
+
   it('should handle boolean conversions correctly', () => {
     const mockForm = createMockFormData({
       medicaidFacility: { isMedicaidApprovedFacility: false },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes schema alignment issue between frontend and backend for VA Form 21-0779 (Nursing Home Information)
- The frontend phone input allows dashes (e.g., `505-555-1977`) but the backend expects 10 digits only (e.g., `5055551977`)
- Added `stripNonDigits` helper function in the transform to strip all non-digit characters from phone numbers before submission

- Benefits Optimization Aquia team owns this form

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#125559

## Testing done

- **Old behavior**: Phone numbers with dashes (e.g., `505-555-1977`) were submitted as-is, causing backend validation failures
- **New behavior**: Phone numbers are stripped of all non-digit characters before submission (e.g., `5055551977`)
- Added unit test `should strip dashes from phone numbers` to verify the transform correctly strips dashes
- All 10 transform unit tests pass
- Verified with Node 14.15: `yarn test:unit src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/tests/unit/transform.unit.spec.jsx`

## Screenshots

### Before

<img width="1684" height="1378" alt="Screenshot 2026-01-13 at 4 34 20 PM" src="https://github.com/user-attachments/assets/a4083609-fc63-4d30-8cda-414040c3078a" />

### After

<img width="914" height="1048" alt="Screenshot 2026-01-13 at 4 42 44 PM" src="https://github.com/user-attachments/assets/546d3aa9-4267-4b44-ac03-d606b23bf5db" />

#### Downloaded PDF

[Anakin Skywalker Nursing Home Info (2).pdf](https://github.com/user-attachments/files/24600703/Anakin.Skywalker.Nursing.Home.Info.2.pdf)


## What areas of the site does it impact?

Form 21-0779 (Request for Nursing Home Information) submission only. No other areas impacted.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a quick fix to address the phone number format mismatch. A follow-up PR to vets-json-schema will align the schema definition with what the backend actually expects (nested `veteranId` structure and correct phone format `^\d{10}$`).