### PR TITLE
Fix returnUrl `:index` in select

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -21,7 +21,13 @@ const checkHash = () => {
 
 const getAvailablePaths = (pageList, data) =>
   getActivePages(pageList, data)
-    .map(page => page.path)
+    .map(
+      page =>
+        // Include '?edit=true' to allow entering array builder pages
+        page.path.includes('/:index')
+          ? `${page.path.replace('/:index', '/0')}?edit=true`
+          : page.path,
+    )
     // remove introduction page (it'll cause an endless loop if selected)
     .slice(1);
 
@@ -137,7 +143,7 @@ const SipsDevModal = props => {
               {availablePaths &&
                 availablePaths.map(path => (
                   <option key={path} value={path}>
-                    {path}
+                    {path.replace('?edit=true', '')}
                   </option>
                 ))}
             </VaSelect>
@@ -160,6 +166,7 @@ const SipsDevModal = props => {
       <va-link
         key={showLink}
         class="vads-u-margin-left--2"
+        href="#"
         onClick={handlers.openSipsModal}
         icon-name="settings"
         text="Open save-in-progress menu"

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -30,6 +30,7 @@ describe('Schemaform <SipsDevModal>', () => {
       { path: '/introduction' },
       { path: '/page-1' },
       { path: '/page-2' },
+      { path: '/page-3/:index/test' },
       { path: 'review-and-submit' },
     ],
   };
@@ -147,6 +148,35 @@ describe('Schemaform <SipsDevModal>', () => {
       version: 1,
       data: newData.data,
       sipsUrl: '/page-2',
+    });
+    // Modal closed
+    expect(dom.querySelector('va-modal')).to.be.null;
+  });
+
+  it('should go to indexed page in return url', () => {
+    setLoc();
+    const data = cloneDeep(props);
+    let result = {};
+    const updateResult = (formId, modData, version, sipsUrl) => {
+      result = { formId, data: modData, version, sipsUrl };
+    };
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...data} saveAndRedirectToReturnUrl={updateResult} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    // open the sips modal
+    dom.click('va-link[icon-name="settings"]');
+    const vaSelect = dom.querySelector('va-select');
+    vaSelect.__events.vaSelect({ target: { value: '/page-3/0/test' } });
+    // Update button
+    dom.click('va-button[text="Update"]');
+    expect(result).to.deep.equal({
+      formId: 'test',
+      version: 1,
+      data: {},
+      sipsUrl: '/page-3/0/test',
     });
     // Modal closed
     expect(dom.querySelector('va-modal')).to.be.null;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Currently the [save-in-progress menu](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-use-the-save-in-progress-m) has a "Return url" select that will include un-processed paths within an array build list loop - it will display `/:index` in the path. This PR replaces the placeholder with a zero index. It may not be easy to correlate the form data with the page 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/130274

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| SiP menu | <img width="563" height="386" alt="Screenshot 2026-01-13 at 11 55 49 AM" src="https://github.com/user-attachments/assets/8a47e943-e9a4-4bc4-be59-29a3ebfdb6fe" /> | <img width="536" height="637" alt="Screenshot 2026-01-16 at 8 28 54 AM" src="https://github.com/user-attachments/assets/507d0204-809e-44d8-a9b6-845d08f66f57" /> |

## What areas of the site does it impact?

All forms, and whomever uses the save-in-progress menu

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
