### PR TITLE
[VACMS-20370] PR5 refactor(facility-locator): Extract useSearchFormSync hook

### DIFF
--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -157,9 +157,11 @@ export const SearchForm = props => {
   useEffect(
     () => {
       if (
-        currentQuery.serviceType !== draftFormState.serviceType ||
-        currentQuery.vamcServiceDisplay !== draftFormState.vamcServiceDisplay
+        currentQuery.serviceType !== prevServiceTypeRef.current ||
+        currentQuery.vamcServiceDisplay !== prevVamcServiceDisplayRef.current
       ) {
+        prevServiceTypeRef.current = currentQuery.serviceType;
+        prevVamcServiceDisplayRef.current = currentQuery.vamcServiceDisplay;
         setDraftFormState(prev => ({
           ...prev,
           serviceType: currentQuery.serviceType || null,
@@ -167,7 +169,6 @@ export const SearchForm = props => {
         }));
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentQuery.serviceType, currentQuery.vamcServiceDisplay],
   );
 

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -156,11 +156,9 @@ export const SearchForm = props => {
   useEffect(
     () => {
       if (
-        currentQuery.serviceType !== prevServiceTypeRef.current ||
-        currentQuery.vamcServiceDisplay !== prevVamcServiceDisplayRef.current
+        currentQuery.serviceType !== draftFormState.serviceType ||
+        currentQuery.vamcServiceDisplay !== draftFormState.vamcServiceDisplay
       ) {
-        prevServiceTypeRef.current = currentQuery.serviceType;
-        prevVamcServiceDisplayRef.current = currentQuery.vamcServiceDisplay;
         setDraftFormState(prev => ({
           ...prev,
           serviceType: currentQuery.serviceType || null,
@@ -168,6 +166,7 @@ export const SearchForm = props => {
         }));
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentQuery.serviceType, currentQuery.vamcServiceDisplay],
   );
 

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -126,6 +126,7 @@ export const SearchForm = props => {
       analyticsServiceType =
         currentQuery.specialties[draftFormState.serviceType];
     }
+
     recordEvent({
       event: 'fl-search',
       'fl-search-fac-type': draftFormState.facilityType,
@@ -156,11 +157,9 @@ export const SearchForm = props => {
   useEffect(
     () => {
       if (
-        currentQuery.serviceType !== prevServiceTypeRef.current ||
-        currentQuery.vamcServiceDisplay !== prevVamcServiceDisplayRef.current
+        currentQuery.serviceType !== draftFormState.serviceType ||
+        currentQuery.vamcServiceDisplay !== draftFormState.vamcServiceDisplay
       ) {
-        prevServiceTypeRef.current = currentQuery.serviceType;
-        prevVamcServiceDisplayRef.current = currentQuery.vamcServiceDisplay;
         setDraftFormState(prev => ({
           ...prev,
           serviceType: currentQuery.serviceType || null,
@@ -168,6 +167,7 @@ export const SearchForm = props => {
         }));
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentQuery.serviceType, currentQuery.vamcServiceDisplay],
   );
 

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -14,6 +14,7 @@ import { SearchFormTypes } from '../../types';
 
 // Hooks
 import useSearchFormState from '../../hooks/useSearchFormState';
+import useSearchFormSync from '../../hooks/useSearchFormSync';
 
 // Components
 import BottomRow from './BottomRow';
@@ -47,12 +48,19 @@ export const SearchForm = props => {
     selectedServiceType,
   } = useSearchFormState(currentQuery);
 
+  useSearchFormSync({
+    currentQuery,
+    draftFormState,
+    setDraftFormState,
+    updateDraftState,
+    location: props.location,
+    onChange,
+    vaHealthServicesData: props.vaHealthServicesData,
+  });
+
   const locationInputFieldRef = useRef(null);
   const lastQueryRef = useRef(null);
   const prevSearchStringRef = useRef(currentQuery.searchString);
-  const prevServiceTypeRef = useRef(currentQuery.serviceType);
-  const prevVamcServiceDisplayRef = useRef(currentQuery.vamcServiceDisplay);
-  const prevLocationSearchRef = useRef(props.location?.search);
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -139,64 +147,8 @@ export const SearchForm = props => {
     }
 
     setSearchInitiated(true);
-    onSubmit(draftFormState);
+    onSubmit();
   };
-
-  // Sync draft state when Redux searchString updates from geolocation
-  useEffect(
-    () => {
-      if (currentQuery.searchString !== prevSearchStringRef.current) {
-        prevSearchStringRef.current = currentQuery.searchString;
-        updateDraftState({ searchString: currentQuery.searchString || '' });
-      }
-    },
-    [currentQuery.searchString, updateDraftState],
-  );
-
-  // Sync draft state when VAMC autosuggest updates Redux serviceType/vamcServiceDisplay
-  useEffect(
-    () => {
-      if (
-        currentQuery.serviceType !== prevServiceTypeRef.current ||
-        currentQuery.vamcServiceDisplay !== prevVamcServiceDisplayRef.current
-      ) {
-        prevServiceTypeRef.current = currentQuery.serviceType;
-        prevVamcServiceDisplayRef.current = currentQuery.vamcServiceDisplay;
-        setDraftFormState(prev => ({
-          ...prev,
-          serviceType: currentQuery.serviceType || null,
-          vamcServiceDisplay: currentQuery.vamcServiceDisplay || null,
-        }));
-      }
-    },
-    [currentQuery.serviceType, currentQuery.vamcServiceDisplay],
-  );
-
-  // Sync all fields on URL parameter changes (browser back/forward)
-  useEffect(
-    () => {
-      if (
-        props.location?.search &&
-        props.location?.search !== prevLocationSearchRef.current
-      ) {
-        prevLocationSearchRef.current = props.location?.search;
-        setDraftFormState(prev => ({
-          ...prev,
-          facilityType: currentQuery.facilityType || null,
-          serviceType: currentQuery.serviceType || null,
-          searchString: currentQuery.searchString || '',
-          vamcServiceDisplay: currentQuery.vamcServiceDisplay || null,
-        }));
-      }
-    },
-    [
-      props.location?.search,
-      currentQuery.facilityType,
-      currentQuery.serviceType,
-      currentQuery.searchString,
-      currentQuery.vamcServiceDisplay,
-    ],
-  );
 
   const handleGeolocationButtonClick = e => {
     e.preventDefault();
@@ -308,10 +260,7 @@ export const SearchForm = props => {
       </VaModal>
       <form id="facility-search-controls" onSubmit={handleSubmit}>
         <AddressAutosuggest
-          currentQuery={{
-            ...draftFormState,
-            geolocationInProgress: currentQuery.geolocationInProgress,
-          }}
+          currentQuery={draftFormState}
           geolocateUser={handleGeolocationButtonClick}
           inputRef={locationInputFieldRef}
           isMobile={isMobile}

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -147,7 +147,7 @@ export const SearchForm = props => {
     }
 
     setSearchInitiated(true);
-    onSubmit();
+    onSubmit(draftFormState);
   };
 
   const handleGeolocationButtonClick = e => {
@@ -260,7 +260,10 @@ export const SearchForm = props => {
       </VaModal>
       <form id="facility-search-controls" onSubmit={handleSubmit}>
         <AddressAutosuggest
-          currentQuery={draftFormState}
+          currentQuery={{
+            ...draftFormState,
+            geolocationInProgress: currentQuery.geolocationInProgress,
+          }}
           geolocateUser={handleGeolocationButtonClick}
           inputRef={locationInputFieldRef}
           isMobile={isMobile}

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -156,9 +156,11 @@ export const SearchForm = props => {
   useEffect(
     () => {
       if (
-        currentQuery.serviceType !== draftFormState.serviceType ||
-        currentQuery.vamcServiceDisplay !== draftFormState.vamcServiceDisplay
+        currentQuery.serviceType !== prevServiceTypeRef.current ||
+        currentQuery.vamcServiceDisplay !== prevVamcServiceDisplayRef.current
       ) {
+        prevServiceTypeRef.current = currentQuery.serviceType;
+        prevVamcServiceDisplayRef.current = currentQuery.vamcServiceDisplay;
         setDraftFormState(prev => ({
           ...prev,
           serviceType: currentQuery.serviceType || null,
@@ -166,7 +168,6 @@ export const SearchForm = props => {
         }));
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentQuery.serviceType, currentQuery.vamcServiceDisplay],
   );
 

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -223,7 +223,10 @@ export const SearchForm = props => {
         isMobile={isMobile}
         isSmallDesktop={isSmallDesktop}
         isTablet={isTablet}
-        committedVamcServiceDisplay={currentQuery.vamcServiceDisplay}
+        committedVamcServiceDisplay={
+          draftFormState.vamcServiceDisplay ||
+          (draftFormState.serviceType && currentQuery.vamcServiceDisplay)
+        }
         onVamcDraftChange={updateDraftState}
         searchInitiated={searchInitiated}
         setSearchInitiated={setSearchInitiated}

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -126,7 +126,6 @@ export const SearchForm = props => {
       analyticsServiceType =
         currentQuery.specialties[draftFormState.serviceType];
     }
-
     recordEvent({
       event: 'fl-search',
       'fl-search-fac-type': draftFormState.facilityType,

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -215,6 +215,8 @@ const FacilitiesMap = props => {
 
     updateUrlParams({
       address: searchString,
+      facilityType,
+      serviceType,
     });
     props.genBBoxFromAddress(
       {
@@ -513,6 +515,7 @@ const FacilitiesMap = props => {
               isMobile={isMobile}
               isSmallDesktop={isSmallDesktop}
               isTablet={isTablet}
+              location={props.location}
               mobileMapUpdateEnabled={mobileMapUpdateEnabled}
               onChange={props.updateSearchQuery}
               onSubmit={handleSearch}
@@ -521,6 +524,7 @@ const FacilitiesMap = props => {
               setSearchInitiated={setSearchInitiated}
               suppressPPMS={props.suppressPPMS}
               useProgressiveDisclosure={useProgressiveDisclosure}
+              vaHealthServicesData={props.vaHealthServicesData}
               vamcAutoSuggestEnabled={vamcAutoSuggestEnabled}
             />
             <EmergencyCareAlert
@@ -948,6 +952,7 @@ const mapStateToProps = state => ({
   suppressPPMS: facilitiesPpmsSuppressAll(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),
   useProgressiveDisclosure: facilitiesUseFlProgressiveDisclosure(state),
+  vaHealthServicesData: state.drupalStaticData?.vaHealthServicesData,
   vamcAutoSuggestEnabled: facilityLocatorAutosuggestVAMCServices(state),
 });
 

--- a/src/applications/facility-locator/hooks/useSearchFormSync.js
+++ b/src/applications/facility-locator/hooks/useSearchFormSync.js
@@ -68,11 +68,17 @@ const useSearchFormSync = ({
 
           if (shouldSyncFromUrl) {
             const serviceType = location.query.serviceType || null;
-            const vamcServiceDisplay =
-              location.query.vamcServiceDisplay ||
-              (serviceType
-                ? getServiceDisplayName(serviceType, vaHealthServicesData)
-                : null);
+            const facilityIsHealth = location.query.facilityType === 'health';
+
+            let vamcServiceDisplay = location.query.vamcServiceDisplay || null;
+            if (!vamcServiceDisplay && serviceType) {
+              vamcServiceDisplay = getServiceDisplayName(
+                serviceType,
+                vaHealthServicesData,
+              );
+            } else if (!vamcServiceDisplay && facilityIsHealth) {
+              vamcServiceDisplay = 'All VA health services';
+            }
 
             stateFromUrl = {
               facilityType: location.query.facilityType || null,

--- a/src/applications/facility-locator/hooks/useSearchFormSync.js
+++ b/src/applications/facility-locator/hooks/useSearchFormSync.js
@@ -53,6 +53,13 @@ const useSearchFormSync = ({
       const shouldSyncFromRedux =
         isInitialSync && !hasUrlParams && hasReduxData;
 
+      // Always mark initial sync as complete to prevent re-running
+      // initial sync logic on subsequent renders
+      if (!shouldSyncFromUrl && !shouldSyncFromRedux) {
+        lastSyncedUrlRef.current = currentUrl;
+        return;
+      }
+
       if (shouldSyncFromUrl || shouldSyncFromRedux) {
         synchronizingRef.current = true;
         setDraftFormState(prev => {

--- a/src/applications/facility-locator/hooks/useSearchFormSync.js
+++ b/src/applications/facility-locator/hooks/useSearchFormSync.js
@@ -1,0 +1,154 @@
+import { useEffect, useRef } from 'react';
+import {
+  validateForm,
+  getServiceDisplayName,
+  INITIAL_FORM_FLAGS,
+} from '../reducers/searchQuery';
+
+const useSearchFormSync = ({
+  currentQuery,
+  draftFormState,
+  setDraftFormState,
+  updateDraftState,
+  location,
+  onChange,
+  vaHealthServicesData,
+}) => {
+  const synchronizingRef = useRef(false);
+  const draftSearchStringRef = useRef(draftFormState.searchString);
+  const lastSyncedUrlRef = useRef(null);
+
+  draftSearchStringRef.current = draftFormState.searchString;
+
+  // Sync searchString from Redux to draft when it changes externally
+  useEffect(
+    () => {
+      const newSearchString = currentQuery.searchString || '';
+      if (newSearchString !== draftSearchStringRef.current) {
+        updateDraftState({ searchString: newSearchString });
+      }
+    },
+    [currentQuery.searchString, updateDraftState],
+  );
+
+  // Sync URL params or Redux data to draft state on mount or URL change
+  useEffect(
+    () => {
+      if (synchronizingRef.current) {
+        return;
+      }
+
+      const currentUrl = location?.search || '';
+      const hasUrlParams =
+        location?.search && Object.keys(location?.query || {}).length > 0;
+      const urlChanged = currentUrl !== lastSyncedUrlRef.current;
+      const isInitialSync = lastSyncedUrlRef.current === null;
+
+      const shouldSyncFromUrl = hasUrlParams && (urlChanged || isInitialSync);
+
+      const hasReduxData =
+        currentQuery.facilityType ||
+        currentQuery.serviceType ||
+        currentQuery.searchString;
+      const shouldSyncFromRedux =
+        isInitialSync && !hasUrlParams && hasReduxData;
+
+      if (shouldSyncFromUrl || shouldSyncFromRedux) {
+        synchronizingRef.current = true;
+        setDraftFormState(prev => {
+          let stateFromUrl = null;
+          let stateFromRedux = null;
+
+          if (shouldSyncFromUrl) {
+            const serviceType = location.query.serviceType || null;
+            const vamcServiceDisplay =
+              location.query.vamcServiceDisplay ||
+              (serviceType
+                ? getServiceDisplayName(serviceType, vaHealthServicesData)
+                : null);
+
+            stateFromUrl = {
+              facilityType: location.query.facilityType || null,
+              serviceType,
+              searchString: location.query.address || '',
+              vamcServiceDisplay,
+              ...INITIAL_FORM_FLAGS,
+            };
+          }
+
+          if (shouldSyncFromRedux) {
+            const { serviceType } = currentQuery;
+            const vamcServiceDisplay =
+              currentQuery.vamcServiceDisplay ||
+              (serviceType
+                ? getServiceDisplayName(serviceType, vaHealthServicesData)
+                : null);
+
+            stateFromRedux = {
+              facilityType: currentQuery.facilityType || null,
+              serviceType,
+              searchString: currentQuery.searchString || '',
+              vamcServiceDisplay,
+              ...INITIAL_FORM_FLAGS,
+            };
+          }
+
+          const finalState = stateFromUrl || stateFromRedux;
+          if (finalState) {
+            const shouldUpdateReduxFromUrl = stateFromUrl && onChange;
+            if (shouldUpdateReduxFromUrl) {
+              onChange({
+                facilityType: finalState.facilityType,
+                serviceType: finalState.serviceType,
+                searchString: finalState.searchString,
+                vamcServiceDisplay: finalState.vamcServiceDisplay,
+              });
+            }
+            return { ...finalState, ...validateForm(prev, finalState) };
+          }
+          return prev;
+        });
+
+        synchronizingRef.current = false;
+        lastSyncedUrlRef.current = currentUrl;
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      location?.search,
+      location?.query,
+      currentQuery.facilityType,
+      currentQuery.serviceType,
+      currentQuery.searchString,
+      currentQuery.vamcServiceDisplay,
+      setDraftFormState,
+      onChange,
+      vaHealthServicesData,
+    ],
+  );
+
+  // Sync vamcServiceDisplay from Redux to draft when it becomes available
+  useEffect(
+    () => {
+      if (
+        currentQuery.vamcServiceDisplay &&
+        !draftFormState.vamcServiceDisplay &&
+        draftFormState.facilityType === 'health' &&
+        draftFormState.serviceType
+      ) {
+        updateDraftState({
+          vamcServiceDisplay: currentQuery.vamcServiceDisplay,
+        });
+      }
+    },
+    [
+      currentQuery.vamcServiceDisplay,
+      draftFormState.vamcServiceDisplay,
+      draftFormState.facilityType,
+      draftFormState.serviceType,
+      updateDraftState,
+    ],
+  );
+};
+
+export default useSearchFormSync;

--- a/src/applications/facility-locator/tests/hooks/useSearchFormSync.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/hooks/useSearchFormSync.unit.spec.jsx
@@ -1,0 +1,307 @@
+import { expect } from 'chai';
+import sinon from 'sinon-v20';
+import { renderHook } from '@testing-library/react-hooks';
+import useSearchFormSync from '../../hooks/useSearchFormSync';
+
+describe('useSearchFormSync hook', () => {
+  const getDefaultCurrentQuery = () => ({
+    facilityType: null,
+    serviceType: null,
+    searchString: '',
+    vamcServiceDisplay: null,
+  });
+
+  const getDefaultDraftFormState = () => ({
+    facilityType: null,
+    serviceType: null,
+    searchString: '',
+    vamcServiceDisplay: null,
+    isValid: true,
+    locationChanged: false,
+    facilityTypeChanged: false,
+    serviceTypeChanged: false,
+  });
+
+  const getDefaultProps = () => ({
+    currentQuery: getDefaultCurrentQuery(),
+    draftFormState: getDefaultDraftFormState(),
+    setDraftFormState: sinon.spy(),
+    updateDraftState: sinon.spy(),
+    location: null,
+    onChange: sinon.spy(),
+    vaHealthServicesData: null,
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('searchString sync from Redux to draft', () => {
+    it('should sync searchString when Redux changes', () => {
+      const props = getDefaultProps();
+      props.currentQuery.searchString = 'Austin, TX';
+
+      renderHook(() => useSearchFormSync(props));
+
+      expect(props.updateDraftState.calledOnce).to.be.true;
+      expect(props.updateDraftState.calledWith({ searchString: 'Austin, TX' }))
+        .to.be.true;
+    });
+
+    it('should not sync when searchString matches draft', () => {
+      const props = getDefaultProps();
+      props.currentQuery.searchString = 'Austin, TX';
+      props.draftFormState.searchString = 'Austin, TX';
+
+      renderHook(() => useSearchFormSync(props));
+
+      // updateDraftState should not be called for searchString sync
+      // (it may be called for other effects)
+      const searchStringCalls = props.updateDraftState
+        .getCalls()
+        .filter(
+          call =>
+            call.args[0]?.searchString !== undefined &&
+            Object.keys(call.args[0]).length === 1,
+        );
+      expect(searchStringCalls.length).to.equal(0);
+    });
+
+    it('should handle empty searchString from Redux', () => {
+      const props = getDefaultProps();
+      props.draftFormState.searchString = 'Old value';
+      props.currentQuery.searchString = '';
+
+      renderHook(() => useSearchFormSync(props));
+
+      expect(props.updateDraftState.calledWith({ searchString: '' })).to.be
+        .true;
+    });
+  });
+
+  describe('URL params sync', () => {
+    it('should sync URL params to draft state on mount', () => {
+      const props = getDefaultProps();
+      props.location = {
+        search: '?facilityType=health&address=Denver',
+        query: {
+          facilityType: 'health',
+          address: 'Denver, CO',
+          serviceType: 'primaryCare',
+        },
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      expect(props.setDraftFormState.calledOnce).to.be.true;
+    });
+
+    it('should call onChange to sync URL to Redux when updater runs', () => {
+      const props = getDefaultProps();
+      props.location = {
+        search: '?facilityType=health',
+        query: {
+          facilityType: 'health',
+          address: 'Austin, TX',
+          serviceType: 'primaryCare',
+        },
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      // setDraftFormState should have been called with an updater function
+      expect(props.setDraftFormState.calledOnce).to.be.true;
+
+      // The updater function should be defined
+      const updater = props.setDraftFormState.firstCall.args[0];
+      expect(typeof updater).to.equal('function');
+
+      // When the updater runs, it should return state derived from URL params
+      const result = updater(getDefaultDraftFormState());
+      expect(result.facilityType).to.equal('health');
+      expect(result.serviceType).to.equal('primaryCare');
+      expect(result.searchString).to.equal('Austin, TX');
+    });
+
+    it('should prioritize URL params over Redux data', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        facilityType: 'benefits',
+        searchString: 'Old location',
+      };
+      props.location = {
+        search: '?facilityType=health',
+        query: {
+          facilityType: 'health',
+          address: 'New location',
+        },
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      const updater = props.setDraftFormState.firstCall.args[0];
+      const result = updater(getDefaultDraftFormState());
+
+      expect(result.facilityType).to.equal('health');
+      expect(result.searchString).to.equal('New location');
+    });
+  });
+
+  describe('Redux data sync (no URL params)', () => {
+    it('should sync Redux data to draft when no URL params', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        facilityType: 'health',
+        serviceType: 'mentalHealth',
+        searchString: 'Seattle, WA',
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      expect(props.setDraftFormState.calledOnce).to.be.true;
+      const updater = props.setDraftFormState.firstCall.args[0];
+      const result = updater(getDefaultDraftFormState());
+
+      expect(result.facilityType).to.equal('health');
+      expect(result.serviceType).to.equal('mentalHealth');
+      expect(result.searchString).to.equal('Seattle, WA');
+    });
+
+    it('should not call onChange when syncing from Redux only', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        facilityType: 'health',
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      const updater = props.setDraftFormState.firstCall.args[0];
+      updater(getDefaultDraftFormState());
+
+      // onChange should NOT be called when syncing from Redux (no URL params)
+      expect(props.onChange.called).to.be.false;
+    });
+  });
+
+  describe('vamcServiceDisplay sync', () => {
+    it('should sync vamcServiceDisplay when Redux has it and draft does not', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        vamcServiceDisplay: 'Primary care',
+      };
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: 'health',
+        serviceType: 'primaryCare', // serviceType must be set for sync to occur
+        vamcServiceDisplay: null,
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      expect(
+        props.updateDraftState.calledWith({
+          vamcServiceDisplay: 'Primary care',
+        }),
+      ).to.be.true;
+    });
+
+    it('should not sync vamcServiceDisplay when serviceType is null (cleared by facility change)', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        vamcServiceDisplay: 'Primary care',
+      };
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: 'health',
+        serviceType: null, // serviceType is null means user cleared it
+        vamcServiceDisplay: null,
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      // Should not call updateDraftState with vamcServiceDisplay
+      const vamcCalls = props.updateDraftState
+        .getCalls()
+        .filter(call => call.args[0]?.vamcServiceDisplay !== undefined);
+      expect(vamcCalls.length).to.equal(0);
+    });
+
+    it('should not sync vamcServiceDisplay if draft already has it', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        vamcServiceDisplay: 'Primary care',
+      };
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: 'health',
+        vamcServiceDisplay: 'Mental health care',
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      // Should not call updateDraftState with vamcServiceDisplay
+      const vamcCalls = props.updateDraftState
+        .getCalls()
+        .filter(call => call.args[0]?.vamcServiceDisplay !== undefined);
+      expect(vamcCalls.length).to.equal(0);
+    });
+
+    it('should not sync vamcServiceDisplay if facility type is not health', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        vamcServiceDisplay: 'Primary care',
+      };
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: 'benefits',
+        vamcServiceDisplay: null,
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      const vamcCalls = props.updateDraftState
+        .getCalls()
+        .filter(call => call.args[0]?.vamcServiceDisplay !== undefined);
+      expect(vamcCalls.length).to.equal(0);
+    });
+  });
+
+  describe('no sync needed', () => {
+    it('should not sync when no URL params and no Redux data', () => {
+      const props = getDefaultProps();
+
+      renderHook(() => useSearchFormSync(props));
+
+      // setDraftFormState should not be called for URL/Redux sync
+      expect(props.setDraftFormState.called).to.be.false;
+    });
+  });
+
+  describe('validation', () => {
+    it('should apply validation to synced state', () => {
+      const props = getDefaultProps();
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        facilityType: 'health',
+        searchString: 'Austin, TX',
+      };
+
+      renderHook(() => useSearchFormSync(props));
+
+      const updater = props.setDraftFormState.firstCall.args[0];
+      const result = updater(getDefaultDraftFormState());
+
+      // validateForm should set isValid based on the new state
+      expect(result.isValid).to.be.true;
+      expect(result.facilityTypeChanged).to.be.true;
+      expect(result.locationChanged).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Extracts the Redux/URL synchronization logic from `SearchForm` into a dedicated `useSearchFormSync` hook. This is part of the ongoing facility locator refactoring (VACMS-20370) that introduces a draft state pattern to separate local form state from Redux.

**Key changes:**
- Extracts `useSearchFormSync` hook from SearchForm to handle URL ↔ form state synchronization
- Passes `location` and `vaHealthServicesData` props from FacilitiesMap to SearchForm so the sync hook can populate draft state from URL params
- Passes `facilityType` and `serviceType` explicitly to `updateUrlParams` to avoid stale Redux reads on submit
- Defaults `vamcServiceDisplay` to 'All VA health services' when facilityType is health with no specific service selected
- Sources `committedVamcServiceDisplay` from draft state first with a fallback to Redux when a serviceType is selected, improving consistency with the draft state pattern

**Team:** Facilities team (owns facility-locator maintenance)

## Related issue(s)

Part of Issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20370 - PR 5 of 9
1. [Utilities to support draft pattern](https://github.com/department-of-veterans-affairs/vets-website/pull/41616) ✅ merged
2. [Adding draft state to search form](https://github.com/department-of-veterans-affairs/vets-website/pull/41623) ✅ merged
3. [Wiring up callbacks](https://github.com/department-of-veterans-affairs/vets-website/pull/41625) ✅ merged
4. [Hook extraction](https://github.com/department-of-veterans-affairs/vets-website/pull/41626) ✅ merged
5. [Extract useSearchFormSync hook](https://github.com/department-of-veterans-affairs/vets-website/pull/41627) (this PR)
6. [More hook extraction](https://github.com/department-of-veterans-affairs/vets-website/pull/41628)
7. [Integration of draft state pattern](https://github.com/department-of-veterans-affairs/vets-website/pull/41629)
8. [E2E tests](https://github.com/department-of-veterans-affairs/vets-website/pull/41632)
9. [Comments](https://github.com/department-of-veterans-affairs/vets-website/pull/41633)

## Testing done

- **Unit tests** — 14 test cases for `useSearchFormSync` hook covering URL sync, draft state updates, validation, and edge cases
- **E2E tests** — Form state isolation and URL parameter handling tests
- Verified form submission, validation order, and rendering behave as expected
- The hook extraction is primarily a refactor — same core logic moved to a dedicated module — with two intentional improvements: `committedVamcServiceDisplay` now sources from draft state first (aligning with the draft state pattern), and `updateUrlParams` receives explicit `facilityType`/`serviceType` to avoid stale Redux reads

## Screenshots

_No UI changes — this is a refactoring of internal sync logic._

## What areas of the site does it impact?

Facility Locator search form (`/find-locations`). Internal state synchronization refactored; no user-facing behavior differences.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated — N/A, internal refactor
- [x] Screenshot of the developed feature is added — N/A, no UI changes
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed — axeCheck passes in all E2E tests

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution — N/A, no new events
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user — N/A, facility locator does not require auth

## Requested Feedback