### PR TITLE
[ARC/129843] - fixed margins on date icon

### DIFF
--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -282,12 +282,7 @@
 .form {
   &__icon {
     &--warning {
-      margin: 0 4px 0 10px;
-    }
-  }
-  &__itf-card {
-    &--date {
-      margin-left: 3px;
+      margin: 0 4px;
     }
   }
 }


### PR DESCRIPTION
updating margins around date icon, see ticket:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/129843

<img width="774" height="370" alt="Screenshot 2026-01-22 at 11 13 27 AM" src="https://github.com/user-attachments/assets/7dbce4b2-d0e5-4fba-8052-5b335e2d7a77" />
