### PR TITLE
Cap first and last name length to match BE.

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
@@ -55,7 +55,7 @@ export const claimantInformationUiSchema = {
         'ui:options': {
           ...baseNameUI.last['ui:options'],
           hint:
-            'Maximum 15 characters. If your name is longer, enter the first 15 characters only.',
+            'Maximum 18 characters. If your name is longer, enter the first 18 characters only.',
         },
       },
     },
@@ -94,7 +94,7 @@ const customNameSchema = {
     },
     last: {
       type: 'string',
-      maxLength: 15,
+      maxLength: 18,
     },
   },
 };

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
@@ -31,13 +31,34 @@ const formatFullNameTitles = name => {
   }
 };
 
+// Generate base name UI configuration
+const baseNameUI = fullNameNoSuffixUI(formatFullNameTitles);
+
 /**
  * uiSchema for Claimant Information page
  * Collects claimant's full name and date of birth
  */
 export const claimantInformationUiSchema = {
   claimantInformation: {
-    claimantFullName: fullNameNoSuffixUI(formatFullNameTitles),
+    claimantFullName: {
+      ...baseNameUI,
+      first: {
+        ...baseNameUI.first,
+        'ui:options': {
+          ...baseNameUI.first['ui:options'],
+          hint:
+            'Maximum 12 characters. If your name is longer, enter the first 12 characters only.',
+        },
+      },
+      last: {
+        ...baseNameUI.last,
+        'ui:options': {
+          ...baseNameUI.last['ui:options'],
+          hint:
+            'Maximum 15 characters. If your name is longer, enter the first 15 characters only.',
+        },
+      },
+    },
     claimantDob: dateOfBirthUI(),
   },
   'ui:options': {
@@ -63,9 +84,17 @@ const customNameSchema = {
   ...fullNameNoSuffixSchema,
   properties: {
     ...fullNameNoSuffixSchema.properties,
+    first: {
+      type: 'string',
+      maxLength: 12,
+    },
     middle: {
       type: 'string',
       maxLength: 1,
+    },
+    last: {
+      type: 'string',
+      maxLength: 15,
     },
   },
 };

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-information.js
@@ -24,6 +24,9 @@ const formatFullNameTitles = name => {
   }
 };
 
+// Generate base name UI configuration
+const baseNameUI = fullNameNoSuffixUI(formatFullNameTitles);
+
 /**
  * uiSchema for Veteran Information page
  * Collects veteran's full name and date of birth
@@ -33,7 +36,25 @@ export const veteranInformationUiSchema = {
   'ui:description':
     'Confirm the personal information we have on file for the Veteran.',
   veteranInformation: {
-    veteranFullName: fullNameNoSuffixUI(formatFullNameTitles),
+    veteranFullName: {
+      ...baseNameUI,
+      first: {
+        ...baseNameUI.first,
+        'ui:options': {
+          ...baseNameUI.first['ui:options'],
+          hint:
+            'Maximum 12 characters. If your name is longer, enter the first 12 characters only.',
+        },
+      },
+      last: {
+        ...baseNameUI.last,
+        'ui:options': {
+          ...baseNameUI.last['ui:options'],
+          hint:
+            'Maximum 15 characters. If your name is longer, enter the first 15 characters only.',
+        },
+      },
+    },
     veteranDob: dateOfBirthUI(),
   },
 };
@@ -47,9 +68,17 @@ const customVeteranNameSchema = {
   ...fullNameNoSuffixSchema,
   properties: {
     ...fullNameNoSuffixSchema.properties,
+    first: {
+      ...fullNameNoSuffixSchema.properties.first,
+      maxLength: 12,
+    },
     middle: {
       type: 'string',
       maxLength: 1,
+    },
+    last: {
+      ...fullNameNoSuffixSchema.properties.last,
+      maxLength: 15,
     },
   },
 };

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-information.js
@@ -51,7 +51,7 @@ export const veteranInformationUiSchema = {
         'ui:options': {
           ...baseNameUI.last['ui:options'],
           hint:
-            'Maximum 15 characters. If your name is longer, enter the first 15 characters only.',
+            'Maximum 18 characters. If your name is longer, enter the first 18 characters only.',
         },
       },
     },
@@ -78,7 +78,7 @@ const customVeteranNameSchema = {
     },
     last: {
       ...fullNameNoSuffixSchema.properties.last,
-      maxLength: 15,
+      maxLength: 18,
     },
   },
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Added FE first and last name validation cap to match BE max length and added helpful hint text to name fields on the Veteran Information page (Form 21-2680) to inform users about character limits before they begin typing.

**Changes:**
- Added first name char limit to a maximum of 12 characters. 
- Added hint text to "First or given name" field: "Maximum 12 characters. If your name is longer, enter the first 12 characters only."
- Added last name char limit to a maximum of 15 characters. 
- Added hint text to "Last or family name" field: "Maximum 15 characters. If your name is longer, enter the first 15 characters only."

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#[ISSUE_NUMBER]](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130162#event-22075679140)

## Testing done

**Old behavior:** Users saw name fields with no indication of character limits until the browser prevented typing beyond the limit.

**New behavior:** Hint text appears below each name field explaining the character limits before users start typing.

**Verification steps:**
1. Navigate to Veteran Information page of Form 21-2680
2. Observe hint text below "First or given name" field
3. Observe hint text below "Last or family name" field
4. Verify character limits still enforce at 12/15 characters
5. Verify form submission works normally

## Screenshots

 |  | Before | After |
 | ------| ------ | ----- |
| Veteran's name | <img width="586" height="599" alt="image" src="https://github.com/user-attachments/assets/9dc324be-bd1b-4aa2-b165-b1d3283df7c0" />   |  <img width="548" height="552" alt="image" src="https://github.com/user-attachments/assets/b5f1f4de-05b2-499b-a8e9-925ccd39ecd4" />  |
| Claimant's name | <img width="647" height="644" alt="image" src="https://github.com/user-attachments/assets/b427f95a-3f98-444c-8d66-1831b398950c" /> | <img width="554" height="518" alt="image" src="https://github.com/user-attachments/assets/8338bd51-9cc9-4f65-8e25-290ab6c93cdd" /> |

_Note: Add screenshots showing the hint text below the name fields_

## What areas of the site does it impact?

Form 21-2680 (Housebound Status) Veteran Information page only.

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Simple UX improvement using the standard fullNameNoSuffixUI pattern. Please verify hint text displays correctly.
