### PR TITLE
10-10dx | Require Medicare Part D for all plan types

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -79,7 +79,6 @@ const hasPartC = ({ medicare }, index) =>
 const hasPartsABorC = (formData, index) =>
   hasPartsAB(formData, index) || hasPartC(formData, index);
 const hasPartD = (formData, index) =>
-  hasPartsABorC(formData, index) &&
   formData.medicare?.[index]?.hasMedicarePartD;
 
 export const medicareOptions = {

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -804,7 +804,6 @@ export const medicarePages = arrayBuilderPages(
     medicarePartDStatus: pageBuilder.itemPage({
       path: 'medicare-part-d-status/:index',
       title: 'Medicare Part D status',
-      depends: hasPartsABorC,
       ...medicarePartDStatusPage,
     }),
     medicarePartDCarrierEffectiveDate: pageBuilder.itemPage({

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/ohi.medicare.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/ohi.medicare.json
@@ -79,7 +79,8 @@
             "name": "sample.png",
             "isEncrypted": false
           }
-        ]
+        ],
+        "hasMedicarePartD": false
       }
     ],
     "view:hasHealthInsurance": false,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR makes a small change to the `medicareInformation.js` file. The change removes the `depends: hasPartsABorC` condition from the `medicarePartDStatus` page configuration.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#130237

## Testing done

- Prior to the change, the Medicare Part D question would render if you indicate you have Medicare Parts A & B or Medicare Part C.
- After the change, the Medicare Part D question will render for ALL Medicare plan types.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Medicare Part D question renders for any Medicare plan type

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
