### PR TITLE
Form 0779 Staging Review Fix - Update paragraph wording

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/certification-level-of-care.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/certification-level-of-care.js
@@ -30,7 +30,7 @@ export const certificationLevelOfCareUiSchema = {
       const data = fullData || formData;
       const patientName = getPatientName(data);
 
-      const title = `I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving`;
+      const title = `I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving the following care`;
 
       return {
         certificationLevelOfCare: {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Changed wording of paragraph based on Staging Review findings:
`I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving`
updated to text:
`I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving the following care`
- Team: Benefits Optimization - Aquia
- Flipper not required

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124632

## Testing done

- Old behavior: wording read `I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving`
New behavior:
`I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving the following care`
- **Verification steps**:
  1. Navigate to Form 21-0779 in local environment
  2. Complete form to Level of Care page
  3. Verify subtitle shows `I certify that ${patientName} is a patient in this facility because of a mental or physical disability and is receiving the following care`
- **Tests completed**: E2E tests passing, no test updates required as tests don't assert on subtitle text

## Screenshots

### Before
<img width="473" height="209" alt="0779-paragraph-update-before" src="https://github.com/user-attachments/assets/5e1f6f9f-4b27-4482-b751-498e962b573b" />

### After
<img width="459" height="222" alt="0779-paragraph-update-after" src="https://github.com/user-attachments/assets/11ae9155-b119-4b28-b0c0-3e6f6febf5d2" />

## What areas of the site does it impact?

**Form 21-0779 (Request for Nursing Home Information in Connection with Claim for Aid and Attendance)**
- Level of Care page - paragraph text

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
