### PR TITLE
changes phone number component to use international phone number comp…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
@@ -16,6 +16,7 @@ import {
   GetHelp,
   preSubmitSignatureConfig,
 } from '@bio-aquia/21-2680-house-bound-status/components';
+import migrations from '@bio-aquia/21-2680-house-bound-status/config/migrations';
 import { IntroductionPage } from '@bio-aquia/21-2680-house-bound-status/containers/introduction-page';
 import { ConfirmationPage } from '@bio-aquia/21-2680-house-bound-status/containers/confirmation-page';
 import { submitTransformer } from '@bio-aquia/21-2680-house-bound-status/config/submit-transformer';
@@ -107,6 +108,7 @@ const formConfig = {
   },
   version: 0,
   prefillEnabled: false,
+  migrations,
   savedFormMessages: {
     notFound: 'Please start over to apply for benefits.',
     noAuth: 'Please sign in again to continue your application for benefits.',

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
@@ -1,16 +1,18 @@
 export default function validateInternationalPhoneNumbers(savedData) {
   const { formData, metadata } = savedData;
-  // add _isValid, _error, and _touched to claimantPhoneNumber
   if (
     formData?.claimantContact?.claimantPhoneNumber &&
     typeof formData.claimantContact.claimantPhoneNumber === 'object' &&
     formData.claimantContact.claimantPhoneNumber.contact
   ) {
-    formData.claimantContact.claimantPhoneNumber._isValid = true;
-    formData.claimantContact.claimantPhoneNumber._error = null;
-    formData.claimantContact.claimantPhoneNumber._touched = false;
+    const { claimantPhoneNumber } = formData.claimantContact;
+    formData.claimantContact.claimantPhoneNumber._isValid =
+      claimantPhoneNumber.IsValid;
+    formData.claimantContact.claimantPhoneNumber._error =
+      claimantPhoneNumber.Error;
+    formData.claimantContact.claimantPhoneNumber._touched =
+      claimantPhoneNumber.Touched;
   }
-
   return {
     formData,
     metadata,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
@@ -7,11 +7,11 @@ export default function validateInternationalPhoneNumbers(savedData) {
   ) {
     const { claimantPhoneNumber } = formData.claimantContact;
     formData.claimantContact.claimantPhoneNumber._isValid =
-      claimantPhoneNumber.IsValid;
+      claimantPhoneNumber.isValid;
     formData.claimantContact.claimantPhoneNumber._error =
-      claimantPhoneNumber.Error;
+      claimantPhoneNumber.error;
     formData.claimantContact.claimantPhoneNumber._touched =
-      claimantPhoneNumber.Touched;
+      claimantPhoneNumber.touched;
   }
   return {
     formData,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
@@ -1,0 +1,18 @@
+export default function validateInternationalPhoneNumbers(savedData) {
+  const { formData, metadata } = savedData;
+  // add _isValid, _error, and _touched to claimantPhoneNumber
+  if (
+    formData?.claimantContact?.claimantPhoneNumber &&
+    typeof formData.claimantContact.claimantPhoneNumber === 'object' &&
+    formData.claimantContact.claimantPhoneNumber.contact
+  ) {
+    formData.claimantContact.claimantPhoneNumber._isValid = true;
+    formData.claimantContact.claimantPhoneNumber._error = null;
+    formData.claimantContact.claimantPhoneNumber._touched = false;
+  }
+
+  return {
+    formData,
+    metadata,
+  };
+}

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
@@ -7,11 +7,11 @@ export default function validateInternationalPhoneNumbers(savedData) {
   ) {
     const { claimantPhoneNumber } = formData.claimantContact;
     formData.claimantContact.claimantPhoneNumber._isValid =
-      claimantPhoneNumber.isValid;
+      claimantPhoneNumber.isValid || claimantPhoneNumber.IsValid;
     formData.claimantContact.claimantPhoneNumber._error =
-      claimantPhoneNumber.error;
+      claimantPhoneNumber.error || claimantPhoneNumber.Error;
     formData.claimantContact.claimantPhoneNumber._touched =
-      claimantPhoneNumber.touched;
+      claimantPhoneNumber.touched || claimantPhoneNumber.Touched;
   }
   return {
     formData,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/01-validate-international-phone-numbers.js
@@ -9,7 +9,7 @@ export default function validateInternationalPhoneNumbers(savedData) {
     formData.claimantContact.claimantPhoneNumber._isValid =
       claimantPhoneNumber.isValid || claimantPhoneNumber.IsValid;
     formData.claimantContact.claimantPhoneNumber._error =
-      claimantPhoneNumber.error || claimantPhoneNumber.Error;
+      claimantPhoneNumber.error ?? claimantPhoneNumber.Error ?? null;
     formData.claimantContact.claimantPhoneNumber._touched =
       claimantPhoneNumber.touched || claimantPhoneNumber.Touched;
   }

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/index.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/migrations/index.js
@@ -1,0 +1,7 @@
+import validateInternationalPhoneNumbers from './01-validate-international-phone-numbers';
+
+// We launched at version 1 and not version 0, so the first _real_ migration is
+// at migrations[1]
+// NOTE: This will probably just get skipped over, but it's here to be safe
+
+export default [validateInternationalPhoneNumbers];

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/submit-transformer/submit-transformer.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/submit-transformer/submit-transformer.js
@@ -110,7 +110,7 @@ function buildClaimantInformation(cleanedData, veteranInformation) {
   );
   const countryCode =
     claimantContactData.claimantPhoneNumber?.countryCode || 'US';
-  if (countryCode !== 'US') {
+  if (claimantPhone && countryCode !== 'US') {
     // combine calling code with contact number for international numbers
     const callingCode =
       claimantContactData.claimantPhoneNumber?.callingCode || '';

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/submit-transformer/submit-transformer.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/submit-transformer/submit-transformer.js
@@ -105,9 +105,17 @@ function buildClaimantInformation(cleanedData, veteranInformation) {
   const claimantSsn = isVeteranClaimant
     ? veteranInformation.ssn
     : cleanNumericString(claimantSsnData.claimantSsn);
-  const claimantPhone = cleanNumericString(
-    claimantContactData.claimantPhoneNumber,
+  let claimantPhone = cleanNumericString(
+    claimantContactData.claimantPhoneNumber?.contact,
   );
+  const countryCode =
+    claimantContactData.claimantPhoneNumber?.countryCode || 'US';
+  if (countryCode !== 'US') {
+    // combine calling code with contact number for international numbers
+    const callingCode =
+      claimantContactData.claimantPhoneNumber?.callingCode || '';
+    claimantPhone = `+${callingCode}${claimantPhone}`;
+  }
 
   // Build base claimant information
   const claimantInformation = {
@@ -138,8 +146,10 @@ function buildClaimantInformation(cleanedData, veteranInformation) {
     claimantInformation.dateOfBirth = claimantDob;
   }
 
-  if (claimantPhone && claimantPhone.length === 10) {
+  if (claimantPhone && countryCode === 'US' && claimantPhone.length === 10) {
     claimantInformation.phoneNumber = claimantPhone;
+  } else if (claimantPhone && countryCode !== 'US') {
+    claimantInformation.internationalPhoneNumber = claimantPhone;
   }
 
   const email = claimantContactData.claimantEmail || '';

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/submit-transformer/submit-transformer.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/submit-transformer/submit-transformer.unit.spec.jsx
@@ -167,11 +167,34 @@ describe('Submit Transformer', () => {
           relationship: 'veteran',
         },
         claimantContact: {
-          claimantPhoneNumber: '(555) 123-4567',
+          claimantPhoneNumber: {
+            callingCode: 1,
+            contact: '(555) 123-4567',
+            countryCode: 'US',
+          },
         },
       };
       const result = transformAndParse(mockFormConfig, formData);
       expect(result.claimantInformation.phoneNumber).to.equal('5551234567');
+    });
+
+    it('should allow international phone numbers', () => {
+      const formData = {
+        claimantRelationship: {
+          relationship: 'veteran',
+        },
+        claimantContact: {
+          claimantPhoneNumber: {
+            callingCode: 880,
+            contact: '212345678',
+            countryCode: 'BD',
+          },
+        },
+      };
+      const result = transformAndParse(mockFormConfig, formData);
+      expect(result.claimantInformation.internationalPhoneNumber).to.equal(
+        '+880212345678',
+      );
     });
   });
 
@@ -207,7 +230,11 @@ describe('Submit Transformer', () => {
           },
         },
         claimantContact: {
-          claimantPhoneNumber: '5559876543',
+          claimantPhoneNumber: {
+            callingCode: 1,
+            contact: '5559876543',
+            countryCode: 'US',
+          },
           claimantEmail: 'padme@naboo.org',
         },
       };

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
@@ -5,10 +5,10 @@
  */
 
 import {
-  phoneUI,
-  phoneSchema,
   emailUI,
   emailSchema,
+  internationalPhoneUI,
+  internationalPhoneSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import { isClaimantVeteran } from '../utils/relationship-helpers';
@@ -20,7 +20,7 @@ import { getVeteranName, getClaimantName } from '../utils/name-helpers';
  */
 export const claimantContactUiSchema = {
   claimantContact: {
-    claimantPhoneNumber: phoneUI('Home phone number'),
+    claimantPhoneNumber: internationalPhoneUI(),
     claimantEmail: emailUI('Email address'),
   },
   'ui:options': {
@@ -79,7 +79,7 @@ export const claimantContactSchema = {
     claimantContact: {
       type: 'object',
       properties: {
-        claimantPhoneNumber: phoneSchema,
+        claimantPhoneNumber: internationalPhoneSchema(),
         claimantEmail: emailSchema,
       },
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/e2e/21-2680-house-bound-status.cypress.spec.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/e2e/21-2680-house-bound-status.cypress.spec.js
@@ -26,6 +26,35 @@ const testConfig = createTestConfig(
             .click();
         });
       },
+      'claimant-contact': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            const { claimantContact } = data;
+            if (claimantContact?.claimantPhoneNumber) {
+              const countryCode =
+                claimantContact.claimantPhoneNumber.countryCode || 'US';
+              cy.get('va-combo-box')
+                .shadow()
+                .find('button.usa-combo-box__toggle-list')
+                .click();
+
+              cy.get(`li[data-value="${countryCode}"]`).click({ force: true });
+
+              const phoneNumber =
+                claimantContact.claimantPhoneNumber.contact || '';
+              cy.get('input[type="tel"]').type(phoneNumber);
+
+              if (claimantContact.claimantEmail) {
+                cy.get('input[name="root_claimantContact_claimantEmail"]').type(
+                  claimantContact.claimantEmail,
+                );
+              }
+            }
+            cy.axeCheck();
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
@@ -47,7 +47,10 @@
       "claimantPhoneNumber": {
         "callingCode": 880,
         "countryCode": "BD",
-        "contact": "212345678"
+        "contact": "212345678",
+        "IsValid": true,
+        "Error": null,
+        "Touched": true
       },
       "claimantEmail": "lando.jr@cloudcity.com"
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/child-claimant-smc.json
@@ -44,7 +44,11 @@
       }
     },
     "claimantContact": {
-      "claimantPhoneNumber": "7205551937",
+      "claimantPhoneNumber": {
+        "callingCode": 880,
+        "countryCode": "BD",
+        "contact": "212345678"
+      },
       "claimantEmail": "lando.jr@cloudcity.com"
     },
     "benefitType": {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
@@ -49,7 +49,8 @@
         "callingCode": 1,
         "countryCode": "US",
         "contact": "(505) 555-1977"
-      }
+      },
+      "claimantEmail": "senator.amidala@galacticsenate.gov"
     },
     "benefitType": {
       "benefitType": "SMP"

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
@@ -48,7 +48,10 @@
       "claimantPhoneNumber": {
         "callingCode": 1,
         "countryCode": "US",
-        "contact": "(505) 555-1977"
+        "contact": "(505) 555-1977",
+        "IsValid": true,
+        "Error": null,
+        "Touched": true
       },
       "claimantEmail": "senator.amidala@galacticsenate.gov"
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/maximal.json
@@ -45,8 +45,11 @@
       }
     },
     "claimantContact": {
-      "claimantPhoneNumber": "5055551977",
-      "claimantEmail": "senator.amidala@galacticsenate.gov"
+      "claimantPhoneNumber": {
+        "callingCode": 1,
+        "countryCode": "US",
+        "contact": "(505) 555-1977"
+      }
     },
     "benefitType": {
       "benefitType": "SMP"

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
@@ -47,7 +47,10 @@
       "claimantPhoneNumber": {
         "callingCode": 1,
         "countryCode": "US",
-        "contact": "(212) 555-1935"
+        "contact": "(212) 555-1935",
+        "IsValid": true,
+        "Error": null,
+        "Touched": true
       },
       "claimantEmail": "bail.organa@alderaan.gov"
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/parent-claimant-smp-hospitalized.json
@@ -44,7 +44,11 @@
       }
     },
     "claimantContact": {
-      "claimantPhoneNumber": "2125551935",
+      "claimantPhoneNumber": {
+        "callingCode": 1,
+        "countryCode": "US",
+        "contact": "(212) 555-1935"
+      },
       "claimantEmail": "bail.organa@alderaan.gov"
     },
     "benefitType": {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
@@ -26,7 +26,10 @@
       "claimantPhoneNumber": {
         "callingCode": 1,
         "countryCode": "US",
-        "contact": "(520) 555-1313"
+        "contact": "(520) 555-1313",
+        "IsValid": true,
+        "Error": null,
+        "Touched": true
       },
       "claimantEmail": "hsolo@smuggler.net"
     },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/tests/fixtures/data/veteran-smp-hospitalized.json
@@ -23,7 +23,11 @@
       "relationship": "veteran"
     },
     "claimantContact": {
-      "claimantPhoneNumber": "5205551313",
+      "claimantPhoneNumber": {
+        "callingCode": 1,
+        "countryCode": "US",
+        "contact": "(520) 555-1313"
+      },
       "claimantEmail": "hsolo@smuggler.net"
     },
     "benefitType": {


### PR DESCRIPTION
…onent, updates tests for expected input format, adds tests for international phone numbers, updates submit transformer to output international phone number separately from us phone number

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing phone number field to use international phone number field, modifying submit transformer to pass a different field to the backend if the phone number entered is a non-US number, adding a migration to modify save-in-progress data being pre-filled to fix issue with international phone number validation

### Issue
The paper form for 21-2680 allows for an international phone number, but the front end did not allow an international phone number to be input. The form has separate boxes for US numbers and international numbers.

### Solution
Changed the phone number field to use the international phone number component, and modified the submit transformer to pass the phone number to a separate key if it's a non-US number. Key is internationalPhoneNumber. Added a migration to fix issue with international phone number validation

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129833](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129833)

## Testing done

### Old behavior
* The form used the plain phone number component

### New behavior
* The form now uses the international phone number component and passes an internationalPhoneNumber key in the json if it is a non-US number.

### Verification Steps
*  Unit tests: verified existing unit tests still pass, modified existing unit tests to conform to international phone number schema, added unit test for international phone number
*  Manual testing in local environment verified that it is showing the international phone number component and passing the internationalPhoneNumber key to the backend
* E2E tests: all existing tests pass, modified datasets to conform to international phone number schema, updated test to allow international phone numbers to be input

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="555" height="530" alt="before int" src="https://github.com/user-attachments/assets/df2b8fc8-b28d-4a87-844c-d0a0915034b9" /> | <img width="551" height="549" alt="after int" src="https://github.com/user-attachments/assets/6333d66e-d8b8-46b2-9519-398fc89e27ab" /> |

## What areas of the site does it impact?

This change affects form 21-2680, specifically on the Claimant Contact page and Review and Submit page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

Not sure if any backend changes are needed, since international phone numbers seem to be added properly to the pdf if passed to the backend as internationalPhoneNumber

There seems to be an issue with the international phone number pattern where loading a save-in-progress form breaks if an international phone number is input. The attributes being saved and loaded are incorrect (and also inconsistent... save-in-progress loads it as either isValid or IsValid when the field expects _isValid). To fix this, I used a migration to copy over the incorrect keys to the correct ones (isValid and IsValid to _isValid, error and Error to _error, touched and Touched to _touched).