### PR TITLE
Add extend to address patterns for min max length and overrides

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/nursing-home-details.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/nursing-home-details.js
@@ -32,18 +32,15 @@ export const nursingHomeDetailsUiSchema = {
  */
 const addressSchemaWithDefault = addressSchema({
   omit: ['isMilitary', 'street3'],
+  extend: {
+    country: { default: 'USA', maxLength: 3 },
+    street: { maxLength: 30 },
+    street2: { maxLength: 5 },
+    city: { maxLength: 18 },
+    state: { maxLength: 2 },
+    postalCode: { maxLength: 9 },
+  },
 });
-
-// Set default country to USA
-addressSchemaWithDefault.properties.country.default = 'USA';
-
-// Apply backend schema maxLength constraints
-addressSchemaWithDefault.properties.street.maxLength = 30;
-addressSchemaWithDefault.properties.street2.maxLength = 5;
-addressSchemaWithDefault.properties.city.maxLength = 18;
-addressSchemaWithDefault.properties.state.maxLength = 2;
-addressSchemaWithDefault.properties.postalCode.maxLength = 9;
-addressSchemaWithDefault.properties.country.maxLength = 3;
 
 export const nursingHomeDetailsSchema = {
   type: 'object',

--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/mailingAddress.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/mailingAddress.js
@@ -6,10 +6,12 @@ import {
 
 const updatedAddressSchema = addressSchema({
   omit: ['street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 13 },
+    city: { maxLength: 18 },
+  },
 });
-updatedAddressSchema.properties.street.maxLength = 30;
-updatedAddressSchema.properties.street2.maxLength = 13;
-updatedAddressSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/simple-forms/21-0845/pages/authorizerAddress.js
+++ b/src/applications/simple-forms/21-0845/pages/authorizerAddress.js
@@ -5,10 +5,12 @@ import {
 
 const addressSchema = addressNoMilitarySchema({
   omit: ['isMilitary', 'street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 5 },
+    city: { maxLength: 18 },
+  },
 });
-addressSchema.properties.street.maxLength = 30;
-addressSchema.properties.street2.maxLength = 5;
-addressSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/simple-forms/21-0845/pages/organizationAddress.js
+++ b/src/applications/simple-forms/21-0845/pages/organizationAddress.js
@@ -6,10 +6,12 @@ import {
 
 const addressSchema = addressNoMilitarySchema({
   omit: ['isMilitary', 'street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 5 },
+    city: { maxLength: 18 },
+  },
 });
-addressSchema.properties.street.maxLength = 30;
-addressSchema.properties.street2.maxLength = 5;
-addressSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/simple-forms/21-0845/pages/personAddress.js
+++ b/src/applications/simple-forms/21-0845/pages/personAddress.js
@@ -6,10 +6,12 @@ import {
 
 const addressSchema = addressNoMilitarySchema({
   omit: ['isMilitary', 'street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 5 },
+    city: { maxLength: 18 },
+  },
 });
-addressSchema.properties.street.maxLength = 30;
-addressSchema.properties.street2.maxLength = 5;
-addressSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/simple-forms/21-10210/pages/claimantAddrInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/claimantAddrInfo.js
@@ -6,10 +6,12 @@ import {
 
 const pdfSchema = addressNoMilitarySchema({
   omit: ['street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 30 },
+    city: { maxLength: 18 },
+  },
 });
-pdfSchema.properties.street.maxLength = 30;
-pdfSchema.properties.street2.maxLength = 30;
-pdfSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/simple-forms/21-10210/pages/vetAddrInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/vetAddrInfo.js
@@ -6,10 +6,12 @@ import {
 
 const pdfSchema = addressNoMilitarySchema({
   omit: ['street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 30 },
+    city: { maxLength: 18 },
+  },
 });
-pdfSchema.properties.street.maxLength = 30;
-pdfSchema.properties.street2.maxLength = 30;
-pdfSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/survivors-benefits/config/chapters/02-claimant-information/mailingAddress.js
+++ b/src/applications/survivors-benefits/config/chapters/02-claimant-information/mailingAddress.js
@@ -6,10 +6,12 @@ import {
 
 const updatedAddressSchema = addressSchema({
   omit: ['street3'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 5 },
+    city: { maxLength: 18 },
+  },
 });
-updatedAddressSchema.properties.street.maxLength = 30;
-updatedAddressSchema.properties.street2.maxLength = 5;
-updatedAddressSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsAddress.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsAddress.js
@@ -6,10 +6,12 @@ import {
 
 const updatedAddressSchema = addressSchema({
   omit: ['street3', 'isMilitary'],
+  extend: {
+    street: { maxLength: 30 },
+    street2: { maxLength: 5 },
+    city: { maxLength: 18 },
+  },
 });
-updatedAddressSchema.properties.street.maxLength = 30;
-updatedAddressSchema.properties.street2.maxLength = 5;
-updatedAddressSchema.properties.city.maxLength = 18;
 
 /** @type {PageSchema} */
 export default {


### PR DESCRIPTION
## Summary

- Add `extend` to `addressSchema` and `addressNoMilitarySchema` for overrides such as min / max lengths

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5471

## Testing done

- unit, regressions

## Screenshots

n/a

## What areas of the site does it impact?

developers can now use `extend` with address patterns

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
