### PR TITLE
fix(devcontainer): Update for Codespaces compatibility and Node version support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/javascript-node/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/tree/main/src/javascript-node
 
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT="14-buster"
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+# Base image includes nvm for managing multiple Node versions
+ARG VARIANT="22-bookworm"
+FROM mcr.microsoft.com/devcontainers/javascript-node:${VARIANT}
 
 # default case is Jenkins, but we want to be able to overwrite this
 ARG userid=504
@@ -10,28 +10,64 @@ RUN groupadd -g $userid vets-website \
   && useradd -u $userid -r -m -d /application -g vets-website vets-website
 
 ENV YARN_VERSION 1.22.19
-ENV NODE_ENV production
+
+# Install Node 14.15.0 (main branch) and Node 22.22.0 (update branch), set Node 14.15.0 as default
+# Use nvm which is pre-installed in the devcontainer base image
+# Also fix permissions so the node user can install additional versions if needed
+RUN bash -c "source /usr/local/share/nvm/nvm.sh && nvm install 14.15.0 && nvm install 22.22.0 && nvm alias default 14.15.0 && nvm use default" \
+    && chmod -R 777 /usr/local/share/nvm/.cache
 
 RUN apt-get update
 
-# Install specific version of Chrome to match ChromeDriver installation.
-ENV CHROME_VERSION 91.0.4472.101-1
-RUN curl -L "https://github.com/webnicer/chrome-downloads/raw/master/x64.deb/google-chrome-stable_${CHROME_VERSION}_amd64.deb" -o "google-chrome.deb"
-RUN dpkg -i google-chrome.deb || apt-get -f -y install
-
-RUN apt-get install -y --no-install-recommends gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
-                                                                 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 \
-                                                                 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
-                                                                 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 \
-                                                                 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-                                                                 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
-                                                libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-                                                fonts-liberation libnss3 lsb-release xdg-utils \
-                                                x11vnc x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable \
-                                                xfonts-cyrillic x11-apps xvfb xauth netcat dumb-init libgbm-dev \
-                                                && wget http://http.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator1_0.4.92-7_amd64.deb -O /tmp/libappindicator1_0.4.92-7_amd64.deb \
-                                                && wget http://http.us.debian.org/debian/pool/main/libi/libindicator/libindicator7_0.5.0-4_amd64.deb -O /tmp/libindicator7_0.5.0-4_amd64.deb \
-                                                && apt-get install -y  /tmp/libindicator7_0.5.0-4_amd64.deb /tmp/libappindicator1_0.4.92-7_amd64.deb
+# Install dependencies for Chrome/Cypress
+RUN apt-get install -y --no-install-recommends \
+    libasound2 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm-dev \
+    libgcc1 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    ca-certificates \
+    fonts-liberation \
+    lsb-release \
+    xdg-utils \
+    x11vnc \
+    x11-xkb-utils \
+    xfonts-100dpi \
+    xfonts-75dpi \
+    xfonts-scalable \
+    x11-apps \
+    xvfb \
+    xauth \
+    netcat-openbsd \
+    dumb-init \
+    wget
 
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
 RUN chmod +x /cc-test-reporter

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "14"
+			"VARIANT": "22-bookworm"
 		}
 	},
+	// Node 14 is default, switch to Node 22 with: nvm use 22
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2":{},
 		"ghcr.io/devcontainers/features/desktop-lite:1": {
@@ -55,6 +56,9 @@
 	],
 	"postCreateCommand": "./.devcontainer/codespaces-create.sh",
 	"postStartCommand": "./.devcontainer/codespaces-start.sh",
+	"remoteEnv": {
+		"NODE_ENV": "development"
+	},
 	"remoteUser": "node",
 	"hostRequirements": {
 		"cpus": 16,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### TeamSites
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updates the devcontainer configuration to work correctly in GitHub Codespaces
- Fixes `yarn install-safe` failing with `husky: not found` error due to `NODE_ENV=production` being set
- Updates base image from deprecated `mcr.microsoft.com/vscode/devcontainers` to current `mcr.microsoft.com/devcontainers`
- Installs both Node 14.15.0 (main branch) and Node 22.22.0 (for Node upgrade work) via nvm
- Removes deprecated packages that no longer exist in Debian Bookworm
- Removes hardcoded Chrome installation (Cypress bundles its own browser)
- Fixes nvm cache permissions so the node user can install additional Node versions

## Related issue(s)

- Related to Node 22 upgrade work in department-of-veterans-affairs/vets-website#41426

## Testing done

- Rebuilt Codespaces container successfully
- Verified `yarn install-safe` completes without errors
- Verified both Node versions available via `nvm use 14.15.0` and `nvm use 22.22.0`

## Screenshots

N/A - Infrastructure/devcontainer changes only

## What areas of the site does it impact?

This only affects the GitHub Codespaces development environment. No production code is changed.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). - N/A, infrastructure change
- [x] No sensitive information is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed - N/A
- [x] Documentation has been updated - Comments added in devcontainer.json
- [x] Screenshot of the developed feature is added - N/A
- [x] Accessibility testing has been performed - N/A

### Error Handling

- [x] Browser console contains no warnings or errors - N/A
- [x] Events are being sent to the appropriate logging solution - N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana - N/A