### PR TITLE
Fixed missing data in payload when chosing no on benefits entitlement question

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/submit-transformer/submit-transformer.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/submit-transformer/submit-transformer.js
@@ -272,6 +272,7 @@ const transformBenefitEntitlementPayments = data => {
   if (benefitEntitlement === 'no' || benefitEntitlement === false) {
     return {
       sickRetirementOtherBenefits: false,
+      remarks: remarks.remarks || null,
     };
   }
 

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/submit-transformer/submit-transformer.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/submit-transformer/submit-transformer.unit.spec.jsx
@@ -590,6 +590,28 @@ describe('Submit Transformer', () => {
         .be.false;
     });
 
+    it('should include remarks when benefitEntitlement is no', () => {
+      const form = {
+        data: {
+          benefitsInformation: {
+            benefitEntitlement: 'no',
+          },
+          remarks: {
+            remarks: 'Additional information here',
+          },
+        },
+      };
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, form));
+
+      expect(result.benefitEntitlementPayments).to.exist;
+      expect(result.benefitEntitlementPayments.sickRetirementOtherBenefits).to
+        .be.false;
+      expect(result.benefitEntitlementPayments.remarks).to.equal(
+        'Additional information here',
+      );
+    });
+
     it('should include benefitEntitlementPayments when benefitEntitlement is true', () => {
       const form = {
         data: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR addresses issue #130086 where the remarks field was not being included in the API payload when users selected "no" for the benefit entitlement question on Form 21-4192.

**Changes Made:**

1. **Submit Transformer Enhancement** - Modified the `transformBenefitEntitlementPayments` function to include the remarks field when benefitEntitlement is 'no' or false. Previously, when users selected "no", only the `sickRetirementOtherBenefits: false` flag was being sent. Now, the remarks field is also included in the payload as `remarks: remarks.remarks || null`.

2. **Test Coverage** - Added comprehensive unit test for the submit transformer to validate that the remarks field is properly included when benefitEntitlement is "no". The test verifies both the presence of the field and its correct value from the form data.

**Form 21-4192 Impact:**
- Users selecting "no" for benefit entitlement will now have their remarks properly captured and sent to the backend API
- Ensures no loss of user-provided remarks data during form submission

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#130086

## Testing done

**Old behavior:** When users selected "no" for the benefit entitlement question and provided remarks, the remarks field was not included in the API payload. Only the `sickRetirementOtherBenefits: false` flag was being sent, resulting in loss of the remarks data.

**Steps to verify:**
1. Navigate to Form 21-4192 (Benefits Optimization Employment Information)
2. Complete the form through the Benefits Details section
3. Select "No" for the "Are you receiving any benefits?" question
4. Enter text in the Additional Remarks field
5. Submit the form
6. Verify in network traffic or API logs that the payload includes the remarks field with the entered text

**Tests completed:**
- Added unit test in `submit-transformer.unit.spec.jsx` to verify remarks field inclusion when benefitEntitlement is "no"
- All new tests pass and verify correct data transformation

## Screenshots
Before:
<img width="746" height="484" alt="image" src="https://github.com/user-attachments/assets/c18cb2aa-71ac-414f-b801-f69f058f5821" />

After:
<img width="755" height="477" alt="image" src="https://github.com/user-attachments/assets/ca3d2abe-32c1-4c2e-b9d7-a4193d7bb6da" />


## What areas of the site does it impact?

This change impacts Form 21-4192 (Benefits Optimization Employment Information Application) specifically the Benefits Details section where users indicate their benefit entitlement status. When users select "no" for benefit entitlements and provide remarks, those remarks are now properly captured and submitted to the backend API.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This PR ensures that user-provided remarks on Form 21-4192 are not lost when selecting "no" for benefit entitlements. The changes are minimal and focused, affecting only the benefit entitlement transformation logic and its corresponding tests. The validation test updates reflect the actual behavior of the MemorableDateUI component without changing the validation logic itself.

Reviewers should verify that the remarks field is properly captured in the API payload when testing the form submission flow with "no" selected for benefit entitlements.
