### PR TITLE
fix(itf): use mockMultipleApiRequests for multi-call tests

### DIFF
--- a/src/platform/shared/itf/tests/IntentToFile.unit.spec.jsx
+++ b/src/platform/shared/itf/tests/IntentToFile.unit.spec.jsx
@@ -3,7 +3,10 @@ import { render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
 
-import { mockApiRequest } from 'platform/testing/unit/helpers';
+import {
+  mockApiRequest,
+  mockMultipleApiRequests,
+} from 'platform/testing/unit/helpers';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import IntentToFile from '../IntentToFile';
 import { activeItf, nonActiveItf, mockItfData } from './helpers';
@@ -79,7 +82,11 @@ describe('IntentToFile', () => {
   });
 
   it('should render ITF created alert', async () => {
-    mockApiRequest(mockItfData(nonActiveItf));
+    // First call: fetch ITF returns non-active, Second call: create ITF succeeds
+    mockMultipleApiRequests([
+      { response: mockItfData(nonActiveItf), shouldResolve: true },
+      { response: mockItfData(activeItf), shouldResolve: true },
+    ]);
     const { container } = renderPage(getData());
 
     await waitFor(() => {
@@ -91,7 +98,11 @@ describe('IntentToFile', () => {
   });
 
   it('should render ITF failed alert', async () => {
-    mockApiRequest(mockItfData(), false);
+    // First call: fetch ITF fails, Second call: create ITF also fails
+    mockMultipleApiRequests([
+      { response: mockItfData(), shouldResolve: false },
+      { response: mockItfData(), shouldResolve: false },
+    ]);
     const { container } = renderPage(getData());
 
     await waitFor(() => {
@@ -173,7 +184,11 @@ describe('IntentToFile', () => {
   });
 
   it('should not autofocus ITF created alert when disableAutoFocus is true and new ITF is created', async () => {
-    mockApiRequest(mockItfData(nonActiveItf));
+    // First call: fetch ITF returns non-active, Second call: create ITF succeeds
+    mockMultipleApiRequests([
+      { response: mockItfData(nonActiveItf), shouldResolve: true },
+      { response: mockItfData(activeItf), shouldResolve: true },
+    ]);
     const { props, mockStore } = getData();
     const { container } = render(
       <Provider store={mockStore}>
@@ -189,12 +204,16 @@ describe('IntentToFile', () => {
     });
   });
 
-  it('should not autofocus ITF failed alert when disableAutoFocus is true and ITF lookup fails', () => {
-    mockApiRequest(mockItfData(), false);
+  it('should not autofocus ITF failed alert when disableAutoFocus is true and ITF lookup fails', async () => {
+    // First call: fetch ITF fails, Second call: create ITF also fails
+    mockMultipleApiRequests([
+      { response: mockItfData(), shouldResolve: false },
+      { response: mockItfData(), shouldResolve: false },
+    ]);
     const { container } = renderPage(getData());
 
-    waitFor(() => {
-      expect($('va-alert[status="success"]', container).textContent).to.include(
+    await waitFor(() => {
+      expect($('va-alert[status="warning"]', container).textContent).to.include(
         'We’re sorry. We can’t find a record of your intent to file',
       );
       expect(document.activeElement?.tagName).to.not.equal('VA-ALERT');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed flaky IntentToFile unit tests that were failing in CI on the Node 22 upgrade branch
- Tests for ITF creation and ITF failure scenarios require multiple sequential API calls, but were using `mockApiRequest` which only mocks a single response
- Solution: Use `mockMultipleApiRequests` to properly mock the two-call flow (fetch ITF, then create ITF)
- Also fixed a bug in the last test where missing `async/await` caused assertions to never actually run (false positive)
- Platform shared code, maintenance fix

### Why multiple API calls?

In [`src/platform/shared/itf/IntentToFile.jsx`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/shared/itf/IntentToFile.jsx#L131-L168), the `useEffect` runs multiple times due to `localItf` being in the dependency array:

1. **First effect run** ([line 136-141](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/shared/itf/IntentToFile.jsx#L136-L141)): When `message` is falsy, `getAndProcessItf()` is called and `setLocalItf()` updates state
2. **Second effect run** ([line 142-165](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/shared/itf/IntentToFile.jsx#L142-L165)): After `localItf` updates, if `message === 'fetch-itf'` and no active ITF exists, `createItf()` is called

So for "ITF created" and "ITF failed" scenarios, two API calls occur across two effect executions. Using `mockMultipleApiRequests` makes this explicit.

## Related issue(s)

- Related to Node 22 upgrade: department-of-veterans-affairs/vets-website#41426

## Testing done

- **Old behavior**: Tests were flaky in CI - the `waitFor` would timeout because the mock was not correctly handling the multi-call async flow
- **Steps to verify**: 
  1. Run `yarn test:unit src/platform/shared/itf/tests/IntentToFile.unit.spec.jsx`
  2. All 11 tests should pass
- **Tests completed**: All unit tests pass locally (11 passing)
- **Note on async/await fix**: The last test was missing `async/await` on the `waitFor` call, meaning the Promise was orphaned and assertions never ran. This was a false positive that now correctly executes.

## Screenshots

N/A - Unit test changes only, no UI changes

## What areas of the site does it impact?

This only impacts unit tests for the shared ITF (Intent to File) component. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test only)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

None