### PR TITLE
Add cancel flow auth wrapper

### DIFF
--- a/src/applications/vass/containers/withFlowGuard.jsx
+++ b/src/applications/vass/containers/withFlowGuard.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { selectFlowType, selectUuid } from '../redux/slices/formSlice';
+import { FLOW_TYPES, URLS } from '../utils/constants';
+
+/**
+ * HOC that restricts route access based on the user's current flow type.
+ *
+ * This prevents users from switching between schedule and cancel flows:
+ * - Users in the 'schedule' flow cannot access cancel-only routes
+ * - Users in the 'cancel' flow cannot access schedule-only routes
+ * - Routes marked as 'any' are accessible from both flows
+ *
+ * @param {React.Component} Component - The component to wrap
+ * @param {'schedule'|'cancel'|'any'} allowedFlow - Which flow can access this route
+ * @returns {React.Component} - The wrapped component with flow guard logic
+ */
+const withFlowGuard = (Component, allowedFlow = FLOW_TYPES.ANY) => {
+  const WrappedComponent = props => {
+    const navigate = useNavigate();
+    const flowType = useSelector(selectFlowType);
+    const uuid = useSelector(selectUuid);
+
+    useEffect(
+      () => {
+        // Skip guard if route allows any flow
+        if (allowedFlow === FLOW_TYPES.ANY) return;
+
+        // Skip guard if flow type hasn't been set yet (user just started)
+        if (!flowType || flowType === FLOW_TYPES.ANY) return;
+
+        // If user's flow doesn't match the allowed flow, redirect to start
+        if (flowType !== allowedFlow) {
+          // Redirect back to Verify page with uuid to restart in their original flow
+          const redirectUrl = uuid
+            ? `${URLS.VERIFY}?uuid=${uuid}`
+            : URLS.VERIFY;
+          navigate(redirectUrl, { replace: true });
+        }
+      },
+      [flowType, navigate, uuid],
+    );
+
+    // Don't render while redirect is pending (wrong flow detected)
+    if (
+      allowedFlow !== FLOW_TYPES.ANY &&
+      flowType &&
+      flowType !== FLOW_TYPES.ANY &&
+      flowType !== allowedFlow
+    ) {
+      return null;
+    }
+
+    return <Component {...props} />;
+  };
+
+  // Set display name for debugging
+  WrappedComponent.displayName = `withFlowGuard(${Component.displayName ||
+    Component.name ||
+    'Component'})`;
+
+  return WrappedComponent;
+};
+
+export default withFlowGuard;

--- a/src/applications/vass/containers/withFlowGuard.unit.spec.jsx
+++ b/src/applications/vass/containers/withFlowGuard.unit.spec.jsx
@@ -1,0 +1,330 @@
+import React from 'react';
+import { expect } from 'chai';
+import { waitFor } from '@testing-library/react';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { renderWithStoreAndRouterV6 } from '~/platform/testing/unit/react-testing-library-helpers';
+
+import withFlowGuard from './withFlowGuard';
+import { FLOW_TYPES, URLS } from '../utils/constants';
+import { getDefaultRenderOptions } from '../utils/test-utils';
+
+// Helper component to display current location for testing navigation
+const LocationDisplay = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location-display">
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+};
+
+// Simple test component to wrap
+const TestComponent = () => (
+  <div data-testid="test-component">Test Content</div>
+);
+
+describe('VASS Containers: withFlowGuard', () => {
+  describe('with FLOW_TYPES.ANY (default)', () => {
+    it('should render the wrapped component regardless of flow type', () => {
+      const WrappedComponent = withFlowGuard(TestComponent, FLOW_TYPES.ANY);
+
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <WrappedComponent />,
+        getDefaultRenderOptions({ flowType: FLOW_TYPES.SCHEDULE }),
+      );
+
+      expect(getByTestId('test-component')).to.exist;
+    });
+
+    it('should render when flow type is cancel', () => {
+      const WrappedComponent = withFlowGuard(TestComponent, FLOW_TYPES.ANY);
+
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <WrappedComponent />,
+        getDefaultRenderOptions({ flowType: FLOW_TYPES.CANCEL }),
+      );
+
+      expect(getByTestId('test-component')).to.exist;
+    });
+
+    it('should render when flow type is not set', () => {
+      const WrappedComponent = withFlowGuard(TestComponent, FLOW_TYPES.ANY);
+
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <WrappedComponent />,
+        getDefaultRenderOptions({ flowType: null }),
+      );
+
+      expect(getByTestId('test-component')).to.exist;
+    });
+  });
+
+  describe('with FLOW_TYPES.SCHEDULE', () => {
+    describe('when user is in schedule flow', () => {
+      it('should render the wrapped component', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.SCHEDULE,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: FLOW_TYPES.SCHEDULE }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+    });
+
+    describe('when user is in cancel flow', () => {
+      it('should not render the component', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.SCHEDULE,
+        );
+
+        const { queryByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: FLOW_TYPES.CANCEL }),
+        );
+
+        expect(queryByTestId('test-component')).to.not.exist;
+      });
+
+      it('should redirect to Verify page with uuid', async () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.SCHEDULE,
+        );
+
+        const { getByTestId, queryByTestId } = renderWithStoreAndRouterV6(
+          <>
+            <Routes>
+              <Route path="/schedule-route" element={<WrappedComponent />} />
+              <Route
+                path="/"
+                element={<div data-testid="verify-page">Verify</div>}
+              />
+            </Routes>
+            <LocationDisplay />
+          </>,
+          {
+            ...getDefaultRenderOptions({
+              flowType: FLOW_TYPES.CANCEL,
+              uuid: 'test-uuid-1234',
+            }),
+            initialEntries: ['/schedule-route'],
+          },
+        );
+
+        await waitFor(() => {
+          expect(getByTestId('location-display').textContent).to.equal(
+            `${URLS.VERIFY}?uuid=test-uuid-1234`,
+          );
+        });
+
+        expect(queryByTestId('test-component')).to.not.exist;
+      });
+
+      it('should redirect to Verify page without uuid when uuid is not set', async () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.SCHEDULE,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <>
+            <Routes>
+              <Route path="/schedule-route" element={<WrappedComponent />} />
+              <Route
+                path="/"
+                element={<div data-testid="verify-page">Verify</div>}
+              />
+            </Routes>
+            <LocationDisplay />
+          </>,
+          {
+            ...getDefaultRenderOptions({
+              flowType: FLOW_TYPES.CANCEL,
+              uuid: null,
+            }),
+            initialEntries: ['/schedule-route'],
+          },
+        );
+
+        await waitFor(() => {
+          expect(getByTestId('location-display').textContent).to.equal(
+            URLS.VERIFY,
+          );
+        });
+      });
+    });
+
+    describe('when flow type is not set yet', () => {
+      it('should render the component when flowType is null', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.SCHEDULE,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: null }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+
+      it('should render the component when flowType is ANY', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.SCHEDULE,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: FLOW_TYPES.ANY }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+    });
+  });
+
+  describe('with FLOW_TYPES.CANCEL', () => {
+    describe('when user is in cancel flow', () => {
+      it('should render the wrapped component', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.CANCEL,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: FLOW_TYPES.CANCEL }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+    });
+
+    describe('when user is in schedule flow', () => {
+      it('should not render the component', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.CANCEL,
+        );
+
+        const { queryByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: FLOW_TYPES.SCHEDULE }),
+        );
+
+        expect(queryByTestId('test-component')).to.not.exist;
+      });
+
+      it('should redirect to Verify page with uuid', async () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.CANCEL,
+        );
+
+        const { getByTestId, queryByTestId } = renderWithStoreAndRouterV6(
+          <>
+            <Routes>
+              <Route path="/cancel-route" element={<WrappedComponent />} />
+              <Route
+                path="/"
+                element={<div data-testid="verify-page">Verify</div>}
+              />
+            </Routes>
+            <LocationDisplay />
+          </>,
+          {
+            ...getDefaultRenderOptions({
+              flowType: FLOW_TYPES.SCHEDULE,
+              uuid: 'test-uuid-5678',
+            }),
+            initialEntries: ['/cancel-route'],
+          },
+        );
+
+        await waitFor(() => {
+          expect(getByTestId('location-display').textContent).to.equal(
+            `${URLS.VERIFY}?uuid=test-uuid-5678`,
+          );
+        });
+
+        expect(queryByTestId('test-component')).to.not.exist;
+      });
+    });
+
+    describe('when flow type is not set yet', () => {
+      it('should render the component when flowType is null', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.CANCEL,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: null }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+
+      it('should render the component when flowType is ANY', () => {
+        const WrappedComponent = withFlowGuard(
+          TestComponent,
+          FLOW_TYPES.CANCEL,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ flowType: FLOW_TYPES.ANY }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+    });
+  });
+
+  describe('displayName', () => {
+    it('should set displayName for debugging', () => {
+      const NamedComponent = () => <div>Named</div>;
+      NamedComponent.displayName = 'NamedComponent';
+
+      const WrappedComponent = withFlowGuard(NamedComponent, FLOW_TYPES.ANY);
+
+      expect(WrappedComponent.displayName).to.equal(
+        'withFlowGuard(NamedComponent)',
+      );
+    });
+
+    it('should use component name when displayName is not set', () => {
+      const MyComponent = () => <div>My</div>;
+
+      const WrappedComponent = withFlowGuard(MyComponent, FLOW_TYPES.ANY);
+
+      expect(WrappedComponent.displayName).to.equal(
+        'withFlowGuard(MyComponent)',
+      );
+    });
+  });
+
+  describe('default allowedFlow parameter', () => {
+    it('should default to FLOW_TYPES.ANY when no allowedFlow is provided', () => {
+      const WrappedComponent = withFlowGuard(TestComponent);
+
+      // Should render regardless of flow type since default is ANY
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <WrappedComponent />,
+        getDefaultRenderOptions({ flowType: FLOW_TYPES.CANCEL }),
+      );
+
+      expect(getByTestId('test-component')).to.exist;
+    });
+  });
+});

--- a/src/applications/vass/pages/EnterOTC.jsx
+++ b/src/applications/vass/pages/EnterOTC.jsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { focusElement } from 'platform/utilities/ui';
 import { useSelector } from 'react-redux';
 import Wrapper from '../layout/Wrapper';
 import { usePostOTCVerificationMutation } from '../redux/api/vassApi';
-import { selectObfuscatedEmail } from '../redux/slices/formSlice';
-import { URLS } from '../utils/constants';
+import {
+  selectFlowType,
+  selectObfuscatedEmail,
+} from '../redux/slices/formSlice';
+import { FLOW_TYPES, URLS } from '../utils/constants';
 
 const getErrorMessage = (errorCode, attemptsRemaining = 0) => {
   switch (errorCode) {
@@ -32,8 +35,8 @@ const getPageTitle = (cancellationFlow, error) => {
 };
 
 const EnterOTC = () => {
-  const [searchParams] = useSearchParams();
-  const cancellationFlow = searchParams.get('cancel') === 'true';
+  const flowType = useSelector(selectFlowType);
+  const cancellationFlow = flowType === FLOW_TYPES.CANCEL;
   const navigate = useNavigate();
   const obfuscatedEmail = useSelector(selectObfuscatedEmail);
 

--- a/src/applications/vass/pages/EnterOTC.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTC.unit.spec.jsx
@@ -12,10 +12,7 @@ import {
 } from '@department-of-veterans-affairs/platform-testing/helpers';
 
 import EnterOTC from './EnterOTC';
-import {
-  getDefaultRenderOptions,
-  defaultScheduledDowntimeState,
-} from '../utils/test-utils';
+import { getDefaultRenderOptions } from '../utils/test-utils';
 import { FLOW_TYPES, URLS } from '../utils/constants';
 
 // Helper component to display current location for testing navigation

--- a/src/applications/vass/pages/EnterOTC.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTC.unit.spec.jsx
@@ -14,10 +14,9 @@ import {
 import EnterOTC from './EnterOTC';
 import {
   getDefaultRenderOptions,
-  reducers,
-  vassApi,
   defaultScheduledDowntimeState,
 } from '../utils/test-utils';
+import { FLOW_TYPES, URLS } from '../utils/constants';
 
 // Helper component to display current location for testing navigation
 const LocationDisplay = () => {
@@ -30,6 +29,15 @@ const defaultRenderOptions = getDefaultRenderOptions({
   uuid: 'c0ffee-1234-beef-5678',
   lastname: 'Smith',
   dob: '1935-04-07',
+  flowType: FLOW_TYPES.SCHEDULE, // default to schedule flow for testing
+});
+
+const defaultRenderOptionsWithCancelFlow = getDefaultRenderOptions({
+  obfuscatedEmail: 't***@test.com',
+  uuid: 'c0ffee-1234-beef-5678',
+  lastname: 'Smith',
+  dob: '1935-04-07',
+  flowType: FLOW_TYPES.CANCEL,
 });
 
 const renderComponent = () =>
@@ -206,24 +214,20 @@ describe('VASS Component: EnterOTC', () => {
       const { container, getByTestId } = renderWithStoreAndRouterV6(
         <>
           <Routes>
-            <Route path="/enter-otc" element={<EnterOTC />} />
-            <Route path="/date-time" element={<div>Date Time Page</div>} />
+            <Route path={URLS.ENTER_OTC} element={<EnterOTC />} />
+            <Route path={URLS.DATE_TIME} element={<div>Date Time Page</div>} />
           </Routes>
           <LocationDisplay />
         </>,
         {
-          initialState: {
-            scheduledDowntime: defaultScheduledDowntimeState,
-          },
-          reducers,
-          initialEntries: ['/enter-otc'],
-          additionalMiddlewares: [vassApi.middleware],
+          ...defaultRenderOptions,
+          initialEntries: [URLS.ENTER_OTC],
         },
       );
 
       // Verify we start on the enter-otc page
       expect(getByTestId('location-display').textContent).to.equal(
-        '/enter-otc',
+        URLS.ENTER_OTC,
       );
 
       inputVaTextInput(container, '123456', 'va-text-input[name="otc"]');
@@ -232,17 +236,17 @@ describe('VASS Component: EnterOTC', () => {
 
       await waitFor(() => {
         expect(getByTestId('location-display').textContent).to.equal(
-          '/date-time',
+          URLS.DATE_TIME,
         );
       });
     });
   });
 
-  describe('when cancellation url parameter is true', () => {
+  describe('when cancellation flow is active', () => {
     it('should display the correct page title', () => {
       const { getByTestId } = renderWithStoreAndRouterV6(<EnterOTC />, {
-        ...defaultRenderOptions,
-        initialEntries: ['/enter-otc?cancel=true'],
+        ...defaultRenderOptionsWithCancelFlow,
+        initialEntries: [URLS.ENTER_OTC],
       });
 
       expect(getByTestId('header').textContent).to.contain(
@@ -262,7 +266,7 @@ describe('VASS Component: EnterOTC', () => {
       const { container, getByTestId } = renderWithStoreAndRouterV6(
         <>
           <Routes>
-            <Route path="/enter-otc" element={<EnterOTC />} />
+            <Route path={URLS.ENTER_OTC} element={<EnterOTC />} />
             <Route
               path="/cancel-appointment/:appointmentId"
               element={<div>Cancel Appointment Page</div>}
@@ -271,9 +275,8 @@ describe('VASS Component: EnterOTC', () => {
           <LocationDisplay />
         </>,
         {
-          ...defaultRenderOptions,
-          initialEntries: ['/enter-otc?cancel=true'],
-          additionalMiddlewares: [vassApi.middleware],
+          ...defaultRenderOptionsWithCancelFlow,
+          initialEntries: [URLS.ENTER_OTC],
         },
       );
 
@@ -283,7 +286,7 @@ describe('VASS Component: EnterOTC', () => {
 
       await waitFor(() => {
         expect(getByTestId('location-display').textContent).to.equal(
-          '/cancel-appointment/abcdef123456',
+          `${URLS.CANCEL_APPOINTMENT}/abcdef123456`,
         );
       });
     });

--- a/src/applications/vass/pages/Verify.jsx
+++ b/src/applications/vass/pages/Verify.jsx
@@ -5,8 +5,8 @@ import { focusElement } from 'platform/utilities/ui';
 import { VaMemorableDate } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import Wrapper from '../layout/Wrapper';
 import { usePostAuthenticationMutation } from '../redux/api/vassApi';
-import { clearFormData } from '../redux/slices/formSlice';
-import { URLS } from '../utils/constants';
+import { clearFormData, setFlowType } from '../redux/slices/formSlice';
+import { FLOW_TYPES, URLS } from '../utils/constants';
 
 const getPageTitle = (cancellationFlow, verificationError) => {
   if (verificationError) {
@@ -30,12 +30,17 @@ const Verify = () => {
     // TODO: route to the "Something went wrong" page
   }
 
-  // Ensures a fresh start when landing on Verify page
+  // Ensures a fresh start when landing on Verify page and sets the flow type
   useEffect(
     () => {
       dispatch(clearFormData());
+      // Set flow type based on URL parameter
+      const flowType = cancellationFlow
+        ? FLOW_TYPES.CANCEL
+        : FLOW_TYPES.SCHEDULE;
+      dispatch(setFlowType(flowType));
     },
-    [dispatch],
+    [dispatch, cancellationFlow],
   );
 
   const [lastname, setLastname] = useState('');
@@ -95,11 +100,7 @@ const Verify = () => {
       setAttemptCount(count => count + 1);
       return;
     }
-    let otcRoute = URLS.ENTER_OTC;
-    if (cancellationFlow) {
-      otcRoute += '?cancel=true';
-    }
-    navigate(otcRoute);
+    navigate(URLS.ENTER_OTC);
   };
 
   const pageTitle = getPageTitle(cancellationFlow, verificationError);

--- a/src/applications/vass/pages/Verify.unit.spec.jsx
+++ b/src/applications/vass/pages/Verify.unit.spec.jsx
@@ -20,6 +20,7 @@ import {
   reducers,
   vassApi,
 } from '../utils/test-utils';
+import { FLOW_TYPES, URLS } from '../utils/constants';
 
 // Helper component to display current location for testing navigation
 const LocationDisplay = () => {
@@ -58,10 +59,27 @@ describe('VASS Component: Verify', () => {
   });
 
   describe('when cancellation url parameter is true', () => {
+    it('should set the flow type to cancel', async () => {
+      const store = createStore(
+        combineReducers({ ...commonReducer, ...reducers }),
+        defaultRenderOptions.initialState,
+        applyMiddleware(thunk, vassApi.middleware),
+      );
+
+      renderWithStoreAndRouterV6(<Verify />, {
+        ...defaultRenderOptions,
+        store,
+        initialEntries: [`${URLS.VERIFY}?cancel=true&uuid=test-uuid`],
+      });
+
+      await waitFor(() => {
+        expect(store.getState().vassForm.flowType).to.equal(FLOW_TYPES.CANCEL);
+      });
+    });
     it('should display the correct page title', () => {
       const { getByTestId } = renderWithStoreAndRouterV6(<Verify />, {
         ...defaultRenderOptions,
-        initialEntries: ['/?cancel=true'],
+        initialEntries: [`${URLS.VERIFY}?cancel=true`],
       });
 
       expect(getByTestId('header').textContent).to.contain(
@@ -69,7 +87,7 @@ describe('VASS Component: Verify', () => {
       );
     });
 
-    it('should navigate to enter otc page passing cancel=true as a url parameter', async () => {
+    it('should navigate to enter otc page', async () => {
       setFetchJSONResponse(global.fetch.onCall(0), {
         data: {
           message: 'OTC sent to registered email address',
@@ -81,14 +99,14 @@ describe('VASS Component: Verify', () => {
       const { container, getByTestId } = renderWithStoreAndRouterV6(
         <>
           <Routes>
-            <Route path="/" element={<Verify />} />
-            <Route path="/enter-otc" element={<div>Enter OTC Page</div>} />
+            <Route path={URLS.VERIFY} element={<Verify />} />
+            <Route path={URLS.ENTER_OTC} element={<div>Enter OTC Page</div>} />
           </Routes>
           <LocationDisplay />
         </>,
         {
           ...defaultRenderOptions,
-          initialEntries: ['/?cancel=true'],
+          initialEntries: [URLS.VERIFY],
         },
       );
 
@@ -108,7 +126,7 @@ describe('VASS Component: Verify', () => {
 
       await waitFor(() => {
         expect(getByTestId('location-display').textContent).to.equal(
-          '/enter-otc?cancel=true',
+          URLS.ENTER_OTC,
         );
       });
     });
@@ -127,8 +145,8 @@ describe('VASS Component: Verify', () => {
       const { container, getByTestId } = renderWithStoreAndRouterV6(
         <>
           <Routes>
-            <Route path="/" element={<Verify />} />
-            <Route path="/enter-otc" element={<div>Enter OTC Page</div>} />
+            <Route path={URLS.VERIFY} element={<Verify />} />
+            <Route path={URLS.ENTER_OTC} element={<div>Enter OTC Page</div>} />
           </Routes>
           <LocationDisplay />
         </>,
@@ -154,7 +172,7 @@ describe('VASS Component: Verify', () => {
 
       await waitFor(() => {
         expect(getByTestId('location-display').textContent).to.equal(
-          '/enter-otc',
+          URLS.ENTER_OTC,
         );
       });
     });

--- a/src/applications/vass/redux/slices/formSlice.js
+++ b/src/applications/vass/redux/slices/formSlice.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
+import { FLOW_TYPES } from '../../utils/constants';
 
 // Storage key constants
 const VASS_CURRENT_UUID_KEY = 'vass_current_uuid';
@@ -67,7 +68,7 @@ const clearFormDataFromStorage = () => {
 };
 
 /** @typedef {{ topicId: string, topicName: string }} Topic */
-/** @type {{ selectedDate: Date | null, selectedTopics: Topic[], obfuscatedEmail: string | null, uuid: string | null, lastname: string | null, dob: string | null }} */
+/** @type {{ selectedDate: Date | null, selectedTopics: Topic[], obfuscatedEmail: string | null, uuid: string | null, token: string | null, lastname: string | null, dob: string | null, flowType: string | null }} */
 const initialState = {
   hydrated: false,
   selectedDate: null,
@@ -76,6 +77,7 @@ const initialState = {
   uuid: null,
   lastname: null,
   dob: null,
+  flowType: FLOW_TYPES.ANY,
 };
 
 export const formSlice = createSlice({
@@ -121,6 +123,9 @@ export const formSlice = createSlice({
         dob: action.payload.dob,
       });
     },
+    setFlowType: (state, action) => {
+      state.flowType = action.payload;
+    },
     clearFormData: state => {
       // Clear from storage before resetting state
       clearFormDataFromStorage();
@@ -131,6 +136,7 @@ export const formSlice = createSlice({
       state.lastname = null;
       state.dob = null;
       state.hydrated = false;
+      state.flowType = FLOW_TYPES.ANY;
     },
     hydrateFormData: (state, action) => {
       state.hydrated = true;
@@ -152,6 +158,9 @@ export const formSlice = createSlice({
       if (action.payload.selectedTopics) {
         state.selectedTopics = action.payload.selectedTopics;
       }
+      if (action.payload.flowType) {
+        state.flowType = action.payload.flowType;
+      }
     },
   },
 });
@@ -161,6 +170,7 @@ export const {
   setSelectedTopics,
   setLowAuthFormData,
   setObfuscatedEmail,
+  setFlowType,
   clearFormData,
   hydrateFormData,
 } = formSlice.actions;
@@ -172,5 +182,6 @@ export const selectHydrated = state => state.vassForm.hydrated;
 export const selectObfuscatedEmail = state => state.vassForm.obfuscatedEmail;
 export const selectLastname = state => state.vassForm.lastname;
 export const selectDob = state => state.vassForm.dob;
+export const selectFlowType = state => state.vassForm.flowType;
 
 export default formSlice.reducer;

--- a/src/applications/vass/redux/slices/formSlice.unit.spec.jsx
+++ b/src/applications/vass/redux/slices/formSlice.unit.spec.jsx
@@ -4,6 +4,7 @@ import formReducer, {
   setSelectedTopics,
   setObfuscatedEmail,
   setLowAuthFormData,
+  setFlowType,
   clearFormData,
   hydrateFormData,
   loadFormDataFromStorage,
@@ -14,7 +15,9 @@ import formReducer, {
   selectUuid,
   selectLastname,
   selectDob,
+  selectFlowType,
 } from './formSlice';
+import { FLOW_TYPES } from '../../utils/constants';
 
 describe('formSlice', () => {
   describe('reducer', () => {
@@ -28,6 +31,7 @@ describe('formSlice', () => {
         uuid: null,
         lastname: null,
         dob: null,
+        flowType: FLOW_TYPES.ANY,
       });
     });
 
@@ -41,6 +45,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const dateString = '2025-01-15T10:00:00.000Z';
         const actual = formReducer(initialState, setSelectedDate(dateString));
@@ -58,6 +63,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const newDateString = '2025-02-20T14:30:00.000Z';
         const actual = formReducer(
@@ -80,6 +86,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const topics = ['topic-1', 'topic-2', 'topic-3'];
         const actual = formReducer(initialState, setSelectedTopics(topics));
@@ -97,6 +104,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const newTopics = ['topic-2', 'topic-3'];
         const actual = formReducer(initialState, setSelectedTopics(newTopics));
@@ -114,6 +122,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const actual = formReducer(initialState, setSelectedTopics([]));
 
@@ -131,6 +140,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const email = 't***@example.com';
         const actual = formReducer(initialState, setObfuscatedEmail(email));
@@ -147,6 +157,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const newEmail = 'new***@example.com';
         const actual = formReducer(initialState, setObfuscatedEmail(newEmail));
@@ -165,6 +176,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const payload = {
           uuid: 'c0ffee-1234-beef-5678',
@@ -187,6 +199,7 @@ describe('formSlice', () => {
           uuid: 'old-uuid',
           lastname: 'OldName',
           dob: '1980-05-20',
+          flowType: FLOW_TYPES.ANY,
         };
         const payload = {
           uuid: 'new-uuid',
@@ -201,8 +214,70 @@ describe('formSlice', () => {
       });
     });
 
+    describe('setFlowType', () => {
+      it('should set the flow type to schedule', () => {
+        const initialState = {
+          hydrated: false,
+          selectedDate: null,
+          selectedTopics: [],
+          obfuscatedEmail: null,
+          token: null,
+          uuid: null,
+          lastname: null,
+          dob: null,
+          flowType: FLOW_TYPES.ANY,
+        };
+        const actual = formReducer(
+          initialState,
+          setFlowType(FLOW_TYPES.SCHEDULE),
+        );
+
+        expect(actual.flowType).to.equal(FLOW_TYPES.SCHEDULE);
+      });
+
+      it('should set the flow type to cancel', () => {
+        const initialState = {
+          hydrated: false,
+          selectedDate: null,
+          selectedTopics: [],
+          obfuscatedEmail: null,
+          token: null,
+          uuid: null,
+          lastname: null,
+          dob: null,
+          flowType: FLOW_TYPES.ANY,
+        };
+        const actual = formReducer(
+          initialState,
+          setFlowType(FLOW_TYPES.CANCEL),
+        );
+
+        expect(actual.flowType).to.equal(FLOW_TYPES.CANCEL);
+      });
+
+      it('should update the flow type when one already exists', () => {
+        const initialState = {
+          hydrated: false,
+          selectedDate: null,
+          selectedTopics: [],
+          obfuscatedEmail: null,
+          token: null,
+          uuid: null,
+          lastname: null,
+          dob: null,
+          flowType: FLOW_TYPES.SCHEDULE,
+        };
+        const actual = formReducer(
+          initialState,
+          setFlowType(FLOW_TYPES.CANCEL),
+        );
+
+        expect(actual.flowType).to.equal(FLOW_TYPES.CANCEL);
+      });
+    });
+
     describe('clearFormData', () => {
-      it('should clear all form data including hydrated flag', () => {
+      it('should clear all form data including hydrated flag and reset flowType', () => {
         const initialState = {
           hydrated: true,
           selectedDate: '2025-01-15T10:00:00.000Z',
@@ -211,6 +286,7 @@ describe('formSlice', () => {
           uuid: 'c0ffee-1234-beef-5678',
           lastname: 'Doe',
           dob: '1990-01-15',
+          flowType: FLOW_TYPES.CANCEL,
         };
         const actual = formReducer(initialState, clearFormData());
 
@@ -221,6 +297,7 @@ describe('formSlice', () => {
         expect(actual.uuid).to.be.null;
         expect(actual.lastname).to.be.null;
         expect(actual.dob).to.be.null;
+        expect(actual.flowType).to.equal(FLOW_TYPES.ANY);
       });
 
       it('should return initial state when clearing already empty data', () => {
@@ -232,6 +309,7 @@ describe('formSlice', () => {
           uuid: null,
           lastname: null,
           dob: null,
+          flowType: FLOW_TYPES.ANY,
         };
         const actual = formReducer(initialState, clearFormData());
 
@@ -242,6 +320,7 @@ describe('formSlice', () => {
         expect(actual.uuid).to.be.null;
         expect(actual.lastname).to.be.null;
         expect(actual.dob).to.be.null;
+        expect(actual.flowType).to.equal(FLOW_TYPES.ANY);
       });
     });
 
@@ -258,9 +337,10 @@ describe('formSlice', () => {
         expect(actual.selectedDate).to.equal(payload.selectedDate);
         expect(actual.selectedTopics).to.deep.equal(payload.selectedTopics);
         expect(actual.uuid).to.be.null;
+        expect(actual.flowType).to.equal(FLOW_TYPES.ANY);
       });
 
-      it('should hydrate all form fields from payload', () => {
+      it('should hydrate all form fields from payload including flowType', () => {
         const payload = {
           uuid: 'test-uuid',
           lastname: 'Smith',
@@ -268,6 +348,7 @@ describe('formSlice', () => {
           obfuscatedEmail: 's***@example.com',
           selectedDate: '2025-04-01T14:00:00.000Z',
           selectedTopics: [{ topicId: '2', topicName: 'Topic 2' }],
+          flowType: FLOW_TYPES.CANCEL,
         };
         const actual = formReducer(undefined, hydrateFormData(payload));
 
@@ -278,6 +359,7 @@ describe('formSlice', () => {
         expect(actual.obfuscatedEmail).to.equal(payload.obfuscatedEmail);
         expect(actual.selectedDate).to.equal(payload.selectedDate);
         expect(actual.selectedTopics).to.deep.equal(payload.selectedTopics);
+        expect(actual.flowType).to.equal(FLOW_TYPES.CANCEL);
       });
 
       it('should only flip hydrated when payload is empty', () => {
@@ -287,6 +369,7 @@ describe('formSlice', () => {
         expect(actual.selectedDate).to.be.null;
         expect(actual.selectedTopics).to.deep.equal([]);
         expect(actual.uuid).to.be.null;
+        expect(actual.flowType).to.equal(FLOW_TYPES.ANY);
       });
     });
   });
@@ -303,6 +386,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectSelectedDate(state);
@@ -319,6 +403,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectSelectedDate(state);
@@ -337,6 +422,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectSelectedTopics(state);
@@ -353,6 +439,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectSelectedTopics(state);
@@ -371,6 +458,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectHydrated(state);
@@ -389,6 +477,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectObfuscatedEmail(state);
@@ -405,6 +494,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectObfuscatedEmail(state);
@@ -423,6 +513,7 @@ describe('formSlice', () => {
             uuid: 'c0ffee-1234-beef-5678',
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectUuid(state);
@@ -441,6 +532,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: 'Doe',
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectLastname(state);
@@ -457,6 +549,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectLastname(state);
@@ -475,6 +568,7 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: '1990-01-15',
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectDob(state);
@@ -491,10 +585,67 @@ describe('formSlice', () => {
             uuid: null,
             lastname: null,
             dob: null,
+            flowType: FLOW_TYPES.ANY,
           },
         };
         const result = selectDob(state);
         expect(result).to.be.null;
+      });
+    });
+
+    describe('selectFlowType', () => {
+      it('should select the flowType from state', () => {
+        const state = {
+          vassForm: {
+            hydrated: false,
+            selectedDate: null,
+            selectedTopics: [],
+            obfuscatedEmail: null,
+            token: null,
+            uuid: null,
+            lastname: null,
+            dob: null,
+            flowType: FLOW_TYPES.SCHEDULE,
+          },
+        };
+        const result = selectFlowType(state);
+        expect(result).to.equal(FLOW_TYPES.SCHEDULE);
+      });
+
+      it('should return cancel when flowType is cancel', () => {
+        const state = {
+          vassForm: {
+            hydrated: false,
+            selectedDate: null,
+            selectedTopics: [],
+            obfuscatedEmail: null,
+            token: null,
+            uuid: null,
+            lastname: null,
+            dob: null,
+            flowType: FLOW_TYPES.CANCEL,
+          },
+        };
+        const result = selectFlowType(state);
+        expect(result).to.equal(FLOW_TYPES.CANCEL);
+      });
+
+      it('should return any when flowType is any (default)', () => {
+        const state = {
+          vassForm: {
+            hydrated: false,
+            selectedDate: null,
+            selectedTopics: [],
+            obfuscatedEmail: null,
+            token: null,
+            uuid: null,
+            lastname: null,
+            dob: null,
+            flowType: FLOW_TYPES.ANY,
+          },
+        };
+        const result = selectFlowType(state);
+        expect(result).to.equal(FLOW_TYPES.ANY);
       });
     });
   });

--- a/src/applications/vass/routes.jsx
+++ b/src/applications/vass/routes.jsx
@@ -3,8 +3,9 @@ import { Route, Routes, Navigate } from 'react-router-dom-v5-compat';
 
 import withAuthorization from './containers/withAuthorization';
 import withFormData from './containers/withFormData';
+import withFlowGuard from './containers/withFlowGuard';
 import { routes } from './utils/navigation';
-import { AUTH_LEVELS } from './utils/constants';
+import { AUTH_LEVELS, FLOW_TYPES } from './utils/constants';
 
 const createRoutes = () => {
   return (
@@ -14,19 +15,25 @@ const createRoutes = () => {
         let Component = route.component;
         const { requiresAuthorization, requireFormData } = route.permissions;
 
+        // 1. Apply authorization HOC first (checks token/auth level)
         if (
           requiresAuthorization === AUTH_LEVELS.TOKEN ||
           requiresAuthorization === AUTH_LEVELS.LOW_AUTH_ONLY
         ) {
-          // Wrap with authorization HOC, passing the auth level
-          Component = withAuthorization(route.component, requiresAuthorization);
+          Component = withAuthorization(Component, requiresAuthorization);
         }
+
+        // 2. Apply form data requirements
         if (requireFormData) {
-          // Routes requiring specific form data fields
           Component = withFormData(
-            route.component,
+            Component,
             Array.isArray(requireFormData) ? requireFormData : [],
           );
+        }
+
+        // 3. Apply flow guard (prevents switching between schedule/cancel flows)
+        if (route.flowType && route.flowType !== FLOW_TYPES.ANY) {
+          Component = withFlowGuard(Component, route.flowType);
         }
 
         return <Route key={index} path={route.path} element={<Component />} />;

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -12,6 +12,12 @@ export const URLS = Object.freeze({
   ALREADY_SCHEDULED: '/already-scheduled',
 });
 
+export const FLOW_TYPES = {
+  SCHEDULE: 'schedule',
+  CANCEL: 'cancel',
+  ANY: 'any',
+};
+
 /**
  * Authorization level enum for route protection.
  * @readonly

--- a/src/applications/vass/utils/navigation.js
+++ b/src/applications/vass/utils/navigation.js
@@ -7,7 +7,7 @@ import Confirmation from '../pages/Confirmation';
 import CancelAppointment from '../pages/CancelAppointment';
 import CancelAppointmentConfirmation from '../pages/CancelConfirmation';
 import AlreadyScheduled from '../pages/AlreadyScheduled';
-import { AUTH_LEVELS, URLS } from './constants';
+import { AUTH_LEVELS, FLOW_TYPES, URLS } from './constants';
 
 /**
  * @typedef {Object} RoutePermissions
@@ -23,6 +23,8 @@ import { AUTH_LEVELS, URLS } from './constants';
  * @property {string} path - The URL path for the route. Supports dynamic segments (e.g., ':appointmentId').
  * @property {React.ComponentType} component - The React component to render for this route.
  * @property {RoutePermissions} permissions - Authorization and form data requirements for the route.
+ * @property {'schedule'|'cancel'|'any'} flowType - Which user flow can access this route.
+ *   'schedule' = only scheduling flow, 'cancel' = only cancellation flow, 'any' = both flows allowed.
  * @property {string[]} [setsData] - Optional array of form data field names that this route's component
  *   is responsible for setting. Used for documentation purposes to track data flow between routes.
  */
@@ -45,6 +47,7 @@ export const routes = [
     permissions: {
       requiresAuthorization: AUTH_LEVELS.NONE,
     },
+    flowType: FLOW_TYPES.ANY, // Entry point for both flows
     setsData: ['uuid', 'lastname', 'dob', 'obfuscatedEmail'],
   },
   // Low auth routes - require form data but redirect if user already has token
@@ -55,14 +58,17 @@ export const routes = [
       requiresAuthorization: AUTH_LEVELS.LOW_AUTH_ONLY,
       requireFormData: ['uuid', 'lastname', 'dob', 'obfuscatedEmail'],
     },
+    flowType: FLOW_TYPES.ANY, // Both flows go through OTC verification
   },
   // Protected routes (require token)
+  // Schedule Flow Routes
   {
     path: URLS.DATE_TIME,
     component: DateTimeSelection,
     permissions: {
       requiresAuthorization: AUTH_LEVELS.TOKEN,
     },
+    flowType: FLOW_TYPES.SCHEDULE,
     setsData: ['selectedDate'],
   },
   {
@@ -71,6 +77,7 @@ export const routes = [
     permissions: {
       requiresAuthorization: AUTH_LEVELS.TOKEN,
     },
+    flowType: FLOW_TYPES.SCHEDULE,
     setsData: ['selectedTopics'],
   },
   {
@@ -88,6 +95,7 @@ export const routes = [
         'obfuscatedEmail',
       ],
     },
+    flowType: FLOW_TYPES.SCHEDULE,
   },
   {
     path: `${URLS.CONFIRMATION}/:appointmentId`,
@@ -95,13 +103,16 @@ export const routes = [
     permissions: {
       requiresAuthorization: AUTH_LEVELS.TOKEN,
     },
+    flowType: FLOW_TYPES.SCHEDULE,
   },
+  // Cancel Appointment Routes
   {
     path: `${URLS.CANCEL_APPOINTMENT}/:appointmentId`,
     component: CancelAppointment,
     permissions: {
       requiresAuthorization: AUTH_LEVELS.TOKEN,
     },
+    flowType: FLOW_TYPES.CANCEL,
   },
   {
     path: URLS.CANCEL_APPOINTMENT_CONFIRMATION,
@@ -109,6 +120,7 @@ export const routes = [
     permissions: {
       requiresAuthorization: AUTH_LEVELS.TOKEN,
     },
+    flowType: FLOW_TYPES.CANCEL,
   },
   {
     path: URLS.ALREADY_SCHEDULED,
@@ -116,6 +128,7 @@ export const routes = [
     permissions: {
       requiresAuthorization: AUTH_LEVELS.TOKEN,
     },
+    flowType: FLOW_TYPES.CANCEL,
   },
 ];
 

--- a/src/applications/vass/utils/test-utils.js
+++ b/src/applications/vass/utils/test-utils.js
@@ -10,6 +10,7 @@ import { commonReducer } from 'platform/startup/store';
 import reducers from '../redux/reducers';
 
 import { vassApi } from '../redux/api/vassApi';
+import { FLOW_TYPES } from './constants';
 
 /**
  * @typedef {{ topicId: string, topicName: string }} Topic
@@ -24,6 +25,7 @@ import { vassApi } from '../redux/api/vassApi';
  * @property {string | null} uuid - Unique identifier from the appointment URL
  * @property {string | null} lastname - User's last name for verification
  * @property {string | null} dob - User's date of birth for verification (YYYY-MM-DD)
+ * @property {'schedule'|'cancel'|'any'} flowType - The current user flow type
  */
 
 /**
@@ -39,6 +41,7 @@ export const defaultVassFormState = {
   uuid: null,
   lastname: null,
   dob: null,
+  flowType: FLOW_TYPES.ANY,
 };
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:
  Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Added a new `withFlowGuard` Higher-Order Component (HOC) that restricts route access based on the user's current flow type (schedule vs cancel)
  - Updated the Verify page to set the flow type in Redux state based on the `?cancel=true` URL parameter
  - Added `flowType` and `setFlowType` to the form slice Redux state
  - Updated routes.jsx to apply the flow guard wrapper to routes with a defined `flowType`
  - Added `FLOW_TYPES` constant with values: `SCHEDULE`, `CANCEL`, and `ANY`
  - Updated EnterOTC page to pass through the cancel query parameter when navigating
  - Team: VASS
  - This change ensures users cannot switch between the scheduling and cancellation flows mid-session, preventing invalid state combinations

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#127909

  ## Testing done

  - **Old behavior**: Users could potentially navigate between schedule and cancel flow routes, leading to invalid form states
  - **New behavior**: Users are redirected to the Verify page if they attempt to access a route that doesn't match their current flow type
  - **Steps to verify**:
    1. Navigate to the VASS application at `/vass/verify`
    2. Complete verification (sets flow to `schedule`)
    3. Attempt to manually navigate to a cancel-only route - should redirect back to Verify
    4. Navigate to `/vass/verify?cancel=true`
    5. Complete verification (sets flow to `cancel`)
    6. Attempt to manually navigate to a schedule-only route - should redirect back to Verify
  - **Tests completed**:
    - Added unit tests for `withFlowGuard.jsx` covering:
      - Rendering when flow type matches allowed flow
      - Redirecting when flow type doesn't match
      - Handling `any` flow type routes
      - Handling unset flow type (new users)
    - Updated `formSlice.unit.spec.jsx` with tests for `setFlowType` action and `selectFlowType` selector
    - Updated `EnterOTC.unit.spec.jsx` and `Verify.unit.spec.jsx` to account for flow type changes
  - **Known gaps**: Integration/e2e tests have not yet been added for the full cancel flow; manual testing recommended

  ## Screenshots

  _N/A - This is a logic/routing change with no visible UI modifications._

  |         | Before | After |
  | ------- | ------ | ----- |
  | Mobile  | N/A    | N/A   |
  | Desktop | N/A    | N/A   |

  ## What areas of the site does it impact?

  This change impacts the VASS application only. Specifically
  - Route access control for schedule vs cancel appointment flows
  - The Verify page (`/vass/verify`)
  - The EnterOTC page (`/vass/enter-otc`)
  - Redux form state management

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [x] Documentation has been updated ([link to documentation](#documentation) *if necessary)
  - [ ] Screenshot of the developed feature is added - N/A, no UI changes
  - [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - N/A, no UI changes

  ### Error Handling

  - [x] Browser console contains no warnings or errors.
  - [x] Events are being sent to the appropriate logging solution
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - Not applicable for this routing change

  ### Authentication

  - [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

  ## Requested Feedback

  Please review the flow guard logic in `withFlowGuard.jsx` to ensure the redirect behavior is appropriate. Specifically interested in feedback on:
  - Whether the guard should redirect to Verify or to a different page
  - Whether additional flows may be needed in the future that would require a different approach

  ---

  <details>
  <summary><strong>Documentation: VASS Authorization HOCs</strong></summary>

  # VASS Authorization HOCs

  This document explains how the `withAuthorization`, `withFormData`, and `withFlowGuard` Higher-Order Components (HOCs) work to protect routes in the VASS application.

  ## Overview

  These HOCs wrap page components to enforce requirements before rendering. They work together to ensure users can only access routes when they have proper authentication, required form data, and are in the correct user flow (schedule or cancel).

  ---

  ## withAuthorization

  **Purpose:** Controls access to routes based on authentication status.

  ### Auth Levels

  | Level         | Behavior                                                            |
  | ------------- | ------------------------------------------------------------------- |
  | `none`        | Public route - anyone can access                                    |
  | `lowAuthOnly` | Only for unauthenticated users (redirects away if user has token)   |
  | `token`       | Requires authentication (redirects to Verify if no token)           |

  ### How It Works

  1. On mount, attempts to hydrate form data from sessionStorage
  2. Checks the user's token status against the route's auth level
  3. Redirects if access requirements aren't met

  ```jsx
  // Usage in route config
  {
    path: '/enter-otc',
    component: EnterOTC,
    permissions: {
      requiresAuthorization: 'lowAuthOnly',
    },
  }

  Flow Diagram

  flowchart TD
      A[User visits route] --> B[Hydrate from sessionStorage]
      B --> C{Check auth level}
      C -->|lowAuthOnly| D{Has token?}
      C -->|token| E{Has token?}
      C -->|none| F[Render component]
      D -->|Yes| G[Redirect to first token route]
      D -->|No| F
      E -->|Yes| F
      E -->|No| H[Redirect to Verify page]

  ---
  withFormData

  Purpose: Ensures required form data exists before rendering a page.

  How It Works

  1. On mount, attempts to hydrate from sessionStorage if data is missing
  2. Checks if all required fields have valid values
  3. If data is missing, redirects to the route that sets that data

  // Usage in route config
  {
    path: '/review',
    component: Review,
    permissions: {
      requiresAuthorization: 'token',
      requireFormData: ['uuid', 'selectedDate', 'selectedTopics'],
    },
  }

  Field Validation

  - Most fields: checks for truthy value
  - selectedTopics: checks for non-empty array

  Flow Diagram

  flowchart TD
      A[User visits route] --> B[Hydrate from sessionStorage]
      B --> C{All required fields present?}
      C -->|Yes| D[Render component]
      C -->|No| E[Find first missing field]
      E --> F[Find route that sets missing field]
      F --> G[Redirect to that route]

  ---
  withFlowGuard

  Purpose: Prevents users from switching between schedule and cancel flows.

  Flow Types
  ┌──────────┬──────────────────────────────────────────────────────────┐
  │   Type   │                       Description                        │
  ├──────────┼──────────────────────────────────────────────────────────┤
  │ schedule │ Routes only accessible during the scheduling flow        │
  ├──────────┼──────────────────────────────────────────────────────────┤
  │ cancel   │ Routes only accessible during the cancellation flow      │
  ├──────────┼──────────────────────────────────────────────────────────┤
  │ any      │ Routes accessible from both flows (entry points, shared) │
  └──────────┴──────────────────────────────────────────────────────────┘
  How It Works

  1. Reads the current flowType from Redux state (set on Verify page based on ?cancel=true URL param)
  2. Compares user's flow type against the route's allowed flow
  3. If flow doesn't match, redirects user back to the Verify page
  4. Routes marked as any skip the guard entirely

  // Usage in route config
  {
    path: '/date-time',
    component: DateTimeSelection,
    permissions: {
      requiresAuthorization: 'token',
    },
    flowType: 'schedule', // Only schedule flow can access
  }

  {
    path: '/cancel-appointment/:appointmentId',
    component: CancelAppointment,
    permissions: {
      requiresAuthorization: 'token',
    },
    flowType: 'cancel', // Only cancel flow can access
  }

  Flow Type Assignment

  The flow type is set when the user lands on the Verify page:

  - ?cancel=true in URL → flowType = 'cancel'
  - No cancel param → flowType = 'schedule'

  Flow Diagram

  flowchart TD
      A[User visits route] --> B{Route allows any flow?}
      B -->|Yes| C[Render component]
      B -->|No| D{Flow type set?}
      D -->|No| C
      D -->|Yes| E{User flow matches allowed flow?}
      E -->|Yes| C
      E -->|No| F[Redirect to Verify page]

  Route Flow Assignments
  ┌────────────────────┬───────────┬───────────────────────────────────────────┐
  │       Route        │ Flow Type │                  Reason                   │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ Verify             │ any       │ Entry point for both flows                │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ EnterOTC           │ any       │ Both flows go through OTC verification    │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ DateTimeSelection  │ schedule  │ Only for scheduling appointments          │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ TopicSelection     │ schedule  │ Only for scheduling appointments          │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ Review             │ schedule  │ Only for scheduling appointments          │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ Confirmation       │ schedule  │ Only for scheduling appointments          │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ CancelAppointment  │ cancel    │ Only for cancelling appointments          │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ CancelConfirmation │ cancel    │ Only for cancelling appointments          │
  ├────────────────────┼───────────┼───────────────────────────────────────────┤
  │ AlreadyScheduled   │ cancel    │ Users land here from schedule, can cancel │
  └────────────────────┴───────────┴───────────────────────────────────────────┘
  ---
  How They Work Together

  Routes can use all three HOCs. The routes.jsx file wraps components based on their permissions and flow type:

  // Simplified example from routes.jsx
  let Component = route.component;

  // 1. Apply authorization HOC first (checks token/auth level)
  if (requiresAuthorization === 'token' || requiresAuthorization === 'lowAuthOnly') {
    Component = withAuthorization(Component, requiresAuthorization);
  }

  // 2. Apply form data requirements
  if (requireFormData) {
    Component = withFormData(Component, requireFormData);
  }

  // 3. Apply flow guard (prevents switching between schedule/cancel flows)
  if (route.flowType && route.flowType !== 'any') {
    Component = withFlowGuard(Component, route.flowType);
  }

  Combined Flow

  flowchart TD
      A[User visits protected route] --> B[withAuthorization]
      B --> C{Token check passes?}
      C -->|No| D[Redirect to Verify]
      C -->|Yes| E[withFormData]
      E --> F{All form data present?}
      F -->|No| G[Redirect to route that sets missing data]
      F -->|Yes| H[withFlowGuard]
      H --> I{Flow type matches?}
      I -->|No| J[Redirect to Verify]
      I -->|Yes| K[Render page component]

  Example: Review Page

  The Review page requires a token, specific form data, AND must be in the schedule flow:

  {
    path: '/review',
    component: Review,
    permissions: {
      requiresAuthorization: 'token',
      requireFormData: ['uuid', 'selectedDate', 'selectedTopics'],
    },
    flowType: 'schedule',
  }

  What happens:

  1. withAuthorization checks for token → redirects to Verify if missing
  2. withFormData checks for required fields → redirects to appropriate page if any are missing
  3. withFlowGuard checks flow type → redirects to Verify if user is in cancel flow

  ---
  Key Points

  - All three HOCs return null while checking/redirecting (prevents flash of content)
  - withAuthorization and withFormData attempt sessionStorage hydration before redirecting
  - withFlowGuard reads flow type from Redux state (set on Verify page)
  - Redirects use replace: true to avoid polluting browser history
  - Route config in utils/navigation.js defines all requirements declaratively
  - Flow type prevents users from switching between schedule and cancel flows mid-session
  - HOCs are applied in order: Authorization → FormData → FlowGuard