### PR TITLE
fix(2680): Turn off prefill in form config

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
@@ -103,7 +103,7 @@ const formConfig = {
     },
   },
   version: 0,
-  prefillEnabled: true,
+  prefillEnabled: false,
   savedFormMessages: {
     notFound: 'Please start over to apply for benefits.',
     noAuth: 'Please sign in again to continue your application for benefits.',

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.unit.spec.jsx
@@ -153,8 +153,8 @@ describe('Form Configuration', () => {
       expect(formConfig.version).to.be.a('number');
     });
 
-    it('should have prefill enabled', () => {
-      expect(formConfig.prefillEnabled).to.be.true;
+    it('should have prefill disabled', () => {
+      expect(formConfig.prefillEnabled).to.be.false;
     });
 
     it('should have submit transformer', () => {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
@@ -151,17 +151,7 @@ export const IntroductionPage = ({ route }) => {
         <SaveInProgressIntro
           headingLevel={2}
           prefillEnabled={formConfig.prefillEnabled}
-          verifiedPrefillAlert={
-            <div>
-              <va-alert status="info" uswds visible slim>
-                <div className="usa-alert-body">
-                  You can save this application in progress and come back later
-                  to finish filling it out.
-                </div>
-              </va-alert>
-              <br />
-            </div>
-          }
+          verifiedPrefillAlert={<></>}
           messages={formConfig.savedFormMessages}
           pageList={pageList}
           startText="Start your application"

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
@@ -151,6 +151,17 @@ export const IntroductionPage = ({ route }) => {
         <SaveInProgressIntro
           headingLevel={2}
           prefillEnabled={formConfig.prefillEnabled}
+          verifiedPrefillAlert={
+            <div>
+              <va-alert status="info" uswds visible slim>
+                <div className="usa-alert-body">
+                  You can save this application in progress and come back later
+                  to finish filling it out.
+                </div>
+              </va-alert>
+              <br />
+            </div>
+          }
           messages={formConfig.savedFormMessages}
           pageList={pageList}
           startText="Start your application"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### TeamSites

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- Disabled prefill functionality for the 21-2680 Housebound Status form by setting `prefillEnabled: false` in the form configuration
- This removes the messaging on the introduction page that states "We've prefilled some of your information. Since you're signed in, we can prefill part of your application based on your profile details."
- Prefill was removed from the form, so we should not tell users that their information will be prefilled
- Benefits Optimization Aquia team owns this form

## Related issue(s)

- Removes outdated prefill messaging after prefill functionality was removed from the form

## Testing done

- Old behavior: Introduction page displayed prefill messaging to signed-in users indicating their information would be prefilled
- New behavior: Introduction page no longer displays prefill messaging
- Steps to verify:
  1. Navigate to the 21-2680 introduction page while signed in
  2. Confirm the prefill messaging no longer appears
- Unit tests pass: `yarn test:unit src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.unit.spec.jsx`

## Screenshots

| Before | After |
| ------ | ----- |
|        | <img width="1328" height="1387" alt="Screenshot 2026-01-14 at 10 17 12 AM" src="https://github.com/user-attachments/assets/d9ece1c3-e075-438e-a17a-532f98e9c203" />  |

## What areas of the site does it impact?

21-2680 Housebound Status form introduction page only.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

None - straightforward configuration change.