### PR TITLE
fix(travel-pay): Make ComplexClaimSubmitFlowWrapper tests async-aware…

### DIFF
--- a/src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx
@@ -465,7 +465,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
       getComplexClaimDetailsStub.restore();
     });
 
-    it('dispatches getComplexClaimDetails when claimId exists in URL and no claim data', () => {
+    it('dispatches getComplexClaimDetails when claimId exists in URL and no claim data', async () => {
       const initialState = getData({
         complexClaimsEnabled: true,
         claimData: null,
@@ -486,7 +486,10 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         { initialState, reducers: reducer },
       );
 
-      expect(getComplexClaimDetailsStub.calledWith(claimId)).to.be.true;
+      // Wait for async rendering to complete before checking stub
+      await waitFor(() => {
+        expect(getComplexClaimDetailsStub.calledWith(claimId)).to.be.true;
+      });
     });
 
     it('does not dispatch getComplexClaimDetails when claim data already exists', () => {
@@ -512,7 +515,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
       expect(getComplexClaimDetailsStub.called).to.be.false;
     });
 
-    it('dispatches getComplexClaimDetails with claim ID from appointment', () => {
+    it('dispatches getComplexClaimDetails with claim ID from appointment', async () => {
       const initialState = getData({
         complexClaimsEnabled: true,
         claimData: null,
@@ -547,8 +550,11 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       );
 
-      expect(getComplexClaimDetailsStub.calledWith('claim-from-appointment')).to
-        .be.true;
+      // Wait for async rendering to complete before checking stub
+      await waitFor(() => {
+        expect(getComplexClaimDetailsStub.calledWith('claim-from-appointment'))
+          .to.be.true;
+      });
     });
   });
 
@@ -792,7 +798,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
   });
 
   describe('Redirect for non-editable claims', () => {
-    it('redirects to claim details when claim status is "Claim submitted"', () => {
+    it('redirects to claim details when claim status is "Claim submitted"', async () => {
       const initialState = getData({
         complexClaimsEnabled: true,
         claimData: { claimId: 'claim-456' },
@@ -805,7 +811,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       });
 
-      const { getByText } = renderWithStoreAndRouter(
+      const { findByText } = renderWithStoreAndRouter(
         <MemoryRouter initialEntries={['/file-new-claim/12345']}>
           <Routes>
             <Route
@@ -823,7 +829,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       );
 
-      expect(getByText('Claim Details')).to.exist;
+      expect(await findByText('Claim Details')).to.exist;
     });
 
     it('does NOT redirect when claim status is "Incomplete"', () => {
@@ -930,7 +936,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
       expect(getByText('Intro')).to.exist;
     });
 
-    it('redirects to claim details when claim source is not VaGov', () => {
+    it('redirects to claim details when claim source is not VaGov', async () => {
       const initialState = getData({
         complexClaimsEnabled: true,
         claimData: {
@@ -946,7 +952,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       });
 
-      const { getByText } = renderWithStoreAndRouter(
+      const { findByText } = renderWithStoreAndRouter(
         <MemoryRouter initialEntries={['/file-new-claim/12345']}>
           <Routes>
             <Route
@@ -964,7 +970,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       );
 
-      expect(getByText('Claim Details')).to.exist;
+      expect(await findByText('Claim Details')).to.exist;
     });
 
     it('does NOT redirect when claim source is VaGov and status is Incomplete', () => {
@@ -1004,7 +1010,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
       expect(getByText('Intro')).to.exist;
     });
 
-    it('redirects to claim details when there are unassociated documents', () => {
+    it('redirects to claim details when there are unassociated documents', async () => {
       const initialState = getData({
         complexClaimsEnabled: true,
         claimData: {
@@ -1028,7 +1034,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       });
 
-      const { getByText } = renderWithStoreAndRouter(
+      const { findByText } = renderWithStoreAndRouter(
         <MemoryRouter initialEntries={['/file-new-claim/12345']}>
           <Routes>
             <Route
@@ -1046,7 +1052,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       );
 
-      expect(getByText('Claim Details')).to.exist;
+      expect(await findByText('Claim Details')).to.exist;
     });
 
     it('does NOT redirect when all documents are associated', () => {
@@ -1094,7 +1100,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
       expect(getByText('Intro')).to.exist;
     });
 
-    it('redirects when multiple redirect conditions are met', () => {
+    it('redirects when multiple redirect conditions are met', async () => {
       const initialState = getData({
         complexClaimsEnabled: true,
         claimData: {
@@ -1118,7 +1124,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       });
 
-      const { getByText } = renderWithStoreAndRouter(
+      const { findByText } = renderWithStoreAndRouter(
         <MemoryRouter initialEntries={['/file-new-claim/12345']}>
           <Routes>
             <Route
@@ -1136,7 +1142,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         },
       );
 
-      expect(getByText('Claim Details')).to.exist;
+      expect(await findByText('Claim Details')).to.exist;
     });
 
     it('does NOT redirect when documents array is empty', () => {
@@ -1237,7 +1243,8 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
     });
 
     it('redirects to get-claim-error when getComplexClaimDetails rejects', async () => {
-      // Stub the thunk correctly
+      // Stub the thunk to throw an error, which should trigger the component's
+      // .catch() handler and set shouldRedirect to true
       getComplexClaimDetailsStub.callsFake(() => () =>
         Promise.reject(new Error('Failed')),
       );
@@ -1248,7 +1255,7 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
         claimError: null,
       });
 
-      const { getByText } = renderWithStoreAndRouter(
+      const { findByText } = renderWithStoreAndRouter(
         <MemoryRouter
           initialEntries={[`/file-new-claim/${appointmentId}/${claimId}`]}
         >
@@ -1267,9 +1274,13 @@ describe('ComplexClaimSubmitFlowWrapper', () => {
       );
 
       // Wait for the redirect to happen and the error page to appear
-      await waitFor(() => {
-        expect(getByText('Get Claim Error Page')).to.exist;
-      });
+      // Using findByText which automatically waits up to 1000ms by default
+      const errorPage = await findByText(
+        'Get Claim Error Page',
+        {},
+        { timeout: 5000 },
+      );
+      expect(errorPage).to.exist;
     });
 
     it('does not redirect if isErrorRoute is already true', async () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug fix** for flaky unit tests in `ComplexClaimSubmitFlowWrapper.unit.spec.jsx` that fail on CI under Node 22
- **Root cause**: After `CurrencyField.unit.spec.jsx` tests run (which render VA web components), the `<Navigate>` component from `react-router-dom-v5-compat` performs redirects **asynchronously** instead of synchronously. This timing change causes 7 tests to fail when run after platform tests on CI.
- **Solution**: Made affected tests async-aware by:
  - Using `findByText` (async) instead of `getByText` (sync) for redirect assertions
  - Wrapping stub assertions in `waitFor()` blocks
- **Team**: Travel Pay (this is our application code)
- No flipper involved

## Related issue(s)

- Related to Node 22 upgrade: department-of-veterans-affairs/vets-website#41426

## Testing done

- **Old behavior**: 7 tests in `ComplexClaimSubmitFlowWrapper.unit.spec.jsx` failed with "Unable to find element" errors showing empty `<body><div /></body>` when run after platform tests on CI
- **Verification steps**:
  1. Run tests alone: `yarn test:unit src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx` → 42 passing
  2. Run tests after CurrencyField (simulates CI pollution): `yarn test:unit src/platform/forms-system/test/js/web-component-fields/CurrencyField.unit.spec.jsx src/applications/travel-pay/tests/containers/ComplexClaimSubmitFlowWrapper.unit.spec.jsx` → 54 passing (12 + 42)
- **Results**: All tests pass in both scenarios

## Screenshots

_N/A - No UI changes, this is a test fix only_

## What areas of the site does it impact?

No production code changes. Only test file modifications for the travel-pay application.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test fix only)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

This fix addresses a test pollution issue where VA web components in `CurrencyField` tests cause async timing changes in react-router-dom-v5-compat's `<Navigate>` component under Node 22. The fix makes our tests resilient to this timing variation by using async queries (`findByText`, `waitFor`) instead of sync queries (`getByText`).