### PR TITLE
123819 BIO - Remove extra line breaks on intro page - form 21P-601

### DIFF
--- a/src/applications/simple-forms/21P-601/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21P-601/containers/IntroductionPage.jsx
@@ -60,7 +60,6 @@ const childContent = (
         don’t submit this form. You can check the status of your current claim
         instead.
         <br />
-        <br />
         <va-link href="/track-claims/" text="Check the status of your claim" />
       </li>
       <li>
@@ -71,7 +70,6 @@ const childContent = (
         you’ll need to use the PDF version of this form. You’ll apply as an
         unpaid creditor. This will allow you to collect signatures from other
         creditors. You’ll apply as an unpaid creditor.
-        <br />
         <br />
         <va-link
           href="https://www.vba.va.gov/pubs/forms/VBA-21P-601-ARE.pdf"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR removes some extra line breaks that were impacting the scanability of the bulleted list on form 21P-601's intro page.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123819

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Intro page |<img width="650" height="326" alt="before" src="https://github.com/user-attachments/assets/9cc010fe-820a-48d0-8e97-2ca85afb3863" />|<img width="616" height="272" alt="after" src="https://github.com/user-attachments/assets/264abb0c-c35d-483c-a445-5959ab4ac303" />|

## What areas of the site does it impact?

```
src/applications/simple-forms/21P-601/containers/IntroductionPage.jsx
```

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
