### PR TITLE
ARP- ITF- Fix when navigating back to intro page

### DIFF
--- a/src/applications/representative-form-upload/config/form-21-0966.jsx
+++ b/src/applications/representative-form-upload/config/form-21-0966.jsx
@@ -60,13 +60,13 @@ const form210966 = (pathname = null) => {
         path: 'intent-to-file-no-representation',
         pageKey: 'intent-to-file-no-representation',
         component: ITF403Error,
-        depends: formData => formData,
+        depends: () => false,
       },
       {
         path: 'intent-to-file-unknown',
         pageKey: 'intent-to-file-unknown',
         component: ITF500Error,
-        depends: formData => formData,
+        depends: () => false,
       },
       {
         path: 'existing-itf',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update `depends` statement for alternate routes so they aren't always truthy.

## Related issue(s)
[QA Finding: "We can't confirm..." status when navigating back to Intro page #129541](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129541)


## Testing done
Locally confirmed going back worked as expected.
Locally confirmed that two error pages were still reachable.
