### PR TITLE
10-7959c | Require Medicare Part D for all plan types

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicare/index.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicare/index.js
@@ -128,8 +128,7 @@ export const medicarePagesRev2025 = {
   medicarePartDStatus: {
     path: 'medicare-part-d-status',
     title: 'Medicare Part D status',
-    depends: formData =>
-      formData[REV2025_TOGGLE_KEY] && hasPartsABorC(formData),
+    depends: formData => formData[REV2025_TOGGLE_KEY] && hasMedicare(formData),
     ...partDStatus,
   },
   medicarePartDCarrierEffectiveDate: {

--- a/src/applications/ivc-champva/10-7959C/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -8,7 +8,7 @@ const ConfirmationScreenView = ({ beneficiary, signee, submitDate }) => {
   return (
     <>
       <va-alert status="success" class="vads-u-margin-bottom--4">
-        <h2>
+        <h2 slot="headline" className="vads-u-font-size--h3">
           You’ve submitted your CHAMPVA Other Health Insurance Certification
           form
         </h2>

--- a/src/applications/ivc-champva/10-7959C/tests/unit/utils/helpers/medicare.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/unit/utils/helpers/medicare.unit.spec.jsx
@@ -144,30 +144,24 @@ describe('10-7959c Medicare helpers', () => {
   });
 
   describe('hasPartD', () => {
-    it('should return "true" when beneficiary has Medicare, the plan type is "ab" or "c" and hasMedicarePartD is "true"', () => {
+    it('should return "true" when beneficiary has Medicare and medicarePartDStatus is "true"', () => {
       const formData = {
         'view:hasMedicare': true,
-        medicarePlanType: 'ab',
-        hasMedicarePartD: true,
+        medicarePartDStatus: true,
       };
       expect(hasPartD(formData)).to.be.true;
     });
 
-    it('should return "false" when beneficiary has Medicare, the plan type is "ab" or "c" hasMedicarePartD is "false"', () => {
+    it('should return "false" when beneficiary has Medicare and medicarePartDStatus is "false"', () => {
       const formData = {
         'view:hasMedicare': true,
-        medicarePlanType: 'ab',
-        hasMedicarePartD: false,
+        medicarePartDStatus: false,
       };
       expect(hasPartD(formData)).to.be.false;
     });
 
-    it('should return "false" when the plan type is not "ab" or "c"', () => {
-      const formData = {
-        'view:hasMedicare': true,
-        medicarePlanType: 'a',
-        hasMedicarePartD: true,
-      };
+    it('should return "false" when beneficiary does not have Medicare', () => {
+      const formData = { 'view:hasMedicare': false };
       expect(hasPartD(formData)).to.be.false;
     });
   });

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
@@ -16,9 +16,7 @@ export const hasPartsABorC = formData =>
   (hasMedicare(formData) && hasPartsAB(formData)) || hasPartC(formData);
 
 export const hasPartD = formData =>
-  hasMedicare(formData) &&
-  hasPartsABorC(formData) &&
-  formData.medicarePartDStatus;
+  hasMedicare(formData) && formData.medicarePartDStatus;
 
 export const needsPartADenialNotice = formData =>
   hasPartB(formData) ||

--- a/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
+++ b/src/applications/ivc-champva/10-7959C/utils/helpers/medicare.js
@@ -16,7 +16,9 @@ export const hasPartsABorC = formData =>
   (hasMedicare(formData) && hasPartsAB(formData)) || hasPartC(formData);
 
 export const hasPartD = formData =>
-  hasMedicare(formData) && hasPartsABorC(formData) && formData.hasMedicarePartD;
+  hasMedicare(formData) &&
+  hasPartsABorC(formData) &&
+  formData.medicarePartDStatus;
 
 export const needsPartADenialNotice = formData =>
   hasPartB(formData) ||


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the logic used to determine Medicare Part D status in the app. The main change is a shift from checking for specific Medicare parts (A, B, or C) to a broader check for any Medicare coverage, which simplifies and clarifies eligibility logic.


## Related issue(s)

department-of-veterans-affairs/va.gov-team#130238

## Testing done

- Prior to the change, the Medicare Part D question would render if you indicate you have Medicare Parts A & B or Medicare Part C.
- After the change, the Medicare Part D question will render for ALL Medicare plan types.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Medicare Part D question renders for any Medicare plan type

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
