### PR TITLE
MHV SM: blocked TG alert refactor

### DIFF
--- a/src/applications/mhv-secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
@@ -1,315 +1,156 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import { datadogRum } from '@datadog/browser-rum';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import { VaLinkAction } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   BlockedTriageAlertStyles,
-  BlockedTriageAlertText,
   ParentComponent,
-  RecipientStatus,
   Recipients,
 } from '../../util/constants';
 import {
-  sortTriageList,
-  updateTriageGroupRecipientStatus,
-} from '../../util/helpers';
+  getBlockedTriageAlertConfig,
+  getAnalyticsAlertType,
+} from '../../util/blockedTriageGroupUtils';
 
-const { alertTitle, alertMessage } = BlockedTriageAlertText;
-const MESSAGE_TO_CARE_TEAM = "You can't send messages to";
-const MESSAGE_TO_CARE_TEAMS = "You can't send messages to care teams at";
-const ACCOUNT_DISCONNECTED = 'Your account is no longer connected to';
-const { MULTIPLE_TEAMS_BLOCKED, ALL_TEAMS_BLOCKED } = alertTitle;
+const DATADOG_FIND_VA_FACILITY_LINK =
+  'Find your VA health facility link - in Blocked/Not Associated alert';
 
-const BlockedTriageGroupAlert = props => {
-  const {
-    alertStyle,
-    parentComponent,
-    currentRecipient,
-    setShowBlockedTriageGroupAlert,
-    isOhMessage,
-  } = props;
-
-  const DATADOG_FIND_VA_FACILITY_LINK =
-    'Find your VA health facility link - in Blocked/Not Associated alert';
-
-  const [alertTitleText, setAlertTitleText] = useState(null);
-  const [alertInfoText, setAlertInfoText] = useState(
-    alertMessage.NO_ASSOCIATIONS,
-  );
-  const [showAlert, setShowAlert] = useState(false);
-  const [blockedTriageList, setBlockedTriageList] = useState([]);
-  const [isAnalyticsSent, setIsAnalyticsSent] = useState(false);
-
+/**
+ * BlockedTriageGroupAlert displays an alert when the user has blocked triage groups
+ * or has lost associations with care teams.
+ *
+ * The alert logic is determined by the `getBlockedTriageAlertConfig` utility which
+ * evaluates the recipients state and returns the appropriate alert configuration.
+ *
+ * @see src/applications/mhv-secure-messaging/util/blockedTriageGroupUtils.js
+ */
+const BlockedTriageGroupAlert = ({
+  alertStyle,
+  parentComponent,
+  currentRecipient,
+  setShowBlockedTriageGroupAlert,
+  isOhMessage,
+}) => {
   const ehrDataByVhaId = useSelector(selectEhrDataByVhaId);
+  const recipients = useSelector(state => state.sm?.recipients);
+  const analyticsRef = useRef(false);
 
-  const { recipients } = useSelector(state => state.sm);
-
-  const {
-    noAssociations,
-    allTriageGroupsBlocked,
-    associatedBlockedTriageGroupsQty,
-    blockedRecipients,
-    blockedFacilities,
-  } = recipients;
-
-  const handleShowBlockedTriageGroupAlert = useCallback(
-    () => {
-      if (setShowBlockedTriageGroupAlert) setShowBlockedTriageGroupAlert(true);
-    },
-    [setShowBlockedTriageGroupAlert],
-  );
-
-  const organizeBlockedList = (recipientList, facilityNames) => {
-    return recipientList?.length > 1 && facilityNames.length > 0
-      ? [
-          ...sortTriageList(
-            recipientList.filter(
-              triageGroup =>
-                !facilityNames?.some(
-                  facility =>
-                    facility.stationNumber === triageGroup.stationNumber,
-                ),
-            ),
-          ),
-          ...sortTriageList(facilityNames),
-        ]
-      : sortTriageList(recipientList);
-  };
-
-  useEffect(
-    () => {
-      const blockedFacilityNames =
-        (blockedFacilities?.length > 0 &&
-          blockedFacilities
-            ?.filter(facility =>
-              getVamcSystemNameFromVhaId(ehrDataByVhaId, facility),
-            )
-            .map(facility => {
-              return {
-                stationNumber: facility,
-                name: getVamcSystemNameFromVhaId(ehrDataByVhaId, facility),
-                type: Recipients.FACILITY,
-              };
-            })) ||
-        [];
-      if (associatedBlockedTriageGroupsQty !== undefined) {
-        if (currentRecipient) {
-          const { formattedRecipient } = updateTriageGroupRecipientStatus(
-            recipients,
-            currentRecipient,
-          );
-
-          if (formattedRecipient.status === RecipientStatus.NOT_ASSOCIATED) {
-            if (blockedRecipients.length > 0) {
-              const organizedList = organizeBlockedList(
-                blockedRecipients,
-                blockedFacilityNames,
-              );
-              setBlockedTriageList(
-                sortTriageList([...organizedList, formattedRecipient]),
-              );
-            } else {
-              setBlockedTriageList([formattedRecipient]);
-            }
-            if (!isOhMessage) {
-              setShowAlert(true);
-              handleShowBlockedTriageGroupAlert();
-            }
-          } else if (formattedRecipient.status === RecipientStatus.BLOCKED) {
-            if (parentComponent === ParentComponent.COMPOSE_FORM) {
-              const organizedList = organizeBlockedList(
-                blockedRecipients,
-                blockedFacilityNames,
-              );
-
-              if (organizedList.length > 0) {
-                setBlockedTriageList([...organizedList]);
-                setShowAlert(true);
-                handleShowBlockedTriageGroupAlert();
-              }
-            } else {
-              setBlockedTriageList([formattedRecipient]);
-              setShowAlert(true);
-              handleShowBlockedTriageGroupAlert();
-            }
-          }
-        } else if (noAssociations || allTriageGroupsBlocked) {
-          setShowAlert(true);
-          handleShowBlockedTriageGroupAlert();
-        } else if (
-          parentComponent === ParentComponent.COMPOSE_FORM ||
-          parentComponent === ParentComponent.CONTACT_LIST
-        ) {
-          const organizedList = organizeBlockedList(
-            blockedRecipients,
-            blockedFacilityNames,
-          );
-
-          if (organizedList.length > 0) {
-            setBlockedTriageList([...organizedList]);
-            setShowAlert(true);
-            handleShowBlockedTriageGroupAlert();
-          }
-        }
-      }
-    },
+  // Compute alert configuration using the centralized utility
+  const alertConfig = useMemo(
+    () =>
+      getBlockedTriageAlertConfig({
+        recipients,
+        currentRecipient,
+        parentComponent,
+        ehrDataByVhaId,
+        isOhMessage,
+      }),
     [
-      currentRecipient,
       recipients,
-      allTriageGroupsBlocked,
-      associatedBlockedTriageGroupsQty,
-      blockedFacilities,
-      blockedRecipients,
-      ehrDataByVhaId,
-      noAssociations,
+      currentRecipient,
       parentComponent,
-      handleShowBlockedTriageGroupAlert,
+      ehrDataByVhaId,
       isOhMessage,
     ],
   );
 
+  // Notify parent when alert should be shown
   useEffect(
     () => {
-      if (associatedBlockedTriageGroupsQty !== undefined) {
-        if (
-          parentComponent === ParentComponent.FOLDER_HEADER ||
-          parentComponent === ParentComponent.COMPOSE_FORM
-        ) {
-          if (noAssociations) {
-            setAlertTitleText(alertTitle.NO_ASSOCIATIONS);
-            return;
-          }
-
-          if (allTriageGroupsBlocked) {
-            setAlertTitleText(alertTitle.ALL_TEAMS_BLOCKED);
-            setAlertInfoText(alertMessage.ALL_TEAMS_BLOCKED);
-            return;
-          }
-        }
-
-        if (blockedTriageList?.length === 1) {
-          const name =
-            blockedTriageList[0].suggestedNameDisplay ||
-            blockedTriageList[0].name;
-          if (blockedTriageList[0].type === Recipients.FACILITY) {
-            setAlertTitleText(`${MESSAGE_TO_CARE_TEAMS} ${name}`);
-            setAlertInfoText(alertMessage.SINGLE_FACILITY_BLOCKED);
-          } else {
-            setAlertTitleText(
-              blockedTriageList[0].status === RecipientStatus.NOT_ASSOCIATED
-                ? `${ACCOUNT_DISCONNECTED} ${name}`
-                : `${MESSAGE_TO_CARE_TEAM} ${name}`,
-            );
-            if (blockedTriageList[0].status === RecipientStatus.BLOCKED) {
-              setAlertInfoText(alertMessage.SINGLE_TEAM_BLOCKED);
-            } else {
-              setAlertInfoText(alertMessage.NO_ASSOCIATIONS);
-            }
-          }
-        } else if (noAssociations) {
-          setAlertTitleText(alertTitle.NO_ASSOCIATIONS);
-          setAlertInfoText(alertMessage.NO_ASSOCIATIONS);
-        } else if (allTriageGroupsBlocked) {
-          setAlertTitleText(alertTitle.ALL_TEAMS_BLOCKED);
-          setAlertInfoText(alertMessage.ALL_TEAMS_BLOCKED);
-        } else if (blockedTriageList?.length > 1) {
-          setAlertTitleText(alertTitle.MULTIPLE_TEAMS_BLOCKED);
-          setAlertInfoText(alertMessage.MULTIPLE_TEAMS_BLOCKED);
-        }
+      if (alertConfig?.shouldShow && setShowBlockedTriageGroupAlert) {
+        setShowBlockedTriageGroupAlert(true);
       }
     },
-    [
-      allTriageGroupsBlocked,
-      associatedBlockedTriageGroupsQty,
-      blockedTriageList,
-      noAssociations,
-      parentComponent,
-      recipients,
-    ],
+    [alertConfig?.shouldShow, setShowBlockedTriageGroupAlert],
   );
 
+  // Track analytics (once per alert)
   useEffect(
     () => {
-      if (showAlert && alertTitleText && !isAnalyticsSent) {
-        let value = '';
-        if (alertTitleText.includes(MESSAGE_TO_CARE_TEAMS)) {
-          value = `${MESSAGE_TO_CARE_TEAMS} FACILITY`;
-        } else if (alertTitleText.includes(MULTIPLE_TEAMS_BLOCKED)) {
-          value = `${alertTitleText}`;
-        } else if (alertTitleText.includes(ALL_TEAMS_BLOCKED)) {
-          value = alertTitleText;
-        } else if (alertTitleText.includes(MESSAGE_TO_CARE_TEAM)) {
-          value = `${MESSAGE_TO_CARE_TEAM} TG_NAME`;
-        } else if (alertTitleText.includes(ACCOUNT_DISCONNECTED)) {
-          value = `${ACCOUNT_DISCONNECTED} TG_NAME`;
-        } else {
-          value = alertTitleText;
-        }
-        datadogRum.addAction('Blocked triage group alert', { type: value });
-        setIsAnalyticsSent(true);
+      if (
+        alertConfig?.shouldShow &&
+        alertConfig?.title &&
+        !analyticsRef.current
+      ) {
+        const analyticsType = getAnalyticsAlertType(alertConfig.title);
+        datadogRum.addAction('Blocked triage group alert', {
+          type: analyticsType,
+        });
+        analyticsRef.current = true;
       }
     },
-    [showAlert, alertTitleText, isAnalyticsSent],
+    [alertConfig],
   );
 
-  if (!showAlert) {
+  // Don't render if no alert should be shown
+  if (!alertConfig?.shouldShow) {
     return null;
   }
 
-  return alertStyle === BlockedTriageAlertStyles.ALERT ? (
-    <va-alert-expandable
-      status="warning"
-      trigger={alertTitleText}
-      data-testid="blocked-triage-group-alert"
-      data-dd-privacy="mask"
-      data-dd-action-name="Blocked Triage Group Alert Expandable"
-    >
-      <div className="vads-u-padding-left--4 vads-u-padding-bottom--1">
-        <p className="vads-u-margin-bottom--1p5">{alertInfoText}</p>
-        {(parentComponent === ParentComponent.COMPOSE_FORM ||
-          parentComponent === ParentComponent.CONTACT_LIST) &&
-          !allTriageGroupsBlocked &&
-          blockedTriageList?.length > 1 && (
+  const { title, message, blockedList } = alertConfig;
+  const { allTriageGroupsBlocked } = recipients || {};
+
+  // Determine if we should show the blocked teams list
+  const showBlockedList =
+    (parentComponent === ParentComponent.COMPOSE_FORM ||
+      parentComponent === ParentComponent.CONTACT_LIST) &&
+    !allTriageGroupsBlocked &&
+    blockedList?.length > 1;
+
+  // Render expandable alert (used for warning style in forms)
+  if (alertStyle === BlockedTriageAlertStyles.ALERT) {
+    return (
+      <va-alert-expandable
+        status="warning"
+        trigger={title}
+        data-testid="blocked-triage-group-alert"
+        data-dd-privacy="mask"
+        data-dd-action-name="Blocked Triage Group Alert Expandable"
+      >
+        <div className="vads-u-padding-left--4 vads-u-padding-bottom--1">
+          <p className="vads-u-margin-bottom--1p5">{message}</p>
+          {showBlockedList && (
             <ul>
-              {blockedTriageList?.map((blockedTriageGroup, i) => (
+              {blockedList.map((item, index) => (
                 <li
                   data-testid="blocked-triage-group"
-                  key={i}
+                  key={item.id || item.name || index}
                   data-dd-privacy="mask"
                   data-dd-action-name="Blocked/Not Associated alert - expandable"
                 >
-                  {`${
-                    blockedTriageGroup.type === Recipients.FACILITY
-                      ? 'Care teams at '
-                      : ''
-                  }${blockedTriageGroup.suggestedNameDisplay ||
-                    blockedTriageGroup.name}`}
+                  {item.type === Recipients.FACILITY
+                    ? `Care teams at ${item.suggestedNameDisplay || item.name}`
+                    : item.suggestedNameDisplay || item.name}
                 </li>
               ))}
             </ul>
           )}
-        <VaLinkAction
-          data-dd-action-name={`${DATADOG_FIND_VA_FACILITY_LINK} - expandable`}
-          href="/find-locations/"
-          text="Find your VA health facility"
-        />
-      </div>
-    </va-alert-expandable>
-  ) : (
+          <VaLinkAction
+            data-dd-action-name={`${DATADOG_FIND_VA_FACILITY_LINK} - expandable`}
+            href="/find-locations/"
+            text="Find your VA health facility"
+          />
+        </div>
+      </va-alert-expandable>
+    );
+  }
+
+  // Render standard alert (info or warning status)
+  return (
     <va-alert
       close-btn-aria-label="Close notification"
+      class="vads-u-margin-bottom--2"
       status={alertStyle}
       visible
       data-testid="blocked-triage-group-alert"
     >
       <h2 slot="headline" data-dd-action-name="Blocked/Not Associated alert">
-        {alertTitleText}
+        {title}
       </h2>
       <div>
-        <p className="vads-u-margin-bottom--1p5">{alertInfoText}</p>
+        <p className="vads-u-margin-bottom--1p5">{message}</p>
         <VaLinkAction
           data-dd-action-name={`${DATADOG_FIND_VA_FACILITY_LINK}`}
           href="/find-locations/"
@@ -322,7 +163,6 @@ const BlockedTriageGroupAlert = props => {
 
 BlockedTriageGroupAlert.propTypes = {
   alertStyle: PropTypes.string,
-  blockedTriageGroupList: PropTypes.arrayOf(PropTypes.object),
   currentRecipient: PropTypes.object,
   isOhMessage: PropTypes.bool,
   parentComponent: PropTypes.string,

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -10,7 +10,9 @@ import {
 import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import EmergencyNote from '../components/EmergencyNote';
+import BlockedTriageGroupAlert from '../components/shared/BlockedTriageGroupAlert';
 import * as Constants from '../util/constants';
+import { BlockedTriageAlertStyles, ParentComponent } from '../util/constants';
 import { getRecentRecipients } from '../actions/recipients';
 import { focusOnErrorField } from '../util/formHelpers';
 import { updateDraftInProgress } from '../actions/threadDetails';
@@ -35,6 +37,8 @@ const RecentCareTeams = () => {
     recentRecipients,
     allRecipients,
     noAssociations,
+    allTriageGroupsBlocked,
+    blockedFacilities,
     error: recipientsError,
   } = recipients;
   const h1Ref = useRef(null);
@@ -186,11 +190,34 @@ const RecentCareTeams = () => {
     return <va-loading-indicator message="Loading..." />;
   }
 
+  if (allTriageGroupsBlocked) {
+    return (
+      <>
+        <h1 className="vads-u-margin-bottom--3" tabIndex="-1" ref={h1Ref}>
+          Care teams you recently sent messages to
+        </h1>
+        <BlockedTriageGroupAlert
+          alertStyle={BlockedTriageAlertStyles.ALERT}
+          parentComponent={ParentComponent.FOLDER_HEADER}
+        />
+      </>
+    );
+  }
+
+  const showSingleFacilityBlockedAlert =
+    blockedFacilities?.length === 1 && !allTriageGroupsBlocked;
+
   return (
     <>
       <h1 className="vads-u-margin-bottom--3" tabIndex="-1" ref={h1Ref}>
         Care teams you recently sent messages to
       </h1>
+      {showSingleFacilityBlockedAlert && (
+        <BlockedTriageGroupAlert
+          alertStyle={BlockedTriageAlertStyles.INFO}
+          parentComponent={ParentComponent.FOLDER_HEADER}
+        />
+      )}
       <EmergencyNote dropDownFlag />
       <VaRadio
         class="vads-u-margin-bottom--3"

--- a/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
@@ -214,6 +214,178 @@ describe('RecentCareTeams component', () => {
     });
   });
 
+  describe('Blocked Triage Group Alert', () => {
+    it('should render BlockedTriageGroupAlert with ALERT style when allTriageGroupsBlocked is true', () => {
+      const state = {
+        featureToggles: {
+          loading: false,
+          [`${'mhv_secure_messaging_recent_recipients'}`]: true,
+        },
+        sm: {
+          recipients: {
+            recentRecipients: mockRecentRecipients,
+            allRecipients: mockAllRecipients,
+            allTriageGroupsBlocked: true,
+            blockedFacilities: [],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 3,
+          },
+          threadDetails: {
+            acceptInterstitial: true,
+          },
+        },
+      };
+      const { container } = renderComponent(state);
+
+      // Should render the h1
+      expect(container.querySelector('h1')).to.exist;
+
+      // Should render the BlockedTriageGroupAlert as va-alert-expandable (ALERT style)
+      const alert = container.querySelector('va-alert-expandable');
+      expect(alert).to.exist;
+      expect(alert.getAttribute('status')).to.equal('warning');
+      expect(alert.getAttribute('trigger')).to.include(
+        "can't send messages to your care teams",
+      );
+
+      // Should NOT render the radio options
+      const radioGroup = container.querySelector('va-radio');
+      expect(radioGroup).to.not.exist;
+
+      // Should NOT render the continue button
+      const continueButton = container.querySelector(
+        '[data-testid="recent-care-teams-continue-button"]',
+      );
+      expect(continueButton).to.not.exist;
+    });
+
+    it('should render BlockedTriageGroupAlert with INFO style when single facility is blocked', () => {
+      const state = {
+        featureToggles: {
+          loading: false,
+          [`${'mhv_secure_messaging_recent_recipients'}`]: true,
+        },
+        drupalStaticData: {
+          vamcEhrData: {
+            data: {
+              ehrDataByVhaId: {
+                // Use string key to match blockedFacilities string values
+                '553': { vamcSystemName: 'VA Detroit Healthcare System' },
+              },
+            },
+          },
+        },
+        sm: {
+          recipients: {
+            recentRecipients: mockRecentRecipients,
+            allRecipients: mockAllRecipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: ['553'],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 1,
+          },
+          threadDetails: {
+            acceptInterstitial: true,
+          },
+        },
+      };
+      const { container } = renderComponent(state);
+
+      // Should render the h1
+      expect(container.querySelector('h1')).to.exist;
+
+      // Should render the BlockedTriageGroupAlert as va-alert (INFO style)
+      const alert = container.querySelector('va-alert');
+      expect(alert).to.exist;
+      expect(alert.getAttribute('status')).to.equal('info');
+
+      // Should still render the radio options
+      const radioGroup = container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+
+      // Should still render the continue button
+      const continueButton = container.querySelector(
+        '[data-testid="recent-care-teams-continue-button"]',
+      );
+      expect(continueButton).to.exist;
+    });
+
+    it('should NOT render BlockedTriageGroupAlert when no blocked facilities or teams', () => {
+      const state = {
+        featureToggles: {
+          loading: false,
+          [`${'mhv_secure_messaging_recent_recipients'}`]: true,
+        },
+        sm: {
+          recipients: {
+            recentRecipients: mockRecentRecipients,
+            allRecipients: mockAllRecipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: [],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 0,
+          },
+          threadDetails: {
+            acceptInterstitial: true,
+          },
+        },
+      };
+      const { container } = renderComponent(state);
+
+      // Should render the h1
+      expect(container.querySelector('h1')).to.exist;
+
+      // Should NOT render any va-alert (BlockedTriageGroupAlert)
+      const alert = container.querySelector('va-alert');
+      expect(alert).to.not.exist;
+
+      // Should render the radio options normally
+      const radioGroup = container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+
+      // Should render the continue button
+      const continueButton = container.querySelector(
+        '[data-testid="recent-care-teams-continue-button"]',
+      );
+      expect(continueButton).to.exist;
+    });
+
+    it('should NOT render BlockedTriageGroupAlert when multiple facilities are blocked but not all', () => {
+      const state = {
+        featureToggles: {
+          loading: false,
+          [`${'mhv_secure_messaging_recent_recipients'}`]: true,
+        },
+        sm: {
+          recipients: {
+            recentRecipients: mockRecentRecipients,
+            allRecipients: mockAllRecipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: ['553', '648'],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 2,
+          },
+          threadDetails: {
+            acceptInterstitial: true,
+          },
+        },
+      };
+      const { container } = renderComponent(state);
+
+      // Should render the h1
+      expect(container.querySelector('h1')).to.exist;
+
+      // Should NOT render BlockedTriageGroupAlert when multiple (not single) facilities blocked
+      // Based on the condition: blockedFacilities?.length === 1 && !allTriageGroupsBlocked
+      const alert = container.querySelector('va-alert');
+      expect(alert).to.not.exist;
+
+      // Should render the radio options normally
+      const radioGroup = container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+    });
+  });
+
   describe('Redux Integration', () => {
     // Note: These tests focus on component behavior rather than action dispatching
     it('should dispatch getRecentRecipients when allRecipients exist', () => {

--- a/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
@@ -1315,4 +1315,315 @@ describe('SelectCareTeam', () => {
       expect(event).to.be.undefined;
     });
   });
+
+  describe('Blocked Triage Group Alert', () => {
+    it('should render BlockedTriageGroupAlert with ALERT style when allTriageGroupsBlocked is true', () => {
+      const allBlockedState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            allTriageGroupsBlocked: true,
+            blockedFacilities: [],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 3,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: allBlockedState,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Should render the h1
+      expect(screen.container.querySelector('h1')).to.exist;
+
+      // Should render the BlockedTriageGroupAlert as va-alert-expandable (ALERT style)
+      const alert = screen.container.querySelector('va-alert-expandable');
+      expect(alert).to.exist;
+      expect(alert.getAttribute('status')).to.equal('warning');
+      expect(alert.getAttribute('trigger')).to.include(
+        "can't send messages to your care teams",
+      );
+
+      // Should NOT render the care system selection (va-radio or va-select)
+      const radioGroup = screen.container.querySelector('va-radio');
+      expect(radioGroup).to.not.exist;
+      const selectDropdown = screen.container.querySelector('va-select');
+      expect(selectDropdown).to.not.exist;
+
+      // Should NOT render the care team combobox
+      const combobox = screen.container.querySelector(
+        '[data-testid="compose-recipient-combobox"]',
+      );
+      expect(combobox).to.not.exist;
+    });
+
+    it('should render BlockedTriageGroupAlert with INFO style when single facility is blocked', () => {
+      const singleFacilityBlockedState = {
+        ...initialState,
+        drupalStaticData: {
+          vamcEhrData: {
+            data: {
+              ehrDataByVhaId: {
+                ...initialState.drupalStaticData.vamcEhrData.data
+                  .ehrDataByVhaId,
+                '553': {
+                  vhaId: '553',
+                  vamcSystemName: 'VA Detroit Healthcare System',
+                  ehr: 'vista',
+                },
+              },
+            },
+          },
+        },
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: ['553'],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 1,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: singleFacilityBlockedState,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Should render the h1
+      expect(screen.container.querySelector('h1')).to.exist;
+
+      // Should render the BlockedTriageGroupAlert as va-alert (INFO style)
+      const alert = screen.container.querySelector('va-alert');
+      expect(alert).to.exist;
+      expect(alert.getAttribute('status')).to.equal('info');
+
+      // Should still render the care system selection
+      const radioGroup = screen.container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+    });
+
+    it('should render BlockedTriageGroupAlert with INFO style when individual teams are blocked', () => {
+      const blockedTeamsState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: [],
+            blockedRecipients: [
+              {
+                id: 12345,
+                name: 'Blocked Team 1',
+                stationNumber: '662',
+              },
+            ],
+            associatedBlockedTriageGroupsQty: 1,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: blockedTeamsState,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Should render the h1
+      expect(screen.container.querySelector('h1')).to.exist;
+
+      // Should render the BlockedTriageGroupAlert as va-alert (INFO style)
+      const alert = screen.container.querySelector('va-alert');
+      expect(alert).to.exist;
+      expect(alert.getAttribute('status')).to.equal('info');
+
+      // Should still render the care system selection
+      const radioGroup = screen.container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+    });
+
+    it('should NOT render BlockedTriageGroupAlert when no blocked facilities or teams', () => {
+      const noBlockedState = {
+        ...initialState,
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: [],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 0,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: noBlockedState,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Should render the h1
+      expect(screen.container.querySelector('h1')).to.exist;
+
+      // Should NOT render any va-alert (BlockedTriageGroupAlert)
+      // Note: EmergencyNote renders a va-alert-expandable, so we check for va-alert specifically
+      const alert = screen.container.querySelector(
+        'va-alert[data-testid="blocked-triage-group-alert"]',
+      );
+      expect(alert).to.not.exist;
+
+      // Should render the care system selection normally
+      const radioGroup = screen.container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+    });
+
+    it('should NOT render BlockedTriageGroupAlert when multiple facilities are blocked but not all', () => {
+      const multipleBlockedState = {
+        ...initialState,
+        drupalStaticData: {
+          vamcEhrData: {
+            data: {
+              ehrDataByVhaId: {
+                ...initialState.drupalStaticData.vamcEhrData.data
+                  .ehrDataByVhaId,
+                '553': {
+                  vhaId: '553',
+                  vamcSystemName: 'VA Detroit Healthcare System',
+                  ehr: 'vista',
+                },
+                '648': {
+                  vhaId: '648',
+                  vamcSystemName: 'VA Portland Healthcare System',
+                  ehr: 'vista',
+                },
+              },
+            },
+          },
+        },
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            allTriageGroupsBlocked: false,
+            blockedFacilities: ['553', '648'],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 2,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: multipleBlockedState,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Should render the h1
+      expect(screen.container.querySelector('h1')).to.exist;
+
+      // Should NOT render BlockedTriageGroupAlert when multiple (not single) facilities blocked
+      // Based on the condition: blockedFacilities?.length === 1 && !allTriageGroupsBlocked
+      const alert = screen.container.querySelector(
+        'va-alert[data-testid="blocked-triage-group-alert"]',
+      );
+      expect(alert).to.not.exist;
+
+      // Should render the care system selection normally
+      const radioGroup = screen.container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+    });
+
+    it('should filter blocked facilities from care system radio options', () => {
+      const stateWithBlockedFacility = {
+        ...initialState,
+        drupalStaticData: {
+          vamcEhrData: {
+            data: {
+              ehrDataByVhaId: {
+                '662': {
+                  vhaId: '662',
+                  vamcSystemName: 'Test Facility 1',
+                  ehr: 'vista',
+                },
+                '636': {
+                  vhaId: '636',
+                  vamcSystemName: 'Test Facility 2',
+                  ehr: 'vista',
+                },
+                '587': {
+                  vhaId: '587',
+                  vamcSystemName: 'Blocked Facility',
+                  ehr: 'vista',
+                },
+              },
+            },
+          },
+        },
+        sm: {
+          ...initialState.sm,
+          recipients: {
+            ...initialState.sm.recipients,
+            allFacilities: ['662', '636', '587'],
+            blockedFacilities: ['587'],
+            blockedRecipients: [],
+            associatedBlockedTriageGroupsQty: 1,
+          },
+          threadDetails: {
+            draftInProgress: {},
+            acceptInterstitial: true,
+          },
+        },
+      };
+
+      const screen = renderWithStoreAndRouter(<SelectCareTeam />, {
+        initialState: stateWithBlockedFacility,
+        reducers: reducer,
+        path: Paths.SELECT_CARE_TEAM,
+      });
+
+      // Should render radio options
+      const radioGroup = screen.container.querySelector('va-radio');
+      expect(radioGroup).to.exist;
+
+      // Should NOT include the blocked facility in radio options
+      const radioOptions = screen.container.querySelectorAll('va-radio-option');
+      const optionLabels = Array.from(radioOptions).map(option =>
+        option.getAttribute('label'),
+      );
+
+      expect(optionLabels).to.include('Test Facility 1');
+      expect(optionLabels).to.include('Test Facility 2');
+      expect(optionLabels).to.not.include('Blocked Facility');
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/util/blockedTriageGroupUtils.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/util/blockedTriageGroupUtils.unit.spec.jsx
@@ -1,0 +1,345 @@
+import { expect } from 'chai';
+import {
+  getRecipientStatus,
+  sortTriageList,
+  getBlockedFacilityNames,
+  buildBlockedItemsList,
+  getBlockedTriageAlertConfig,
+  getAnalyticsAlertType,
+} from '../../util/blockedTriageGroupUtils';
+import {
+  RecipientStatus,
+  Recipients,
+  ParentComponent,
+  BlockedTriageAlertText,
+} from '../../util/constants';
+
+const { alertTitle, alertMessage } = BlockedTriageAlertText;
+
+describe('blockedTriageGroupUtils', () => {
+  describe('getRecipientStatus', () => {
+    it('returns null when recipient is null', () => {
+      const recipients = { allRecipients: [], blockedRecipients: [] };
+      expect(getRecipientStatus(recipients, null)).to.be.null;
+    });
+
+    it('returns NOT_ASSOCIATED when recipient is not in allRecipients', () => {
+      const recipients = {
+        allRecipients: [{ id: 1, name: 'Team 1' }],
+        blockedRecipients: [],
+      };
+      const recipient = { recipientId: 999, name: 'Unknown Team' };
+      expect(getRecipientStatus(recipients, recipient)).to.equal(
+        RecipientStatus.NOT_ASSOCIATED,
+      );
+    });
+
+    it('returns BLOCKED when recipient is in blockedRecipients', () => {
+      const recipients = {
+        allRecipients: [{ id: 1, name: 'Team 1' }],
+        blockedRecipients: [{ id: 1, name: 'Team 1' }],
+      };
+      const recipient = { recipientId: 1, name: 'Team 1' };
+      expect(getRecipientStatus(recipients, recipient)).to.equal(
+        RecipientStatus.BLOCKED,
+      );
+    });
+
+    it('returns ALLOWED when recipient is associated but not blocked', () => {
+      const recipients = {
+        allRecipients: [{ id: 1, name: 'Team 1' }],
+        blockedRecipients: [],
+      };
+      const recipient = { recipientId: 1, name: 'Team 1' };
+      expect(getRecipientStatus(recipients, recipient)).to.equal(
+        RecipientStatus.ALLOWED,
+      );
+    });
+
+    it('matches by triageGroupName when recipientId does not match', () => {
+      const recipients = {
+        allRecipients: [{ id: 1, name: 'Team 1' }],
+        blockedRecipients: [],
+      };
+      const recipient = { recipientId: 999, triageGroupName: 'Team 1' };
+      expect(getRecipientStatus(recipients, recipient)).to.equal(
+        RecipientStatus.ALLOWED,
+      );
+    });
+  });
+
+  describe('sortTriageList', () => {
+    it('returns empty array for null/undefined input', () => {
+      expect(sortTriageList(null)).to.deep.equal([]);
+      expect(sortTriageList(undefined)).to.deep.equal([]);
+    });
+
+    it('sorts alphabetically by name', () => {
+      const list = [
+        { name: 'Zebra Team' },
+        { name: 'Alpha Team' },
+        { name: 'Beta Team' },
+      ];
+      const sorted = sortTriageList(list);
+      expect(sorted[0].name).to.equal('Alpha Team');
+      expect(sorted[1].name).to.equal('Beta Team');
+      expect(sorted[2].name).to.equal('Zebra Team');
+    });
+
+    it('sorts non-alphabetic names first, then alphabetic', () => {
+      const list = [
+        { name: 'Alpha Team' },
+        { name: '###Special Team###' },
+        { name: '***Another Special***' },
+      ];
+      const sorted = sortTriageList(list);
+      // Non-alphabetic names should be sorted first (by localeCompare), then alphabetic
+      // The last item should be the alphabetic one
+      expect(sorted[2].name).to.equal('Alpha Team');
+    });
+
+    it('uses suggestedNameDisplay when available', () => {
+      const list = [
+        { name: 'Zebra', suggestedNameDisplay: 'Alpha Display' },
+        { name: 'Alpha', suggestedNameDisplay: 'Zebra Display' },
+      ];
+      const sorted = sortTriageList(list);
+      expect(sorted[0].suggestedNameDisplay).to.equal('Alpha Display');
+    });
+  });
+
+  describe('getBlockedFacilityNames', () => {
+    const mockEhrData = {
+      '662': {
+        facilityId: '662',
+        vamcSystemName: 'Test Facility 1',
+      },
+      '636': {
+        facilityId: '636',
+        vamcSystemName: 'Test Facility 2',
+      },
+    };
+
+    it('returns empty array for null/empty input', () => {
+      expect(getBlockedFacilityNames(null, mockEhrData)).to.deep.equal([]);
+      expect(getBlockedFacilityNames([], mockEhrData)).to.deep.equal([]);
+    });
+
+    it('converts station numbers to facility objects', () => {
+      const result = getBlockedFacilityNames(['662'], mockEhrData);
+      expect(result).to.have.length(1);
+      expect(result[0].stationNumber).to.equal('662');
+      expect(result[0].name).to.equal('Test Facility 1');
+      expect(result[0].type).to.equal(Recipients.FACILITY);
+    });
+
+    it('filters out facilities not found in EHR data', () => {
+      const result = getBlockedFacilityNames(['999', '662'], mockEhrData);
+      expect(result).to.have.length(1);
+      expect(result[0].stationNumber).to.equal('662');
+    });
+  });
+
+  describe('buildBlockedItemsList', () => {
+    it('returns empty array when no blocked items', () => {
+      expect(buildBlockedItemsList([], [])).to.deep.equal([]);
+      expect(buildBlockedItemsList(null, null)).to.deep.equal([]);
+    });
+
+    it('returns sorted blocked recipients when no facilities', () => {
+      const recipients = [
+        { name: 'Zebra Team', stationNumber: '662' },
+        { name: 'Alpha Team', stationNumber: '636' },
+      ];
+      const result = buildBlockedItemsList(recipients, []);
+      expect(result[0].name).to.equal('Alpha Team');
+    });
+
+    it('excludes teams from fully blocked facilities', () => {
+      const recipients = [
+        { name: 'Team at 662', stationNumber: '662' },
+        { name: 'Team at 636', stationNumber: '636' },
+      ];
+      const facilities = [
+        {
+          stationNumber: '662',
+          name: 'Facility 662',
+          type: Recipients.FACILITY,
+        },
+      ];
+      const result = buildBlockedItemsList(recipients, facilities);
+      // Should include team at 636 and the facility 662, but not team at 662
+      const hasTeamAt662 = result.some(r => r.name === 'Team at 662');
+      expect(hasTeamAt662).to.be.false;
+    });
+  });
+
+  describe('getBlockedTriageAlertConfig', () => {
+    const baseRecipients = {
+      noAssociations: false,
+      allTriageGroupsBlocked: false,
+      associatedBlockedTriageGroupsQty: 0,
+      blockedRecipients: [],
+      blockedFacilities: [],
+    };
+
+    it('returns null when associatedBlockedTriageGroupsQty is undefined', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: {
+          ...baseRecipients,
+          associatedBlockedTriageGroupsQty: undefined,
+        },
+        parentComponent: ParentComponent.COMPOSE_FORM,
+        ehrDataByVhaId: {},
+      });
+      expect(result).to.be.null;
+    });
+
+    it('returns NO_ASSOCIATIONS config when noAssociations is true', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: { ...baseRecipients, noAssociations: true },
+        parentComponent: ParentComponent.FOLDER_HEADER,
+        ehrDataByVhaId: {},
+      });
+      expect(result.shouldShow).to.be.true;
+      expect(result.title).to.equal(alertTitle.NO_ASSOCIATIONS);
+      expect(result.message).to.equal(alertMessage.NO_ASSOCIATIONS);
+    });
+
+    it('returns ALL_TEAMS_BLOCKED config when allTriageGroupsBlocked is true', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: { ...baseRecipients, allTriageGroupsBlocked: true },
+        parentComponent: ParentComponent.FOLDER_HEADER,
+        ehrDataByVhaId: {},
+      });
+      expect(result.shouldShow).to.be.true;
+      expect(result.title).to.equal(alertTitle.ALL_TEAMS_BLOCKED);
+      expect(result.message).to.equal(alertMessage.ALL_TEAMS_BLOCKED);
+    });
+
+    it('returns NOT_ASSOCIATED config for unassociated current recipient with no other blocked', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: {
+          ...baseRecipients,
+          allRecipients: [{ id: 1, name: 'Other Team' }],
+        },
+        currentRecipient: { recipientId: 999, name: 'Missing Team' },
+        parentComponent: ParentComponent.REPLY_FORM,
+        ehrDataByVhaId: {},
+      });
+      expect(result.shouldShow).to.be.true;
+      expect(result.title).to.include('Your account is no longer connected to');
+      expect(result.status).to.equal(RecipientStatus.NOT_ASSOCIATED);
+    });
+
+    it('returns MULTIPLE_TEAMS_BLOCKED for unassociated current recipient with other blocked', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: {
+          ...baseRecipients,
+          allRecipients: [{ id: 1, name: 'Other Team' }],
+          blockedRecipients: [
+            { id: 1, name: 'Blocked Team', stationNumber: '662' },
+          ],
+        },
+        currentRecipient: { recipientId: 999, name: 'Missing Team' },
+        parentComponent: ParentComponent.COMPOSE_FORM,
+        ehrDataByVhaId: {},
+      });
+      expect(result.shouldShow).to.be.true;
+      expect(result.title).to.equal(alertTitle.MULTIPLE_TEAMS_BLOCKED);
+      expect(result.blockedList).to.have.length(2);
+    });
+
+    it('returns null for NOT_ASSOCIATED recipient when isOhMessage is true', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: {
+          ...baseRecipients,
+          allRecipients: [],
+        },
+        currentRecipient: { recipientId: 999, name: 'Missing Team' },
+        parentComponent: ParentComponent.REPLY_FORM,
+        ehrDataByVhaId: {},
+        isOhMessage: true,
+      });
+      expect(result).to.be.null;
+    });
+
+    it('returns BLOCKED config for blocked current recipient', () => {
+      const blockedTeam = { id: 1, name: 'Blocked Team' };
+      const result = getBlockedTriageAlertConfig({
+        recipients: {
+          ...baseRecipients,
+          allRecipients: [blockedTeam],
+          blockedRecipients: [blockedTeam],
+        },
+        currentRecipient: { recipientId: 1, name: 'Blocked Team' },
+        parentComponent: ParentComponent.MESSAGE_THREAD,
+        ehrDataByVhaId: {},
+      });
+      expect(result.shouldShow).to.be.true;
+      expect(result.title).to.include("You can't send messages to");
+      expect(result.status).to.equal(RecipientStatus.BLOCKED);
+    });
+
+    it('returns MULTIPLE_TEAMS_BLOCKED config when multiple teams blocked', () => {
+      const result = getBlockedTriageAlertConfig({
+        recipients: {
+          ...baseRecipients,
+          blockedRecipients: [
+            { id: 1, name: 'Team 1', stationNumber: '662' },
+            { id: 2, name: 'Team 2', stationNumber: '636' },
+          ],
+        },
+        parentComponent: ParentComponent.COMPOSE_FORM,
+        ehrDataByVhaId: {},
+      });
+      expect(result.shouldShow).to.be.true;
+      expect(result.title).to.equal(alertTitle.MULTIPLE_TEAMS_BLOCKED);
+      expect(result.blockedList).to.have.length(2);
+    });
+  });
+
+  describe('getAnalyticsAlertType', () => {
+    it('returns empty string for null/undefined title', () => {
+      expect(getAnalyticsAlertType(null)).to.equal('');
+      expect(getAnalyticsAlertType(undefined)).to.equal('');
+    });
+
+    it('sanitizes facility names', () => {
+      const result = getAnalyticsAlertType(
+        "You can't send messages to care teams at VA Facility Name",
+      );
+      expect(result).to.equal(
+        "You can't send messages to care teams at FACILITY",
+      );
+    });
+
+    it('sanitizes team names', () => {
+      const result = getAnalyticsAlertType(
+        "You can't send messages to Team Name",
+      );
+      expect(result).to.equal("You can't send messages to TG_NAME");
+    });
+
+    it('sanitizes disconnected team names', () => {
+      const result = getAnalyticsAlertType(
+        'Your account is no longer connected to Team Name',
+      );
+      expect(result).to.equal('Your account is no longer connected to TG_NAME');
+    });
+
+    it('preserves non-PII titles as-is', () => {
+      expect(
+        getAnalyticsAlertType(
+          "You can't send messages to your care teams right now",
+        ),
+      ).to.equal("You can't send messages to your care teams right now");
+
+      expect(
+        getAnalyticsAlertType(
+          "You can't send messages to some of your care teams",
+        ),
+      ).to.equal("You can't send messages to some of your care teams");
+    });
+  });
+});

--- a/src/applications/mhv-secure-messaging/util/blockedTriageGroupUtils.js
+++ b/src/applications/mhv-secure-messaging/util/blockedTriageGroupUtils.js
@@ -1,0 +1,374 @@
+import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
+import {
+  BlockedTriageAlertText,
+  ParentComponent,
+  RecipientStatus,
+  Recipients,
+} from './constants';
+
+const { alertTitle, alertMessage } = BlockedTriageAlertText;
+
+/**
+ * Determines if a recipient is blocked by checking if they exist in the blocked recipients list.
+ * @param {Object} recipients - The recipients state from Redux
+ * @param {Object} recipient - The recipient to check
+ * @returns {boolean} True if recipient is blocked
+ */
+const isRecipientBlocked = (recipients, recipient) => {
+  if (!recipients?.blockedRecipients || !recipient) return false;
+
+  return recipients.blockedRecipients.some(
+    blocked =>
+      blocked.id === recipient.recipientId ||
+      blocked.name === recipient.name ||
+      blocked.name === recipient.triageGroupName,
+  );
+};
+
+/**
+ * Determines if a recipient is associated with the user's account.
+ * @param {Object} recipients - The recipients state from Redux
+ * @param {Object} recipient - The recipient to check
+ * @returns {boolean} True if recipient is associated
+ */
+const isRecipientAssociated = (recipients, recipient) => {
+  if (!recipients?.allRecipients || !recipient) return false;
+
+  return recipients.allRecipients.some(
+    r =>
+      r.id === recipient.recipientId ||
+      r.name === recipient.name ||
+      r.name === recipient.triageGroupName,
+  );
+};
+
+/**
+ * Determines the status of a recipient (ALLOWED, BLOCKED, or NOT_ASSOCIATED)
+ * @param {Object} recipients - The recipients state from Redux
+ * @param {Object} recipient - The recipient to check
+ * @returns {string} RecipientStatus value
+ */
+export const getRecipientStatus = (recipients, recipient) => {
+  if (!recipient) return null;
+
+  const isAssociated = isRecipientAssociated(recipients, recipient);
+  if (!isAssociated) return RecipientStatus.NOT_ASSOCIATED;
+
+  const isBlocked = isRecipientBlocked(recipients, recipient);
+  if (isBlocked) return RecipientStatus.BLOCKED;
+
+  return RecipientStatus.ALLOWED;
+};
+
+/**
+ * Sorts a list of triage groups/facilities alphabetically by name.
+ * Non-alphabetic names are sorted first (to match the original sortRecipients behavior).
+ * @param {Array} list - List of triage groups or facilities
+ * @returns {Array} Sorted list
+ */
+export const sortTriageList = list => {
+  if (!list?.length) return [];
+  const isAlphabetical = str => /^\w/.test(str);
+  return [...list].sort((a, b) => {
+    const nameA = a.suggestedNameDisplay || a.name || '';
+    const nameB = b.suggestedNameDisplay || b.name || '';
+    // Non-alphabetical names come first, then alphabetical sorted
+    return (
+      isAlphabetical(nameA) - isAlphabetical(nameB) ||
+      nameA.localeCompare(nameB)
+    );
+  });
+};
+
+/**
+ * Converts blocked facilities (station numbers) to objects with names.
+ * @param {Array} blockedFacilities - Array of station numbers
+ * @param {Object} ehrDataByVhaId - EHR data from Drupal
+ * @returns {Array} Array of facility objects with name and stationNumber
+ */
+export const getBlockedFacilityNames = (blockedFacilities, ehrDataByVhaId) => {
+  if (!blockedFacilities?.length) return [];
+
+  return blockedFacilities
+    .filter(facility => getVamcSystemNameFromVhaId(ehrDataByVhaId, facility))
+    .map(facility => ({
+      stationNumber: facility,
+      name: getVamcSystemNameFromVhaId(ehrDataByVhaId, facility),
+      type: Recipients.FACILITY,
+    }));
+};
+
+/**
+ * Builds the list of blocked items to display in the alert.
+ * Combines blocked recipients and facilities, excluding recipients from fully-blocked facilities.
+ * @param {Array} blockedRecipients - List of blocked recipients
+ * @param {Array} blockedFacilityObjects - List of blocked facility objects with names
+ * @returns {Array} Combined and sorted list of blocked items
+ */
+export const buildBlockedItemsList = (
+  blockedRecipients,
+  blockedFacilityObjects,
+) => {
+  if (!blockedRecipients?.length && !blockedFacilityObjects?.length) return [];
+
+  if (blockedRecipients?.length <= 1 || !blockedFacilityObjects?.length) {
+    return sortTriageList(blockedRecipients || []);
+  }
+
+  // Exclude individual teams that belong to fully blocked facilities
+  const teamsNotInBlockedFacilities = blockedRecipients.filter(
+    team =>
+      !blockedFacilityObjects.some(
+        facility => facility.stationNumber === team.stationNumber,
+      ),
+  );
+
+  return [
+    ...sortTriageList(teamsNotInBlockedFacilities),
+    ...sortTriageList(blockedFacilityObjects),
+  ];
+};
+
+/**
+ * Helper function to get alert configuration for a list of blocked items.
+ * @param {Array} blockedList - List of blocked items
+ * @returns {Object} Alert configuration
+ */
+const getAlertConfigForBlockedList = blockedList => {
+  if (blockedList.length === 1) {
+    const item = blockedList[0];
+    const name = item.suggestedNameDisplay || item.name;
+
+    if (item.type === Recipients.FACILITY) {
+      return {
+        shouldShow: true,
+        title: `You can't send messages to care teams at ${name}`,
+        message: alertMessage.SINGLE_FACILITY_BLOCKED,
+        blockedList,
+        status: RecipientStatus.BLOCKED,
+      };
+    }
+
+    if (item.status === RecipientStatus.NOT_ASSOCIATED) {
+      return {
+        shouldShow: true,
+        title: `Your account is no longer connected to ${name}`,
+        message: alertMessage.NO_ASSOCIATIONS,
+        blockedList,
+        status: RecipientStatus.NOT_ASSOCIATED,
+      };
+    }
+
+    return {
+      shouldShow: true,
+      title: `You can't send messages to ${name}`,
+      message: alertMessage.SINGLE_TEAM_BLOCKED,
+      blockedList,
+      status: RecipientStatus.BLOCKED,
+    };
+  }
+
+  // Multiple blocked items
+  return {
+    shouldShow: true,
+    title: alertTitle.MULTIPLE_TEAMS_BLOCKED,
+    message: alertMessage.MULTIPLE_TEAMS_BLOCKED,
+    blockedList,
+    status: RecipientStatus.BLOCKED,
+  };
+};
+
+/**
+ * Determines the alert configuration based on the blocked triage group state.
+ *
+ * @param {Object} params - Configuration object
+ * @param {Object} params.recipients - Recipients state from Redux
+ * @param {Object} params.currentRecipient - The current recipient (if viewing a thread or draft)
+ * @param {string} params.parentComponent - Which component is rendering the alert
+ * @param {Object} params.ehrDataByVhaId - EHR data for facility name resolution
+ * @param {boolean} params.isOhMessage - Whether this is an Oracle Health message
+ * @returns {Object|null} Alert configuration with { shouldShow, title, message, blockedList, status }
+ */
+export const getBlockedTriageAlertConfig = ({
+  recipients,
+  currentRecipient,
+  parentComponent,
+  ehrDataByVhaId,
+  isOhMessage = false,
+}) => {
+  const {
+    noAssociations,
+    allTriageGroupsBlocked,
+    associatedBlockedTriageGroupsQty,
+    blockedRecipients,
+    blockedFacilities,
+  } = recipients || {};
+
+  // If we haven't loaded the data yet, don't show anything
+  if (associatedBlockedTriageGroupsQty === undefined) {
+    return null;
+  }
+
+  // Get blocked facility objects with names
+  const blockedFacilityObjects = getBlockedFacilityNames(
+    blockedFacilities,
+    ehrDataByVhaId,
+  );
+
+  // Handle current recipient scenarios first (thread, reply, draft editing)
+  // This takes priority over noAssociations for specific recipient messaging
+  if (currentRecipient) {
+    const recipientStatus = getRecipientStatus(recipients, currentRecipient);
+    const formattedRecipient = {
+      ...currentRecipient,
+      status: recipientStatus,
+    };
+
+    // SCENARIO: Current recipient is NOT_ASSOCIATED
+    if (recipientStatus === RecipientStatus.NOT_ASSOCIATED) {
+      // Oracle Health messages don't show alert for NOT_ASSOCIATED
+      if (isOhMessage) {
+        return null;
+      }
+
+      // Build the combined list including the not-associated recipient
+      const baseBlockedList = buildBlockedItemsList(
+        blockedRecipients,
+        blockedFacilityObjects,
+      );
+      const blockedList = baseBlockedList.length
+        ? sortTriageList([...baseBlockedList, formattedRecipient])
+        : [formattedRecipient];
+
+      // If multiple items, use MULTIPLE_TEAMS_BLOCKED title (matching original behavior)
+      if (blockedList.length > 1) {
+        return {
+          shouldShow: true,
+          title: alertTitle.MULTIPLE_TEAMS_BLOCKED,
+          message: alertMessage.MULTIPLE_TEAMS_BLOCKED,
+          blockedList,
+          status: RecipientStatus.NOT_ASSOCIATED,
+        };
+      }
+
+      // Single not-associated recipient
+      const name =
+        currentRecipient.suggestedNameDisplay || currentRecipient.name;
+      return {
+        shouldShow: true,
+        title: `Your account is no longer connected to ${name}`,
+        message: alertMessage.NO_ASSOCIATIONS,
+        blockedList,
+        status: RecipientStatus.NOT_ASSOCIATED,
+      };
+    }
+
+    // SCENARIO: Current recipient is BLOCKED
+    if (recipientStatus === RecipientStatus.BLOCKED) {
+      // In ComposeForm, show all blocked teams; in other contexts, show just the current one
+      if (parentComponent === ParentComponent.COMPOSE_FORM) {
+        const blockedList = buildBlockedItemsList(
+          blockedRecipients,
+          blockedFacilityObjects,
+        );
+        if (!blockedList.length) return null;
+
+        return getAlertConfigForBlockedList(blockedList);
+      }
+
+      const name =
+        currentRecipient.suggestedNameDisplay || currentRecipient.name;
+      return {
+        shouldShow: true,
+        title: `You can't send messages to ${name}`,
+        message: alertMessage.SINGLE_TEAM_BLOCKED,
+        blockedList: [formattedRecipient],
+        status: RecipientStatus.BLOCKED,
+      };
+    }
+
+    // Recipient is ALLOWED - no alert needed for the current recipient
+    // But in ComposeForm, still show blocked teams alert if there are any
+    if (parentComponent === ParentComponent.COMPOSE_FORM) {
+      const blockedList = buildBlockedItemsList(
+        blockedRecipients,
+        blockedFacilityObjects,
+      );
+      if (blockedList.length) {
+        return getAlertConfigForBlockedList(blockedList);
+      }
+    }
+
+    // No alert needed for ALLOWED recipient
+    return null;
+  }
+
+  // No current recipient - handle global states
+
+  // SCENARIO: No associations at all
+  if (noAssociations) {
+    return {
+      shouldShow: true,
+      title: alertTitle.NO_ASSOCIATIONS,
+      message: alertMessage.NO_ASSOCIATIONS,
+      blockedList: [],
+      status: null,
+    };
+  }
+
+  // SCENARIO: All teams are blocked
+  if (allTriageGroupsBlocked) {
+    return {
+      shouldShow: true,
+      title: alertTitle.ALL_TEAMS_BLOCKED,
+      message: alertMessage.ALL_TEAMS_BLOCKED,
+      blockedList: [],
+      status: RecipientStatus.BLOCKED,
+    };
+  }
+
+  // No current recipient - check if we should show blocked teams alert
+  const showBlockedAlert =
+    parentComponent === ParentComponent.COMPOSE_FORM ||
+    parentComponent === ParentComponent.CONTACT_LIST ||
+    parentComponent === ParentComponent.FOLDER_HEADER;
+
+  if (showBlockedAlert) {
+    const blockedList = buildBlockedItemsList(
+      blockedRecipients,
+      blockedFacilityObjects,
+    );
+    if (blockedList.length) {
+      return getAlertConfigForBlockedList(blockedList);
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Sanitizes the alert title for Datadog analytics to avoid PII/PHI.
+ * @param {string} title - The alert title
+ * @returns {string} Sanitized title for analytics
+ */
+export const getAnalyticsAlertType = title => {
+  if (!title) return '';
+
+  if (title.includes("You can't send messages to care teams at")) {
+    return "You can't send messages to care teams at FACILITY";
+  }
+  if (title.includes("You can't send messages to some of your care teams")) {
+    return title;
+  }
+  if (title.includes("You can't send messages to your care teams right now")) {
+    return title;
+  }
+  if (title.includes("You can't send messages to")) {
+    return "You can't send messages to TG_NAME";
+  }
+  if (title.includes('Your account is no longer connected to')) {
+    return 'Your account is no longer connected to TG_NAME';
+  }
+
+  return title;
+};

--- a/src/applications/mhv-secure-messaging/util/blockedTriageGroupUtils.js
+++ b/src/applications/mhv-secure-messaging/util/blockedTriageGroupUtils.js
@@ -109,13 +109,26 @@ export const buildBlockedItemsList = (
   blockedRecipients,
   blockedFacilityObjects,
 ) => {
+  // If neither has items, return empty
   if (!blockedRecipients?.length && !blockedFacilityObjects?.length) return [];
 
-  if (blockedRecipients?.length <= 1 || !blockedFacilityObjects?.length) {
+  // If only blocked facilities (no individual blocked recipients)
+  if (!blockedRecipients?.length && blockedFacilityObjects?.length) {
+    return sortTriageList(blockedFacilityObjects);
+  }
+
+  // If only blocked recipients (no blocked facilities)
+  if (!blockedFacilityObjects?.length && blockedRecipients?.length) {
+    return sortTriageList(blockedRecipients);
+  }
+
+  // If 1 or fewer blocked recipients, just return them (don't combine with facilities)
+  // This handles the case where we want to show just the blocked recipient
+  if (blockedRecipients?.length <= 1) {
     return sortTriageList(blockedRecipients || []);
   }
 
-  // Exclude individual teams that belong to fully blocked facilities
+  // Both have items - exclude individual teams that belong to fully blocked facilities
   const teamsNotInBlockedFacilities = blockedRecipients.filter(
     team =>
       !blockedFacilityObjects.some(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request refactors how blocked care teams and facilities are handled and displayed in the secure messaging application. It centralizes the alert logic into a utility, updates the rendering of alerts for blocked triage groups, and ensures that blocked facilities are excluded from selection lists. The changes improve maintainability, clarity, and user experience by providing more consistent and context-aware alerts across different components.

**Blocked Triage Group Alert Refactor and UI Improvements**

* Refactored `BlockedTriageGroupAlert.jsx` to use a centralized utility (`getBlockedTriageAlertConfig`) for determining alert configuration, simplifying state management and alert logic. The component now uses `useMemo` and `useRef` for more efficient rendering and analytics tracking.
* Updated rendering logic in `BlockedTriageGroupAlert.jsx` to consistently show either an expandable or standard alert depending on context, and to display a list of blocked care teams/facilities only when appropriate.
* Removed unused `blockedTriageGroupList` prop from the alert component, further simplifying its API.

**Integration of Blocked Alerts in Care Team Selection and Recent Care Teams**


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130635

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
