### PR TITLE
534ez update hideIf for marriage loop summary questions

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -149,10 +149,10 @@ const summaryPage = {
         title:
           'Are there any other marriages to add that were before your marriage to the Veteran?',
       }),
-      'ui:required': formData =>
-        formData?.spouseHasAdditionalMarriages?.length === 2,
+      'ui:required': formData => formData?.spouseMarriages?.length === 2,
       'ui:options': {
-        hideIf: formData => formData?.spouseHasAdditionalMarriages?.length < 2,
+        hideIf: formData =>
+          !formData?.spouseMarriages || formData?.spouseMarriages?.length < 2,
       },
     },
   },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -119,7 +119,8 @@ const summaryPage = {
       }),
       'ui:required': formData => formData?.veteranMarriages?.length === 2,
       'ui:options': {
-        hideIf: formData => formData?.veteranMarriages?.length < 2,
+        hideIf: formData =>
+          !formData?.veteranMarriages || formData?.veteranMarriages?.length < 2,
       },
     },
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Check to make sure the loop key exists when landing on the summary page and hiding the max item question if it does. 
- Switch the variable being checked in previousMarriage loop to the arrayPath instead of the yes/no sent to pdf_fill

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129965
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129964

## Testing done

- Manually tested the summary pages

## Screenshots

N/A

## What areas of the site does it impact?

The summary pages for the 534ez previous marriage loops

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A