### PR TITLE
removes address line 3 on employer information page

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employer-information.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employer-information.js
@@ -29,7 +29,7 @@ export const employerInformationUiSchema = {
   },
 };
 
-const baseAddressSchema = addressNoMilitarySchema();
+const baseAddressSchema = addressNoMilitarySchema({ omit: ['street3'] });
 
 const customAddressSchema = {
   ...baseAddressSchema,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Removing Street Address Line 3 on the Employer's name and address page

### Issue
The frontend collects Street Address Line 3, but the backend does not

### Solution
Omitted Street Address Line 3 from the frontend

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-4192 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 130077](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130077)

## Testing done

### Old behavior
* The form had Street Address Line 3 on the Employer's name and address page

### New behavior
* The form no longer has Street Address Line 3 on the Employer's name and address page

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed as this is display only)
*  Manual testing in local environment verified that the Street Address Line 3 field is omitted from the Employer's name and address page
* E2E tests: all existing tests pass, no modifications needed (none of the tests had a street 3)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="552" height="837" alt="before line 3" src="https://github.com/user-attachments/assets/7de98396-4d1b-4925-ab73-3660e36c952c" /> | <img width="566" height="738" alt="after line 3 " src="https://github.com/user-attachments/assets/d01d638a-e4a7-46e8-ae35-8bc3483d46cf" /> |

## What areas of the site does it impact?

This change affects form 21-4192, specifically on the Employer's name and address page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user