### PR TITLE
Add navigator.platform to before hook and added cleanup to after hoo…

### DIFF
--- a/src/platform/pdf/test/pdf.unit.spec.jsx
+++ b/src/platform/pdf/test/pdf.unit.spec.jsx
@@ -34,6 +34,12 @@ const blobToArrayBuffer = blob => {
 
 describe('PDF generation API', () => {
   before(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: '',
+      writable: true,
+      configurable: true,
+    });
+
     fileSaverMock = sinon.stub(fileSaver, 'saveAs').returns('foo');
   });
   after(() => {

--- a/src/platform/pdf/test/pdf.unit.spec.jsx
+++ b/src/platform/pdf/test/pdf.unit.spec.jsx
@@ -12,6 +12,10 @@ const { expect } = chai;
 // Workaround for pdf.js incompatibility.
 // cf. https://github.com/mozilla/pdf.js/issues/15728
 const originalPlatform = navigator.platform;
+Object.defineProperty(navigator, 'platform', {
+  value: 'Linux',
+  configurable: true,
+});
 const pdfjs = require('pdfjs-dist/legacy/build/pdf');
 
 let fileSaverMock = {};

--- a/src/platform/pdf/test/pdf.unit.spec.jsx
+++ b/src/platform/pdf/test/pdf.unit.spec.jsx
@@ -12,10 +12,8 @@ const { expect } = chai;
 // Workaround for pdf.js incompatibility.
 // cf. https://github.com/mozilla/pdf.js/issues/15728
 const originalPlatform = navigator.platform;
-Object.defineProperty(navigator, 'platform', {
-  value: 'Linux',
-  configurable: true,
-});
+navigator.platform = '';
+
 const pdfjs = require('pdfjs-dist/legacy/build/pdf');
 
 let fileSaverMock = {};
@@ -41,7 +39,6 @@ describe('PDF generation API', () => {
       writable: true,
       configurable: true,
     });
-
     fileSaverMock = sinon.stub(fileSaver, 'saveAs').returns('foo');
   });
   after(() => {
@@ -50,7 +47,6 @@ describe('PDF generation API', () => {
       writable: true,
       configurable: true,
     });
-
     fileSaverMock.restore();
   });
 

--- a/src/platform/pdf/test/pdf.unit.spec.jsx
+++ b/src/platform/pdf/test/pdf.unit.spec.jsx
@@ -12,8 +12,6 @@ const { expect } = chai;
 // Workaround for pdf.js incompatibility.
 // cf. https://github.com/mozilla/pdf.js/issues/15728
 const originalPlatform = navigator.platform;
-navigator.platform = '';
-
 const pdfjs = require('pdfjs-dist/legacy/build/pdf');
 
 let fileSaverMock = {};
@@ -34,10 +32,22 @@ const blobToArrayBuffer = blob => {
 
 describe('PDF generation API', () => {
   before(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: '',
+      writable: true,
+      configurable: true,
+    });
+
     fileSaverMock = sinon.stub(fileSaver, 'saveAs').returns('foo');
   });
   after(() => {
-    navigator.platform = originalPlatform;
+    Object.defineProperty(navigator, 'platform', {
+      value: originalPlatform,
+      writable: true,
+      configurable: true,
+    });
+
+    fileSaverMock.restore();
   });
 
   describe('Template selection', () => {

--- a/src/platform/pdf/test/pdf.unit.spec.jsx
+++ b/src/platform/pdf/test/pdf.unit.spec.jsx
@@ -34,20 +34,10 @@ const blobToArrayBuffer = blob => {
 
 describe('PDF generation API', () => {
   before(() => {
-    Object.defineProperty(navigator, 'platform', {
-      value: '',
-      writable: true,
-      configurable: true,
-    });
     fileSaverMock = sinon.stub(fileSaver, 'saveAs').returns('foo');
   });
   after(() => {
-    Object.defineProperty(navigator, 'platform', {
-      value: originalPlatform,
-      writable: true,
-      configurable: true,
-    });
-    fileSaverMock.restore();
+    navigator.platform = originalPlatform;
   });
 
   describe('Template selection', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates a unit test workaround for pdfjs-dist to comply with stricter property semantics enforced in Node 22.
- Prior implementation attempted to assign directly to navigator.platform, which is no longer writable in modern Node/jsdom environments.
- The test now uses Object.defineProperty with explicit writable and configurable descriptors to safely override and restore navigator.platform during setup and teardown.

## Related issue(s)

- _[Platform Support Ticket](https://dsva.slack.com/archives/CBU0KDSB1/p1768510574783209)_


## Testing done

- _Spec passes local runs, CI run, and node 22 compatibility check._

## What areas of the site does it impact?

*These changes only affect our testing infrastructure*
