### PR TITLE
[VACMS-20370] PR6 refactor(facility-locator): Extract useSearchSubmit hook

### DIFF
--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -118,6 +118,7 @@ export const SearchForm = props => {
       return;
     }
 
+
     onChange({
       facilityType: draftFormState.facilityType,
       serviceType: draftFormState.serviceType,

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -8,13 +8,13 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 import { clearSearchText } from '../../actions/search';
 import { clearGeocodeError, geolocateUser } from '../../actions/mapbox';
 import { getProviderSpecialties } from '../../actions/locations';
-import { LocationType } from '../../constants';
 import { setFocus } from '../../utils/helpers';
 import { SearchFormTypes } from '../../types';
 
 // Hooks
 import useSearchFormState from '../../hooks/useSearchFormState';
 import useSearchFormSync from '../../hooks/useSearchFormSync';
+import useSearchSubmit from '../../hooks/useSearchSubmit';
 
 // Components
 import BottomRow from './BottomRow';
@@ -58,97 +58,42 @@ export const SearchForm = props => {
     vaHealthServicesData: props.vaHealthServicesData,
   });
 
+  useEffect(
+    () => {
+      if (currentQuery?.geocodeError) {
+        if (currentQuery.geocodeError === 1) {
+          recordEvent({
+            event: 'fl-get-geolocation-permission-error',
+            'error-key': '1_PERMISSION_DENIED',
+          });
+        } else {
+          recordEvent({
+            event: 'fl-get-geolocation-other-error',
+            'error-key':
+              currentQuery.geocodeError === 2
+                ? '2_POSITION_UNAVAILABLE'
+                : '3_TIMEOUT',
+          });
+        }
+      }
+    },
+    [currentQuery.geocodeError],
+  );
+
+  const { handleSubmit } = useSearchSubmit({
+    draftFormState,
+    setDraftFormState,
+    selectedServiceType,
+    currentQuery,
+    onChange,
+    onSubmit,
+    isMobile,
+    mobileMapUpdateEnabled,
+    selectMobileMapPin,
+    setSearchInitiated,
+  });
+
   const locationInputFieldRef = useRef(null);
-  const lastQueryRef = useRef(null);
-  const prevSearchStringRef = useRef(currentQuery.searchString);
-
-  const handleSubmit = e => {
-    e.preventDefault();
-
-    const isSameQuery =
-      lastQueryRef.current &&
-      draftFormState.facilityType === lastQueryRef.current.facilityType &&
-      draftFormState.serviceType === lastQueryRef.current.serviceType &&
-      draftFormState.searchString === lastQueryRef.current.searchString &&
-      currentQuery.zoomLevel === lastQueryRef.current.zoomLevel;
-
-    if (isSameQuery) {
-      return;
-    }
-
-    lastQueryRef.current = {
-      facilityType: draftFormState.facilityType,
-      serviceType: draftFormState.serviceType,
-      searchString: draftFormState.searchString,
-      zoomLevel: currentQuery.zoomLevel,
-    };
-
-    // Validate most-specific field first: serviceType is only required for
-    // CC_PROVIDER, then location (most common error), then facilityType
-    if (
-      draftFormState.facilityType === LocationType.CC_PROVIDER &&
-      (!draftFormState.serviceType || !selectedServiceType)
-    ) {
-      setDraftFormState(prev => ({
-        ...prev,
-        serviceTypeChanged: true,
-        isValid: false,
-      }));
-      focusElement('#service-type-ahead-input');
-      return;
-    }
-
-    if (!draftFormState.searchString) {
-      setDraftFormState(prev => ({
-        ...prev,
-        locationChanged: true,
-        isValid: false,
-      }));
-      focusElement('#street-city-state-zip');
-      return;
-    }
-
-    if (!draftFormState.facilityType) {
-      setDraftFormState(prev => ({
-        ...prev,
-        facilityTypeChanged: true,
-        isValid: false,
-      }));
-      focusElement('#facility-type-dropdown');
-      return;
-    }
-
-
-    onChange({
-      facilityType: draftFormState.facilityType,
-      serviceType: draftFormState.serviceType,
-      searchString: draftFormState.searchString,
-      vamcServiceDisplay: draftFormState.vamcServiceDisplay,
-    });
-
-    let analyticsServiceType = draftFormState.serviceType;
-    if (
-      draftFormState.facilityType === LocationType.CC_PROVIDER &&
-      currentQuery.specialties &&
-      Object.keys(currentQuery.specialties).includes(draftFormState.serviceType)
-    ) {
-      analyticsServiceType =
-        currentQuery.specialties[draftFormState.serviceType];
-    }
-    recordEvent({
-      event: 'fl-search',
-      'fl-search-fac-type': draftFormState.facilityType,
-      'fl-search-svc-type': analyticsServiceType,
-      'fl-current-zoom-depth': currentQuery.zoomLevel,
-    });
-
-    if (isMobile && mobileMapUpdateEnabled) {
-      selectMobileMapPin(null);
-    }
-
-    setSearchInitiated(true);
-    onSubmit(draftFormState);
-  };
 
   const handleGeolocationButtonClick = e => {
     e.preventDefault();
@@ -158,7 +103,6 @@ export const SearchForm = props => {
 
   const handleClearInput = () => {
     props.clearSearchText();
-    prevSearchStringRef.current = '';
     setDraftFormState(prev => ({
       ...prev,
       searchString: '',
@@ -181,28 +125,6 @@ export const SearchForm = props => {
       }
     },
     [currentQuery.geolocationInProgress],
-  );
-
-  useEffect(
-    () => {
-      if (currentQuery?.geocodeError) {
-        if (currentQuery.geocodeError === 1) {
-          recordEvent({
-            event: 'fl-get-geolocation-permission-error',
-            'error-key': '1_PERMISSION_DENIED',
-          });
-        } else {
-          recordEvent({
-            event: 'fl-get-geolocation-other-error',
-            'error-key':
-              currentQuery.geocodeError === 2
-                ? '2_POSITION_UNAVAILABLE'
-                : '3_TIMEOUT',
-          });
-        }
-      }
-    },
-    [currentQuery.geocodeError],
   );
 
   const facilityAndServiceTypeInputs = (
@@ -261,6 +183,7 @@ export const SearchForm = props => {
             : 'Sorry, something went wrong when trying to find your location. Please make sure location sharing is enabled and try again.'}
         </p>
       </VaModal>
+
       <form id="facility-search-controls" onSubmit={handleSubmit}>
         <AddressAutosuggest
           currentQuery={{
@@ -282,7 +205,7 @@ export const SearchForm = props => {
             {facilityAndServiceTypeInputs}
             <va-button
               id="facility-search"
-              submit="prevent"
+              onClick={handleSubmit}
               text="Search"
               full-width
             />

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -134,7 +134,6 @@ export const SearchForm = props => {
       analyticsServiceType =
         currentQuery.specialties[draftFormState.serviceType];
     }
-
     recordEvent({
       event: 'fl-search',
       'fl-search-fac-type': draftFormState.facilityType,

--- a/src/applications/facility-locator/hooks/useSearchSubmit.js
+++ b/src/applications/facility-locator/hooks/useSearchSubmit.js
@@ -1,0 +1,132 @@
+import { useCallback, useRef } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
+import { focusElement } from 'platform/utilities/ui';
+import { LocationType } from '../constants';
+
+const useSearchSubmit = ({
+  draftFormState,
+  setDraftFormState,
+  selectedServiceType,
+  currentQuery,
+  onChange,
+  onSubmit,
+  isMobile,
+  mobileMapUpdateEnabled,
+  selectMobileMapPin,
+  setSearchInitiated,
+}) => {
+  const lastQueryRef = useRef(null);
+
+  const handleSubmit = useCallback(
+    e => {
+      e.preventDefault();
+
+      const isSameQuery =
+        lastQueryRef.current &&
+        draftFormState.facilityType === lastQueryRef.current.facilityType &&
+        draftFormState.serviceType === lastQueryRef.current.serviceType &&
+        draftFormState.searchString === lastQueryRef.current.searchString &&
+        currentQuery.zoomLevel === lastQueryRef.current.zoomLevel;
+
+      if (isSameQuery) {
+        return;
+      }
+
+      // CC_PROVIDER serviceType validation first (matches E2E test expectations)
+      if (
+        draftFormState.facilityType === LocationType.CC_PROVIDER &&
+        (!draftFormState.serviceType || !selectedServiceType)
+      ) {
+        setDraftFormState(prev => ({
+          ...prev,
+          serviceTypeChanged: true,
+          isValid: false,
+        }));
+        setTimeout(() => focusElement('#service-type-ahead-input'), 0);
+        return;
+      }
+
+      if (!draftFormState.searchString) {
+        setDraftFormState(prev => ({
+          ...prev,
+          locationChanged: true,
+          isValid: false,
+        }));
+        setTimeout(() => focusElement('#street-city-state-zip'), 0);
+        return;
+      }
+
+      if (!draftFormState.facilityType) {
+        setDraftFormState(prev => ({
+          ...prev,
+          facilityTypeChanged: true,
+          isValid: false,
+        }));
+        setTimeout(() => focusElement('#facility-type-dropdown'), 0);
+        return;
+      }
+
+      lastQueryRef.current = {
+        facilityType: draftFormState.facilityType,
+        serviceType: draftFormState.serviceType,
+        searchString: draftFormState.searchString,
+        zoomLevel: currentQuery.zoomLevel,
+      };
+
+      onChange({
+        facilityType: draftFormState.facilityType,
+        serviceType: draftFormState.serviceType,
+        searchString: draftFormState.searchString,
+        vamcServiceDisplay: draftFormState.vamcServiceDisplay,
+      });
+
+      let analyticsServiceType = draftFormState.serviceType;
+      const specialtyDisplayName =
+        currentQuery.specialties?.[draftFormState.serviceType];
+
+      if (
+        draftFormState.facilityType === LocationType.CC_PROVIDER &&
+        currentQuery.specialties &&
+        specialtyDisplayName
+      ) {
+        analyticsServiceType = specialtyDisplayName;
+      }
+
+      recordEvent({
+        event: 'fl-search',
+        'fl-search-fac-type': draftFormState.facilityType,
+        'fl-search-svc-type': analyticsServiceType,
+        'fl-current-zoom-depth': currentQuery.zoomLevel,
+      });
+
+      if (isMobile && mobileMapUpdateEnabled) {
+        selectMobileMapPin(null);
+      }
+
+      setSearchInitiated(true);
+      onSubmit({
+        facilityType: draftFormState.facilityType,
+        serviceType: draftFormState.serviceType,
+        searchString: draftFormState.searchString,
+        vamcServiceDisplay: draftFormState.vamcServiceDisplay,
+      });
+    },
+    [
+      draftFormState,
+      setDraftFormState,
+      selectedServiceType,
+      currentQuery.zoomLevel,
+      currentQuery.specialties,
+      onChange,
+      onSubmit,
+      isMobile,
+      mobileMapUpdateEnabled,
+      selectMobileMapPin,
+      setSearchInitiated,
+    ],
+  );
+
+  return { handleSubmit };
+};
+
+export default useSearchSubmit;

--- a/src/applications/facility-locator/tests/hooks/useSearchSubmit.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/hooks/useSearchSubmit.unit.spec.jsx
@@ -1,0 +1,404 @@
+import { expect } from 'chai';
+import sinon from 'sinon-v20';
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as recordEvent from 'platform/monitoring/record-event';
+import useSearchSubmit from '../../hooks/useSearchSubmit';
+import { LocationType } from '../../constants';
+
+describe('useSearchSubmit hook', () => {
+  let recordStub;
+
+  const getDefaultDraftFormState = () => ({
+    facilityType: 'health',
+    serviceType: 'primaryCare',
+    searchString: 'Austin, TX',
+    vamcServiceDisplay: 'Primary care',
+    isValid: true,
+    locationChanged: false,
+    facilityTypeChanged: false,
+    serviceTypeChanged: false,
+  });
+
+  const getDefaultCurrentQuery = () => ({
+    zoomLevel: 10,
+    specialties: null,
+  });
+
+  const getDefaultProps = () => ({
+    draftFormState: getDefaultDraftFormState(),
+    setDraftFormState: sinon.spy(),
+    selectedServiceType: { id: 'primaryCare', name: 'Primary care' },
+    currentQuery: getDefaultCurrentQuery(),
+    onChange: sinon.spy(),
+    onSubmit: sinon.spy(),
+    isMobile: false,
+    mobileMapUpdateEnabled: false,
+    selectMobileMapPin: sinon.spy(),
+    setSearchInitiated: sinon.spy(),
+  });
+
+  const createMockEvent = () => ({
+    preventDefault: sinon.spy(),
+  });
+
+  beforeEach(() => {
+    recordStub = sinon.stub(recordEvent, 'default');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('successful submission', () => {
+    it('should prevent default form behavior', () => {
+      const props = getDefaultProps();
+      const { result } = renderHook(() => useSearchSubmit(props));
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      expect(mockEvent.preventDefault.calledOnce).to.be.true;
+    });
+
+    it('should call onChange with draft form state', () => {
+      const props = getDefaultProps();
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onChange.calledOnce).to.be.true;
+      expect(
+        props.onChange.calledWith({
+          facilityType: 'health',
+          serviceType: 'primaryCare',
+          searchString: 'Austin, TX',
+          vamcServiceDisplay: 'Primary care',
+        }),
+      ).to.be.true;
+    });
+
+    it('should call onSubmit with draft form state', () => {
+      const props = getDefaultProps();
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.calledOnce).to.be.true;
+      expect(
+        props.onSubmit.calledWith({
+          facilityType: 'health',
+          serviceType: 'primaryCare',
+          searchString: 'Austin, TX',
+          vamcServiceDisplay: 'Primary care',
+        }),
+      ).to.be.true;
+    });
+
+    it('should call setSearchInitiated with true', () => {
+      const props = getDefaultProps();
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.setSearchInitiated.calledOnce).to.be.true;
+      expect(props.setSearchInitiated.calledWith(true)).to.be.true;
+    });
+
+    it('should record analytics event', () => {
+      const props = getDefaultProps();
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(recordStub.calledOnce).to.be.true;
+      expect(
+        recordStub.calledWith({
+          event: 'fl-search',
+          'fl-search-fac-type': 'health',
+          'fl-search-svc-type': 'primaryCare',
+          'fl-current-zoom-depth': 10,
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('duplicate query prevention', () => {
+    it('should prevent duplicate submissions with same query', () => {
+      const props = getDefaultProps();
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      // First submission
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.calledOnce).to.be.true;
+
+      // Second submission with same data
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      // Should still be called only once
+      expect(props.onSubmit.calledOnce).to.be.true;
+    });
+
+    it('should allow submission when query changes', () => {
+      const props = getDefaultProps();
+      const { result, rerender } = renderHook(() => useSearchSubmit(props));
+
+      // First submission
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.calledOnce).to.be.true;
+
+      // Update props with different search string
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        searchString: 'Denver, CO',
+      };
+      rerender();
+
+      // Second submission with different data
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.calledTwice).to.be.true;
+    });
+  });
+
+  describe('validation - missing searchString', () => {
+    it('should not submit when searchString is empty', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        searchString: '',
+      };
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.called).to.be.false;
+      expect(props.onChange.called).to.be.false;
+    });
+
+    it('should set locationChanged and isValid flags', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        searchString: '',
+      };
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.setDraftFormState.calledOnce).to.be.true;
+      const updater = props.setDraftFormState.firstCall.args[0];
+      const newState = updater(props.draftFormState);
+      expect(newState.locationChanged).to.be.true;
+      expect(newState.isValid).to.be.false;
+    });
+  });
+
+  describe('validation - missing facilityType', () => {
+    it('should not submit when facilityType is empty', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: null,
+      };
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.called).to.be.false;
+      expect(props.onChange.called).to.be.false;
+    });
+
+    it('should set facilityTypeChanged and isValid flags', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: null,
+      };
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.setDraftFormState.calledOnce).to.be.true;
+      const updater = props.setDraftFormState.firstCall.args[0];
+      const newState = updater(props.draftFormState);
+      expect(newState.facilityTypeChanged).to.be.true;
+      expect(newState.isValid).to.be.false;
+    });
+  });
+
+  describe('validation - CC_PROVIDER requires serviceType', () => {
+    it('should not submit when CC_PROVIDER has no serviceType', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: LocationType.CC_PROVIDER,
+        serviceType: null,
+      };
+      props.selectedServiceType = null;
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.called).to.be.false;
+    });
+
+    it('should not submit when CC_PROVIDER has no selectedServiceType', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: LocationType.CC_PROVIDER,
+        serviceType: 'dentist',
+      };
+      props.selectedServiceType = null;
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.called).to.be.false;
+    });
+
+    it('should set serviceTypeChanged and isValid flags', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: LocationType.CC_PROVIDER,
+        serviceType: null,
+      };
+      props.selectedServiceType = null;
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.setDraftFormState.calledOnce).to.be.true;
+      const updater = props.setDraftFormState.firstCall.args[0];
+      const newState = updater(props.draftFormState);
+      expect(newState.serviceTypeChanged).to.be.true;
+      expect(newState.isValid).to.be.false;
+    });
+
+    it('should submit when CC_PROVIDER has valid serviceType', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: LocationType.CC_PROVIDER,
+        serviceType: 'dentist',
+      };
+      props.selectedServiceType = { id: 'dentist', name: 'Dentist' };
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.onSubmit.calledOnce).to.be.true;
+    });
+  });
+
+  describe('analytics - CC_PROVIDER specialty name', () => {
+    it('should use specialty display name for CC_PROVIDER analytics', () => {
+      const props = getDefaultProps();
+      props.draftFormState = {
+        ...getDefaultDraftFormState(),
+        facilityType: LocationType.CC_PROVIDER,
+        serviceType: '101YA0400X',
+      };
+      props.selectedServiceType = { id: '101YA0400X', name: 'Counselor' };
+      props.currentQuery = {
+        ...getDefaultCurrentQuery(),
+        specialties: {
+          '101YA0400X': 'Counselor - Addiction',
+        },
+      };
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(
+        recordStub.calledWith({
+          event: 'fl-search',
+          'fl-search-fac-type': LocationType.CC_PROVIDER,
+          'fl-search-svc-type': 'Counselor - Addiction',
+          'fl-current-zoom-depth': 10,
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('mobile map pin clearing', () => {
+    it('should clear mobile map pin when isMobile and mobileMapUpdateEnabled', () => {
+      const props = getDefaultProps();
+      props.isMobile = true;
+      props.mobileMapUpdateEnabled = true;
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.selectMobileMapPin.calledOnce).to.be.true;
+      expect(props.selectMobileMapPin.calledWith(null)).to.be.true;
+    });
+
+    it('should not clear mobile map pin when not isMobile', () => {
+      const props = getDefaultProps();
+      props.isMobile = false;
+      props.mobileMapUpdateEnabled = true;
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.selectMobileMapPin.called).to.be.false;
+    });
+
+    it('should not clear mobile map pin when mobileMapUpdateEnabled is false', () => {
+      const props = getDefaultProps();
+      props.isMobile = true;
+      props.mobileMapUpdateEnabled = false;
+      const { result } = renderHook(() => useSearchSubmit(props));
+
+      act(() => {
+        result.current.handleSubmit(createMockEvent());
+      });
+
+      expect(props.selectMobileMapPin.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR extracts form submission logic from the SearchForm component into a dedicated  custom hook as part of the facility-locator refactoring chain (VACMS-20370).

**Changes:**
- Created new  hook that encapsulates all submission logic:
  - Duplicate query prevention via 
  - Form validation with correct order: CC_PROVIDER serviceType → searchString → facilityType
  - Focus management on validation errors
  - Redux state commit via `onChange`
  - Analytics event recording with CC_PROVIDER specialty name resolution
  - Mobile map pin clearing
  - Search initiation flag
  - Explicit `onSubmit` call with form values
- Removed inline `handleSubmit` function and `lastQueryRef` from SearchForm component
- Updated SearchForm to use the new hook
- Changed progressive disclosure search button from `submit="prevent"` to `onClick={handleSubmit}`
- Updated `committedVamcServiceDisplay` to use draft state fallback for correct VAMC service display before submission

**Team:** Facilities team (owns facility-locator maintenance)

## Related issue(s)

Part of Issue https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20370 - PR 6 of 9

1. [Utilities to support draft pattern](https://github.com/department-of-veterans-affairs/vets-website/pull/41616) ✅ Merged
2. [Adding draft state to search form](https://github.com/department-of-veterans-affairs/vets-website/pull/41623) ✅ Merged
3. [Wiring up callbacks](https://github.com/department-of-veterans-affairs/vets-website/pull/41625) ✅
4. [Hook extraction](https://github.com/department-of-veterans-affairs/vets-website/pull/41626) ✅
5. [More hook extraction](https://github.com/department-of-veterans-affairs/vets-website/pull/41627) ✅
6. [More hook extraction](https://github.com/department-of-veterans-affairs/vets-website/pull/41628) (this PR)
7. [Integration of draft state pattern](https://github.com/department-of-veterans-affairs/vets-website/pull/41629)
8. [E2E tests](https://github.com/department-of-veterans-affairs/vets-website/pull/41632)
9. [Comments](https://github.com/department-of-veterans-affairs/vets-website/pull/41633)

## Testing done

**Old behavior:** Form submission logic was tightly coupled to the SearchForm component, making it difficult to test in isolation and reuse.

**New behavior:** Submission logic is now encapsulated in a custom hook that can be tested independently and reused if needed.

**Tests completed:**
- Unit/E2E tests
- Facility Locator remains fully functional in attached RI

## Screenshots

N/A - This is a pure refactoring with no UI changes.

## What areas of the site does it impact?

Facility Locator search form submission behavior (internal refactoring, no user-facing changes).

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (inline code comments added to hook)
- [x] Screenshot of the developed feature is added (N/A - refactoring only)
- [x] Accessibility testing has been performed (no changes to accessible components)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
