### PR TITLE
adds service number to veteran information page, updates tests with n…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-identification.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-identification.js
@@ -1,19 +1,39 @@
 import {
   ssnOrVaFileNumberUI,
-  ssnOrVaFileNumberSchema,
+  ssnSchema,
+  vaFileNumberSchema,
+  serviceNumberSchema,
+  serviceNumberUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+
+const veteranInformationUI = () => {
+  return {
+    ...ssnOrVaFileNumberUI(),
+    vaServiceNumber: serviceNumberUI('Service number'),
+  };
+};
+
+const veteranInformationSchema = {
+  type: 'object',
+  properties: {
+    ssn: ssnSchema,
+    vaServiceNumber: serviceNumberSchema,
+    vaFileNumber: vaFileNumberSchema,
+  },
+  required: ['ssn'],
+};
 
 export const veteranIdentificationPage = {
   uiSchema: {
     ...titleUI('Veteran’s identification information'),
-    veteranInformation: ssnOrVaFileNumberUI(),
+    veteranInformation: veteranInformationUI(),
   },
   schema: {
     type: 'object',
     required: ['veteranInformation'],
     properties: {
-      veteranInformation: ssnOrVaFileNumberSchema,
+      veteranInformation: veteranInformationSchema,
     },
   },
 };

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/fixtures/data/maximal.json
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/fixtures/data/maximal.json
@@ -12,6 +12,7 @@
       "state": "Arizona"
     },
     "ssn": "796121234",
+    "vaServiceNumber": "A12345678",
     "vaFileNumber": "987654321",
     "fullName": {
       "first": "Anakin",


### PR DESCRIPTION
…ew field

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Adding "Service number" field to veteran identification page to match paper form

### Issue
The paper form accepts a service number, but the front end was not collecting this info.

### Solution
Added a field to the front end to collect service numbers

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21p-530a form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 128943](https://github.com/department-of-veterans-affairs/va.gov-team/issues/128943)

## Testing done

### Old behavior
* There was no service number field on the online form

### New behavior
* There is now a service number field on the form. Submitting the form populates the PDF with this value

### Verification Steps
*  Unit tests: verified existing unit tests still pass
*  Manual testing in local environment verified that the new field shows up on Veteran Information page and the PDF populates with this value
* E2E tests: all existing tests pass, added service number value to maximal test

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="570" height="438" alt="before service" src="https://github.com/user-attachments/assets/5ffe0aae-5e9d-4a30-a1ff-c9f3a558ea47" /> | <img width="558" height="556" alt="after service" src="https://github.com/user-attachments/assets/5a71d08b-8fad-4d91-803d-2585b17bd520" /> |

## What areas of the site does it impact?

This change affects form 21p-530a, specifically on the Veteran’s identification information page at /submit-state-interment-allowance-form-21p-530a/veteran-identification

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

