### PR TITLE
Fix flaky preCheckinExpired test near midnight UTC

### DIFF
--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.jsx
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.jsx
@@ -503,18 +503,28 @@ describe('check in', () => {
     });
     describe('preCheckinExpired', () => {
       it('identifies an expired pre-check-in appointment list', () => {
+        // Set a fixed time at noon to avoid flakiness near midnight UTC
+        const today = new Date();
+        today.setUTCHours(12, 0, 0, 0);
+        MockDate.set(today);
         const appointments = [
           createAppointment({ preCheckInValid: false }),
           createAppointment({ preCheckInValid: false }),
         ];
         expect(preCheckinExpired(appointments)).to.be.true;
+        MockDate.reset();
       });
       it('identifies a valid pre-check-in appointment list', () => {
+        // Set a fixed time at noon to avoid flakiness near midnight UTC
+        const today = new Date();
+        today.setUTCHours(12, 0, 0, 0);
+        MockDate.set(today);
         const appointments = [
           createAppointment({ preCheckInValid: true }),
           createAppointment({ preCheckInValid: true }),
         ];
         expect(preCheckinExpired(appointments)).to.be.false;
+        MockDate.reset();
       });
     });
     describe('hasPhoneAppointments', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes a flaky test in the check-in application that could fail when run near midnight UTC
- The `preCheckinExpired` test creates appointments with a start time 15 minutes in the future
- When tests run near midnight UTC (e.g., 23:50), adding 15 minutes pushes the appointment into the next day
- This causes `preCheckinExpired()` to return `false` instead of `true`, failing the test
- **Solution**: Use `MockDate` to set a fixed time at noon UTC before creating appointments, ensuring consistent behavior regardless of when the test runs
- Team: Platform / Node.js upgrade effort

## Related issue(s)

- Related to department-of-veterans-affairs/vets-website#41426 (Node 22 upgrade)

## Testing done

- Ran the unit test multiple times locally and confirmed it passes consistently
- `yarn test:unit src/applications/check-in/utils/appointment/appointment.utils.unit.spec.jsx`
- All 56 tests pass

## Screenshots

N/A - No UI changes

## What areas of the site does it impact?

Only affects unit tests in the check-in application. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - no UI)
- [x] Accessibility testing has been performed (N/A - no UI)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test fix only)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)