### PR TITLE
Resolve mileage expense bugs

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -19,8 +19,8 @@ import {
   selectExpenseUpdateLoadingState,
   selectExpenseCreationLoadingState,
   selectAllExpenses,
-  selectAppointment,
   selectExpenseBackDestination,
+  selectComplexClaim,
 } from '../../../redux/selectors';
 import TravelPayButtonPair from '../../shared/TravelPayButtonPair';
 import {
@@ -39,7 +39,8 @@ const Mileage = () => {
 
   useSetFocus();
 
-  const { data: appointment } = useSelector(selectAppointment);
+  const { data: claimDetails = {} } = useSelector(selectComplexClaim);
+
   const allExpenses = useSelector(selectAllExpenses);
   const address = useSelector(selectVAPResidentialAddress);
   const backDestination = useSelector(selectExpenseBackDestination);
@@ -139,10 +140,10 @@ const Mileage = () => {
     }
 
     // Building the mileage expense request body
+
     const expenseData = {
-      purchaseDate: appointment?.localStartTime
-        ? appointment.localStartTime.slice(0, 10) // Only the date portion of the localStartTime
-        : '',
+      purchaseDate:
+        claimDetails.appointment?.localStartTime?.split('T')[0] ?? '',
       description: 'Mileage',
       tripType: formState.tripType,
     };

--- a/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/Mileage.jsx
@@ -21,6 +21,7 @@ import {
   selectAllExpenses,
   selectExpenseBackDestination,
   selectComplexClaim,
+  selectAppointment,
 } from '../../../redux/selectors';
 import TravelPayButtonPair from '../../shared/TravelPayButtonPair';
 import {
@@ -39,6 +40,7 @@ const Mileage = () => {
 
   useSetFocus();
 
+  const { data: appointment } = useSelector(selectAppointment);
   const { data: claimDetails = {} } = useSelector(selectComplexClaim);
 
   const allExpenses = useSelector(selectAllExpenses);
@@ -143,7 +145,9 @@ const Mileage = () => {
 
     const expenseData = {
       purchaseDate:
-        claimDetails.appointment?.localStartTime?.split('T')[0] ?? '',
+        appointment?.localStartTime?.slice(0, 10) ??
+        claimDetails.appointment?.localStartTime?.slice(0, 10) ??
+        '',
       description: 'Mileage',
       tripType: formState.tripType,
     };

--- a/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
@@ -103,7 +103,7 @@ const ReviewPage = () => {
   };
 
   const numGroupedExpenses = Object.keys(groupedExpenses).length;
-  const isAlertVisible = !!alertMessage && numGroupedExpenses > 0;
+  const isAlertVisible = !!alertMessage;
 
   return (
     <div data-testid="review-page">

--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -758,14 +758,13 @@ export function deleteExpenseDeleteDocument(
         dispatch(deleteDocumentFailure(error, documentId));
         throw error;
       }
-
-      /**
-       * After deleting the expense + document, fetch the updated claim details.
-       * If this fetch fails, we ignore the error because the deletions have
-       * already completed successfully.
-       */
-      await dispatch(getComplexClaimDetails(claimId));
     }
+    /**
+     * After deleting the expense and for nonmileage expenses the document, fetch the
+     * updated claim details. If this fetch fails, we ignore the error because the deletions
+     * have already completed successfully.
+     */
+    await dispatch(getComplexClaimDetails(claimId));
   };
 }
 

--- a/src/applications/travel-pay/services/mocks/index.js
+++ b/src/applications/travel-pay/services/mocks/index.js
@@ -390,6 +390,22 @@ EXPENSE_TYPES.forEach(type => {
   responses[
     `POST /travel_pay/v0/claims/:claimId/expenses/${type}`
   ] = createExpenseHandler(type);
+  // Error condition example:
+  // responses[`POST /travel_pay/v0/claims/:claimId/expenses/${type}`] = (
+  //   req,
+  //   res,
+  // ) => {
+  //   return res.status(500).json({
+  //     errors: [
+  //       {
+  //         title: 'Server error',
+  //         status: 500,
+  //         detail: 'Failed to create expense',
+  //         code: 'VA900',
+  //       },
+  //     ],
+  //   });
+  // };
 
   // Get individual expense
   responses[

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
@@ -50,6 +50,20 @@ describe('Complex Claims Mileage - Add', () => {
           submission: { id: '', isSubmitting: false, error: null, data: null },
           fetch: { isLoading: false, error: null },
           data: {
+            claimId: TEST_CLAIM_ID,
+            appointment: {
+              id: TEST_APPT_ID,
+              facilityName: 'Test VA Medical Center',
+              facilityAddress: {
+                addressLine1: '123 Medical Center Drive',
+                city: 'Test City',
+                stateCode: 'TX',
+                zipCode: '12345',
+              },
+              appointmentDate: '2024-01-15',
+              appointmentTime: '10:00 AM',
+              localStartTime: '2024-01-15T10:00:00.000-08:00',
+            },
             documents: [],
           },
         },
@@ -549,6 +563,20 @@ describe('Complex Claims Mileage - Edit', () => {
           submission: { id: '', isSubmitting: false, error: null, data: null },
           fetch: { isLoading: false, error: null },
           data: {
+            claimId: TEST_CLAIM_ID,
+            appointment: {
+              id: TEST_APPT_ID,
+              facilityName: 'Test VA Medical Center',
+              facilityAddress: {
+                addressLine1: '123 Medical Center Drive',
+                city: 'Test City',
+                stateCode: 'TX',
+                zipCode: '12345',
+              },
+              appointmentDate: '2024-01-15',
+              appointmentTime: '10:00 AM',
+              localStartTime: '2024-01-15T10:00:00.000-08:00',
+            },
             documents: [],
           },
         },

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/Mileage.unit.spec.jsx
@@ -108,7 +108,6 @@ describe('Complex Claims Mileage - Add', () => {
       </MemoryRouter>,
       { initialState: getAddState(), reducers: reducer },
     );
-
   it('renders the component with all elements', () => {
     const screen = renderComponent();
 
@@ -208,6 +207,47 @@ describe('Complex Claims Mileage - Add', () => {
       expect(expenseData.tripType).to.equal('RoundTrip');
 
       stub.restore();
+    });
+    it('falls back to claimDetails appointment localStartTime when appointment is missing', async () => {
+      const state = getAddState();
+      state.travelPay.appointment.data.localStartTime = undefined;
+
+      const { container } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[
+            `/file-new-claim/${TEST_APPT_ID}/${TEST_CLAIM_ID}/mileage/`,
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/mileage"
+              element={<Mileage />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { initialState: state, reducers: reducer },
+      );
+
+      fireEvent(
+        $('va-radio[name="departureAddress"]'),
+        new CustomEvent('vaValueChange', {
+          detail: { name: 'departureAddress', value: 'home-address' },
+        }),
+      );
+
+      fireEvent(
+        $('va-radio[name="tripType"]'),
+        new CustomEvent('vaValueChange', {
+          detail: { name: 'tripType', value: 'RoundTrip' },
+        }),
+      );
+
+      fireEvent.click(
+        container.querySelector('.travel-pay-button-group va-button[continue]'),
+      );
+
+      const expenseData = stub.firstCall.args[2];
+      expect(expenseData.purchaseDate).to.equal('2024-01-15');
     });
   });
 


### PR DESCRIPTION
## Summary

There were 3 bugs occurring when adding a mileage expense...
1. The Claim state not refreshed after deleting a mileage expense: When a user would delete a mileage expense on the review page, the `actions.rb` method `deleteExpenseDeleteDocument` was only calling `GET complex claims` for the non-mileage expenses and not the mileage expenses. Updated this code so that the `GET complex claims` is called for all expenses in the `deleteExpenseDeleteDocument` method
2. The mileage expense creation api call was failing due to it missing the purchaseDate: Found that this was due to the `purchaseDate` field being dependent on the `GET appointment` call being successful and if it wasnt then we were setting the date to `" "`. Updated the code to handle this scenario and if `GET appointment` call is not successful, then we look at the complexClaims appointment information to populate the purchaseDate (this field should never return `" "`), kept the logic to say if for some reason that is also empty then we would set the field to `" "` and the CREATE mileage expense call with fail and an error alert will be shown on the Review Page.
3. An error alert was not shown when mileage creation errored and no other expenses existed: When a user didnt have any other expenses on a claim and attempted to add a mileage expense and the api call failed, no error alert was being displayed on the Review Page. This was due to some bad logic on the Review Page where the error alert only showed if there was at least one expense on the claim. Updated this logic so that this dependency no longer exists and error alerts display if an error exists, no matter how many expenses the claim has.



## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130427

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| When CREATE mileage expense fails and an error alert SHOULD be displayed on the review page |   <img width="2924" height="1238" alt="Screenshot 2026-01-21 at 3 00 21 PM" src="https://github.com/user-attachments/assets/41b5faf5-fd7e-4254-82d4-457227fb79f2" />     |    <img width="1462" height="619" alt="Screenshot 2026-01-21 at 4 50 30 PM" src="https://github.com/user-attachments/assets/4be99f28-ac66-4d2f-bb9b-413ca673ef3a" />   |
| When adding a mileage expense and GET appointment fails we should still set the purchaseDate and allow a user to add a mileage expense  |     https://github.com/user-attachments/assets/135fdd41-73a2-4e6b-9874-a67dc2a53df0   |   https://github.com/user-attachments/assets/27b66e4b-c13d-4fe0-8041-324baab2cf5b   |
| When a user deletes and expense the get complex claims call should be called. |   https://github.com/user-attachments/assets/e9ba7402-91c5-4fa8-a821-cbba8156dc71    |   https://github.com/user-attachments/assets/1b38f56b-38b3-45e7-9c15-cbbf5d5d7279  |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
