### PR TITLE
128387 - Limit scheduling preferences by user response

### DIFF
--- a/src/applications/personalization/profile/components/HealthCareSettings.jsx
+++ b/src/applications/personalization/profile/components/HealthCareSettings.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Toggler } from 'platform/utilities/feature-toggles';
+import { connect } from 'react-redux';
+import { isSchedulingPreferencesPilotEligible as selectIsSchedulingPreferencesPilotEligible } from 'platform/user/selectors';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../constants';
 import Tier2PageContent from './Tier2PageContent';
 import { ProfileHubItem } from './hub/ProfileHubItem';
 
-const HealthCareSettings = () => {
+const HealthCareSettings = ({ isSchedulingPreferencesPilotEligible }) => {
   return (
     <Tier2PageContent pageHeader="Health care settings">
       <Toggler toggleName={Toggler.TOGGLE_NAMES.profileHideHealthCareContacts}>
@@ -21,11 +24,13 @@ const HealthCareSettings = () => {
         content="Manage the signature on your messages."
         href={PROFILE_PATHS.MESSAGES_SIGNATURE}
       />
-      <ProfileHubItem
-        heading={PROFILE_PATH_NAMES.SCHEDULING_PREFERENCES}
-        content="Manage your scheduling preferences for health care appointments."
-        href={PROFILE_PATHS.SCHEDULING_PREFERENCES}
-      />
+      {isSchedulingPreferencesPilotEligible && (
+        <ProfileHubItem
+          heading={PROFILE_PATH_NAMES.SCHEDULING_PREFERENCES}
+          content="Manage your scheduling preferences for health care appointments."
+          href={PROFILE_PATHS.SCHEDULING_PREFERENCES}
+        />
+      )}
       <va-card
         background
         title="Manage your other health care needs on My HealtheVet"
@@ -44,6 +49,14 @@ const HealthCareSettings = () => {
   );
 };
 
-HealthCareSettings.propTypes = {};
+HealthCareSettings.propTypes = {
+  isSchedulingPreferencesPilotEligible: PropTypes.bool,
+};
 
-export default HealthCareSettings;
+const mapStateToProps = state => ({
+  isSchedulingPreferencesPilotEligible: selectIsSchedulingPreferencesPilotEligible(
+    state,
+  ),
+});
+
+export default connect(mapStateToProps)(HealthCareSettings);

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -331,9 +331,7 @@ const mapStateToProps = state => {
     !profileToggles?.profileHideDirectDeposit;
 
   const shouldFetchSchedulingPreferences =
-    (isSchedulingPreferencesPilotEligible &&
-      profileToggles?.profileSchedulingPreferences) ||
-    false;
+    isSchedulingPreferencesPilotEligible || false;
 
   // block profile access for deceased, fiduciary flagged, and incompetent veterans
   const isBlocked = selectIsBlocked(state);

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -180,6 +180,10 @@ class Profile extends Component {
       );
     }
 
+    if (!this.props.isSchedulingPreferencesPilotEligible) {
+      routes = routes.filter(item => !item.requiresSchedulingPreferencesPilot);
+    }
+
     return (
       <BrowserRouter>
         <LastLocationProvider>
@@ -204,19 +208,6 @@ class Profile extends Component {
                           ? PROFILE_PATHS.SIGNIN_INFORMATION
                           : PROFILE_PATHS.ACCOUNT_SECURITY
                       }
-                      key={route.path}
-                    />
-                  );
-                }
-
-                if (
-                  route.requiresSchedulingPreferencesPilot &&
-                  !this.props.isSchedulingPreferencesPilotEligible
-                ) {
-                  return (
-                    <Redirect
-                      from={route.path}
-                      to={PROFILE_PATHS.HEALTH_CARE_SETTINGS}
                       key={route.path}
                     />
                   );

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -39,6 +39,7 @@ import {
   isLOA1 as isLOA1Selector,
   isLOA3 as isLOA3Selector,
   isInMPI as isInMVISelector,
+  isSchedulingPreferencesPilotEligible as isSchedulingPreferencesPilotEligibleSelector,
   isLoggedIn,
 } from '~/platform/user/selectors';
 import { signInServiceName as signInServiceNameSelector } from '~/platform/user/authentication/selectors';
@@ -208,6 +209,19 @@ class Profile extends Component {
                   );
                 }
 
+                if (
+                  route.requiresSchedulingPreferencesPilot &&
+                  !this.props.isSchedulingPreferencesPilotEligible
+                ) {
+                  return (
+                    <Redirect
+                      from={route.path}
+                      to={PROFILE_PATHS.HEALTH_CARE_SETTINGS}
+                      key={route.path}
+                    />
+                  );
+                }
+
                 return (
                   <Route
                     component={route.component}
@@ -277,6 +291,7 @@ Profile.propTypes = {
   isDowntimeWarningDismissed: PropTypes.bool.isRequired,
   isInMVI: PropTypes.bool.isRequired,
   isLOA3: PropTypes.bool.isRequired,
+  isSchedulingPreferencesPilotEligible: PropTypes.bool.isRequired,
   profileToggles: PropTypes.object.isRequired,
   shouldFetchDirectDeposit: PropTypes.bool.isRequired,
   shouldFetchSchedulingPreferences: PropTypes.bool.isRequired,
@@ -309,6 +324,9 @@ const mapStateToProps = state => {
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);
+  const isSchedulingPreferencesPilotEligible = isSchedulingPreferencesPilotEligibleSelector(
+    state,
+  );
   const shouldShowAccreditedRepTab =
     profileToggles?.representativeStatusEnableV2Features;
   const shouldShowProfile2 = profileToggles?.profile2Enabled;
@@ -322,7 +340,9 @@ const mapStateToProps = state => {
     !profileToggles?.profileHideDirectDeposit;
 
   const shouldFetchSchedulingPreferences =
-    profileToggles?.profileSchedulingPreferences || false;
+    (isSchedulingPreferencesPilotEligible &&
+      profileToggles?.profileSchedulingPreferences) ||
+    false;
 
   // block profile access for deceased, fiduciary flagged, and incompetent veterans
   const isBlocked = selectIsBlocked(state);
@@ -384,6 +404,7 @@ const mapStateToProps = state => {
       'profile',
     ),
     isBlocked,
+    isSchedulingPreferencesPilotEligible,
     togglesLoaded,
     profileToggles,
   };

--- a/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
@@ -12,7 +12,12 @@ const menuButtonClasses = prefixUtilityClasses([
   'display--inline',
 ]).join(' ');
 
-const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
+const ProfileMobileSubNav = ({
+  isLOA3,
+  isInMVI,
+  isSchedulingPreferencesPilotEligible,
+  routes,
+}) => {
   // refs used so we can easily set focus
   const closeMenuButton = useRef(null);
   const openMenuButton = useRef(null);
@@ -109,6 +114,9 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
               isLOA3={isLOA3}
               isInMVI={isInMVI}
               routes={routes}
+              isSchedulingPreferencesPilotEligible={
+                isSchedulingPreferencesPilotEligible
+              }
               clickHandler={() => {
                 setIsMenuOpen(false);
               }}
@@ -123,6 +131,7 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
 ProfileMobileSubNav.propTypes = {
   isInMVI: PropTypes.bool.isRequired,
   isLOA3: PropTypes.bool.isRequired,
+  isSchedulingPreferencesPilotEligible: PropTypes.bool.isRequired,
   routes: PropTypes.arrayOf(
     PropTypes.shape({
       path: PropTypes.string.isRequired,

--- a/src/applications/personalization/profile/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNav.jsx
@@ -18,6 +18,7 @@ const ProfileSubNav = ({
   routes,
   clickHandler = null,
   className,
+  isSchedulingPreferencesPilotEligible,
 }) => {
   const mobileNavRef = useRef();
   const history = useHistory();
@@ -32,6 +33,13 @@ const ProfileSubNav = ({
   const filteredRoutes = routes.filter(route => {
     // loa3 check and isBlocked check
     if (route.requiresLOA3 && (!isLOA3 || isBlocked)) {
+      return false;
+    }
+    // scheduling preferences pilot check
+    if (
+      route.requiresSchedulingPreferencesPilot &&
+      !isSchedulingPreferencesPilotEligible
+    ) {
       return false;
     }
 
@@ -148,6 +156,7 @@ ProfileSubNav.propTypes = {
   // Optional handler to fire when a nav item is clicked
   className: PropTypes.string,
   clickHandler: PropTypes.func,
+  isSchedulingPreferencesPilotEligible: PropTypes.bool,
 };
 
 export default ProfileSubNav;

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -237,6 +237,7 @@ ProfileWrapper.propTypes = {
   hero: PropTypes.object,
   isInMVI: PropTypes.bool,
   isLOA3: PropTypes.bool,
+  isSchedulingPreferencesPilotEligible: PropTypes.bool,
   location: PropTypes.object,
   profile2Enabled: PropTypes.bool,
   showNameTag: PropTypes.bool,

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom';
 import NameTag from '~/applications/personalization/components/NameTag';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
+import { isSchedulingPreferencesPilotEligible as isSchedulingPreferencesPilotEligibleSelector } from '~/platform/user/selectors';
 import { hasTotalDisabilityError } from '../../common/selectors/ratedDisabilities';
 import ProfileSubNav from './ProfileSubNav';
 import { PROFILE_PATHS } from '../constants';
@@ -55,6 +56,7 @@ const ProfileWrapper = ({
   children,
   isLOA3,
   isInMVI,
+  isSchedulingPreferencesPilotEligible,
   profile2Enabled,
   totalDisabilityRating,
   totalDisabilityRatingError,
@@ -105,6 +107,9 @@ const ProfileWrapper = ({
                   routes={routesForNav}
                   isLOA3={isLOA3}
                   isInMVI={isInMVI}
+                  isSchedulingPreferencesPilotEligible={
+                    isSchedulingPreferencesPilotEligible
+                  }
                 />
               </>
             ) : (
@@ -112,6 +117,9 @@ const ProfileWrapper = ({
                 routes={routesForNav}
                 isLOA3={isLOA3}
                 isInMVI={isInMVI}
+                isSchedulingPreferencesPilotEligible={
+                  isSchedulingPreferencesPilotEligible
+                }
               />
             )}
           </div>
@@ -132,6 +140,9 @@ const ProfileWrapper = ({
                     routes={routesForNav}
                     isLOA3={isLOA3}
                     isInMVI={isInMVI}
+                    isSchedulingPreferencesPilotEligible={
+                      isSchedulingPreferencesPilotEligible
+                    }
                   />
                 ) : (
                   <nav className="va-subnav" aria-labelledby="subnav-header">
@@ -146,6 +157,9 @@ const ProfileWrapper = ({
                         routes={routesForNav}
                         isLOA3={isLOA3}
                         isInMVI={isInMVI}
+                        isSchedulingPreferencesPilotEligible={
+                          isSchedulingPreferencesPilotEligible
+                        }
                       />
                     </div>
                   </nav>
@@ -202,12 +216,16 @@ const mapStateToProps = (state, ownProps) => {
   const hero = state.vaProfile?.hero;
   const profileToggles = selectProfileToggles(state);
   const profile2Enabled = profileToggles?.profile2Enabled;
+  const isSchedulingPreferencesPilotEligible = isSchedulingPreferencesPilotEligibleSelector(
+    state,
+  );
   return {
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
     totalDisabilityRatingError: hasTotalDisabilityError(state),
     showNameTag: ownProps.isLOA3 && isEmpty(hero?.errors) && !profile2Enabled,
     profile2Enabled,
+    isSchedulingPreferencesPilotEligible,
   };
 };
 

--- a/src/applications/personalization/profile/components/edit/Edit.jsx
+++ b/src/applications/personalization/profile/components/edit/Edit.jsx
@@ -17,7 +17,10 @@ import getProfileInfoFieldAttributes from '@@vap-svc/util/getProfileInfoFieldAtt
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 import InitializeVAPServiceIDContainer from '@@vap-svc/containers/InitializeVAPServiceID';
 
-import { hasVAPServiceConnectionError } from '~/platform/user/selectors';
+import {
+  hasVAPServiceConnectionError,
+  isSchedulingPreferencesPilotEligible as isSchedulingPreferencesPilotEligibleSelector,
+} from '~/platform/user/selectors';
 
 import { isSubtaskSchedulingPreference } from '@@vap-svc/util/health-care-settings/schedulingPreferencesUtils';
 import { EditFallbackContent } from './EditFallbackContent';
@@ -74,14 +77,14 @@ export const Edit = () => {
   const profileHealthCareSettingsPageToggle = useToggleValue(
     TOGGLE_NAMES.profileHealthCareSettingsPage,
   );
-  const profileSchedulingPreferencesToggle = useToggleValue(
-    TOGGLE_NAMES.profileSchedulingPreferences,
+  const isSchedulingPreferencesPilotEligible = useSelector(state =>
+    isSchedulingPreferencesPilotEligibleSelector(state),
   );
 
   const routesForNav = getRoutesForNav({
     profile2Enabled: profile2Toggle,
     profileHealthCareSettingsPage: profileHealthCareSettingsPageToggle,
-    profileSchedulingPreferencesEnabled: profileSchedulingPreferencesToggle,
+    profileSchedulingPreferencesEnabled: isSchedulingPreferencesPilotEligible,
   });
 
   const fieldInfo = getFieldInfo(query.get('fieldName'));

--- a/src/applications/personalization/profile/components/health-care-settings/sub-tasks/contact-method/ContactMethodContainer.jsx
+++ b/src/applications/personalization/profile/components/health-care-settings/sub-tasks/contact-method/ContactMethodContainer.jsx
@@ -14,6 +14,7 @@ import {
   selectVAPWorkPhone,
   selectVAPEmailAddress,
   selectVAPMailingAddress,
+  isSchedulingPreferencesPilotEligible as isSchedulingPreferencesPilotEligibleSelector,
 } from 'platform/user/selectors';
 
 import { FIELD_NAMES, FIELD_SECTION_HEADERS } from '@@vap-svc/constants';
@@ -82,14 +83,15 @@ export const ContactMethodContainer = () => {
   const profileHealthCareSettingsPageToggle = useToggleValue(
     TOGGLE_NAMES.profileHealthCareSettingsPage,
   );
-  const profileSchedulingPreferencesToggle = useToggleValue(
-    TOGGLE_NAMES.profileSchedulingPreferences,
+
+  const isSchedulingPreferencesPilotEligible = useSelector(state =>
+    isSchedulingPreferencesPilotEligibleSelector(state),
   );
 
   const routesForNav = getRoutesForNav({
     profile2Enabled: profile2Toggle,
     profileHealthCareSettingsPage: profileHealthCareSettingsPageToggle,
-    profileSchedulingPreferencesEnabled: profileSchedulingPreferencesToggle,
+    profileSchedulingPreferencesEnabled: isSchedulingPreferencesPilotEligible,
   });
 
   const fieldName = FIELD_NAMES.SCHEDULING_PREF_CONTACT_METHOD;

--- a/src/applications/personalization/profile/components/hub/ProfileHub.jsx
+++ b/src/applications/personalization/profile/components/hub/ProfileHub.jsx
@@ -3,24 +3,21 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isSchedulingPreferencesPilotEligible as selectIsSchedulingPreferencesPilotEligible } from 'platform/user/selectors';
-import { capitalize } from 'lodash';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
-import oxfordCommaList from '../../utils/oxfordCommaList';
 import Tier2PageContent from '../Tier2PageContent';
 import { ProfileHubItem } from './ProfileHubItem';
 import NameTag from './NameTag';
+import { getHealthCareSettingsHubDescription } from '../../util';
 
 const ProfileHub = ({ isSchedulingPreferencesPilotEligible }) => {
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
-  const healthCareSettingsItems = [];
-  if (!useToggleValue(TOGGLE_NAMES.profileHideHealthCareContacts)) {
-    healthCareSettingsItems.push('health care contacts');
-  }
-  healthCareSettingsItems.push('messages signature');
-  if (isSchedulingPreferencesPilotEligible) {
-    healthCareSettingsItems.push('scheduling preferences');
-  }
-  const healthCareSettingsContent = oxfordCommaList(healthCareSettingsItems);
+  const hideHealthCareContacts = useToggleValue(
+    TOGGLE_NAMES.profileHideHealthCareContacts,
+  );
+  const healthCareSettingsContent = getHealthCareSettingsHubDescription({
+    hideHealthCareContacts,
+    isSchedulingPreferencesPilotEligible,
+  });
   return (
     <Tier2PageContent pageHeader="Profile">
       <NameTag />
@@ -50,7 +47,7 @@ const ProfileHub = ({ isSchedulingPreferencesPilotEligible }) => {
       />
       <ProfileHubItem
         heading={PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS}
-        content={capitalize(healthCareSettingsContent)}
+        content={healthCareSettingsContent}
         href={PROFILE_PATHS.HEALTH_CARE_SETTINGS}
         reactLink
       />

--- a/src/applications/personalization/profile/components/hub/ProfileHub.jsx
+++ b/src/applications/personalization/profile/components/hub/ProfileHub.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { isSchedulingPreferencesPilotEligible as selectIsSchedulingPreferencesPilotEligible } from 'platform/user/selectors';
+import { isSchedulingPreferencesPilotEligible as isSchedulingPreferencesPilotEligibleSelector } from 'platform/user/selectors';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
 import Tier2PageContent from '../Tier2PageContent';
 import { ProfileHubItem } from './ProfileHubItem';
@@ -84,7 +84,7 @@ ProfileHub.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  isSchedulingPreferencesPilotEligible: selectIsSchedulingPreferencesPilotEligible(
+  isSchedulingPreferencesPilotEligible: isSchedulingPreferencesPilotEligibleSelector(
     state,
   ),
 });

--- a/src/applications/personalization/profile/components/hub/ProfileHub.jsx
+++ b/src/applications/personalization/profile/components/hub/ProfileHub.jsx
@@ -1,11 +1,26 @@
 import React from 'react';
-import { Toggler } from 'platform/utilities/feature-toggles';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { isSchedulingPreferencesPilotEligible as selectIsSchedulingPreferencesPilotEligible } from 'platform/user/selectors';
+import { capitalize } from 'lodash';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
+import oxfordCommaList from '../../utils/oxfordCommaList';
 import Tier2PageContent from '../Tier2PageContent';
 import { ProfileHubItem } from './ProfileHubItem';
 import NameTag from './NameTag';
 
-const ProfileHub = () => {
+const ProfileHub = ({ isSchedulingPreferencesPilotEligible }) => {
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const healthCareSettingsItems = [];
+  if (!useToggleValue(TOGGLE_NAMES.profileHideHealthCareContacts)) {
+    healthCareSettingsItems.push('health care contacts');
+  }
+  healthCareSettingsItems.push('messages signature');
+  if (isSchedulingPreferencesPilotEligible) {
+    healthCareSettingsItems.push('scheduling preferences');
+  }
+  const healthCareSettingsContent = oxfordCommaList(healthCareSettingsItems);
   return (
     <Tier2PageContent pageHeader="Profile">
       <NameTag />
@@ -33,30 +48,12 @@ const ProfileHub = () => {
         href={PROFILE_PATHS.FINANCIAL_INFORMATION}
         reactLink
       />
-      <Toggler toggleName={Toggler.TOGGLE_NAMES.profileHealthCareSettingsPage}>
-        <Toggler.Enabled>
-          <Toggler
-            toggleName={Toggler.TOGGLE_NAMES.profileHideHealthCareContacts}
-          >
-            <Toggler.Enabled>
-              <ProfileHubItem
-                heading={PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS}
-                content="Messages signature and scheduling preferences"
-                href={PROFILE_PATHS.HEALTH_CARE_SETTINGS}
-                reactLink
-              />
-            </Toggler.Enabled>
-            <Toggler.Disabled>
-              <ProfileHubItem
-                heading={PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS}
-                content="Health care contacts, messages signature, and scheduling preferences"
-                href={PROFILE_PATHS.HEALTH_CARE_SETTINGS}
-                reactLink
-              />
-            </Toggler.Disabled>
-          </Toggler>
-        </Toggler.Enabled>
-      </Toggler>
+      <ProfileHubItem
+        heading={PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS}
+        content={capitalize(healthCareSettingsContent)}
+        href={PROFILE_PATHS.HEALTH_CARE_SETTINGS}
+        reactLink
+      />
       <ProfileHubItem
         heading={PROFILE_PATH_NAMES.DEPENDENTS_AND_CONTACTS}
         content="Benefits dependents and accredited representative or VSO"
@@ -85,6 +82,14 @@ const ProfileHub = () => {
   );
 };
 
-ProfileHub.propTypes = {};
+ProfileHub.propTypes = {
+  isSchedulingPreferencesPilotEligible: PropTypes.bool,
+};
 
-export default ProfileHub;
+const mapStateToProps = state => ({
+  isSchedulingPreferencesPilotEligible: selectIsSchedulingPreferencesPilotEligible(
+    state,
+  ),
+});
+
+export default connect(mapStateToProps)(ProfileHub);

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -11,7 +11,6 @@ export const PROFILE_TOGGLES = {
   profileShowPaperlessDelivery: false,
   profile2Enabled: false,
   profileHealthCareSettingsPage: false,
-  profileSchedulingPreferences: false,
   profileHideHealthCareContacts: false,
 };
 

--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -315,7 +315,7 @@ const baseUserResponses = {
           ],
           vaPatient: true,
           mhvAccountState: 'NONE',
-          // schedulingPreferencesPilotEligible: false,
+          schedulingPreferencesPilotEligible: true,
         },
         veteranStatus: {
           status: 'OK',

--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -91,6 +91,7 @@ const baseUserResponses = {
           ],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: {
           status: 'OK',
@@ -314,6 +315,7 @@ const baseUserResponses = {
           ],
           vaPatient: true,
           mhvAccountState: 'NONE',
+          // schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: {
           status: 'OK',
@@ -529,6 +531,7 @@ const baseUserResponses = {
           ],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: {
           status: 'OK',
@@ -740,6 +743,7 @@ const baseUserResponses = {
           ],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: {
           status: 'OK',
@@ -951,6 +955,7 @@ const baseUserResponses = {
           ],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: 'NOT_AUTHORIZED',
         inProgressForms: [],
@@ -1145,6 +1150,7 @@ const baseUserResponses = {
           facilities: [],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: 'NOT_AUTHORIZED',
         inProgressForms: [],
@@ -1352,6 +1358,7 @@ const baseUserResponses = {
           ],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: {
           status: 'OK',
@@ -1566,6 +1573,7 @@ const mockErrorResponses = {
           ],
           vaPatient: false,
           mhvAccountState: 'NONE',
+          schedulingPreferencesPilotEligible: false,
         },
         veteranStatus: {
           status: 'OK',
@@ -1759,6 +1767,7 @@ const loa3UserNoVaProfile = {
         ],
         vaPatient: true,
         mhvAccountState: 'REGISTERED',
+        schedulingPreferencesPilotEligible: false,
       },
       veteranStatus: {
         status: 'OK',
@@ -1846,6 +1855,7 @@ const loa3UserNeedsVapInit = {
         ],
         vaPatient: true,
         mhvAccountState: 'REGISTERED',
+        schedulingPreferencesPilotEligible: false,
       },
       veteranStatus: {
         status: 'OK',

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -122,7 +122,6 @@ const responses = {
             profileShowPaperlessDelivery: false,
             profile2Enabled: true,
             profileHealthCareSettingsPage: true,
-            profileSchedulingPreferences: true,
             profileHideHealthCareContacts: true,
             vetStatusPdfLogging: true,
             veteranStatusCardUseLighthouse: true,

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -28,6 +28,7 @@ const getRoutes = (
       path: PROFILE_PATHS.EDIT,
       requiresLOA3: true,
       requiresMVI: true,
+      requiresSchedulingPreferencesPilot: false,
     },
     {
       component: profile2Enabled ? ProfileHub : Hub,
@@ -35,6 +36,7 @@ const getRoutes = (
       path: PROFILE_PATHS.PROFILE_ROOT,
       requiresLOA3: true,
       requiresMVI: true,
+      requiresSchedulingPreferencesPilot: false,
     },
     {
       component: ContactMethodContainer,
@@ -42,6 +44,7 @@ const getRoutes = (
       path: PROFILE_PATHS.SCHEDULING_PREF_CONTACT_METHOD,
       requiresLOA3: true,
       requiresMVI: true,
+      requiresSchedulingPreferencesPilot: true,
     },
     {
       component: Edit,
@@ -49,6 +52,7 @@ const getRoutes = (
       path: PROFILE_PATHS.SCHEDULING_PREF_CONTACT_TIMES,
       requiresLOA3: true,
       requiresMVI: true,
+      requiresSchedulingPreferencesPilot: true,
     },
     {
       component: Edit,
@@ -56,6 +60,7 @@ const getRoutes = (
       path: PROFILE_PATHS.SCHEDULING_PREF_APPOINTMENT_TIMES,
       requiresLOA3: true,
       requiresMVI: true,
+      requiresSchedulingPreferencesPilot: true,
     },
   ];
 };

--- a/src/applications/personalization/profile/routesForNav.js
+++ b/src/applications/personalization/profile/routesForNav.js
@@ -28,6 +28,7 @@ const routesForNav = [
     path: PROFILE_PATHS.PERSONAL_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: ContactInformation,
@@ -35,6 +36,7 @@ const routesForNav = [
     path: PROFILE_PATHS.CONTACT_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: PersonalHealthCareContacts,
@@ -42,6 +44,7 @@ const routesForNav = [
     path: PROFILE_PATHS.CONTACTS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     featureFlag: 'profileHideHealthCareContacts',
   },
   {
@@ -50,6 +53,7 @@ const routesForNav = [
     path: PROFILE_PATHS.MILITARY_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: VeteranStatus,
@@ -57,6 +61,7 @@ const routesForNav = [
     path: PROFILE_PATHS.VETERAN_STATUS_CARD,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: DirectDeposit,
@@ -64,6 +69,7 @@ const routesForNav = [
     path: PROFILE_PATHS.DIRECT_DEPOSIT,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: AccreditedRepresentative,
@@ -71,6 +77,7 @@ const routesForNav = [
     path: PROFILE_PATHS.ACCREDITED_REPRESENTATIVE,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: NotificationSettings,
@@ -78,6 +85,7 @@ const routesForNav = [
     path: PROFILE_PATHS.NOTIFICATION_SETTINGS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: AccountSecurity,
@@ -85,6 +93,7 @@ const routesForNav = [
     path: PROFILE_PATHS.ACCOUNT_SECURITY,
     requiresLOA3: false,
     requiresMVI: false,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: ConnectedApplications,
@@ -92,6 +101,7 @@ const routesForNav = [
     path: PROFILE_PATHS.CONNECTED_APPLICATIONS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
 ];
 
@@ -102,6 +112,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.PERSONAL_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: ContactInformation,
@@ -109,6 +120,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.CONTACT_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: MilitaryInformation,
@@ -116,6 +128,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.SERVICE_HISTORY_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: FinancialInformation,
@@ -123,6 +136,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.FINANCIAL_INFORMATION,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     hasSubnav: true,
   },
   {
@@ -131,6 +145,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.DIRECT_DEPOSIT,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     subnavParent: PROFILE_PATH_NAMES.FINANCIAL_INFORMATION,
   },
   {
@@ -139,6 +154,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.HEALTH_CARE_SETTINGS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     hasSubnav: true,
     featureFlag: 'profileHealthCareSettingsPage',
   },
@@ -148,6 +164,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.HEALTH_CARE_CONTACTS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     subnavParent: PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS,
     featureFlag: 'profileHealthCareSettingsPage|profileHideHealthCareContacts',
     // This field allows for toggling based on two feature flags by using string.includes()
@@ -158,6 +175,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.MESSAGES_SIGNATURE,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     subnavParent: PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS,
     featureFlag: 'profileHealthCareSettingsPage',
   },
@@ -167,6 +185,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.SCHEDULING_PREFERENCES,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: true,
     subnavParent: PROFILE_PATH_NAMES.HEALTH_CARE_SETTINGS,
     featureFlag: 'profileHealthCareSettingsPage',
   },
@@ -176,6 +195,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.DEPENDENTS_AND_CONTACTS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     hasSubnav: true,
   },
   {
@@ -184,6 +204,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.ACCREDITED_REPRESENTATIVE,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     subnavParent: PROFILE_PATH_NAMES.DEPENDENTS_AND_CONTACTS,
   },
   {
@@ -192,6 +213,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.LETTERS_AND_DOCUMENTS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     hasSubnav: true,
   },
   {
@@ -200,6 +222,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.VETERAN_STATUS_CARD,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     subnavParent: PROFILE_PATH_NAMES.LETTERS_AND_DOCUMENTS,
   },
   {
@@ -208,6 +231,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.EMAIL_AND_TEXT_NOTIFICATIONS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
   },
   {
     component: AccountSecurityPage,
@@ -222,6 +246,7 @@ const routesForProfile2Nav = [
     path: PROFILE_PATHS.CONNECTED_APPLICATIONS,
     requiresLOA3: true,
     requiresMVI: true,
+    requiresSchedulingPreferencesPilot: false,
     subnavParent: PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
   },
   {

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.jsx
@@ -226,6 +226,7 @@ describe('mapStateToProps', () => {
       'shouldFetchTotalDisabilityRating',
       'isDowntimeWarningDismissed',
       'isBlocked',
+      'isSchedulingPreferencesPilotEligible',
       'togglesLoaded',
       'profileToggles',
     ];

--- a/src/applications/personalization/profile/tests/e2e/scheduling-preferences/scheduling-preferences-contact-method--missing-details.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/scheduling-preferences/scheduling-preferences-contact-method--missing-details.cypress.spec.js
@@ -28,10 +28,6 @@ const setup = (preferences = []) => {
           name: 'profile_health_care_settings_page',
           value: true,
         },
-        {
-          name: 'profile_scheduling_preferences',
-          value: true,
-        },
       ],
     },
   }));

--- a/src/applications/personalization/profile/tests/e2e/scheduling-preferences/scheduling-preferences-contact-method.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/scheduling-preferences/scheduling-preferences-contact-method.cypress.spec.js
@@ -21,10 +21,6 @@ const setup = (preferences = []) => {
           name: 'profile_health_care_settings_page',
           value: true,
         },
-        {
-          name: 'profile_scheduling_preferences',
-          value: true,
-        },
       ],
     },
   }));

--- a/src/applications/personalization/profile/tests/fixtures/users/user-36.json
+++ b/src/applications/personalization/profile/tests/fixtures/users/user-36.json
@@ -28,7 +28,8 @@
         "givenNames": ["Wesley", "Watson"],
         "facilities": [{ "facilityId": "983", "isCerner": false }],
         "vaPatient": true,
-        "mhvAccountState": "OK"
+        "mhvAccountState": "OK",
+        "schedulingPreferencesPilotEligible": true
       },
       "veteranStatus": {
         "status": "OK",

--- a/src/applications/personalization/profile/tests/fixtures/users/user.js
+++ b/src/applications/personalization/profile/tests/fixtures/users/user.js
@@ -66,6 +66,7 @@ export const makeMockUser = () => {
           facilities: [{ facilityId: '983', isCerner: false }],
           vaPatient: true,
           mhvAccountState: 'OK',
+          schedulingPreferencesPilotEligible: true,
         },
         veteranStatus: {
           status: 'OK',

--- a/src/applications/personalization/profile/tests/util/index.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/index.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   hasAccountFlaggedError,
   hasRoutingNumberFlaggedError,
   hasInvalidHomePhoneNumberError,
+  getHealthCareSettingsHubDescription,
 } from '../../util';
 
 describe('profile utils', () => {
@@ -138,6 +139,45 @@ describe('profile utils', () => {
           ...mockDirectDeposits.updates.errors.invalidAccountNumber.errors,
         ]),
       ).to.be.not.ok;
+    });
+  });
+
+  describe('ProfileHub content for Health Care Settings', () => {
+    it('returns correct description when both properties are true', () => {
+      const description = getHealthCareSettingsHubDescription({
+        hideHealthCareContacts: true,
+        isSchedulingPreferencesPilotEligible: true,
+      });
+      expect(description).to.equal(
+        'Messages signature and scheduling preferences',
+      );
+    });
+    it('returns correct description when both properties are false', () => {
+      const description = getHealthCareSettingsHubDescription({
+        hideHealthCareContacts: false,
+        isSchedulingPreferencesPilotEligible: false,
+      });
+      expect(description).to.equal(
+        'Health care contacts and messages signature',
+      );
+    });
+    it('returns correct description when just scheduling preferences is true', () => {
+      const description = getHealthCareSettingsHubDescription({
+        hideHealthCareContacts: false,
+        isSchedulingPreferencesPilotEligible: true,
+      });
+      expect(description).to.equal(
+        'Health care contacts, messages signature, and scheduling preferences',
+      );
+    });
+    it('returns correct description when just health care contacts is true', () => {
+      const description = getHealthCareSettingsHubDescription({
+        hideHealthCareContacts: true,
+        isSchedulingPreferencesPilotEligible: false,
+      });
+      expect(description).to.equal(
+        'Messages signature and other health care settings',
+      );
     });
   });
 });

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -1,6 +1,8 @@
 import cloneDeep from 'lodash/cloneDeep';
 import recordEvent from '~/platform/monitoring/record-event';
 import { apiRequest } from '~/platform/utilities/api';
+import { capitalize } from 'lodash';
+import { oxfordCommaList } from './textUtils';
 
 export const BASE_DIRECT_DEPOSIT_ERROR_KEYS = {
   ACCOUNT_FLAGGED_FOR_FRAUD: '.account.number.fraud',
@@ -204,6 +206,24 @@ const getLighthouseErrorCode = (errors = []) => {
   // there should only be one error code in the errors array, but just in case
   const error = errors.find(err => err?.code);
   return `${error?.code || OTHER_ERROR_GA_KEY} | ${error?.detail || ''}`;
+};
+
+export const getHealthCareSettingsHubDescription = ({
+  hideHealthCareContacts,
+  isSchedulingPreferencesPilotEligible,
+}) => {
+  const healthCareSettingsItems = [];
+  if (!hideHealthCareContacts) {
+    healthCareSettingsItems.push('health care contacts');
+  }
+  healthCareSettingsItems.push('messages signature');
+  if (isSchedulingPreferencesPilotEligible) {
+    healthCareSettingsItems.push('scheduling preferences');
+  }
+  if (hideHealthCareContacts && !isSchedulingPreferencesPilotEligible) {
+    healthCareSettingsItems.push('other health care settings');
+  }
+  return capitalize(oxfordCommaList(healthCareSettingsItems));
 };
 
 // Helper that creates and returns an object to pass to the recordEvent()

--- a/src/applications/personalization/profile/util/textUtils.js
+++ b/src/applications/personalization/profile/util/textUtils.js
@@ -6,7 +6,7 @@
  * ['A', 'B'] -> 'A and B'
  * ['A', 'B', 'C'] -> 'A, B, and C'
  */
-export default function oxfordCommaList(items = []) {
+export function oxfordCommaList(items = []) {
   if (!Array.isArray(items) || items.length < 2) {
     return items.toString();
   }

--- a/src/applications/personalization/profile/utils/oxfordCommaList.js
+++ b/src/applications/personalization/profile/utils/oxfordCommaList.js
@@ -1,0 +1,18 @@
+/**
+ * Join an array of strings with commas and an Oxford comma for the last item.
+ * Examples:
+ * [] -> ''
+ * ['A'] -> 'A'
+ * ['A', 'B'] -> 'A and B'
+ * ['A', 'B', 'C'] -> 'A, B, and C'
+ */
+export default function oxfordCommaList(items = []) {
+  if (!Array.isArray(items) || items.length < 2) {
+    return items.toString();
+  }
+  if (items.length === 2) return items.join(' and ');
+
+  const head = items.slice(0, -1).join(', ');
+  const last = items[items.length - 1];
+  return `${head}, and ${last}`;
+}

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -112,6 +112,8 @@ export function mapRawUserDataToState(json) {
     }
     userState.vaPatient = vaProfile.vaPatient;
     userState.mhvAccountState = vaProfile.mhvAccountState;
+    userState.schedulingPreferencesPilotEligible =
+      vaProfile.schedulingPreferencesPilotEligible;
   }
 
   // This one is checking userState because there's no extra mapping and it's

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -16,6 +16,8 @@ export const isLOA1 = state => selectProfile(state).loa.current === 1;
 export const isMultifactorEnabled = state => selectProfile(state).multifactor;
 export const selectAvailableServices = state =>
   selectProfile(state)?.services || [];
+export const isSchedulingPreferencesPilotEligible = state =>
+  selectProfile(state).schedulingPreferencesPilotEligible || false;
 
 export const selectVAPContactInfo = state =>
   selectProfile(state).vapContactInfo;

--- a/src/platform/user/tests/selectors.unit.spec.jsx
+++ b/src/platform/user/tests/selectors.unit.spec.jsx
@@ -413,4 +413,20 @@ describe('user selectors', () => {
       expect(selectors.isInMPI(state)).to.be.false;
     });
   });
+
+  describe('isSchedulingPreferencesPilotEligible', () => {
+    it('returns true if the user is eligible for the scheduling preferences pilot', () => {
+      const state = {
+        user: {
+          profile: {},
+        },
+      };
+      state.user.profile = { schedulingPreferencesPilotEligible: true };
+      expect(selectors.isSchedulingPreferencesPilotEligible(state)).to.be.true;
+      state.user.profile = { schedulingPreferencesPilotEligible: false };
+      expect(selectors.isSchedulingPreferencesPilotEligible(state)).to.be.false;
+      state.user.profile = {};
+      expect(selectors.isSchedulingPreferencesPilotEligible(state)).to.be.false;
+    });
+  });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -251,7 +251,6 @@
   "profileUseExperimental": "profile_use_experimental",
   "profile2Enabled": "profile_2_enabled",
   "profileHealthCareSettingsPage": "profile_health_care_settings_page",
-  "profileSchedulingPreferences": "profile_scheduling_preferences",
   "profileHideHealthCareContacts": "profile_hide_health_care_contacts",
   "pwEhrCtaUseSlo": "pw_ehr_cta_use_slo",
   "representativeStatusEnabled": "representative_status_enabled",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The ability for a user to see the Scheduling preferences page is now available from the API endpoint for the user. This PR updates the frontend to listen to that property to determine if it should be available to the user or hidden away entirely.
- Authenticated Experience Team AuthentiKnights
- profile_2_enabled profile_health_care_settings_page profile_scheduling_preferences

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#128387

## Testing done

- Provided new unit test coverage for the new oxford comma helper

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="374" height="129" alt="image" src="https://github.com/user-attachments/assets/c499c673-4cca-4a86-91e1-ddabdfa1d443" />|<img width="375" height="104" alt="image" src="https://github.com/user-attachments/assets/b6f5f6f6-ed9b-4fd8-8281-192bf13b1c77" /><img width="361" height="231" alt="image" src="https://github.com/user-attachments/assets/2d190837-fd3c-4df4-aa89-432edf6eb517" /><img width="375" height="514" alt="image" src="https://github.com/user-attachments/assets/e092741f-6d34-4079-915c-4afa02ec69cf" />|
| Desktop |<img width="504" height="92" alt="image" src="https://github.com/user-attachments/assets/a772bdb2-8a42-46bf-8525-be7232ac67c6" />|<img width="416" height="91" alt="image" src="https://github.com/user-attachments/assets/43dd3794-8dd5-4eca-a818-033482b6dffe" /><img width="907" height="506" alt="image" src="https://github.com/user-attachments/assets/25a00a14-c0fe-431d-9ae6-e600fcb00539" />|

## What areas of the site does it impact?

Just the Profile 2.0 pages in their side nav and some on page content based on whether or not the user has access to the scheduling preferences pilot.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
