### PR TITLE
Removed DS Logon from USiP Configs

### DIFF
--- a/src/platform/user/authentication/config/dev.config.js
+++ b/src/platform/user/authentication/config/dev.config.js
@@ -4,7 +4,6 @@ import {
   EXTERNAL_REDIRECTS_ALT,
 } from '../constants';
 import {
-  legacySignInProviders,
   defaultSignInProviders,
   defaultMobileQueryParams,
   defaultWebOAuthOptions,
@@ -15,7 +14,6 @@ import {
 export default {
   default: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: true,
@@ -28,7 +26,6 @@ export default {
   },
   [EXTERNAL_APPS.MHV]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: false,
@@ -41,7 +38,6 @@ export default {
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: false,
@@ -55,7 +51,6 @@ export default {
   },
   [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
@@ -68,7 +63,6 @@ export default {
       idme: true,
       logingov: true,
     },
-    legacySignInProviders,
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: false,
@@ -80,9 +74,6 @@ export default {
     allowedSignInProviders: {
       idme: true,
       logingov: true,
-    },
-    legacySignInProviders: {
-      dslogon: false,
     },
     isMobile: false,
     queryParams: {
@@ -99,9 +90,6 @@ export default {
     allowedSignInProviders: {
       idme: true,
       logingov: true,
-    },
-    legacySignInProviders: {
-      dslogon: false,
     },
     isMobile: false,
     queryParams: {

--- a/src/platform/user/authentication/config/prod.config.js
+++ b/src/platform/user/authentication/config/prod.config.js
@@ -4,7 +4,6 @@ import {
   EXTERNAL_REDIRECTS_ALT,
 } from '../constants';
 import {
-  legacySignInProviders,
   defaultSignInProviders,
   defaultMobileQueryParams,
   defaultWebOAuthOptions,
@@ -15,7 +14,6 @@ import {
 export default {
   default: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: true,
@@ -28,7 +26,6 @@ export default {
   },
   [EXTERNAL_APPS.MHV]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: false,
@@ -41,7 +38,6 @@ export default {
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: false,
@@ -55,7 +51,6 @@ export default {
   },
   [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
@@ -68,7 +63,6 @@ export default {
       idme: true,
       logingov: true,
     },
-    legacySignInProviders,
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: false,
@@ -80,9 +74,6 @@ export default {
     allowedSignInProviders: {
       idme: true,
       logingov: true,
-    },
-    legacySignInProviders: {
-      dslogon: false,
     },
     isMobile: false,
     queryParams: {
@@ -102,9 +93,6 @@ export default {
     allowedSignInProviders: {
       idme: true,
       logingov: true,
-    },
-    legacySignInProviders: {
-      dslogon: false,
     },
     isMobile: false,
     queryParams: {

--- a/src/platform/user/authentication/config/staging.config.js
+++ b/src/platform/user/authentication/config/staging.config.js
@@ -4,7 +4,6 @@ import {
   EXTERNAL_REDIRECTS_ALT,
 } from '../constants';
 import {
-  legacySignInProviders,
   defaultSignInProviders,
   defaultMobileQueryParams,
   defaultWebOAuthOptions,
@@ -15,7 +14,6 @@ import {
 export default {
   default: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: true,
@@ -28,7 +26,6 @@ export default {
   },
   [EXTERNAL_APPS.MHV]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: false,
@@ -41,7 +38,6 @@ export default {
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: false,
     queryParams: {
       allowOAuth: false,
@@ -55,7 +51,6 @@ export default {
   },
   [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: {
     allowedSignInProviders: { ...defaultSignInProviders },
-    legacySignInProviders,
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
@@ -68,7 +63,6 @@ export default {
       idme: true,
       logingov: true,
     },
-    legacySignInProviders,
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: false,
@@ -80,10 +74,6 @@ export default {
     allowedSignInProviders: {
       idme: true,
       logingov: true,
-    },
-    legacySignInProviders: {
-      mhv: false,
-      dslogon: false,
     },
     isMobile: false,
     queryParams: {
@@ -103,9 +93,6 @@ export default {
     allowedSignInProviders: {
       idme: true,
       logingov: true,
-    },
-    legacySignInProviders: {
-      dslogon: false,
     },
     isMobile: false,
     queryParams: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed DS Logon and `legacySignInProviders` references from USiP Configs.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/298)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/platform/user/tests/**/**/**/*.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts the USiP Configs.

## Acceptance criteria
- [x] Remove DS Logon from USIP Configs