### PR TITLE
fix(mhv-secure-messaging): add curated list flow toggle to move message test

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-on-reply-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-on-reply-draft.cypress.spec.js
@@ -17,6 +17,10 @@ describe('SM DELETE REPLY DRAFT', () => {
       name: 'mhv_secure_messaging_custom_folders_redesign',
       value: false,
     },
+    {
+      name: 'mhv_secure_messaging_curated_list_flow',
+      value: false,
+    },
   ]);
   it('verify user can delete draft on reply', () => {
     SecureMessagingSite.login(updatedFeatureToggles);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Add explicit `mhv_secure_messaging_curated_list_flow: false` toggle to the move message on reply draft Cypress test
- The test was failing intermittently because it relied on the toggle being `undefined` (falsy) rather than explicitly `false`
- This caused flaky behavior due to timing differences in feature toggle loading - faster execution (e.g., Node 22) can expose this race condition where the component renders before toggles are loaded
- MHV Secure Messaging team

## Related issue(s)

- Discovered during Node 22 upgrade testing

## Testing done

- Verified the test passes with the explicit toggle setting
- The change is additive and only affects test behavior, not production code
- Before: Test relied on `undefined` being falsy for `mhv_secure_messaging_curated_list_flow`
- After: Test explicitly sets the toggle to `false`, ensuring consistent behavior

## Screenshots

N/A - Test-only change, no UI modifications

## What areas of the site does it impact?

Only affects the Cypress E2E test for secure messaging move message functionality. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix)
- [x] Screenshot of the developed feature is added (N/A - test fix)
- [x] Accessibility testing has been performed (N/A - test fix)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)