### PR TITLE
8416 limit text character length on address and full names

### DIFF
--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/claimantInformation.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/claimantInformation.js
@@ -6,7 +6,6 @@ import {
 
 const updatedFullNameSchema = fullNameSchema;
 updatedFullNameSchema.properties.first.maxLength = 40;
-updatedFullNameSchema.properties.middle.maxLength = 3;
 updatedFullNameSchema.properties.last.maxLength = 50;
 
 /** @type {PageSchema} */

--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/claimantInformation.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/claimantInformation.js
@@ -4,6 +4,11 @@ import {
   fullNameUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+const updatedFullNameSchema = fullNameSchema;
+updatedFullNameSchema.properties.first.maxLength = 40;
+updatedFullNameSchema.properties.middle.maxLength = 3;
+updatedFullNameSchema.properties.last.maxLength = 50;
+
 /** @type {PageSchema} */
 export default {
   uiSchema: {
@@ -17,7 +22,7 @@ export default {
     type: 'object',
     required: ['claimantFullName'],
     properties: {
-      claimantFullName: fullNameSchema,
+      claimantFullName: updatedFullNameSchema,
     },
   },
 };

--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/mailingAddress.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/mailingAddress.js
@@ -7,9 +7,9 @@ import {
 const updatedAddressSchema = addressSchema({
   omit: ['street3'],
   extend: {
-    street: { maxLength: 30 },
+    street: { maxLength: 74 },
     street2: { maxLength: 13 },
-    city: { maxLength: 18 },
+    city: { maxLength: 22 },
   },
 });
 

--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/veteranInformation.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/veteranInformation.js
@@ -13,6 +13,11 @@ import {
 } from 'platform/forms-system/src/js/web-component-fields';
 import { setDefaultIsOver65 } from './helpers';
 
+const updatedFullNameSchema = fullNameSchema;
+updatedFullNameSchema.properties.first.maxLength = 40;
+updatedFullNameSchema.properties.middle.maxLength = 3;
+updatedFullNameSchema.properties.last.maxLength = 50;
+
 /** @type {PageSchema} */
 export default {
   updateFormData: setDefaultIsOver65,
@@ -76,7 +81,7 @@ export default {
         type: 'object',
         properties: {},
       },
-      veteranFullName: { ...fullNameSchema, required: [] },
+      veteranFullName: { ...updatedFullNameSchema, required: [] },
       veteranSocialSecurityNumber: ssnOrVaFileNumberSchema,
       veteranDateOfBirth: dateOfBirthSchema,
     },

--- a/src/applications/medical-expense-report/config/chapters/01-applicant-information/veteranInformation.js
+++ b/src/applications/medical-expense-report/config/chapters/01-applicant-information/veteranInformation.js
@@ -15,7 +15,6 @@ import { setDefaultIsOver65 } from './helpers';
 
 const updatedFullNameSchema = fullNameSchema;
 updatedFullNameSchema.properties.first.maxLength = 40;
-updatedFullNameSchema.properties.middle.maxLength = 3;
 updatedFullNameSchema.properties.last.maxLength = 50;
 
 /** @type {PageSchema} */


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adjusted the character limit for chapter 1 full name and address

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128211

## Testing done

- The form just used the default length, after adding the new, I tested manually I couldn't go past the limit

## Screenshots

N/A

## What areas of the site does it impact?

Text fields on the 8416 chapter 1

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
