### PR TITLE
fix(tests): use mocked time for expired form test

### DIFF
--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -415,14 +415,21 @@ describe('Schemaform <SaveInProgressIntro>', () => {
   });
 
   it('should render expired message if signed in with an expired form', () => {
+    // Mock time to ensure consistent test behavior
+    const now = new Date('2025-01-15T12:00:00Z');
+    const nowUnix = Math.floor(now.getTime() / 1000);
+    const clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
+
     const user = {
       profile: {
         savedForms: [
           {
             form: VA_FORM_IDS.FORM_10_10EZ,
             metadata: {
-              lastUpdated: 3000,
-              expiresAt: Math.floor(Date.now() / 1000),
+              // Last updated 60 days ago
+              lastUpdated: nowUnix - 60 * 86400,
+              // Expired 1 day ago
+              expiresAt: nowUnix - 86400,
             },
           },
         ],
@@ -454,6 +461,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     );
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.true;
     tree.unmount();
+    clock.restore();
   });
 
   it('should render downtime notification', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fix flaky unit test `should render expired message if signed in with an expired form` in SaveInProgressIntro component
- The test was failing because it used `Date.now()` for the expiration timestamp, which created a race condition with the `isBefore()` check in the component
- Solution: Mock time using `sinon.useFakeTimers` with `toFake: ["Date"]` to ensure deterministic test behavior
- Also updated `lastUpdated` timestamp from `3000` (which displayed as "January 1, 1970") to a realistic value relative to mocked time
- Platform team owns this component

## Related issue(s)

- CI failure in SaveInProgressIntro.unit.spec.jsx

## Testing done

- **Old behavior**: Test used `expiresAt: Math.floor(Date.now() / 1000)` which set expiration to "exactly now". The component's `isBefore(expiresAt, new Date())` check requires expiration to be *strictly before* current time, causing intermittent failures when timestamps were equal.
- **Steps to verify**: Run `yarn test:unit "src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx"`
- **Tests completed**: All 23 tests in the file pass consistently. Ran multiple times to confirm no flakiness.

## Screenshots

N/A - Test-only change, no UI modifications.

## What areas of the site does it impact?

No site impact. This is a test-only change.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated - N/A
- [x] Screenshot of the developed feature is added - N/A (test-only change)
- [x] Accessibility testing has been performed - N/A (test-only change)

### Error Handling

- [x] Browser console contains no warnings or errors - N/A (test-only change)
- [x] Events are being sent to the appropriate logging solution - N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A (test-only change)

## Requested Feedback

None - straightforward test fix using established patterns (`sinon.useFakeTimers` with `toFake: ["Date"]`) already used elsewhere in the codebase.