### PR TITLE
removes mobile phone number, makes phone number not required, updates…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
@@ -41,8 +41,8 @@ export const claimantContactUiSchema = {
         : `${fallback} phone number and email address`;
 
       const homePhoneLabel = fullName
-        ? `${fullName}'s home phone number`
-        : `${fallback} home phone number`;
+        ? `${fullName}'s phone number`
+        : `${fallback} phone number`;
 
       const emailLabel = fullName
         ? `${fullName}'s email address`
@@ -75,11 +75,9 @@ export const claimantContactUiSchema = {
  */
 export const claimantContactSchema = {
   type: 'object',
-  required: ['claimantContact'],
   properties: {
     claimantContact: {
       type: 'object',
-      required: ['claimantEmail'],
       properties: {
         claimantPhoneNumber: phoneSchema,
         claimantEmail: emailSchema,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
@@ -21,7 +21,6 @@ import { getVeteranName, getClaimantName } from '../utils/name-helpers';
 export const claimantContactUiSchema = {
   claimantContact: {
     claimantPhoneNumber: phoneUI('Home phone number'),
-    claimantMobilePhone: phoneUI('Mobile phone number'),
     claimantEmail: emailUI('Email address'),
   },
   'ui:options': {
@@ -45,10 +44,6 @@ export const claimantContactUiSchema = {
         ? `${fullName}'s home phone number`
         : `${fallback} home phone number`;
 
-      const mobilePhoneLabel = fullName
-        ? `${fullName}'s mobile phone number`
-        : `${fallback} mobile phone number`;
-
       const emailLabel = fullName
         ? `${fullName}'s email address`
         : `${fallback} email address`;
@@ -64,9 +59,6 @@ export const claimantContactUiSchema = {
         claimantContact: {
           claimantPhoneNumber: {
             'ui:title': homePhoneLabel,
-          },
-          claimantMobilePhone: {
-            'ui:title': mobilePhoneLabel,
           },
           claimantEmail: {
             'ui:title': emailLabel,
@@ -87,10 +79,9 @@ export const claimantContactSchema = {
   properties: {
     claimantContact: {
       type: 'object',
-      required: ['claimantPhoneNumber', 'claimantEmail'],
+      required: ['claimantEmail'],
       properties: {
         claimantPhoneNumber: phoneSchema,
-        claimantMobilePhone: phoneSchema,
         claimantEmail: emailSchema,
       },
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
@@ -45,7 +45,6 @@
     },
     "claimantContact": {
       "claimantPhoneNumber": "7205551937",
-      "claimantMobilePhone": "7205551980",
       "claimantEmail": "lando.jr@cloudcity.com"
     },
     "benefitType": {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
@@ -46,7 +46,6 @@
     },
     "claimantContact": {
       "claimantPhoneNumber": "5055551977",
-      "claimantMobilePhone": "5055551983",
       "claimantEmail": "senator.amidala@galacticsenate.gov"
     },
     "benefitType": {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/minimal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/minimal.json
@@ -20,9 +20,6 @@
     "claimantRelationship": {
       "relationship": "veteran"
     },
-    "claimantContact": {
-      "claimantEmail": "luke@moisture-farm.net"
-    },
     "benefitType": {
       "benefitType": "SMC"
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/minimal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/minimal.json
@@ -21,7 +21,6 @@
       "relationship": "veteran"
     },
     "claimantContact": {
-      "claimantPhoneNumber": "5205551138",
       "claimantEmail": "luke@moisture-farm.net"
     },
     "benefitType": {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
@@ -45,7 +45,6 @@
     },
     "claimantContact": {
       "claimantPhoneNumber": "2125551935",
-      "claimantMobilePhone": "2125551956",
       "claimantEmail": "bail.organa@alderaan.gov"
     },
     "benefitType": {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
@@ -24,7 +24,6 @@
     },
     "claimantContact": {
       "claimantPhoneNumber": "5205551313",
-      "claimantMobilePhone": "5205551314",
       "claimantEmail": "hsolo@smuggler.net"
     },
     "benefitType": {


### PR DESCRIPTION
… e2e test datasets to reflect this change

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Removes mobile phone number, changes "home phone number" label to just "phone number", and makes home phone number and email not required

### Issue
Mobile phone number was not collected anywhere on the form, and phone number and email are listed as optional.

### Solution
Removed mobile phone number field and made home phone number and email fields optional on the claimant contact page

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 130208](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130208)

## Testing done

### Old behavior
* On Claimant Contact page, home phone number and email are required and mobile phone number field exists

### New behavior
* On Claimant Contact page, home phone number and email are not required, and there is no mobile phone number field

### Verification Steps
*  Unit tests: verified existing unit tests still pass
*  Manual testing in local environment verified that the home phone number and email are no longer required by the front end and mobile phone number field is gone. Also verified that the form still submits and pdf is generated properly
* E2E tests: all existing tests pass, removed phone number from minimal.json and removed mobile phone from all jsons

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  | |
| Desktop | <img width="574" height="590" alt="before 3" src="https://github.com/user-attachments/assets/29488109-f957-4d2e-aa91-228ef7284d0a" /> | <img width="582" height="491" alt="after 4" src="https://github.com/user-attachments/assets/20043163-25d9-4d50-9023-830250c6832b" /> |

## What areas of the site does it impact?

This change affects form 21-2680, specifically on the Claimant Contact page at /pension/aid-attendance-housebound/apply-form-21-2680/claimant-contact

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user