### PR TITLE
stop sending hardcoded Facilities params

### DIFF
--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -22,9 +22,7 @@ const formatAddress = ({
 export const fetchFacilities = async ({
   lat = null,
   long = null,
-  radius = null,
   page = null,
-  perPage = null,
   facilityIds = [],
   type = 'health',
 }) => {
@@ -37,9 +35,7 @@ export const fetchFacilities = async ({
         type,
         lat,
         long,
-        radius,
         page,
-        perPage,
         facilityIds: facilityIds.join(','),
       }),
       headers: { 'Content-Type': 'application/json' },

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -34,8 +34,6 @@ const FacilitySearch = props => {
     coordinates: { lat: '', long: '' },
   });
   const vaSearchInputRef = useRef(null);
-  const radius = 500;
-  const resultsPerPage = 5;
   const hasFacilities = localState.facilities.length > 0;
   const hasMoreFacilities =
     localState.facilities.length < localState.pagination.totalEntries;
@@ -149,9 +147,7 @@ const FacilitySearch = props => {
       const fetchResponse = await fetchFacilities({
         long: longitude,
         lat: latitude,
-        perPage: resultsPerPage,
         page: 1,
-        radius,
       });
       if (fetchResponse.errorMessage) {
         return setLocalState(prev => ({
@@ -188,8 +184,6 @@ const FacilitySearch = props => {
       const response = await fetchFacilities({
         ...localState.coordinates,
         page: localState.pagination.currentPage + 1,
-        perPage: resultsPerPage,
-        radius,
       });
       return response.errorMessage
         ? setLocalState(prev => ({

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/facilities.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/facilities.json
@@ -570,10 +570,10 @@
     }
   ],
   "links": {
-    "self": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=1&per_page=5",
-    "first": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=1&per_page=5",
-    "next": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=2&per_page=5",
-    "last": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=108&per_page=5"
+    "self": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&type=health&page=1",
+    "first": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&type=health&page=1",
+    "next": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&type=health&page=2",
+    "last": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&type=health&page=108"
   },
   "meta": {
     "pagination": {

--- a/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.jsx
@@ -19,9 +19,7 @@ describe('CG fetchFacilities action', () => {
   const buildExpectedBody = ({
     lat = null,
     long = null,
-    radius = null,
     page = null,
-    perPage = null,
     type = 'health',
     facilityIds = '',
   } = {}) =>
@@ -29,9 +27,7 @@ describe('CG fetchFacilities action', () => {
       type,
       lat,
       long,
-      radius,
       page,
-      perPage,
       facilityIds,
     });
   const requestArgs = {
@@ -40,9 +36,7 @@ describe('CG fetchFacilities action', () => {
   };
   const lat = 1;
   const long = 2;
-  const perPage = 5;
   const page = 1;
-  const radius = 500;
   const facilityIds = ['12', '34'];
   const endpoint = API_ENDPOINTS.facilities;
   let apiRequestStub;
@@ -59,15 +53,13 @@ describe('CG fetchFacilities action', () => {
 
   context('when the fetch succeeds', () => {
     it('should make the correct request when all params are passed', async () => {
-      await fetchFacilities({ long, lat, perPage, radius, page, facilityIds });
+      await fetchFacilities({ long, lat, page, facilityIds });
       sinon.assert.calledOnceWithExactly(apiRequestStub, endpoint, {
         ...requestArgs,
         body: buildExpectedBody({
           lat,
           long,
-          radius,
           page,
-          perPage,
           facilityIds: `${facilityIds[0]},${facilityIds[1]}`,
         }),
       });
@@ -91,21 +83,21 @@ describe('CG fetchFacilities action', () => {
 
     it('should correctly format facility with address data', async () => {
       apiRequestStub.resolves(mockVetsApiFacilitiesResponse);
-      const response = await fetchFacilities({ long, lat, perPage, radius });
+      const response = await fetchFacilities({ long, lat });
       expect(response).to.deep.eq(mockFetchFacilitiesResponse);
       sinon.assert.calledOnce(apiRequestStub);
     });
 
     it('should correctly format facility without address data', async () => {
       apiRequestStub.resolves(mockVetsApiFacilitiesWithoutAddressResponse);
-      const response = await fetchFacilities({ long, lat, perPage, radius });
+      const response = await fetchFacilities({ long, lat });
       expect(response).to.deep.eq(mockFetchFacilitiesReponseWithoutAddress);
       sinon.assert.calledOnce(apiRequestStub);
     });
 
     it('should return `NO_SEARCH_RESULTS` if no data array', async () => {
       apiRequestStub.resolves({ meta: {} });
-      const response = await fetchFacilities({ long, lat, perPage, radius });
+      const response = await fetchFacilities({ long, lat });
       expect(response).to.deep.eq({
         type: 'NO_SEARCH_RESULTS',
         errorMessage: ERROR_MSG_NO_RESULTS,

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch-search.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch-search.unit.spec.jsx
@@ -25,8 +25,6 @@ const ERROR_MSG_DEFAULT = content['validation-facilities--default-required'];
 describe('CG <FacilitySearch>', () => {
   const lat = 1;
   const long = 2;
-  const perPage = 5;
-  const radius = 500;
   const query = 'Tampa';
   const mapBoxSuccessResponse = { center: [long, lat] };
   let mockLogger;
@@ -99,8 +97,6 @@ describe('CG <FacilitySearch>', () => {
       sinon.assert.calledWithExactly(facilitiesStub, {
         lat,
         long,
-        perPage,
-        radius,
         page: 1,
       });
     });
@@ -122,7 +118,6 @@ describe('CG <FacilitySearch>', () => {
             currentPage: 1,
             totalPages: 3,
             totalEntries,
-            perPage,
           },
         },
       });
@@ -323,8 +318,6 @@ describe('CG <FacilitySearch>', () => {
       sinon.assert.calledWithExactly(facilitiesStub, {
         lat,
         long,
-        perPage,
-        radius,
         page: 2,
       });
 
@@ -370,8 +363,6 @@ describe('CG <FacilitySearch>', () => {
       sinon.assert.calledWithExactly(facilitiesStub, {
         lat,
         long,
-        perPage,
-        radius,
         page: 2,
       });
 


### PR DESCRIPTION
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Do not send the CG Facilities backend any request parameters for `radius` or `perPage`, since they're hardcoded on the backend.
- These params should not be user-modifiable, and are now ignored on the backend. Sending them is misleading - better to clear them out of the codebase.
- Health Applications 10-10 CG

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128114
department-of-veterans-affairs/va.gov-team#0000
- This should be merged after the backend change is live: https://github.com/department-of-veterans-affairs/vets-api/pull/26050

## Testing done

- Previously, the frontend sent `radius` and `perPage` params to the backend, which the backend forwarded to the Lighthouse API.
- Start the CG form, and proceed to the Facilities search. Open the Network tab of the browser console, and confirm that these params are no longer sent in the search request.
- the Request's Payload should look like: `{type: "health", lat: 42.825113, long: -73.878976, page: 1, facilityIds: ""}`, without the removed parameters

## Screenshots
<img width="883" height="249" alt="Screenshot 2026-01-21 at 3 17 26 PM" src="https://github.com/user-attachments/assets/68f1c4dc-9e9a-4e95-b73f-4b64b5c88dde" />

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
