### PR TITLE
ARP: ITF - re-wrap null checker

### DIFF
--- a/src/applications/representative-form-upload/helpers/intent-to-file-helper.jsx
+++ b/src/applications/representative-form-upload/helpers/intent-to-file-helper.jsx
@@ -48,10 +48,10 @@ const fetchIntentToFile = async (
   } catch (error) {
     const { status } = error?.errors?.[0] ?? {};
     if (
-      (error.errors &&
-        (typeof error.errors[0] === 'string' &&
-          error.errors[0].match(/^not allowed/))) ||
-      (typeof error.errors[0] === 'object' && error.errors[0].code === '400')
+      error.errors &&
+      ((typeof error.errors[0] === 'string' &&
+        error.errors[0].match(/^not allowed/)) ||
+        (typeof error.errors[0] === 'object' && error.errors[0].code === '400'))
       // handle no representation or cannot find ICN
     ) {
       goPath(`${urlPrefix}intent-to-file-no-representation`);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Re-wrap null check so it handles both error cases

## Related issue(s)

[Error not handled when blocking network request in ITF #130443](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130443)


## Testing done

Tested locally

## Screenshots

<img width="558" height="575" alt="Screenshot 2026-01-20 at 12 20 32" src="https://github.com/user-attachments/assets/e57319d4-0611-424f-9bbe-a961c3fd7023" />

## What areas of the site does it impact?

n/a


