### PR TITLE
534ez remove flags from service branch combobox

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
+++ b/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
@@ -22,10 +22,7 @@ export default {
         required: 'Select a branch',
       },
       'ui:options': {
-        labels: Object.keys(servicesOptions).map(key => ({
-          value: key,
-          label: servicesOptions[key],
-        })),
+        labels: servicesOptions,
       },
     },
     activeServiceDateRange: currentOrPastDateRangeUI(
@@ -49,10 +46,7 @@ export default {
     properties: {
       serviceBranch: {
         type: 'string',
-        enum: Object.keys(servicesOptions),
-        enumNames: Object.keys(servicesOptions).map(
-          key => servicesOptions[key],
-        ),
+        enum: Object.entries(servicesOptions).map(key => key[0]),
       },
       activeServiceDateRange: {
         type: 'object',

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -10,14 +10,30 @@ export const dicOptions = {
 };
 
 export const servicesOptions = {
-  army: 'Army',
-  navy: 'Navy',
-  airForce: 'Air Force',
-  coastGuard: 'Coast Guard',
-  marineCorps: 'Marine Corps',
-  spaceForce: 'Space Force',
-  usphs: 'USPHS',
-  noaa: 'NOAA',
+  army: {
+    label: 'Army',
+  },
+  navy: {
+    label: 'Navy',
+  },
+  airForce: {
+    label: 'Air Force',
+  },
+  coastGuard: {
+    label: 'Coast Guard',
+  },
+  marineCorps: {
+    label: 'Marine Corps',
+  },
+  spaceForce: {
+    label: 'Space Force',
+  },
+  usphs: {
+    label: 'USPHS',
+  },
+  noaa: {
+    label: 'NOAA',
+  },
 };
 
 export const claimantRelationshipOptions = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Restructure data/labels for service branch combobox to remove flags on each entry
- Tried to match the structure of https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/src/js/web-component-patterns/serviceBranchPattern.jsx which lists all the branches

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127891

## Testing done

- Manually tested as it didn't happen every time locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="638" height="360" alt="536304857-95288cb2-1993-452f-96b5-c2c04fd4919d" src="https://github.com/user-attachments/assets/ffd9db80-cc11-47b2-bd08-de474381212d" /> | <img width="524" height="403" alt="Screenshot 2026-01-15 at 12 37 56 PM" src="https://github.com/user-attachments/assets/64a8b851-922e-4799-a17d-f68ade378b2c" /> |

## What areas of the site does it impact?

Service branch combo box on the 534ez.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
