### PR TITLE
fix grammatical error in earnings and loss

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
@@ -35,11 +35,8 @@ const getTypeOfWorkTitle = formData => {
 const getAmountEarnedTitle = formData => {
   if (!formData || typeof formData !== 'object') return 'Amount earned';
   const veteranName = getVeteranName(formData);
-  const tense = getEmploymentTense(formData);
   const timeframe = getEmploymentTimeframe(formData);
-  return `How much ${
-    tense.does
-  } ${veteranName} earn in the ${timeframe} (before deductions)?`;
+  return `How much did ${veteranName} earn in the ${timeframe} (before deductions)?`;
 };
 
 /**
@@ -49,11 +46,8 @@ const getTimeLostTitle = formData => {
   if (!formData || typeof formData !== 'object')
     return 'Time lost to disability';
   const veteranName = getVeteranName(formData);
-  const tense = getEmploymentTense(formData);
   const timeframe = getEmploymentTimeframe(formData);
-  return `How many hours ${
-    tense.does
-  } ${veteranName} lose to disability in the ${timeframe}?`;
+  return `How many hours did ${veteranName} lose to disability in the ${timeframe}?`;
 };
 
 /**


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Form 21-4192 - Grammar Correction for Past Tense Questions**
- Fixed verb tense in two questions on the Employment Earnings and Hours page
- Changed "does...earn" to "did...earn" and "does...lose" to "did...lose" when referring to "the last 12 months"
- Questions about past time periods should use past tense verbs regardless of current employment status
- Team: Benefits Optimization - Aquia
- No flipper required

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129839

## Testing done

- **Old behavior**: 
  - "How much **does** [NAME] earn in the last 12 months (before deductions)?"
  - "How many hours **does** [NAME] lose to disability in the last 12 months?"
  - Incorrect grammar - present tense verbs used with past time period
  
- **New behavior**: 
  - "How much **did** [NAME] earn in the last 12 months (before deductions)?"
  - "How many hours **did** [NAME] lose to disability in the last 12 months?"
  - Correct grammar - past tense verbs used with past time period
  
- **Verification steps**:
  1. Navigate to Form 21-4192 in local environment
  2. Complete form through to Employment Earnings and Hours page
  3. Verify both questions now use "did" (past tense)
  4. Test with both scenarios:
     - Veteran currently employed (no end date) → Still shows "did" for past 12 months questions
     - Veteran no longer employed (has end date) → Still shows "did" for past 12 months questions
  5. Verify other questions on the page remain in appropriate tense (daily/weekly hours use present/past based on employment status)
  
- **Tests completed**: E2E tests passing, no test updates required as tests don't assert on field label text

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    <img width="578" height="249" alt="image" src="https://github.com/user-attachments/assets/25cdea8e-6cd7-48d6-8c4e-c353d899c470" />    |    <img width="615" height="548" alt="image" src="https://github.com/user-attachments/assets/52a69bc0-d5c9-4e2d-a1b4-8efb7024bf61" />   |

## What areas of the site does it impact?

**Form 21-4192 (Request for Employment Information)**
- Employment Earnings and Hours page - two question labels

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). - No test updates needed
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary) - N/A, text change only
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - No accessibility impact, text change only

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - N/A, no logging changes
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Grammar fix: Questions referring to "the last 12 months" (a completed past time period) should use past tense verbs "did" rather than present tense "does". This applies regardless of whether the veteran is currently employed or terminated, since "the last 12 months" is always a past timeframe.