### PR TITLE
[MHV-SM] Fix focus indicator obscured on "What's a message ID?" (WCAG 2.4.11)

### DIFF
--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -322,7 +322,7 @@ const SearchForm = props => {
         {!location.pathname.includes(Paths.DRAFTS) && (
           <va-additional-info
             trigger="What's a message ID?"
-            class="message-id-info"
+            class="message-id-info vads-u-margin-top--1"
             data-dd-action-name="What's a message ID? Expandable Info"
           >
             A message ID is a number we assign to each message. If you sign up


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes a WCAG 2.4.11 (Focus Not Obscured) accessibility violation in the MHV Secure Messaging SearchForm component
- When users tab to the "What's a message ID?" expandable info component, its focus indicator was partially hidden (~2px) under the text input element above it
- Added `vads-u-margin-top--1` utility class to the `va-additional-info` component to provide adequate spacing (8px) so the focus indicator is fully visible
- Team: MHV Secure Messaging
- No flipper required

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#122612

## Testing done

- **Before**: When tabbing to "What's a message ID?" on Inbox or Sent pages, the focus indicator ring was partially obscured (~2px) by the text input above it
- **After**: Added `vads-u-margin-top--1` class to create 8px spacing, ensuring the focus indicator is fully visible
- **Steps to verify**:
  1. Navigate to MHV Secure Messaging Inbox or Sent page
  2. Tab to the "What's a message ID?" expandable info
  3. Verify the focus indicator is fully visible and not obscured by the text input above
- Unit tests pass (no changes to test files needed - this is a styling-only change)

## Screenshots

_Screenshots requested from accessibility specialist who reported the issue_

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="776" height="329" alt="503342186-f5119768-7dcc-498c-8a42-a75c1aa58427" src="https://github.com/user-attachments/assets/d462bfd0-9442-4356-a83e-9b17f9c4437d" /> | <img width="830" height="657" alt="Screenshot 2026-01-14 at 3 30 40 PM" src="https://github.com/user-attachments/assets/13ff72ab-014b-475a-a376-5121b9eb9f19" /> |


## What areas of the site does it impact?

- MHV Secure Messaging: Inbox page filter section
- MHV Secure Messaging: Sent page filter section

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - N/A - styling-only change, no logic modified
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated - N/A
- [ ] Screenshot of the developed feature is added - pending
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
  - This fix directly addresses WCAG 2.4.11 Focus Not Obscured violation

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - N/A (no new logging)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a minimal accessibility fix (1 line change) adding a VADS utility class for margin. Please verify the spacing is appropriate to ensure the focus indicator is no longer obscured per WCAG 2.4.11.

cc: @steveg-IAT for accessibility validation