### PR TITLE
fix: use glob patterns instead of expanded file paths to avoid E2BIG …

### DIFF
--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -35,10 +35,11 @@ const COMMAND_LINE_OPTIONS = [
 const options = commandLineArgs(COMMAND_LINE_OPTIONS);
 // log this out to determing if we still need this
 
-// Helper function to get test paths
-function getTestPaths() {
+// Helper function to get test patterns (returns glob patterns, not expanded file paths)
+// This avoids E2BIG errors when there are too many test files
+function getTestPatterns() {
   if (options['full-suite']) {
-    return glob.sync(DEFAULT_SPEC_PATTERN);
+    return [DEFAULT_SPEC_PATTERN];
   }
 
   const changedFiles = process.env.CHANGED_FILES
@@ -48,7 +49,7 @@ function getTestPaths() {
     : [];
 
   if (changedFiles.length === 0) {
-    return glob.sync(STATIC_PAGES_PATTERN);
+    return [STATIC_PAGES_PATTERN];
   }
 
   // May need to convert this output into an array?
@@ -56,35 +57,54 @@ function getTestPaths() {
     return JSON.parse(fs.readFileSync(path.resolve(`changed_unit_tests.json`)));
   }
 
-  // Get app-specific tests
-  const appTests = changedFiles
-    .filter(file => file.startsWith('src/applications/'))
-    .map(file => {
-      const appName = file.split('/')[2];
-      return `src/applications/${appName}/**/*.unit.spec.js?(x)`;
-    })
-    .flatMap(pattern => glob.sync(pattern));
+  // Get unique app-specific test patterns
+  const appPatterns = [
+    ...new Set(
+      changedFiles
+        .filter(file => file.startsWith('src/applications/'))
+        .map(file => {
+          const appName = file.split('/')[2];
+          return `src/applications/${appName}/**/*.unit.spec.js?(x)`;
+        }),
+    ),
+  ];
 
-  // Get platform tests
-  const platformTests = changedFiles
-    .filter(file => file.startsWith('src/platform/'))
-    .map(file => {
-      const platformPath = file
-        .split('/')
-        .slice(0, 3)
-        .join('/');
-      return `${platformPath}/**/*.unit.spec.js?(x)`;
-    })
-    .flatMap(pattern => glob.sync(pattern));
+  // Get unique platform test patterns
+  const platformPatterns = [
+    ...new Set(
+      changedFiles
+        .filter(file => file.startsWith('src/platform/'))
+        .map(file => {
+          const platformPath = file
+            .split('/')
+            .slice(0, 3)
+            .join('/');
+          return `${platformPath}/**/*.unit.spec.js?(x)`;
+        }),
+    ),
+  ];
 
-  // Always include static pages tests
-  const staticPagesTests = glob.sync(STATIC_PAGES_PATTERN);
+  // Always include static pages pattern
+  const patterns = [...appPatterns, ...platformPatterns, STATIC_PAGES_PATTERN];
 
-  return [...new Set([...appTests, ...platformTests, ...staticPagesTests])];
+  // Remove duplicates (static pages may already be in platform patterns)
+  return [...new Set(patterns)];
+}
+
+// Helper function to check if any tests match the patterns
+function hasMatchingTests(patterns) {
+  for (const pattern of patterns) {
+    const matches = glob.sync(pattern);
+    if (matches.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Helper function to build test command
-function buildTestCommand(testPaths) {
+// Takes glob patterns (not expanded file paths) to avoid E2BIG errors
+function buildTestCommand(testPatterns) {
   const coverageInclude = options['app-folder']
     ? `--include 'src/applications/${options['app-folder']}/**'`
     : '';
@@ -100,25 +120,29 @@ function buildTestCommand(testPaths) {
     ? `NODE_ENV=test nyc --all ${coverageInclude} ${coverageReporter}`
     : `BABEL_ENV=test NODE_ENV=test mocha ${reporterOption}`;
 
+  // Quote each pattern to prevent shell expansion issues and allow mocha to expand them
+  const quotedPatterns = testPatterns.map(p => `'${p}'`).join(' ');
+
   return `STEP=unit-tests LOG_LEVEL=${options[
     'log-level'
   ].toLowerCase()} ${testRunner} --max-old-space-size=${MAX_MEMORY} --config ${
     options.config
-  } ${testPaths.join(' ')}`;
+  } ${quotedPatterns}`;
 }
 
 // Main execution
 async function main() {
   try {
-    const testPaths = getTestPaths();
+    const testPatterns = getTestPatterns();
 
-    if (testPaths.length === 0) {
+    if (!hasMatchingTests(testPatterns)) {
       console.log('No tests to run');
       core.exportVariable('tests_ran', 'false');
       return;
     }
 
-    const command = buildTestCommand(testPaths);
+    console.log(`Running tests matching patterns: ${testPatterns.join(', ')}`);
+    const command = buildTestCommand(testPatterns);
     await runCommand(command);
     core.exportVariable('tests_ran', 'true');
   } catch (error) {


### PR DESCRIPTION
…error

When many apps are changed, the test command was hitting the OS argument list limit (E2BIG) because all test file paths were being expanded and joined into a single command string (136k+ characters).

This change:
- Returns glob patterns instead of expanded file paths
- Lets mocha expand the globs itself
- Reduces command length from ~136k to ~1k characters
- Adds logging to show which patterns are being run

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
