### PR TITLE
Update copy for medication eligible for renewal

### DIFF
--- a/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
+++ b/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { pharmacyPhoneNumber } from '@department-of-veterans-affairs/mhv/exports';
 import { VaIcon } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import environment from 'platform/utilities/environment';
 import { dateFormat, rxSourceIsNonVA } from '../../util/helpers';
 import {
   DATETIME_FORMATS,
@@ -13,7 +12,7 @@ import {
 } from '../../util/constants';
 import CallPharmacyPhone from './CallPharmacyPhone';
 import SendRxRenewalMessage from './SendRxRenewalMessage';
-import { pageType, dataDogActionNames } from '../../util/dataDogConstants';
+import { pageType } from '../../util/dataDogConstants';
 import {
   selectCernerPilotFlag,
   selectV2StatusMappingFlag,
@@ -278,16 +277,6 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
               You can’t refill this prescription. Contact your VA provider if
               you need more of this medication.
             </p>
-            <va-link
-              href={`${
-                environment.BASE_URL
-              }/my-health/secure-messages/new-message/`}
-              text="Start a new message"
-              data-testid="discontinued-compose-message-link"
-              data-dd-action-name={
-                dataDogActionNames.detailsPage.COMPOSE_A_MESSAGE_LINK
-              }
-            />
           </div>
         );
 

--- a/src/applications/mhv-medications/components/shared/SendRxRenewalMessage.jsx
+++ b/src/applications/mhv-medications/components/shared/SendRxRenewalMessage.jsx
@@ -54,6 +54,7 @@ const SendRxRenewalMessage = ({
         isActionLink={isActionLink}
         setShowRenewalModal={setShowRenewalModal}
         isExpired={isExpiredLessThan120Days}
+        isActiveNoRefills={isActiveNoRefills}
       />
       <VaModal
         modalTitle="You're leaving medications to send a message"
@@ -86,6 +87,7 @@ const SendRxRenewalMessage = ({
 SendRxRenewalMessage.propTypes = {
   fallbackContent: PropTypes.node,
   isActionLink: PropTypes.bool,
+  isActiveNoRefills: PropTypes.bool,
   rx: PropTypes.shape({
     refillRemaining: PropTypes.number,
     dispStatus: PropTypes.string,
@@ -100,6 +102,7 @@ const RenderLinkVariation = ({
   isActionLink,
   setShowRenewalModal,
   isExpired,
+  isActiveNoRefills,
 }) => {
   return isActionLink ? (
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
@@ -113,13 +116,14 @@ const RenderLinkVariation = ({
     </Link>
   ) : (
     <>
-      {isExpired && (
+      {(isExpired || isActiveNoRefills) && (
         <p
           className="vads-u-margin-y--0"
-          data-testid="expired-less-than-120-days"
+          data-testid={
+            isExpired ? 'expired-less-than-120-days' : 'active-no-refills'
+          }
         >
-          You can’t refill this prescription. If you need more, send a secure
-          message to your care team.
+          You have no refills left. If you need more, request a renewal.
         </p>
       )}
       <va-link
@@ -134,6 +138,7 @@ const RenderLinkVariation = ({
 
 RenderLinkVariation.propTypes = {
   isActionLink: PropTypes.bool,
+  isActiveNoRefills: PropTypes.bool,
   isExpired: PropTypes.bool,
   setShowRenewalModal: PropTypes.func,
 };


### PR DESCRIPTION
# [MHV Medications] - Update renewal messaging for discontinued and active prescriptions with no refills

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Follow up PR to this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/41497) as some details were missed
- Removed the "Start a new message" link from discontinued prescriptions in the `ExtraDetails` component
- Updated `SendRxRenewalMessage` component to display the "no refills left" message for active prescriptions with zero refills remaining (in addition to expired prescriptions)
- Updated messaging copy from "You can't refill this prescription. If you need more, send a secure message to your care team." to "You have no refills left. If you need more, request a renewal."
- Added `isActiveNoRefills` prop to `RenderLinkVariation` to differentiate messaging between expired and active-no-refill scenarios
- Cleaned up unused imports (`environment`, `dataDogActionNames`) from `ExtraDetails.jsx`

**Team**: MHV Medications team owns these components and will maintain this fix

**Feature flag**: N/A - Uses existing `showSecureMessagingRenewalRequest` feature flag

**Steps to verify**:
1. Start dev server: `yarn watch --env entry=mhv-medications`
2. Navigate to http://localhost:3001/my-health/medications
3. Click on a prescription with "Discontinued" status
4. Verify the "Start a new message" link is no longer present
5. Navigate to an active prescription with 0 refills remaining (Oracle Health prescription)
6. Verify the message "You have no refills left. If you need more, request a renewal." is displayed
7. Verify the "Send a renewal request message" link is present and opens the modal
8. Navigate to an expired prescription (within 120 days, Oracle Health)
9. Verify the same messaging appears for expired prescriptions

**Tests completed**:
<!-- TODO: Update with actual test results -->
- Unit tests: [Update with test results]
- Cypress E2E: [Update with test results]
- Accessibility testing: [Update with accessibility testing results]
- Manual browser testing: [Update with browsers tested]

## What areas of the site does it impact?

Changes isolated to MHV Medications prescription details page:
- `ExtraDetails` component - displays prescription status information
- `SendRxRenewalMessage` component - handles renewal request messaging and modal

Affected pages:
- `/my-health/medications/prescription/[id]` - Prescription details page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A, messaging update only

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

1. Please verify the removal of the "Start a new message" link from discontinued prescriptions is the intended behavior
2. Confirm the new messaging copy "You have no refills left. If you need more, request a renewal." aligns with content standards
3. Review the logic for displaying the renewal message for both expired and active-no-refill scenarios
