### PR TITLE
Burial | PDF form alignment - update burial allowance conditional

### DIFF
--- a/src/applications/burials-ez/config/chapters/04-benefits-selection/burialAllowanceConfirmation.js
+++ b/src/applications/burials-ez/config/chapters/04-benefits-selection/burialAllowanceConfirmation.js
@@ -8,7 +8,7 @@ const confError = 'Confirm that these statements are true';
 export default {
   uiSchema: {
     'view:allowanceStatement': {
-      'ui:title': generateTitle('Type of burial allowance'),
+      'ui:title': generateTitle('Statement of truth'),
       'ui:description': (
         <>
           <p>

--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -392,7 +392,9 @@ const formConfig = {
               'burialAllowanceRequested.unclaimed',
               form,
             );
-            return burialsSelected && unclaimedSelected;
+            const isFuneralDirector =
+              get('relationshipToVeteran', form) === 'funeralDirector';
+            return burialsSelected && unclaimedSelected && isFuneralDirector;
           },
           uiSchema: burialAllowanceConfirmation.uiSchema,
           schema: burialAllowanceConfirmation.schema,

--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -380,7 +380,7 @@ const formConfig = {
           schema: burialAllowancePartOne.schema,
         },
         burialAllowanceConfirmation: {
-          title: 'Burial allowance',
+          title: 'Statement of truth',
           reviewTitle: ' ',
           path: 'benefits/burial-allowance/statement-of-truth',
           depends: form => {

--- a/src/applications/burials-ez/tests/config/form.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/config/form.unit.spec.jsx
@@ -133,6 +133,7 @@ describe('Burials Form', () => {
     it('should hide state of true when burial allowance not selected', () => {
       const result = formConfig.chapters.benefitsSelection.pages.burialAllowanceConfirmation.depends(
         {
+          relationshipToVeteran: 'spouse',
           'view:claimedBenefits': {
             plotAllowance: true,
           },
@@ -147,6 +148,7 @@ describe('Burials Form', () => {
     it('should show state of true when burial allowance not selected', () => {
       const result = formConfig.chapters.benefitsSelection.pages.burialAllowanceConfirmation.depends(
         {
+          relationshipToVeteran: 'funeralDirector',
           'view:claimedBenefits': {
             burialAllowance: true,
           },


### PR DESCRIPTION
### Summary of Changes
This PR updates the **Burial Benefits form (VA Form 21P-530EZ)** to align with PDF form requirements by updating the conditional logic for displaying the **Statement of truth** page.  

The page is now conditionally displayed **only when** the applicant’s `relationshipToVeteran` is **`funeralDirector`**, ensuring the flow matches the PDF-aligned business rules.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128912

### How to Set Up in Local Environment
1. Run the local environment:  
2. Enable the required feature toggles:
   - `burial_form_enabled`  
     http://localhost:3000/flipper/features/burial_form_enabled
3. Navigate to the Burial Benefits form:  
   http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/

### How to Test
1. Start a new **21P-530EZ** application.
2. Select **Funeral director** as the relationship to the Veteran.
3. Check 'Burial and funeral costs' on the 'Costs you paid for' page
4. Check 'Burial allowance for a Veteran’s unclaimed remains' on the 'Statment of truth' page
5. Verify:
   - The **Type of burial allowance** page is displayed.
6. Restart the form and select a different relationship to the Veteran.
7. Verify:
   - The **Statement of truth** page is skipped.
8. Continue through the form and confirm there are no navigation or validation errors.


### Screenshot
'Statement of truth' page
<img width="720" height="884" alt="Screenshot 2026-01-21 at 1 08 04 PM" src="https://github.com/user-attachments/assets/f79ec91e-3871-4b44-86af-c8b90ecc2638" />

### Acceptance Criteria
- [x] Type of burial allowance page is displayed only when `relationshipToVeteran` is `funeralDirector`.
- [x] Page is skipped for all other relationship types.
- [x] Navigation and validation behave correctly.
- [x] No regressions or accessibility issues introduced.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggles enabled.
- [ ] No console errors or accessibility issues.
- [ ] Tests updated or verified passing.