### PR TITLE
[Disability Benefits] rel: vets-json-schema latest version (25.2.43) bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1a1b735653b3687e6265093a2a66d4f37cf1b3e1",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25182,9 +25182,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#1a1b735653b3687e6265093a2a66d4f37cf1b3e1":
-  version "25.2.42"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1a1b735653b3687e6265093a2a66d4f37cf1b3e1"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c":
+  version "25.2.43"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Bumps `vets-json-schema` dependency to latest version (25.2.43)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129871
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1105
- https://github.com/department-of-veterans-affairs/vets-api/pull/26085
- https://github.com/department-of-veterans-affairs/vets-website/pull/41319
