### PR TITLE
534ez move info box below dependent count field

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsCount.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsCount.js
@@ -16,22 +16,31 @@ export default {
         max: 99,
       }),
     },
-    'ui:description': (
-      <va-additional-info trigger="Who we consider a dependent child">
-        <p>
-          In most circumstances, children over the age of 23 aren’t considered
-          dependent for VA purposes, unless the child is determined to be
-          seriously disabled based on a condition that started before turning
-          18.
-        </p>
-      </va-additional-info>
-    ),
+    'view:dependentChildInfo': {
+      'ui:description': (
+        <va-additional-info trigger="Who we consider a dependent child">
+          <p>
+            In most circumstances, children over the age of 23 aren’t considered
+            dependent for VA purposes, unless the child is determined to be
+            seriously disabled based on a condition that started before turning
+            18.
+          </p>
+        </va-additional-info>
+      ),
+      'ui:options': {
+        displayEmptyObjectOnReview: true,
+      },
+    },
   },
   schema: {
     type: 'object',
     required: ['veteranChildrenCount'],
     properties: {
       veteranChildrenCount: numberSchema,
+      'view:dependentChildInfo': {
+        type: 'object',
+        properties: {},
+      },
     },
   },
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Move the additional info from the page description to a view description under the field

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130426

## Testing done

- manual testing

## Screenshots
<img width="666" height="502" alt="Screenshot 2026-01-20 at 1 37 58 PM" src="https://github.com/user-attachments/assets/3dc61e01-c275-4234-b883-000fa9a58f69" />


## What areas of the site does it impact?

The dependent count page of the 534ez.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
