### PR TITLE
[ARC/129609] - updating error message for bad pattern check on va file number

### DIFF
--- a/src/applications/representative-form-upload/pages/itfClaimantInformation.jsx
+++ b/src/applications/representative-form-upload/pages/itfClaimantInformation.jsx
@@ -59,6 +59,9 @@ const veteranSubPageUI = {
   vaFileNumber: {
     ...vaFileNumberUI,
     'ui:title': 'VA file number',
+    'ui:errorMessages': {
+      pattern: 'Your VA file number must be 8 or 9 digits',
+    },
   },
   selectBenefits: checkboxGroupUI({
     title: 'Select the benefit you intend to file a claim for',

--- a/src/applications/representative-form-upload/pages/itfVeteranInformation.jsx
+++ b/src/applications/representative-form-upload/pages/itfVeteranInformation.jsx
@@ -46,6 +46,9 @@ export const itfVeteranInformationPage = {
     vaFileNumber: {
       ...vaFileNumberUI,
       'ui:title': 'VA file number',
+      'ui:errorMessages': {
+        pattern: 'Your VA file number must be 8 or 9 digits',
+      },
     },
     benefitType: radioUI({
       title: 'Select the benefit you intend to file a claim for',


### PR DESCRIPTION
updating error message for bad pattern on va file number, see ticket:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/129609

<img width="1086" height="394" alt="Screenshot 2026-01-20 at 11 15 18 AM" src="https://github.com/user-attachments/assets/c5413078-0e49-4228-82e9-a47d430c3968" />
<img width="1077" height="617" alt="Screenshot 2026-01-20 at 11 14 59 AM" src="https://github.com/user-attachments/assets/fc7079fa-0ec4-4424-924d-694b7b22d8a3" />
