### PR TITLE
Burial | PDF form alignment - add v4 migration

### DIFF
--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -96,7 +96,7 @@ const formConfig = {
       saved: 'Your burial benefits application has been saved.',
     },
   },
-  version: 3, // Change to 4 when PDF alignment feature toggle is enabled
+  version: 3, // Change to 4 when PDF alignment feature toggle is enabled and enable migration
   migrations,
   prefillEnabled: true,
   dev: {

--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -96,7 +96,7 @@ const formConfig = {
       saved: 'Your burial benefits application has been saved.',
     },
   },
-  version: 3,
+  version: 3, // Change to 4 when PDF alignment feature toggle is enabled
   migrations,
   prefillEnabled: true,
   dev: {

--- a/src/applications/burials-ez/migrations.js
+++ b/src/applications/burials-ez/migrations.js
@@ -42,58 +42,58 @@ export default [
     return { formData: newFormData, metadata };
   },
   // 3 > 4, align with new PDF form and redirect
-  ({ formData, metadata }) => {
-    let newFormData = { ...formData };
-    const newMetadata = {
-      ...metadata,
-      // Always redirect to the first page of the application
-      returnUrl: '/claimant-information/relationship-to-veteran',
-    };
+  // ({ formData, metadata }) => {
+  //   let newFormData = { ...formData };
+  //   const newMetadata = {
+  //     ...metadata,
+  //     // Always redirect to the first page of the application
+  //     returnUrl: '/claimant-information/relationship-to-veteran',
+  //   };
 
-    if (
-      !Array.isArray(formData.toursOfDuty) ||
-      formData.toursOfDuty.length === 0
-    ) {
-      return { formData: newFormData, metadata: newMetadata };
-    }
+  //   if (
+  //     !Array.isArray(formData.toursOfDuty) ||
+  //     formData.toursOfDuty.length === 0
+  //   ) {
+  //     return { formData: newFormData, metadata: newMetadata };
+  //   }
 
-    const [servicePeriod] = formData.toursOfDuty;
+  //   const [servicePeriod] = formData.toursOfDuty;
 
-    // Old (stored) label -> new (stored) key mapping
-    const branchLabelToKey = {
-      Army: 'army',
-      Navy: 'navy',
-      'Air Force': 'airForce',
-      'Coast Guard': 'coastGuard',
-      'Marine Corps': 'marineCorps',
-      // Note: intentionally no mappings for Reserve/Guard/Other,
-      // since those are not 1:1 with the new enum keys.
-    };
+  //   // Old (stored) label -> new (stored) key mapping
+  //   const branchLabelToKey = {
+  //     Army: 'army',
+  //     Navy: 'navy',
+  //     'Air Force': 'airForce',
+  //     'Coast Guard': 'coastGuard',
+  //     'Marine Corps': 'marineCorps',
+  //     // Note: intentionally no mappings for Reserve/Guard/Other,
+  //     // since those are not 1:1 with the new enum keys.
+  //   };
 
-    const mappedServiceBranchKey =
-      branchLabelToKey[(servicePeriod?.serviceBranch)];
+  //   const mappedServiceBranchKey =
+  //     branchLabelToKey[(servicePeriod?.serviceBranch)];
 
-    const migratedFields = {
-      serviceDateRange: servicePeriod?.dateRange,
-      placeOfSeparation: servicePeriod?.placeOfSeparation,
-    };
+  //   const migratedFields = {
+  //     serviceDateRange: servicePeriod?.dateRange,
+  //     placeOfSeparation: servicePeriod?.placeOfSeparation,
+  //   };
 
-    // Only set serviceBranch when we can safely map it
-    if (mappedServiceBranchKey) {
-      migratedFields.serviceBranch = mappedServiceBranchKey;
-    }
+  //   // Only set serviceBranch when we can safely map it
+  //   if (mappedServiceBranchKey) {
+  //     migratedFields.serviceBranch = mappedServiceBranchKey;
+  //   }
 
-    newFormData = {
-      ...newFormData,
-      ...migratedFields,
-    };
+  //   newFormData = {
+  //     ...newFormData,
+  //     ...migratedFields,
+  //   };
 
-    // Remove legacy array to prevent schema mismatch / resume issues
-    delete newFormData.toursOfDuty;
+  //   // Remove legacy array to prevent schema mismatch / resume issues
+  //   delete newFormData.toursOfDuty;
 
-    return {
-      formData: newFormData,
-      metadata: newMetadata,
-    };
-  },
+  //   return {
+  //     formData: newFormData,
+  //     metadata: newMetadata,
+  //   };
+  // },
 ];

--- a/src/applications/burials-ez/migrations.js
+++ b/src/applications/burials-ez/migrations.js
@@ -44,7 +44,11 @@ export default [
   // 3 > 4, align with new PDF form and redirect
   ({ formData, metadata }) => {
     let newFormData = { ...formData };
-    let newMetadata = { ...metadata };
+    const newMetadata = {
+      ...metadata,
+      // Always redirect to the first page of the application
+      returnUrl: '/claimant-information/relationship-to-veteran',
+    };
 
     if (
       !Array.isArray(formData.toursOfDuty) ||
@@ -86,13 +90,6 @@ export default [
 
     // Remove legacy array to prevent schema mismatch / resume issues
     delete newFormData.toursOfDuty;
-
-    // Send the applicant to the first page of the application
-    newMetadata = {
-      ...newMetadata,
-      // Redirect to first page of application
-      returnUrl: '/claimant-information/relationship-to-veteran',
-    };
 
     return {
       formData: newFormData,

--- a/src/applications/burials-ez/migrations.js
+++ b/src/applications/burials-ez/migrations.js
@@ -41,4 +41,62 @@ export default [
 
     return { formData: newFormData, metadata };
   },
+  // 3 > 4, align with new PDF form and redirect
+  ({ formData, metadata }) => {
+    let newFormData = { ...formData };
+    let newMetadata = { ...metadata };
+
+    if (
+      !Array.isArray(formData.toursOfDuty) ||
+      formData.toursOfDuty.length === 0
+    ) {
+      return { formData: newFormData, metadata: newMetadata };
+    }
+
+    const [servicePeriod] = formData.toursOfDuty;
+
+    // Old (stored) label -> new (stored) key mapping
+    const branchLabelToKey = {
+      Army: 'army',
+      Navy: 'navy',
+      'Air Force': 'airForce',
+      'Coast Guard': 'coastGuard',
+      'Marine Corps': 'marineCorps',
+      // Note: intentionally no mappings for Reserve/Guard/Other,
+      // since those are not 1:1 with the new enum keys.
+    };
+
+    const mappedServiceBranchKey =
+      branchLabelToKey[(servicePeriod?.serviceBranch)];
+
+    const migratedFields = {
+      serviceDateRange: servicePeriod?.dateRange,
+      placeOfSeparation: servicePeriod?.placeOfSeparation,
+    };
+
+    // Only set serviceBranch when we can safely map it
+    if (mappedServiceBranchKey) {
+      migratedFields.serviceBranch = mappedServiceBranchKey;
+    }
+
+    newFormData = {
+      ...newFormData,
+      ...migratedFields,
+    };
+
+    // Remove legacy array to prevent schema mismatch / resume issues
+    delete newFormData.toursOfDuty;
+
+    // Send the applicant to the first page of the application
+    newMetadata = {
+      ...newMetadata,
+      // Redirect to first page of application
+      returnUrl: '/claimant-information/relationship-to-veteran',
+    };
+
+    return {
+      formData: newFormData,
+      metadata: newMetadata,
+    };
+  },
 ];

--- a/src/applications/burials-ez/tests/migrations.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/migrations.unit.spec.jsx
@@ -296,7 +296,7 @@ describe('Burials migrations', () => {
       expect(formData.placeOfSeparation).to.equal('Norfolk, VA');
     });
 
-    it('should not change formData or returnUrl when toursOfDuty is missing or empty', () => {
+    it('should always redirect to first page of application', () => {
       const input = {
         formData: {
           claimantEmail: 'user@example.com',
@@ -308,7 +308,9 @@ describe('Burials migrations', () => {
 
       const { formData, metadata } = migrations[3](input);
 
-      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(metadata.returnUrl).to.equal(
+        '/claimant-information/relationship-to-veteran',
+      );
       expect(formData).to.deep.equal({
         claimantEmail: 'user@example.com',
       });

--- a/src/applications/burials-ez/tests/migrations.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/migrations.unit.spec.jsx
@@ -187,7 +187,7 @@ describe('Burials migrations', () => {
     });
   });
 
-  context('v4 migration', () => {
+  context.skip('v4 migration', () => {
     it('should migrate toursOfDuty to new service period fields when serviceBranch maps cleanly', () => {
       const { formData, metadata } = migrations[3]({
         formData: {

--- a/src/applications/burials-ez/tests/migrations.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/migrations.unit.spec.jsx
@@ -186,4 +186,132 @@ describe('Burials migrations', () => {
       expect(formData.locationOfDeath.other).to.equal('Location');
     });
   });
+
+  context('v4 migration', () => {
+    it('should migrate toursOfDuty to new service period fields when serviceBranch maps cleanly', () => {
+      const { formData, metadata } = migrations[3]({
+        formData: {
+          toursOfDuty: [
+            {
+              serviceBranch: 'Air Force',
+              dateRange: {
+                from: '2005-07-19',
+                to: '2009-04-02',
+              },
+              placeOfEntry: 'Denver, CO',
+              placeOfSeparation: 'Salt Lake City, UT',
+              // legacy fields that may exist on old objects
+              rank: 'E-4',
+              unit: 'Unit 1',
+            },
+          ],
+        },
+        metadata: {
+          returnUrl: '/some-old-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal(
+        '/claimant-information/relationship-to-veteran',
+      );
+
+      expect(formData).to.not.have.property('toursOfDuty');
+      expect(formData.serviceBranch).to.equal('airForce');
+      expect(formData.serviceDateRange).to.deep.equal({
+        from: '2005-07-19',
+        to: '2009-04-02',
+      });
+      expect(formData.placeOfSeparation).to.equal('Salt Lake City, UT');
+    });
+
+    it('should leave serviceBranch undefined when there is no one-to-one mapping but still migrate other fields', () => {
+      const { formData, metadata } = migrations[3]({
+        formData: {
+          toursOfDuty: [
+            {
+              serviceBranch: 'Army National Guard',
+              dateRange: {
+                from: '2010-01-01',
+                to: '2012-01-01',
+              },
+              placeOfSeparation: 'Ogden, UT',
+            },
+          ],
+        },
+        metadata: {
+          returnUrl: '/some-old-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal(
+        '/claimant-information/relationship-to-veteran',
+      );
+
+      expect(formData).to.not.have.property('toursOfDuty');
+      expect(formData).to.not.have.property('serviceBranch');
+      expect(formData.serviceDateRange).to.deep.equal({
+        from: '2010-01-01',
+        to: '2012-01-01',
+      });
+      expect(formData.placeOfSeparation).to.equal('Ogden, UT');
+    });
+
+    it('should use the first toursOfDuty entry when multiple exist', () => {
+      const { formData, metadata } = migrations[3]({
+        formData: {
+          toursOfDuty: [
+            {
+              serviceBranch: 'Navy',
+              dateRange: {
+                from: '2000-01-01',
+                to: '2004-01-01',
+              },
+              placeOfSeparation: 'Norfolk, VA',
+            },
+            {
+              serviceBranch: 'Army',
+              dateRange: {
+                from: '2005-01-01',
+                to: '2009-01-01',
+              },
+              placeOfSeparation: 'Fort Bragg, NC',
+            },
+          ],
+        },
+        metadata: {
+          returnUrl: '/some-old-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal(
+        '/claimant-information/relationship-to-veteran',
+      );
+
+      expect(formData).to.not.have.property('toursOfDuty');
+      expect(formData.serviceBranch).to.equal('navy');
+      expect(formData.serviceDateRange).to.deep.equal({
+        from: '2000-01-01',
+        to: '2004-01-01',
+      });
+      expect(formData.placeOfSeparation).to.equal('Norfolk, VA');
+    });
+
+    it('should not change formData or returnUrl when toursOfDuty is missing or empty', () => {
+      const input = {
+        formData: {
+          claimantEmail: 'user@example.com',
+        },
+        metadata: {
+          returnUrl: '/original-url',
+        },
+      };
+
+      const { formData, metadata } = migrations[3](input);
+
+      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(formData).to.deep.equal({
+        claimantEmail: 'user@example.com',
+      });
+    });
+  });
 });


### PR DESCRIPTION
**Note:**
The v4 form migration logic included in this PR is currently commented out, and the associated unit tests are intentionally skipped. This is temporary and done to avoid failures in the platform migration test suite, which expects the current form version to match the number of migrations. Once we are ready to officially bump the form version to v4, the migration will be enabled and the skipped unit tests will be re-enabled to validate the new behavior.

### Summary of Changes
This PR adds a **v4 form data migration** for the **Burial Benefits form (VA Form 21P-530EZ)** to support **PDF form alignment**.  
The migration updates existing saved-in-progress submissions to ensure form data remains compatible with the updated PDF-aligned schema, page flow, and conditional logic.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129644

### How to Set Up in Local Environment
1. Run the local environment:  
2. Enable the required feature toggles:
   - `burial_form_enabled`  
     http://localhost:3000/flipper/features/burial_form_enabled
   - `burial_pdf_form_alignment`  
     http://localhost:3000/flipper/features/burial_pdf_form_alignment
3. Navigate to the Burial Benefits form:  
   http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/

### How to Test
1. Create or use existing saved form data that represents a pre-alignment state (pre-v4).
2. Update the form version from '3' to '4' and confirm the migration runs successfully:
   - Form loads without errors.
   - User is routed to the first page of the application
3. Verify migrated data remains valid for the PDF-aligned flow:
   - Updated fields exist as expected.
   - Removed/renamed fields are handled safely.
   - Conditional pages (PDF alignment) do not break due to legacy data.
4. Confirm no console errors and that the form can still be completed and submitted.

### Feature Flag Note
Migration supports the PDF-aligned flow behind `burial_pdf_form_alignment`.

### Acceptance Criteria
- [x] v4 migration is added and wired into the Burials migrations list.
- [x] Legacy saved-in-progress data is migrated safely without runtime errors.
- [x] Migrated data supports the PDF-aligned flow and page conditions.
- [x] No regressions in form load, navigation, or submission.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggles enabled.
- [ ] No console errors or accessibility issues.
- [ ] Unit tests updated or added to cover the migration behavior.
- [ ] Tests passing.