### PR TITLE
removes street address line 3, changes street address line 2 to apt./u…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-address.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-address.js
@@ -19,6 +19,7 @@ export const claimantAddressUiSchema = {
       labels: {
         militaryCheckbox:
           'Claimant lives on a United States military base outside of the U.S.',
+        street2: 'Apt./Unit Number',
       },
     }),
   },
@@ -46,7 +47,9 @@ export const claimantAddressUiSchema = {
 const customAddressSchema = {
   ...addressSchema(),
   properties: {
-    ...addressSchema().properties,
+    ...addressSchema({
+      omit: ['street3'],
+    }).properties,
     street: {
       type: 'string',
       maxLength: 30,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/hospitalization-facility.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/hospitalization-facility.js
@@ -24,7 +24,11 @@ export const hospitalizationFacilityUiSchema = {
       title: 'Name of hospital',
     }),
     facilityAddress: {
-      ...addressNoMilitaryUI(),
+      ...addressNoMilitaryUI({
+        labels: {
+          street2: 'Apt./Unit Number',
+        },
+      }),
       'ui:description': () => (
         <h4 className="vads-u-font-family--serif vads-u-font-weight--bold vads-u-font-size--base vads-u-line-height--3 vads-u-margin-top--2 vads-u-margin-bottom--1">
           Address of hospital
@@ -42,7 +46,9 @@ export const hospitalizationFacilityUiSchema = {
 const customHospitalAddressSchema = {
   ...addressNoMilitarySchema(),
   properties: {
-    ...addressNoMilitarySchema().properties,
+    ...addressNoMilitarySchema({
+      omit: ['street3'],
+    }).properties,
     street: {
       type: 'string',
       maxLength: 30,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-address.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-address.js
@@ -20,6 +20,7 @@ export const veteranAddressUiSchema = {
       labels: {
         militaryCheckbox:
           'Veteran lives on a United States military base outside of the U.S.',
+        street2: 'Apt./Unit Number',
       },
     }),
   },
@@ -33,7 +34,9 @@ export const veteranAddressUiSchema = {
 const customVeteranAddressSchema = {
   ...addressSchema(),
   properties: {
-    ...addressSchema().properties,
+    ...addressSchema({
+      omit: ['street3'],
+    }).properties,
     street: {
       type: 'string',
       maxLength: 30,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
@@ -13,7 +13,6 @@
       "veteranAddress": {
         "street": "Cloud City Administration",
         "street2": "BQ",
-        "street3": "Level 121-138",
         "city": "Denver",
         "state": "CO",
         "country": "USA",
@@ -38,7 +37,6 @@
       "claimantAddress": {
         "street": "Bespin Mining Colony",
         "street2": "Res",
-        "street3": "Suite 42",
         "city": "Cloud City",
         "state": "CO",
         "country": "USA",

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
@@ -14,7 +14,6 @@
       "veteranAddress": {
         "street": "501 Jedi Temple Avenue",
         "street2": "Rm 1A",
-        "street3": "Floor 1138",
         "city": "Coruscant",
         "state": "DC",
         "country": "USA",
@@ -39,7 +38,6 @@
       "claimantAddress": {
         "street": "500 Republica Luxury Apts",
         "street2": "PH",
-        "street3": "Tower A",
         "city": "Naboo",
         "state": "NM",
         "country": "USA",
@@ -65,7 +63,6 @@
       "facilityAddress": {
         "street": "1 Outer Rim Medical Center",
         "street2": "ER",
-        "street3": "Bldg C",
         "city": "Washington",
         "state": "DC",
         "country": "USA",

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
@@ -13,7 +13,6 @@
       "veteranAddress": {
         "street": "2000 Resistance Base",
         "street2": "CC",
-        "street3": "Level 3",
         "city": "Alderaan City",
         "state": "NY",
         "country": "USA",
@@ -38,7 +37,6 @@
       "claimantAddress": {
         "street": "1 Royal Palace Avenue",
         "street2": "SW",
-        "street3": "",
         "city": "Alderaan City",
         "state": "NY",
         "country": "USA",
@@ -64,7 +62,6 @@
       "facilityAddress": {
         "street": "500 Medical District",
         "street2": "ED",
-        "street3": "",
         "city": "Albany",
         "state": "NY",
         "country": "USA",

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
@@ -13,7 +13,6 @@
       "veteranAddress": {
         "street": "1313 Millennium Falcon Way",
         "street2": "Dock",
-        "street3": "",
         "city": "Mos Eisley",
         "state": "AZ",
         "country": "USA",
@@ -42,7 +41,6 @@
       "facilityAddress": {
         "street": "9000 Spaceport Boulevard",
         "street2": "ICU",
-        "street3": "",
         "city": "Mos Eisley",
         "state": "AZ",
         "country": "USA",


### PR DESCRIPTION
…nit number for all address fields

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Removing Street Address Line 3 and changing Street Address Line 2 to Apt./Unit Number on all address fields on form 2680

### Issue
The Street Address Line 3 wasn't being collected anywhere and doesn't go anywhere on the form. Also, the paper form labels the Claimant Address field as Apt./Unit Number. For the Hospitalization Facility address, the street2 field only accepts 5 characters as well, implying that it is also supposed to be a unit number.

### Solution
Omitted Street Address Line 3 and overrode the Street Address Line 2 label to Apt./Unit Number to align with paper form.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129638](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129638)

## Testing done

### Old behavior
* The form had Street Address Line 3 for all address fields, with Street Address Line 2 as the label for the second line

### New behavior
* The form no longer has Street Address Line 3 in any of the address fields, and Street Address Line 2 is labeled "Apt./Unit Number"

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the Street Address Line 3 fields are gone and Street Address Line 2 is now Apt./Unit number (on /veteran-address, /claimant-address, and /hospitalization-facility
* E2E tests: all existing tests pass, removed street3 from jsons

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="584" height="604" alt="before 2" src="https://github.com/user-attachments/assets/1610c732-d2a5-4754-ba61-f05f05c729a4" /> | <img width="569" height="509" alt="after 2" src="https://github.com/user-attachments/assets/45715727-e7b9-4e11-9ec2-49d5e4c404ea" /> |

## What areas of the site does it impact?

This change affects form 21-2680, specifically on the Veteran Address, Claimant Address, and Hospitalization Facility pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user