### PR TITLE
adds middle initial field to veteran information page, removes option…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/veteran-information.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/veteran-information.js
@@ -5,10 +5,10 @@
  */
 
 import {
-  firstNameLastNameNoSuffixUI,
-  firstNameLastNameNoSuffixSchema,
   dateOfBirthUI,
   dateOfBirthSchema,
+  fullNameNoSuffixUI,
+  fullNameNoSuffixSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /**
@@ -20,7 +20,19 @@ import {
 const formatVeteranNameTitle = title => {
   if (title === 'first or given name') return "Veteran's first or given name";
   if (title === 'last or family name') return "Veteran's last or family name";
+  if (title === 'middle name') return "Veteran's middle initial";
   return title; // Keep defaults for middle name and suffix
+};
+
+const customVeteranNameSchema = {
+  ...fullNameNoSuffixSchema,
+  properties: {
+    ...fullNameNoSuffixSchema.properties,
+    middle: {
+      type: 'string',
+      maxLength: 1,
+    },
+  },
 };
 
 /**
@@ -30,7 +42,7 @@ const formatVeteranNameTitle = title => {
 export const veteranInformationUiSchema = {
   'ui:title': 'Who is the Veteran you are providing information for?',
   veteranInformation: {
-    veteranFullName: firstNameLastNameNoSuffixUI(formatVeteranNameTitle),
+    veteranFullName: fullNameNoSuffixUI(formatVeteranNameTitle),
     dateOfBirth: dateOfBirthUI({
       title: "Veteran's date of birth",
       errorMessages: {
@@ -52,7 +64,7 @@ export const veteranInformationSchema = {
       type: 'object',
       required: ['veteranFullName', 'dateOfBirth'],
       properties: {
-        veteranFullName: firstNameLastNameNoSuffixSchema,
+        veteranFullName: customVeteranNameSchema,
         dateOfBirth: dateOfBirthSchema,
       },
     },

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/tests/fixtures/data/minimal.json
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/tests/fixtures/data/minimal.json
@@ -3,7 +3,6 @@
     "veteranInformation": {
       "veteranFullName": {
         "first": "Ahsoka",
-        "middle": "T",
         "last": "Tano"
       },
       "dateOfBirth": "2004-05-04"


### PR DESCRIPTION
…al middle initial from minimal test

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Adding middle initial field to veteran information page on form 21-4192

### Issue
On form 21-4192, there's a field for the middle initial on the pdf, but this wasn't being asked for on the front end.

### Solution
Added a middle initial field to the front end.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-4192 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129817](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129817)

## Testing done

### Old behavior
* The form did not have a field to input the middle initial

### New behavior
* The form has a field to input the middle initial

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed)
*  Manual testing in local environment verified that the new field was added and is populating on the pdf after submission
* E2E tests: all existing tests pass, removed middle initial from minimal test case

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="569" height="461" alt="before middle" src="https://github.com/user-attachments/assets/87bbbfa7-4508-4a74-989e-5f68d33881fc" /> | <img width="568" height="578" alt="after middle" src="https://github.com/user-attachments/assets/65273f4b-5f89-4b2e-96a7-910fd69d70cb" /> |

## What areas of the site does it impact?

This change affects form 21-4192, specifically on the Veteran Information page at /disability/eligibility/special-claims/unemployability/submit-employment-information-form-21-4192/veteran-information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user