### PR TITLE
534ez Reset confirmation and statement of truth to default

### DIFF
--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import environment from 'platform/utilities/environment';
 import FormFooter from 'platform/forms/components/FormFooter';
@@ -111,24 +110,10 @@ const formConfig = {
   },
   preSubmitInfo: {
     statementOfTruth: {
-      body: (
-        <div>
-          <p>
-            I confirm that the identifying information in this form is accurate
-            and has been represented correctly.
-          </p>
-          <p>
-            <span className="vads-u-font-weight--bold">
-              I have not and will not
-            </span>{' '}
-            receive reimbursement for these expenses. I certify the information
-            contained on this form and the attached addendums is a true
-            representation of expenses I have paid.
-          </p>
-        </div>
-      ),
+      body:
+        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
       messageAriaDescribedby:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly. I have not and will not receive reimbursement for these expenses. I certify the information contained on this form and the attached addendums is a true representation of expenses I have paid.',
+        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
       fullNamePath: 'claimantFullName',
     },
   },

--- a/src/applications/survivors-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/survivors-benefits/containers/ConfirmationPage.jsx
@@ -24,29 +24,6 @@ export const ConfirmationPage = props => {
       <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList />
-      <h2>If you need to submit supporting documents</h2>
-      <p>
-        If you didn’t already submit your supporting documents and additional
-        evidence, you can submit copies of your documents by mail.
-      </p>
-      <p>Mail and supporting documents to this address:</p>
-      <p className="va-address-block">
-        Department of Veterans Affairs
-        <br />
-        Pension Intake Center
-        <br />
-        PO Box 5365
-        <br />
-        Janesville, WI 53547-5365
-        <br />
-        United States of America
-        <br />
-      </p>
-      <p>
-        <span className="vads-u-font-weight--bold">Note:</span> Mail us copies
-        of your documents only. Don’t send us your original documents. We can’t
-        return them.
-      </p>
       <ConfirmationView.HowToContact />
       <ConfirmationView.GoBackLink />
       <ConfirmationView.NeedHelp />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove statement of truth and confirmation page updates, they were meant for the 8416

## Related issue(s)

- Accidentally added in https://github.com/department-of-veterans-affairs/vets-website/pull/40872

## Testing done

- Manual testing

## Screenshots
<img width="442" height="344" alt="535880174-2a085c1c-0ad5-466a-ac0d-4567f30a2394" src="https://github.com/user-attachments/assets/76196c70-8c2b-4c04-b7c7-4ef0e83b4327" />
<img width="395" height="242" alt="535879464-97d9a148-b880-48e7-9c82-f99e40082fee" src="https://github.com/user-attachments/assets/8a7affc6-5de5-4ded-bd60-67eefcc7fc6f" />


## What areas of the site does it impact?

Last two pages of the 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A