### PR TITLE
Added E2E Tests to Verify ACR Values

### DIFF
--- a/src/applications/verify/tests/e2e/verify.cypress.spec.js
+++ b/src/applications/verify/tests/e2e/verify.cypress.spec.js
@@ -67,6 +67,34 @@ describe('Verify App', () => {
     cy.get('.idme-verify-button').should('not.exist');
   });
 
+  it('should have an acr value of "ial2" when the Login.gov verify button is clicked', () => {
+    cy.intercept('GET', '/v0/sign_in/authorize*', req => {
+      expect(req.query.acr).to.equal('ial2');
+    }).as('verifyRequest');
+
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.get('.logingov-verify-button').should('exist');
+    cy.get('.logingov-verify-button').click();
+
+    cy.wait('@verifyRequest');
+  });
+
+  it('should have an acr value of "loa3" when the ID.me verify button is clicked', () => {
+    cy.intercept('GET', '/v0/sign_in/authorize*', req => {
+      expect(req.query.acr).to.equal('loa3');
+    }).as('verifyRequest');
+
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.get('.idme-verify-button').should('exist');
+    cy.get('.idme-verify-button').click();
+
+    cy.wait('@verifyRequest');
+  });
+
   it('should show success message for a verified ID.me user', () => {
     const mockUser = createMockUser({
       verified: true,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added E2E tests to the Verify app to confirm that the correct acr values are used for each CSP button.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1015)

## Testing done
- Added tests to `src/applications/verify/tests/e2e/verify.cypress.spec.js`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn cy:run --spec src/applications/verify/tests/e2e/verify.cypress.spec.js`.

## What areas of the site does it impact?
This only impacts the Verify tests.

## Acceptance criteria
- [x] Add E2E tests to Verify app to confirm correct acr value usage.