### PR TITLE
[COPILOT] Update apostrophe usage instructions in guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ This is a monorepo for VA.gov, with shared code in `src/platform` and individual
 - For E2E tests, use Cypress.
 - Prefer functional components and hooks for new components.
 - Files should end with a newline.
-- Use ’ instead of ' for apostrophes in text content.
+- The codebase uses curly apostrophes (') in user-facing text content. Always write straight apostrophes (') instead - eslint will auto-fix them to curly apostrophes. Run `yarn lint:js:changed:fix` after making changes.
 - Use `yarn lint:js:working:fix` to fix formatting issues.
 - All code should conform to WCAG 2.2 AA and Section 508 accessibility guidelines.
 


### PR DESCRIPTION
I've had a lot of trouble with copilot going in circles trying to write curly apostrophes. I've updated the instructions and this is working much better for me.