### PR TITLE
Update content to match SME feedback.

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/containers/introduction-page/introduction-page.jsx
@@ -57,6 +57,10 @@ const ProcessList = () => {
             </ul>
           </li>
           <li>Are housebound (because of permanent disability)</li>
+          <li>
+            Are a Veteran, and your spouse is in need of regular aid and
+            attendance
+          </li>
         </ul>
       </va-process-list-item>
       <va-process-list-item header="Gather your information">

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/benefit-type.js
@@ -66,8 +66,8 @@ export const benefitTypeUiSchema = {
         </va-accordion-item>
         <va-accordion-item header="Special Monthly Pension (SMP)" id="smp">
           <p>
-            SMP is an increased monthly amount paid to a veteran or survivor who
-            is eligible for Veterans Pension or Survivors benefits. Apply for
+            SMP is an increased monthly amount paid to a Veteran or survivor who
+            is eligible for Veterans Pension or Survivors pension. Apply for
             Special Monthly Pension (SMP) if you:
           </p>
           <ul>
@@ -76,7 +76,7 @@ export const benefitTypeUiSchema = {
             <li>Are housebound (because of permanent disability)</li>
             <li>
               Currently receive, or are eligible for, Veteran’s Pension and/or
-              Survivors benefits
+              Survivors pension
             </li>
           </ul>
         </va-accordion-item>
@@ -92,9 +92,9 @@ export const benefitTypeUiSchema = {
       },
       descriptions: {
         SMC:
-          'is paid in addition to compensation or Dependency Indemnity Compensation (DIC) for a service-related disability.',
+          'is paid in addition to compensation or Dependency Indemnity Compensation (DIC)',
         SMP:
-          'is an increased monthly amount paid to a Veteran or survivor who is eligible for Veterans Pension or Survivors benefits.',
+          'is an increased monthly amount paid to a Veteran or survivor who is eligible for Veterans Pension or Survivors pension',
       },
       tile: true,
       labelHeaderLevel: 3,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated content in VA Form 21-2680 (Housebound Status and Permanent Need for Regular Aid and Attendance) based on Subject Matter Expert feedback
- Added eligibility criterion to Introduction page: "Are a Veteran, and your spouse is in need of regular aid and attendance"
- Modified Special Monthly Compensation (SMC) radio button description to clarify benefit structure
- Updated accordion descriptions on Benefit Type page to reflect correct terminology for both SMC and SMP benefit types
- All changes are content-only with no functional modifications to the form logic

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#130055

## Testing done

- Manually verified all content updates in both files match the provided changes
- Reviewed updated text for accuracy:
  - Introduction page now correctly lists eligibility criteria including spouse aid and attendance requirement
  - Benefit Type page accordion information properly distinguishes between SMC (compensation/DIC-based) and SMP (pension-based) benefits
  - Radio button descriptions now accurately reflect benefit payment structures
- Verified no functional form logic or behavior was affected by content updates
- No automated tests require updates as this is a content-only change

## Screenshots

| Before | After |
| ------ | ----- |
|  <img width="777" height="475" alt="image" src="https://github.com/user-attachments/assets/86c9221a-40d3-4e7a-b1da-8226fde63614" />   | <img width="700" height="529" alt="image" src="https://github.com/user-attachments/assets/9b0e3d37-1e77-4e2f-a796-1c6f112610c1" /> |
| <img width="579" height="676" alt="image" src="https://github.com/user-attachments/assets/b800a011-344e-4a5e-9672-b9262bb59ab1" />   | <img width="580" height="657" alt="image" src="https://github.com/user-attachments/assets/c680a51e-bda5-4258-ad18-3d8bf0922a55" />  |

_Note: No screenshots required as this is a content-only update with no UI changes._

## What areas of the site does it impact?

VA Form 21-2680 (Housebound Status and Permanent Need for Regular Aid and Attendance) application:
- Introduction page eligibility requirements section
- Benefit Type selection page including accordion information and radio button descriptions

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


