### PR TITLE
[ARC/127475] Add ITF help page content behind feature flag

### DIFF
--- a/src/applications/accredited-representative-portal/containers/HelpPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/HelpPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from 'platform/utilities/ui';
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { HELP_BC_LABEL, HelpBC } from '../utilities/poaRequests';
 
 const VAGovLink = () => (
@@ -487,55 +488,130 @@ const HelpPage = title => {
               </p>
             </va-accordion-item>
           </va-accordion>
-          <h2 id="submitting-va-forms">Submitting VA forms</h2>
-          <p>
-            If you or one of your organizations has representation with an
-            individual, you can submit forms through the portal on their behalf.
-          </p>
-          <va-accordion>
-            <va-accordion-item
-              header="Uploading and submitting completed PDFs"
-              id="section-seventeen"
-              level="3"
-            >
-              To submit VA forms, you will need to upload a completed PDF of the
-              form and any additional relevant evidence or documentation. Prior
-              to submission, the system will verify that you or one of your VSOs
-              has existing representation with the claimant. We’ll notify you of
-              the status of receipt in VBMS and track submissions for 60 days.
-            </va-accordion-item>
-            <va-accordion-item
-              header="Supported forms"
-              id="section-eighteen"
-              level="3"
-            >
-              Currently, you can submit these forms through the portal:
-              <ul>
-                <li>
-                  Application Request to Add and/or Remove Dependents (VA Form
-                  21-686c)
-                </li>
-                <li>
-                  Application for Disability Compensation and Related
-                  Compensation Benefits (VA Form 21-526EZ)
-                </li>
-              </ul>
-            </va-accordion-item>
-            <va-accordion-item
-              header="In SEP, I was able to submit a 21-686c and establish dependents within 24 hours. Will I be able to do this in the portal?"
-              id="section-nineteen"
-              level="3"
-            >
+          <Toggler
+            toggleName={
+              Toggler.TOGGLE_NAMES.accreditedRepresentativePortalIntentToFile
+            }
+          >
+            <Toggler.Enabled>
+              <h2 id="submitting-va-forms">Submitting VA forms</h2>
               <p>
-                The capability to establish dependents within 24 hours won’t be
-                available in the portal upon initial release.
+                There are two methods the portal uses for submissions. Some
+                forms require you to upload a completed PDF to submit. Other
+                forms can be submitted by filling out the required steps in the
+                portal.
               </p>
               <p>
-                We are exploring ways to speed up this process as a future
-                enhancement.
+                Prior to submission, the system will verify that you or your
+                Veterans Service Organization (VSO) currently represent the
+                claimant.
               </p>
-            </va-accordion-item>
-          </va-accordion>
+              <va-accordion>
+                <va-accordion-item
+                  header="VA Form 21-0966 (Intent to File a Claim for Compensation and/or Pension, or Survivors Pension and/or DIC)"
+                  id="section-seventeen"
+                  level="3"
+                >
+                  <p>
+                    Fill out the required steps in the portal for VA Form
+                    21-0966, and then submit.
+                  </p>
+                  <p>
+                    The intent to file will be recorded immediately after
+                    submission.
+                  </p>
+                </va-accordion-item>
+                <va-accordion-item
+                  header="VA Form 21-526EZ (Application for Disability Compensation and Related Compensation Benefits)"
+                  id="section-eighteen"
+                  level="3"
+                >
+                  <p>
+                    Upload the completed VA Form 21-526EZ PDF, and then submit.
+                  </p>
+                  <p>
+                    The form will be processed by VA Centralized Mail after
+                    submission. We’ll notify you of the status of receipt in
+                    VBMS. The portal will track the submission for 60 days.
+                  </p>
+                </va-accordion-item>
+                <va-accordion-item
+                  header="VA Form 21-686c (Application Request to Add and/or Remove Dependents)"
+                  id="section-nineteen"
+                  level="3"
+                >
+                  <p>
+                    Upload the completed VA Form 21-686c PDF and any supporting
+                    evidence, and then submit.
+                  </p>
+                  <p>
+                    The form will be processed by VA Centralized Mail after
+                    submission. We’ll notify you of the status of receipt in
+                    VBMS. The portal will track the submission for 60 days.
+                  </p>
+                  <p>
+                    <strong>Note:</strong> The portal isn’t able to establish
+                    dependents within 24 hours at this time. We’re exploring
+                    ways to speed up this process as a future enhancement.
+                  </p>
+                </va-accordion-item>
+              </va-accordion>
+            </Toggler.Enabled>
+            <Toggler.Disabled>
+              <h2 id="submitting-va-forms">Submitting VA forms</h2>
+              <p>
+                If you or one of your organizations has representation with an
+                individual, you can submit forms through the portal on their
+                behalf.
+              </p>
+              <va-accordion>
+                <va-accordion-item
+                  header="Uploading and submitting completed PDFs"
+                  id="section-seventeen"
+                  level="3"
+                >
+                  To submit VA forms, you will need to upload a completed PDF of
+                  the form and any additional relevant evidence or
+                  documentation. Prior to submission, the system will verify
+                  that you or one of your VSOs has existing representation with
+                  the claimant. We’ll notify you of the status of receipt in
+                  VBMS and track submissions for 60 days.
+                </va-accordion-item>
+                <va-accordion-item
+                  header="Supported forms"
+                  id="section-eighteen"
+                  level="3"
+                >
+                  Currently, you can submit these forms through the portal:
+                  <ul>
+                    <li>
+                      Application Request to Add and/or Remove Dependents (VA
+                      Form 21-686c)
+                    </li>
+                    <li>
+                      Application for Disability Compensation and Related
+                      Compensation Benefits (VA Form 21-526EZ)
+                    </li>
+                  </ul>
+                </va-accordion-item>
+                <va-accordion-item
+                  header="In SEP, I was able to submit a 21-686c and establish dependents within 24 hours. Will I be able to do this in the portal?"
+                  id="section-nineteen"
+                  level="3"
+                >
+                  <p>
+                    The capability to establish dependents within 24 hours won’t
+                    be available in the portal upon initial release.
+                  </p>
+                  <p>
+                    We are exploring ways to speed up this process as a future
+                    enhancement.
+                  </p>
+                </va-accordion-item>
+              </va-accordion>
+              `
+            </Toggler.Disabled>
+          </Toggler>
           <div className="va-h-ruled--stars mobile-view-divider" />
         </div>
         <div className="vads-l-col--12 medium-screen:vads-l-col--4 contact-us">

--- a/src/applications/accredited-representative-portal/sass/GetHelp.scss
+++ b/src/applications/accredited-representative-portal/sass/GetHelp.scss
@@ -29,6 +29,7 @@
 
   p {
     margin-top: 0px;
+    max-width: unset;
   }
   .subtext {
     font-family: var(--font-serif);


### PR DESCRIPTION
## Summary

- Updated Help page with new content related to ITF (see ticket [ARC/127475](https://github.com/department-of-veterans-affairs/va.gov-team/issues/127475#event-22027093153))
- Changed paragraph styling on the Help page to make width consistent across accordions

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127475#event-22027093153

## Testing done

- Checked with feature flag enabled and disabled locally
- Ran axe DevTools full page scan and required manual checks, no new accessibility issues added

## Screenshots

Feature flag enabled:
<img width="668" height="939" alt="Screenshot 2026-01-15 at 10 32 19 AM" src="https://github.com/user-attachments/assets/83355989-c722-4f89-984e-9d75f4a97e22" />

Feature flag disabled:
<img width="656" height="768" alt="Screenshot 2026-01-15 at 10 34 22 AM" src="https://github.com/user-attachments/assets/a0c00471-2446-4e35-9df2-a2107965ef85" />

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
