### PR TITLE
ARP - Hide edit buttons on ITF review screen

### DIFF
--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -225,6 +225,12 @@
 }
 
 .form-21-0966 {
+  .form-review-panel-page-header-row {
+    va-button[text="Edit"] {
+      display: none;
+    }
+  }
+
   .form-review-panel-page {
     div[name="veteranInformationPageScrollElement"] {
       display: none;

--- a/src/applications/representative-form-upload/tests/e2e/itf.cypress.spec.js
+++ b/src/applications/representative-form-upload/tests/e2e/itf.cypress.spec.js
@@ -257,6 +257,10 @@ describe('Intent to file submission', () => {
           'eq',
           `/representative/representative-form-upload/submit-va-form-21-0966/review-and-submit`,
         );
+        cy.get("button[data-testid='expand-all-accordions']").click();
+
+        // hide the edit button that could cause issues with submission
+        cy.get("va-button[text='Edit']").should('be.hidden');
 
         cy.get("va-button[text='Submit form']").click();
         cy.axeCheck();
@@ -318,6 +322,9 @@ describe('Intent to file submission', () => {
           'eq',
           '/representative/representative-form-upload/submit-va-form-21-0966/review-and-submit',
         );
+
+        // hide the edit button that could cause issues with submission
+        cy.get("va-button[text='Edit']").should('be.hidden');
 
         cy.get("va-button[text='Submit form']").click();
         cy.location('pathname').should(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Hide edit buttons on review screen to avoid issues that could arise when info is changed after the ITF check.

## Related issue(s)

[QA Finding: Review "Edit" buttons should link to the form page (no edit on Review page) ](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129528)

## Testing done

Tested locally, e2e test updated.

## Screenshots

Veteran flow 
<img width="683" height="716" alt="Screenshot 2026-01-16 at 15 36 02" src="https://github.com/user-attachments/assets/3564b239-8f0a-4c1f-8318-5f4ce21f0b86" />

Non-veteran flow
<img width="704" height="724" alt="Screenshot 2026-01-16 at 15 36 30" src="https://github.com/user-attachments/assets/083af96d-98ad-487c-bfd1-bd7863aa74ed" />

## What areas of the site does it impact?

n/a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
