### PR TITLE
129917 Fix RUM date error

### DIFF
--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -18,10 +18,12 @@ import {
   extractContainedByRecourceType,
   extractContainedResource,
   formatDate,
+  formatDateAndTime,
   formatDateInLocalTimezone,
   formatNameFirstToLast,
   getActiveLinksStyle,
   getAppointmentsDateRange,
+  getLastSuccessfulUpdate,
   getLastUpdatedText,
   getMonthFromSelectedDate,
   getObservationValueWithUnits,
@@ -623,6 +625,177 @@ describe('getLastUpdatedText', () => {
     const extractType = 'type1';
 
     const result = getLastUpdatedText(refreshStateStatus, extractType);
+
+    expect(result).to.be.null;
+  });
+});
+
+describe('formatDateAndTime', () => {
+  it('formats a valid Date object into date, time, and timeZone parts', () => {
+    const date = new Date(2025, 0, 15, 14, 30, 0); // Jan 15, 2025 2:30 PM
+    const result = formatDateAndTime(date);
+
+    expect(result).to.not.be.null;
+    expect(result.date).to.equal('January 15, 2025');
+    expect(result.time).to.equal('2:30 p.m.');
+    expect(result.timeZone).to.be.a('string');
+  });
+
+  it('formats a valid ISO date string', () => {
+    const result = formatDateAndTime('2025-01-15T14:30:00');
+
+    expect(result).to.not.be.null;
+    expect(result.date).to.equal('January 15, 2025');
+    expect(result.time).to.equal('2:30 p.m.');
+  });
+
+  it('returns null for an Invalid Date object', () => {
+    const invalidDate = new Date('not-a-date');
+    const result = formatDateAndTime(invalidDate);
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null for an invalid date string', () => {
+    const result = formatDateAndTime('garbage');
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null for an empty string', () => {
+    const result = formatDateAndTime('');
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null for a Date created from NaN', () => {
+    const result = formatDateAndTime(new Date(NaN));
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null when passed null', () => {
+    const result = formatDateAndTime(null);
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null when passed undefined', () => {
+    const result = formatDateAndTime(undefined);
+
+    expect(result).to.be.null;
+  });
+
+  it('handles midnight correctly (12:00 a.m.)', () => {
+    const date = new Date(2025, 0, 15, 0, 0, 0); // Midnight
+    const result = formatDateAndTime(date);
+
+    expect(result).to.not.be.null;
+    expect(result.time).to.equal('12:00 a.m.');
+  });
+
+  it('handles noon correctly (12:00 p.m.)', () => {
+    const date = new Date(2025, 0, 15, 12, 0, 0); // Noon
+    const result = formatDateAndTime(date);
+
+    expect(result).to.not.be.null;
+    expect(result.time).to.equal('12:00 p.m.');
+  });
+});
+
+describe('getLastSuccessfulUpdate', () => {
+  it('returns formatted date for valid extract statuses', () => {
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: '2024-09-15T10:00:00Z' },
+      { extract: 'type2', lastSuccessfulCompleted: '2024-09-16T10:00:00Z' },
+    ];
+    const extractTypeList = ['type1', 'type2'];
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
+
+    expect(result).to.not.be.null;
+    expect(result.date).to.be.a('string');
+    expect(result.time).to.be.a('string');
+  });
+
+  it('returns the earliest date when multiple valid dates are present', () => {
+    const earlier = new Date(2024, 8, 10, 10, 0, 0); // Sept 10
+    const later = new Date(2024, 8, 15, 10, 0, 0); // Sept 15
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: earlier },
+      { extract: 'type2', lastSuccessfulCompleted: later },
+    ];
+    const extractTypeList = ['type1', 'type2'];
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
+
+    expect(result).to.not.be.null;
+    // The result should be based on the earlier date (Sept 10)
+    expect(result.date).to.include('September 10');
+  });
+
+  it('returns null when an extract has an invalid date string', () => {
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: 'not-a-date' },
+    ];
+    const extractTypeList = ['type1'];
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
+
+    expect(result).to.be.null;
+  });
+
+  it('filters out invalid dates and returns result from valid ones', () => {
+    const validDate = new Date(2024, 8, 15, 10, 0, 0);
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: validDate },
+      { extract: 'type2', lastSuccessfulCompleted: 'invalid-date' },
+    ];
+    // Only request one extract type to avoid the length check
+    const extractTypeList = ['type1'];
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
+
+    expect(result).to.not.be.null;
+    expect(result.date).to.include('September 15');
+  });
+
+  it('returns null when all dates are invalid', () => {
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: 'garbage' },
+      { extract: 'type2', lastSuccessfulCompleted: '' },
+    ];
+    const extractTypeList = ['type1', 'type2'];
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null when refreshStateStatus is undefined', () => {
+    const result = getLastSuccessfulUpdate(undefined, ['type1']);
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null when extract type list does not match available extracts', () => {
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: '2024-09-15T10:00:00Z' },
+    ];
+    const extractTypeList = ['type1', 'type2']; // type2 not in refreshStateStatus
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
+
+    expect(result).to.be.null;
+  });
+
+  it('handles Date objects that are Invalid Date', () => {
+    const refreshStateStatus = [
+      { extract: 'type1', lastSuccessfulCompleted: new Date('invalid') },
+    ];
+    const extractTypeList = ['type1'];
+
+    const result = getLastSuccessfulUpdate(refreshStateStatus, extractTypeList);
 
     expect(result).to.be.null;
   });

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -325,11 +325,17 @@ export const formatDate = str => {
  * Returns a date formatted into three parts -- a date portion, a time portion, and a time zone.
  *
  * @param {Date | string} date
+ * @returns {{ date: string, time: string, timeZone: string } | null} Returns null if the date is invalid.
  */
 export const formatDateAndTime = rawDate => {
   let date = rawDate;
   if (typeof rawDate === 'string') {
     date = new Date(rawDate);
+  }
+
+  // Validate the date before formatting to prevent RangeError in formatToParts
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return null;
   }
 
   const hours = date.getHours();
@@ -569,9 +575,15 @@ export const getLastSuccessfulUpdate = (
     matchingDates?.length &&
     matchingDates.length === extractTypeList.length
   ) {
-    const minDate = new Date(
-      Math.min(...matchingDates.map(date => date.getTime())),
-    );
+    // Filter out any invalid dates
+    const timestamps = matchingDates
+      .map(date => date.getTime())
+      .filter(t => !Number.isNaN(t));
+    if (timestamps.length === 0) {
+      return null;
+    }
+    // Get the earliest date (minimum timestamp)
+    const minDate = new Date(Math.min(...timestamps));
     return formatDateAndTime(minDate);
   }
   return null;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added guards against invalid dates in a few key functions. In this case, date timestamps that are `NaN` were poisoning the `Math.min` function, preventing the other--valid--dates from being used.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129917

## Testing done

- Full suite of unit tests to cover the affected functions, including the new functionality

## Screenshots

N/A -- logic-only change

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
