### PR TITLE
8416 add custom confirmation and statement of truth

### DIFF
--- a/src/applications/medical-expense-report/config/form.js
+++ b/src/applications/medical-expense-report/config/form.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import environment from 'platform/utilities/environment';
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import FormFooter from 'platform/forms/components/FormFooter';
@@ -64,10 +65,24 @@ const formConfig = {
   },
   preSubmitInfo: {
     statementOfTruth: {
-      body:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+      body: (
+        <div>
+          <p>
+            I confirm that the identifying information in this form is accurate
+            and has been represented correctly.
+          </p>
+          <p>
+            <span className="vads-u-font-weight--bold">
+              I have not and will not
+            </span>{' '}
+            receive reimbursement for these expenses. I certify the information
+            contained on this form and the attached addendums is a true
+            representation of expenses I have paid.
+          </p>
+        </div>
+      ),
       messageAriaDescribedby:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+        'I confirm that the identifying information in this form is accurate and has been represented correctly. I have not and will not receive reimbursement for these expenses. I certify the information contained on this form and the attached addendums is a true representation of expenses I have paid.',
       fullNamePath: 'claimantFullName',
     },
   },

--- a/src/applications/medical-expense-report/containers/ConfirmationPage.jsx
+++ b/src/applications/medical-expense-report/containers/ConfirmationPage.jsx
@@ -24,6 +24,29 @@ export const ConfirmationPage = props => {
       <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList />
+      <h2>If you need to submit supporting documents</h2>
+      <p>
+        If you didn’t already submit your supporting documents and additional
+        evidence, you can submit copies of your documents by mail.
+      </p>
+      <p>Mail and supporting documents to this address:</p>
+      <p className="va-address-block">
+        Department of Veterans Affairs
+        <br />
+        Pension Intake Center
+        <br />
+        PO Box 5365
+        <br />
+        Janesville, WI 53547-5365
+        <br />
+        United States of America
+        <br />
+      </p>
+      <p>
+        <span className="vads-u-font-weight--bold">Note:</span> Mail us copies
+        of your documents only. Don’t send us your original documents. We can’t
+        return them.
+      </p>
       <ConfirmationView.HowToContact />
       <ConfirmationView.GoBackLink />
       <ConfirmationView.NeedHelp />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add custom confirmation page elements
- Update the statement of truth

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122760
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127886

## Testing done

- Manual testing

## Screenshots

<img width="675" height="503" alt="Screenshot 2026-01-15 at 11 10 44 AM" src="https://github.com/user-attachments/assets/9e383721-79c1-499f-8d94-176a4cdb7879" />
<img width="808" height="1132" alt="Screenshot 2026-01-15 at 11 10 33 AM" src="https://github.com/user-attachments/assets/46424045-d618-4cf6-bfb6-bf9839613a51" />


## What areas of the site does it impact?

The last two pages of the 8416 form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
