### PR TITLE
fix: use app-folder to derive unit test pattern in GHA script

### DIFF
--- a/.github/workflows/full-suite-tests.yml
+++ b/.github/workflows/full-suite-tests.yml
@@ -380,7 +380,7 @@ jobs:
           if [[ "${{ matrix.app.type }}" == "platform" ]]; then
             yarn test:unit:gha --coverage --log-level verbose "src/platform/**/*.unit.spec.js?(x)"
           else
-            yarn test:unit:gha --app-folder ${{ matrix.app.folder }} --coverage --log-level verbose "src/applications/${{ matrix.app.folder }}/**/*.unit.spec.js?(x)"
+            yarn test:unit:gha --app-folder ${{ matrix.app.folder }} --coverage --log-level verbose
           fi
         env:
           MOCHA_FILE: test-results/unit-tests.xml


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes a bug in `run-unit-tests-gha.js` where the script ignored the explicitly passed test pattern and defaulted to `src/platform/site-wide/**/*.unit.spec.js?(x)` for all app folder tests
- Added `hasCustomPathPattern()` function to detect when a custom path pattern is passed
- Added handling for `--app-folder` to derive the test pattern from the folder name
- Updated workflow to pass only `--app-folder` for application tests (pattern is derived), and explicit pattern for platform tests

## Related issue(s)

- Bug discovered when running full unit test suite - all app folders were running platform site-wide tests instead of their own tests

## Testing done

- Ran `node ./script/github-actions/run-unit-tests-gha.js --app-folder check-in --log-level verbose` locally
- Old behavior: `Running tests matching patterns: src/platform/site-wide/**/*.unit.spec.js?(x)`
- New behavior: `Running tests matching patterns: src/applications/check-in/**/*.unit.spec.js?(x)` with 97 test files found

## Screenshots

N/A - CI/script changes only

## What areas of the site does it impact?

GitHub Actions unit test workflow only. No user-facing changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A)
- [ ] Screenshot of the developed feature is added (N/A - CI changes)
- [ ] Accessibility testing has been performed (N/A - CI changes)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - CI changes)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - CI changes)