### PR TITLE
added env var to run cypress tests block of full-suite-tests.yml

### DIFF
--- a/.github/workflows/full-suite-tests.yml
+++ b/.github/workflows/full-suite-tests.yml
@@ -561,6 +561,7 @@ jobs:
           CYPRESS_CI: true
           STEP: ${{ matrix.ci_node_index }}
           NUM_CONTAINERS: ${{ needs.tests-prep.outputs.num_containers }}
+          APP_URLS: 'http://localhost:3001'
 
       - name: Archive test videos
         if: ${{ needs.tests-prep.outputs.cypress-tests != '[]' && failure() }}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _It was discovered that the e2e test functionality of the Full Test Suite was missing an env variable.  It has now been added to ensure that the e2e test jobs run as intended._

## Related issue(s)

- _[Platform Support ticket](https://dsva.slack.com/archives/CBU0KDSB1/p1768927271443179)_

## Testing done

- _Changes were tested directly in a GHA runner at the [Full Test Suite page.](https://github.com/department-of-veterans-affairs/vets-website/actions/workflows/full-suite-tests.yml)_

