### PR TITLE
Switch token to cookies

### DIFF
--- a/src/applications/vass/containers/withAuthorization.jsx
+++ b/src/applications/vass/containers/withAuthorization.jsx
@@ -36,7 +36,7 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
     // Attempt to hydrate from sessionStorage on mount
     useEffect(
       () => {
-        if (!hydrated && !hasValidToken) {
+        if (!hydrated) {
           const savedData = loadFormDataFromStorage();
           if (savedData) {
             dispatch(hydrateFormData(savedData));

--- a/src/applications/vass/containers/withAuthorization.jsx
+++ b/src/applications/vass/containers/withAuthorization.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
-  selectToken,
   selectUuid,
   selectHydrated,
   hydrateFormData,
@@ -11,6 +10,7 @@ import {
 } from '../redux/slices/formSlice';
 import { getFirstTokenRoute } from '../utils/navigation';
 import { AUTH_LEVELS, URLS } from '../utils/constants';
+import { getVassToken, isTokenExpired, removeVassToken } from '../utils/auth';
 
 /**
  * HOC that handles route authorization based on auth level.
@@ -23,7 +23,9 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
   return props => {
     const navigate = useNavigate();
     const dispatch = useDispatch();
-    const token = useSelector(selectToken);
+    const token = getVassToken();
+    const tokenExpired = token ? isTokenExpired(token) : false;
+    const hasValidToken = token && !tokenExpired;
     const uuid = useSelector(selectUuid);
     const hydrated = useSelector(selectHydrated);
     const [isHydrating, setIsHydrating] = useState(!hydrated);
@@ -34,7 +36,7 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
     // Attempt to hydrate from sessionStorage on mount
     useEffect(
       () => {
-        if (!hydrated && !token) {
+        if (!hydrated && !hasValidToken) {
           const savedData = loadFormDataFromStorage();
           if (savedData) {
             dispatch(hydrateFormData(savedData));
@@ -44,7 +46,7 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
           setIsHydrating(false);
         }
       },
-      [hydrated, token, dispatch],
+      [hydrated, hasValidToken, dispatch],
     );
 
     // Handle lowAuthOnly routes - redirect authenticated users to first token route
@@ -52,21 +54,26 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
       () => {
         if (isHydrating) return;
 
-        if (isLowAuthOnly && token) {
+        if (isLowAuthOnly && hasValidToken) {
           const firstTokenRoute = getFirstTokenRoute();
           navigate(firstTokenRoute, { replace: true });
         }
       },
-      [token, navigate, isHydrating, isLowAuthOnly],
+      [hasValidToken, navigate, isHydrating, isLowAuthOnly],
     );
 
-    // Handle token routes - redirect unauthenticated users to Verify page
+    // Handle token routes - redirect unauthenticated or expired token users to Verify page
     useEffect(
       () => {
         // Wait for hydration to complete before redirecting
         if (isHydrating) return;
 
-        if (requiresToken && !token) {
+        if (requiresToken && !hasValidToken) {
+          // Remove expired token cookie if it exists
+          if (token && tokenExpired) {
+            removeVassToken();
+          }
+
           // Clear form data when redirecting to Verify page
           dispatch(clearFormData());
 
@@ -80,16 +87,25 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
           }
         }
       },
-      [token, navigate, uuid, isHydrating, dispatch, requiresToken],
+      [
+        token,
+        tokenExpired,
+        hasValidToken,
+        navigate,
+        uuid,
+        isHydrating,
+        dispatch,
+        requiresToken,
+      ],
     );
 
-    // For lowAuthOnly routes: don't render if user has token (they shouldn't be here)
-    if (isLowAuthOnly && token) {
+    // For lowAuthOnly routes: don't render if user has valid token (they shouldn't be here)
+    if (isLowAuthOnly && hasValidToken) {
       return null;
     }
 
-    // For token routes: don't render until hydration is complete and we have a token
-    if (requiresToken && (isHydrating || !token)) {
+    // For token routes: don't render until hydration is complete and we have a valid token
+    if (requiresToken && (isHydrating || !hasValidToken)) {
       return null;
     }
 

--- a/src/applications/vass/containers/withAuthorization.unit.spec.jsx
+++ b/src/applications/vass/containers/withAuthorization.unit.spec.jsx
@@ -3,18 +3,16 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { waitFor } from '@testing-library/react';
 import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
-import { combineReducers, applyMiddleware, createStore } from 'redux';
-import thunk from 'redux-thunk';
-import { commonReducer } from 'platform/startup/store';
 import { renderWithStoreAndRouterV6 } from '~/platform/testing/unit/react-testing-library-helpers';
 
 import withAuthorization from './withAuthorization';
 import { AUTH_LEVELS, URLS } from '../utils/constants';
 import * as formSlice from '../redux/slices/formSlice';
+import * as authUtils from '../utils/auth';
+import { createMockJwt } from '../utils/mock-helpers';
 import {
   getDefaultRenderOptions,
-  reducers,
-  vassApi,
+  getHydratedFormRenderOptions,
 } from '../utils/test-utils';
 
 // Helper component to display current location for testing navigation
@@ -35,6 +33,9 @@ const TestComponent = () => (
 
 describe('VASS Containers: withAuthorization', () => {
   let loadFormDataFromStorageStub;
+  let getVassTokenStub;
+  let isTokenExpiredStub;
+  let removeVassTokenStub;
 
   beforeEach(() => {
     loadFormDataFromStorageStub = sinon.stub(
@@ -42,15 +43,55 @@ describe('VASS Containers: withAuthorization', () => {
       'loadFormDataFromStorage',
     );
     loadFormDataFromStorageStub.returns(null);
+
+    getVassTokenStub = sinon.stub(authUtils, 'getVassToken');
+    isTokenExpiredStub = sinon.stub(authUtils, 'isTokenExpired');
+    removeVassTokenStub = sinon.stub(authUtils, 'removeVassToken');
+
+    // Default: no token
+    getVassTokenStub.returns(null);
+    isTokenExpiredStub.returns(false);
   });
 
   afterEach(() => {
     loadFormDataFromStorageStub.restore();
+    getVassTokenStub.restore();
+    isTokenExpiredStub.restore();
+    removeVassTokenStub.restore();
   });
+
+  /**
+   * Helper to set up auth stubs for a valid token scenario
+   */
+  const setupValidToken = () => {
+    const validToken = createMockJwt('test-uuid', 3600);
+    getVassTokenStub.returns(validToken);
+    isTokenExpiredStub.returns(false);
+    return validToken;
+  };
+
+  /**
+   * Helper to set up auth stubs for an expired token scenario
+   */
+  const setupExpiredToken = () => {
+    const expiredToken = createMockJwt('test-uuid', -3600);
+    getVassTokenStub.returns(expiredToken);
+    isTokenExpiredStub.returns(true);
+    return expiredToken;
+  };
+
+  /**
+   * Helper to set up auth stubs for no token scenario
+   */
+  const setupNoToken = () => {
+    getVassTokenStub.returns(null);
+    isTokenExpiredStub.returns(false);
+  };
 
   describe('with AUTH_LEVELS.TOKEN', () => {
     describe('when user has a valid token', () => {
       it('should render the wrapped component', () => {
+        setupValidToken();
         const WrappedComponent = withAuthorization(
           TestComponent,
           AUTH_LEVELS.TOKEN,
@@ -58,7 +99,7 @@ describe('VASS Containers: withAuthorization', () => {
 
         const { getByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ token: 'valid-token', hydrated: true }),
+          getDefaultRenderOptions({ hydrated: true }),
         );
 
         expect(getByTestId('test-component')).to.exist;
@@ -67,6 +108,7 @@ describe('VASS Containers: withAuthorization', () => {
 
     describe('when user has no token', () => {
       it('should not render the component', () => {
+        setupNoToken();
         const WrappedComponent = withAuthorization(
           TestComponent,
           AUTH_LEVELS.TOKEN,
@@ -74,18 +116,19 @@ describe('VASS Containers: withAuthorization', () => {
 
         const { queryByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ token: null, hydrated: true }),
+          getDefaultRenderOptions({ hydrated: true }),
         );
 
         expect(queryByTestId('test-component')).to.not.exist;
       });
 
       it('should not render the component after hydration completes', async () => {
+        setupNoToken();
         const WrappedComponent = withAuthorization(TestComponent);
 
         const { queryByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ token: null, hydrated: false }),
+          getDefaultRenderOptions({ hydrated: false }),
         );
 
         await waitFor(() => {
@@ -94,6 +137,7 @@ describe('VASS Containers: withAuthorization', () => {
       });
 
       it('should redirect to Verify page when no token but uuid exists', async () => {
+        setupNoToken();
         const WrappedComponent = withAuthorization(TestComponent);
 
         const { getByTestId, queryByTestId } = renderWithStoreAndRouterV6(
@@ -109,7 +153,6 @@ describe('VASS Containers: withAuthorization', () => {
           </>,
           {
             ...getDefaultRenderOptions({
-              token: null,
               uuid: 'test-uuid-1234',
               hydrated: true,
             }),
@@ -126,11 +169,89 @@ describe('VASS Containers: withAuthorization', () => {
         expect(queryByTestId('test-component')).to.not.exist;
       });
     });
+
+    describe('when user has an expired token', () => {
+      it('should not render the component', () => {
+        setupExpiredToken();
+        const WrappedComponent = withAuthorization(
+          TestComponent,
+          AUTH_LEVELS.TOKEN,
+        );
+
+        const { queryByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ hydrated: true }),
+        );
+
+        expect(queryByTestId('test-component')).to.not.exist;
+      });
+
+      it('should remove the expired token cookie', async () => {
+        setupExpiredToken();
+        const WrappedComponent = withAuthorization(TestComponent);
+
+        renderWithStoreAndRouterV6(
+          <>
+            <Routes>
+              <Route path="/test" element={<WrappedComponent />} />
+              <Route
+                path="/"
+                element={<div data-testid="verify-page">Verify</div>}
+              />
+            </Routes>
+            <LocationDisplay />
+          </>,
+          {
+            ...getDefaultRenderOptions({
+              uuid: 'test-uuid',
+              hydrated: true,
+            }),
+            initialEntries: ['/test'],
+          },
+        );
+
+        await waitFor(() => {
+          expect(removeVassTokenStub.calledOnce).to.be.true;
+        });
+      });
+
+      it('should redirect to Verify page when token is expired', async () => {
+        setupExpiredToken();
+        const WrappedComponent = withAuthorization(TestComponent);
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <>
+            <Routes>
+              <Route path="/test" element={<WrappedComponent />} />
+              <Route
+                path="/"
+                element={<div data-testid="verify-page">Verify</div>}
+              />
+            </Routes>
+            <LocationDisplay />
+          </>,
+          {
+            ...getDefaultRenderOptions({
+              uuid: 'test-uuid-1234',
+              hydrated: true,
+            }),
+            initialEntries: ['/test'],
+          },
+        );
+
+        await waitFor(() => {
+          expect(getByTestId('location-display').textContent).to.equal(
+            `${URLS.VERIFY}?uuid=test-uuid-1234`,
+          );
+        });
+      });
+    });
   });
 
   describe('with AUTH_LEVELS.LOW_AUTH_ONLY', () => {
     describe('when user has no token', () => {
       it('should render the wrapped component', () => {
+        setupNoToken();
         const WrappedComponent = withAuthorization(
           TestComponent,
           AUTH_LEVELS.LOW_AUTH_ONLY,
@@ -138,15 +259,16 @@ describe('VASS Containers: withAuthorization', () => {
 
         const { getByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ token: null, hydrated: true }),
+          getDefaultRenderOptions({ hydrated: true }),
         );
 
         expect(getByTestId('test-component')).to.exist;
       });
     });
 
-    describe('when user has a token', () => {
+    describe('when user has a valid token', () => {
       it('should not render the component', () => {
+        setupValidToken();
         const WrappedComponent = withAuthorization(
           TestComponent,
           AUTH_LEVELS.LOW_AUTH_ONLY,
@@ -154,13 +276,14 @@ describe('VASS Containers: withAuthorization', () => {
 
         const { queryByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ token: 'valid-token', hydrated: true }),
+          getDefaultRenderOptions({ hydrated: true }),
         );
 
         expect(queryByTestId('test-component')).to.not.exist;
       });
 
-      it('should redirect to first token route when user has a token', async () => {
+      it('should redirect to first token route when user has a valid token', async () => {
+        setupValidToken();
         const WrappedComponent = withAuthorization(
           TestComponent,
           AUTH_LEVELS.LOW_AUTH_ONLY,
@@ -179,7 +302,6 @@ describe('VASS Containers: withAuthorization', () => {
           </>,
           {
             ...getDefaultRenderOptions({
-              token: 'valid-token',
               hydrated: true,
             }),
             initialEntries: [URLS.ENTER_OTC],
@@ -193,23 +315,44 @@ describe('VASS Containers: withAuthorization', () => {
         });
       });
     });
+
+    describe('when user has an expired token', () => {
+      it('should render the wrapped component (expired token is treated as no token)', () => {
+        setupExpiredToken();
+        const WrappedComponent = withAuthorization(
+          TestComponent,
+          AUTH_LEVELS.LOW_AUTH_ONLY,
+        );
+
+        const { getByTestId } = renderWithStoreAndRouterV6(
+          <WrappedComponent />,
+          getDefaultRenderOptions({ hydrated: true }),
+        );
+
+        expect(getByTestId('test-component')).to.exist;
+      });
+    });
   });
 
   describe('hydration behavior', () => {
-    it('should attempt to hydrate from sessionStorage when not hydrated and no token', async () => {
+    it('should attempt to hydrate from sessionStorage when not hydrated and no valid token', async () => {
+      setupNoToken();
       const savedData = {
         uuid: 'saved-uuid',
         lastname: 'SavedName',
         dob: '1990-01-01',
-        token: 'saved-token',
       };
       loadFormDataFromStorageStub.returns(savedData);
 
-      const WrappedComponent = withAuthorization(TestComponent);
+      // Use LOW_AUTH_ONLY to test hydration behavior without requiring a token
+      const WrappedComponent = withAuthorization(
+        TestComponent,
+        AUTH_LEVELS.LOW_AUTH_ONLY,
+      );
 
       const { getByTestId } = renderWithStoreAndRouterV6(
         <WrappedComponent />,
-        getDefaultRenderOptions({ hydrated: false, token: null }),
+        getDefaultRenderOptions({ hydrated: false }),
       );
 
       await waitFor(() => {
@@ -222,11 +365,12 @@ describe('VASS Containers: withAuthorization', () => {
     });
 
     it('should not attempt to load from storage when already hydrated', async () => {
+      setupValidToken();
       const WrappedComponent = withAuthorization(TestComponent);
 
       renderWithStoreAndRouterV6(
         <WrappedComponent />,
-        getDefaultRenderOptions({ hydrated: true, token: 'existing-token' }),
+        getDefaultRenderOptions({ hydrated: true }),
       );
 
       await waitFor(() => {
@@ -236,6 +380,7 @@ describe('VASS Containers: withAuthorization', () => {
 
     describe('auth level is LOW_AUTH_ONLY', () => {
       it('should complete hydration even when no saved data exists', async () => {
+        setupNoToken();
         loadFormDataFromStorageStub.returns(null);
 
         const WrappedComponent = withAuthorization(
@@ -245,7 +390,7 @@ describe('VASS Containers: withAuthorization', () => {
 
         const { getByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ hydrated: false, token: null }),
+          getDefaultRenderOptions({ hydrated: false }),
         );
 
         // For LOW_AUTH_ONLY with no token, component should render after hydration completes
@@ -257,6 +402,7 @@ describe('VASS Containers: withAuthorization', () => {
 
     describe('auth level is TOKEN', () => {
       it('should not render anything while waiting for hydration on token route', () => {
+        setupNoToken();
         const WrappedComponent = withAuthorization(
           TestComponent,
           AUTH_LEVELS.TOKEN,
@@ -264,7 +410,7 @@ describe('VASS Containers: withAuthorization', () => {
 
         const { queryByTestId } = renderWithStoreAndRouterV6(
           <WrappedComponent />,
-          getDefaultRenderOptions({ token: null, hydrated: false }),
+          getDefaultRenderOptions({ hydrated: false }),
         );
 
         expect(queryByTestId('test-component')).to.not.exist;
@@ -274,26 +420,10 @@ describe('VASS Containers: withAuthorization', () => {
 
   describe('clearFormData behavior', () => {
     it('should dispatch clearFormData when redirecting unauthenticated user to Verify', async () => {
+      setupNoToken();
       const WrappedComponent = withAuthorization(TestComponent);
 
-      const initialState = {
-        vassForm: {
-          hydrated: true,
-          selectedDate: '2025-01-01',
-          obfuscatedEmail: 's***@example.com',
-          token: null,
-          selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
-          uuid: 'test-uuid',
-          lastname: 'Smith',
-          dob: '1935-04-07',
-        },
-      };
-
-      const store = createStore(
-        combineReducers({ ...commonReducer, ...reducers }),
-        initialState,
-        applyMiddleware(thunk, vassApi.middleware),
-      );
+      const defaultOptions = getHydratedFormRenderOptions();
 
       const { getByTestId } = renderWithStoreAndRouterV6(
         <>
@@ -307,9 +437,7 @@ describe('VASS Containers: withAuthorization', () => {
           <LocationDisplay />
         </>,
         {
-          reducers,
-          additionalMiddlewares: [vassApi.middleware],
-          store,
+          ...defaultOptions,
           initialEntries: ['/test'],
         },
       );
@@ -320,9 +448,47 @@ describe('VASS Containers: withAuthorization', () => {
         );
       });
 
-      const state = store.getState();
+      const state = defaultOptions.store.getState();
       expect(state.vassForm.selectedDate).to.be.null;
       expect(state.vassForm.selectedTopics).to.deep.equal([]);
+    });
+
+    it('should dispatch clearFormData when redirecting user with expired token to Verify', async () => {
+      setupExpiredToken();
+      const WrappedComponent = withAuthorization(TestComponent);
+
+      const defaultOptions = getHydratedFormRenderOptions();
+
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <>
+          <Routes>
+            <Route path="/test" element={<WrappedComponent />} />
+            <Route
+              path={URLS.VERIFY}
+              element={<div data-testid="verify-page">Verify</div>}
+            />
+          </Routes>
+          <LocationDisplay />
+        </>,
+        {
+          ...defaultOptions,
+          initialEntries: ['/test'],
+        },
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('location-display').textContent).to.include(
+          URLS.VERIFY,
+        );
+      });
+
+      // Verify clearFormData was called (state was reset)
+      const state = defaultOptions.store.getState();
+      expect(state.vassForm.selectedDate).to.be.null;
+      expect(state.vassForm.selectedTopics).to.deep.equal([]);
+
+      // Verify expired token was removed
+      expect(removeVassTokenStub.calledOnce).to.be.true;
     });
   });
 });

--- a/src/applications/vass/containers/withFormData.unit.spec.jsx
+++ b/src/applications/vass/containers/withFormData.unit.spec.jsx
@@ -3,9 +3,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { waitFor } from '@testing-library/react';
 import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
-import { combineReducers, applyMiddleware, createStore } from 'redux';
-import thunk from 'redux-thunk';
-import { commonReducer } from 'platform/startup/store';
 import { renderWithStoreAndRouterV6 } from '~/platform/testing/unit/react-testing-library-helpers';
 
 import withFormData from './withFormData';
@@ -13,8 +10,7 @@ import { URLS } from '../utils/constants';
 import * as formSlice from '../redux/slices/formSlice';
 import {
   getDefaultRenderOptions,
-  reducers,
-  vassApi,
+  getHydratedFormRenderOptions,
 } from '../utils/test-utils';
 
 // Helper component to display current location for testing navigation
@@ -327,24 +323,10 @@ describe('VASS Containers: withFormData', () => {
     it('should dispatch clearFormData when redirecting to Verify route', async () => {
       const WrappedComponent = withFormData(TestComponent, ['uuid']);
 
-      const initialState = {
-        vassForm: {
-          hydrated: true,
-          selectedDate: '2025-01-01',
-          obfuscatedEmail: 's***@example.com',
-          token: 'valid-token',
-          selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
-          uuid: null,
-          lastname: 'Smith',
-          dob: '1935-04-07',
-        },
-      };
-
-      const store = createStore(
-        combineReducers({ ...commonReducer, ...reducers }),
-        initialState,
-        applyMiddleware(thunk, vassApi.middleware),
-      );
+      // Set uuid to null to reroute to Verify page
+      const defaultOptions = getHydratedFormRenderOptions({
+        uuid: null,
+      });
 
       const { getByTestId } = renderWithStoreAndRouterV6(
         <>
@@ -358,9 +340,7 @@ describe('VASS Containers: withFormData', () => {
           <LocationDisplay />
         </>,
         {
-          reducers,
-          additionalMiddlewares: [vassApi.middleware],
-          store,
+          ...defaultOptions,
           initialEntries: ['/test'],
         },
       );
@@ -371,33 +351,18 @@ describe('VASS Containers: withFormData', () => {
         );
       });
 
-      const state = store.getState();
+      const state = defaultOptions.store.getState();
       expect(state.vassForm.selectedDate).to.be.null;
       expect(state.vassForm.selectedTopics).to.deep.equal([]);
-      expect(state.vassForm.token).to.be.null;
     });
 
     it('should not clear form data when redirecting to non-Verify routes', async () => {
       const WrappedComponent = withFormData(TestComponent, ['selectedDate']);
 
-      const initialState = {
-        vassForm: {
-          hydrated: true,
-          selectedDate: null,
-          obfuscatedEmail: 's***@example.com',
-          token: 'valid-token',
-          selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
-          uuid: 'test-uuid',
-          lastname: 'Smith',
-          dob: '1935-04-07',
-        },
-      };
-
-      const store = createStore(
-        combineReducers({ ...commonReducer, ...reducers }),
-        initialState,
-        applyMiddleware(thunk, vassApi.middleware),
-      );
+      // Set selectedDate to reroute to Date Time page
+      const defaultOptions = getHydratedFormRenderOptions({
+        selectedDate: null,
+      });
 
       const { getByTestId } = renderWithStoreAndRouterV6(
         <>
@@ -411,9 +376,7 @@ describe('VASS Containers: withFormData', () => {
           <LocationDisplay />
         </>,
         {
-          reducers,
-          additionalMiddlewares: [vassApi.middleware],
-          store,
+          ...defaultOptions,
           initialEntries: ['/test'],
         },
       );
@@ -424,9 +387,8 @@ describe('VASS Containers: withFormData', () => {
         );
       });
 
-      const state = store.getState();
+      const state = defaultOptions.store.getState();
       // Form data should NOT be cleared when redirecting to non-Verify routes
-      expect(state.vassForm.token).to.equal('valid-token');
       expect(state.vassForm.uuid).to.equal('test-uuid');
     });
   });

--- a/src/applications/vass/redux/api/vassApi.js
+++ b/src/applications/vass/redux/api/vassApi.js
@@ -1,14 +1,14 @@
 import environment from 'platform/utilities/environment';
-import Cookies from 'js-cookie';
 import { apiRequest } from 'platform/utilities/api';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { setObfuscatedEmail, setLowAuthFormData } from '../slices/formSlice';
-import { VASS_TOKEN_COOKIE_NAME } from '../../utils/constants';
+import { setVassToken, getVassToken } from '../../utils/auth';
 
 const api = async (url, options, ...rest) => {
   return apiRequest(`${environment.API_URL}${url}`, options, ...rest);
 };
 
+// TODO if token is not found reject the requets
 export const vassApi = createApi({
   reducerPath: 'vassApi',
   baseQuery: () => ({ data: null }),
@@ -66,14 +66,11 @@ export const vassApi = createApi({
           };
         }
       },
-      async onQueryStarted(arg, { queryFulfilled }) {
+      async onQueryStarted(_, { queryFulfilled }) {
         try {
           const { data } = await queryFulfilled;
           if (data?.token) {
-            Cookies.set(VASS_TOKEN_COOKIE_NAME, data.token, {
-              secure: true,
-              sameSite: 'Strict',
-            });
+            setVassToken(data.token);
           }
         } catch {
           // Error is handled by the queryFn
@@ -81,9 +78,9 @@ export const vassApi = createApi({
       },
     }),
     postAppointment: builder.mutation({
-      async queryFn({ topics, dtStartUtc, dtEndUtc }, { getState }) {
+      async queryFn({ topics, dtStartUtc, dtEndUtc }) {
         try {
-          const { token } = getState().vassForm;
+          const token = getVassToken();
           return await api('/vass/v0/appointment', {
             method: 'POST',
             headers: {
@@ -106,9 +103,9 @@ export const vassApi = createApi({
       },
     }),
     getAppointment: builder.query({
-      async queryFn({ appointmentId }, { getState }) {
+      async queryFn({ appointmentId }) {
         try {
-          const { token } = getState().vassForm;
+          const token = getVassToken();
           return await api(`/vass/v0/appointment/${appointmentId}`, {
             method: 'GET',
             headers: {
@@ -126,9 +123,9 @@ export const vassApi = createApi({
       },
     }),
     getTopics: builder.query({
-      async queryFn(arg, { getState }) {
+      async queryFn() {
         try {
-          const { token } = getState().vassForm;
+          const token = getVassToken();
           return await api('/vass/v0/topics', {
             method: 'GET',
             headers: {
@@ -146,9 +143,9 @@ export const vassApi = createApi({
       },
     }),
     getAppointmentAvailability: builder.query({
-      async queryFn(arg, { getState }) {
+      async queryFn() {
         try {
-          const { token } = getState().vassForm;
+          const token = getVassToken();
           return await api('/vass/v0/appointment-availablity', {
             method: 'GET',
             headers: {

--- a/src/applications/vass/redux/api/vassApi.js
+++ b/src/applications/vass/redux/api/vassApi.js
@@ -1,11 +1,9 @@
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import environment from 'platform/utilities/environment';
+import Cookies from 'js-cookie';
 import { apiRequest } from 'platform/utilities/api';
 import { createApi } from '@reduxjs/toolkit/query/react';
-import {
-  setObfuscatedEmail,
-  setToken,
-  setLowAuthFormData,
-} from '../slices/formSlice';
+import { setObfuscatedEmail, setLowAuthFormData } from '../slices/formSlice';
+import { VASS_TOKEN_COOKIE_NAME } from '../../utils/constants';
 
 const api = async (url, options, ...rest) => {
   return apiRequest(`${environment.API_URL}${url}`, options, ...rest);
@@ -68,11 +66,14 @@ export const vassApi = createApi({
           };
         }
       },
-      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+      async onQueryStarted(arg, { queryFulfilled }) {
         try {
           const { data } = await queryFulfilled;
           if (data?.token) {
-            dispatch(setToken(data.token));
+            Cookies.set(VASS_TOKEN_COOKIE_NAME, data.token, {
+              secure: true,
+              sameSite: 'Strict',
+            });
           }
         } catch {
           // Error is handled by the queryFn

--- a/src/applications/vass/redux/slices/formSlice.js
+++ b/src/applications/vass/redux/slices/formSlice.js
@@ -67,13 +67,12 @@ const clearFormDataFromStorage = () => {
 };
 
 /** @typedef {{ topicId: string, topicName: string }} Topic */
-/** @type {{ selectedDate: Date | null, selectedTopics: Topic[], obfuscatedEmail: string | null, uuid: string | null, token: string | null, lastname: string | null, dob: string | null }} */
+/** @type {{ selectedDate: Date | null, selectedTopics: Topic[], obfuscatedEmail: string | null, uuid: string | null, lastname: string | null, dob: string | null }} */
 const initialState = {
   hydrated: false,
   selectedDate: null,
   selectedTopics: [],
   obfuscatedEmail: null,
-  token: null,
   uuid: null,
   lastname: null,
   dob: null,
@@ -99,12 +98,6 @@ export const formSlice = createSlice({
           ...state,
           selectedTopics: action.payload,
         });
-      }
-    },
-    setToken: (state, action) => {
-      state.token = action.payload;
-      if (state.uuid) {
-        saveFormDataToStorage(state.uuid, { ...state, token: action.payload });
       }
     },
     setObfuscatedEmail: (state, action) => {
@@ -135,7 +128,6 @@ export const formSlice = createSlice({
       state.selectedTopics = [];
       state.obfuscatedEmail = null;
       state.uuid = null;
-      state.token = null;
       state.lastname = null;
       state.dob = null;
       state.hydrated = false;
@@ -154,9 +146,6 @@ export const formSlice = createSlice({
       if (action.payload.obfuscatedEmail) {
         state.obfuscatedEmail = action.payload.obfuscatedEmail;
       }
-      if (action.payload.token) {
-        state.token = action.payload.token;
-      }
       if (action.payload.selectedDate) {
         state.selectedDate = action.payload.selectedDate;
       }
@@ -171,7 +160,6 @@ export const {
   setSelectedDate,
   setSelectedTopics,
   setLowAuthFormData,
-  setToken,
   setObfuscatedEmail,
   clearFormData,
   hydrateFormData,
@@ -181,7 +169,6 @@ export const selectSelectedDate = state => state.vassForm.selectedDate;
 export const selectSelectedTopics = state => state.vassForm.selectedTopics;
 export const selectUuid = state => state.vassForm.uuid;
 export const selectHydrated = state => state.vassForm.hydrated;
-export const selectToken = state => state.vassForm.token;
 export const selectObfuscatedEmail = state => state.vassForm.obfuscatedEmail;
 export const selectLastname = state => state.vassForm.lastname;
 export const selectDob = state => state.vassForm.dob;

--- a/src/applications/vass/redux/slices/formSlice.unit.spec.jsx
+++ b/src/applications/vass/redux/slices/formSlice.unit.spec.jsx
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import formReducer, {
   setSelectedDate,
   setSelectedTopics,
-  setToken,
   setObfuscatedEmail,
   setLowAuthFormData,
   clearFormData,
@@ -11,7 +10,6 @@ import formReducer, {
   selectSelectedDate,
   selectSelectedTopics,
   selectHydrated,
-  selectToken,
   selectObfuscatedEmail,
   selectUuid,
   selectLastname,
@@ -27,7 +25,6 @@ describe('formSlice', () => {
         selectedDate: null,
         selectedTopics: [],
         obfuscatedEmail: null,
-        token: null,
         uuid: null,
         lastname: null,
         dob: null,
@@ -41,7 +38,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -59,7 +55,6 @@ describe('formSlice', () => {
           selectedDate: '2025-01-15T10:00:00.000Z',
           selectedTopics: ['topic-1'],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -82,7 +77,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -100,7 +94,6 @@ describe('formSlice', () => {
           selectedDate: '2025-01-15T10:00:00.000Z',
           selectedTopics: ['topic-1'],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -118,7 +111,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: ['topic-1', 'topic-2'],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -129,42 +121,6 @@ describe('formSlice', () => {
       });
     });
 
-    describe('setToken', () => {
-      it('should set the token', () => {
-        const initialState = {
-          hydrated: false,
-          selectedDate: null,
-          selectedTopics: [],
-          obfuscatedEmail: null,
-          token: null,
-          uuid: null,
-          lastname: null,
-          dob: null,
-        };
-        const token = 'abc123';
-        const actual = formReducer(initialState, setToken(token));
-
-        expect(actual.token).to.equal(token);
-      });
-
-      it('should update the token when one already exists', () => {
-        const initialState = {
-          hydrated: false,
-          selectedDate: null,
-          selectedTopics: [],
-          obfuscatedEmail: null,
-          token: 'old-token',
-          uuid: null,
-          lastname: null,
-          dob: null,
-        };
-        const newToken = 'new-token';
-        const actual = formReducer(initialState, setToken(newToken));
-
-        expect(actual.token).to.equal(newToken);
-      });
-    });
-
     describe('setObfuscatedEmail', () => {
       it('should set the obfuscated email', () => {
         const initialState = {
@@ -172,7 +128,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -189,7 +144,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: 'old***@example.com',
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -208,7 +162,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -231,7 +184,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: null,
-          token: null,
           uuid: 'old-uuid',
           lastname: 'OldName',
           dob: '1980-05-20',
@@ -256,7 +208,6 @@ describe('formSlice', () => {
           selectedDate: '2025-01-15T10:00:00.000Z',
           selectedTopics: ['topic-1', 'topic-2'],
           obfuscatedEmail: 't***@example.com',
-          token: 'abc123',
           uuid: 'c0ffee-1234-beef-5678',
           lastname: 'Doe',
           dob: '1990-01-15',
@@ -267,7 +218,6 @@ describe('formSlice', () => {
         expect(actual.selectedDate).to.be.null;
         expect(actual.selectedTopics).to.deep.equal([]);
         expect(actual.obfuscatedEmail).to.be.null;
-        expect(actual.token).to.be.null;
         expect(actual.uuid).to.be.null;
         expect(actual.lastname).to.be.null;
         expect(actual.dob).to.be.null;
@@ -279,7 +229,6 @@ describe('formSlice', () => {
           selectedDate: null,
           selectedTopics: [],
           obfuscatedEmail: null,
-          token: null,
           uuid: null,
           lastname: null,
           dob: null,
@@ -290,7 +239,6 @@ describe('formSlice', () => {
         expect(actual.selectedDate).to.be.null;
         expect(actual.selectedTopics).to.deep.equal([]);
         expect(actual.obfuscatedEmail).to.be.null;
-        expect(actual.token).to.be.null;
         expect(actual.uuid).to.be.null;
         expect(actual.lastname).to.be.null;
         expect(actual.dob).to.be.null;
@@ -302,7 +250,6 @@ describe('formSlice', () => {
         const payload = {
           selectedDate: '2025-03-01T10:00:00.000Z',
           selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
-          token: null,
           uuid: null,
         };
         const actual = formReducer(undefined, hydrateFormData(payload));
@@ -319,7 +266,6 @@ describe('formSlice', () => {
           lastname: 'Smith',
           dob: '1985-05-15',
           obfuscatedEmail: 's***@example.com',
-          token: 'test-token',
           selectedDate: '2025-04-01T14:00:00.000Z',
           selectedTopics: [{ topicId: '2', topicName: 'Topic 2' }],
         };
@@ -330,7 +276,6 @@ describe('formSlice', () => {
         expect(actual.lastname).to.equal(payload.lastname);
         expect(actual.dob).to.equal(payload.dob);
         expect(actual.obfuscatedEmail).to.equal(payload.obfuscatedEmail);
-        expect(actual.token).to.equal(payload.token);
         expect(actual.selectedDate).to.equal(payload.selectedDate);
         expect(actual.selectedTopics).to.deep.equal(payload.selectedTopics);
       });
@@ -355,7 +300,6 @@ describe('formSlice', () => {
             selectedDate: '2025-01-15T10:00:00.000Z',
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -372,7 +316,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -391,7 +334,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: ['topic-1', 'topic-2'],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -408,7 +350,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -427,7 +368,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -435,42 +375,6 @@ describe('formSlice', () => {
         };
         const result = selectHydrated(state);
         expect(result).to.be.true;
-      });
-    });
-
-    describe('selectToken', () => {
-      it('should select the token from state', () => {
-        const state = {
-          vassForm: {
-            hydrated: false,
-            selectedDate: null,
-            selectedTopics: [],
-            obfuscatedEmail: null,
-            token: 'abc123',
-            uuid: null,
-            lastname: null,
-            dob: null,
-          },
-        };
-        const result = selectToken(state);
-        expect(result).to.equal('abc123');
-      });
-
-      it('should return null when no token is set', () => {
-        const state = {
-          vassForm: {
-            hydrated: false,
-            selectedDate: null,
-            selectedTopics: [],
-            obfuscatedEmail: null,
-            token: null,
-            uuid: null,
-            lastname: null,
-            dob: null,
-          },
-        };
-        const result = selectToken(state);
-        expect(result).to.be.null;
       });
     });
 
@@ -482,7 +386,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: 't***@example.com',
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -499,7 +402,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -518,7 +420,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: 'c0ffee-1234-beef-5678',
             lastname: null,
             dob: null,
@@ -537,7 +438,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: 'Doe',
             dob: null,
@@ -554,7 +454,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,
@@ -573,7 +472,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: '1990-01-15',
@@ -590,7 +488,6 @@ describe('formSlice', () => {
             selectedDate: null,
             selectedTopics: [],
             obfuscatedEmail: null,
-            token: null,
             uuid: null,
             lastname: null,
             dob: null,

--- a/src/applications/vass/services/mocks/index.js
+++ b/src/applications/vass/services/mocks/index.js
@@ -2,11 +2,8 @@
 /* eslint-disable camelcase */
 const delay = require('mocker-api/lib/delay');
 const mockTopics = require('./utils/topic');
-const {
-  generateSlots,
-  createMockJwt,
-  decodeJwtUuid,
-} = require('../../utils/mock-helpers');
+const { generateSlots, createMockJwt } = require('../../utils/mock-helpers');
+const { decodeJwt } = require('../../utils/auth');
 
 const mockUUIDs = Object.freeze({
   'c0ffee-1234-beef-5678': {
@@ -176,10 +173,9 @@ const responses = {
         errors: [{ code: 'unauthorized', detail: 'Unauthorized' }],
       });
     }
-    const uuid = decodeJwtUuid(token);
+    const uuid = decodeJwt(token).sub;
     return res.json({
       data: {
-        // TODO: extract this from the token
         appointmentId: uuid,
         availableTimeSlots: generateSlots(),
       },

--- a/src/applications/vass/services/mocks/index.js
+++ b/src/applications/vass/services/mocks/index.js
@@ -3,7 +3,7 @@
 const delay = require('mocker-api/lib/delay');
 const mockTopics = require('./utils/topic');
 const { generateSlots, createMockJwt } = require('../../utils/mock-helpers');
-const { decodeJwt } = require('../../utils/auth');
+const { decodeJwt } = require('../../utils/jwt-utils');
 
 const mockUUIDs = Object.freeze({
   'c0ffee-1234-beef-5678': {
@@ -167,13 +167,15 @@ const responses = {
   },
   'GET /vass/v0/appointment-availablity': (req, res) => {
     const { headers } = req;
-    const token = headers.authorization;
-    if (!token) {
+    const [, token] = headers.authorization?.split(' ') || [];
+    const tokenPayload = decodeJwt(token);
+
+    const uuid = tokenPayload?.payload?.sub;
+    if (!token || !uuid) {
       return res.status(401).json({
         errors: [{ code: 'unauthorized', detail: 'Unauthorized' }],
       });
     }
-    const uuid = decodeJwt(token).sub;
     return res.json({
       data: {
         appointmentId: uuid,

--- a/src/applications/vass/utils/auth.js
+++ b/src/applications/vass/utils/auth.js
@@ -1,0 +1,78 @@
+import Cookies from 'js-cookie';
+import { VASS_TOKEN_COOKIE_NAME } from './constants';
+
+/**
+ * Base64 URL decode a string (browser-compatible)
+ * @param {string} data - The base64url encoded string to decode
+ * @returns {string} Decoded string
+ */
+const base64UrlDecode = data => {
+  if (!data) return null;
+
+  // Convert base64url to base64
+  let base64 = data.replace(/-/g, '+').replace(/_/g, '/');
+
+  // Add padding if needed
+  const padding = base64.length % 4;
+  if (padding) {
+    base64 += '='.repeat(4 - padding);
+  }
+
+  return atob(base64);
+};
+
+/**
+ * Decodes a JWT token and extracts the payload.
+ * Note: This does NOT verify the signature.
+ *
+ * @param {string} token - The JWT token to decode
+ * @returns {Object|null} The decoded payload, or null if invalid
+ */
+export const decodeJwt = token => {
+  if (!token) return null;
+
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    return JSON.parse(base64UrlDecode(parts[1]));
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Checks if a JWT token is expired.
+ *
+ * @param {string} token - The JWT token to check
+ * @returns {boolean} True if the token is expired or invalid, false otherwise
+ */
+export const isTokenExpired = token => {
+  const payload = decodeJwt(token);
+  if (!payload || !payload.exp) return true;
+
+  // exp is in seconds, Date.now() is in milliseconds
+  const now = Math.floor(Date.now() / 1000);
+  return payload.exp <= now;
+};
+
+export const getVassToken = () => Cookies.get(VASS_TOKEN_COOKIE_NAME);
+
+/**
+ * Gets the VASS token if it exists and is not expired.
+ * @returns {string|null} The token if valid, null if missing or expired
+ */
+export const getValidVassToken = () => {
+  const token = getVassToken();
+  if (!token || isTokenExpired(token)) {
+    return null;
+  }
+  return token;
+};
+
+/**
+ * Removes the VASS token cookie.
+ */
+export const removeVassToken = () => {
+  Cookies.remove(VASS_TOKEN_COOKIE_NAME);
+};

--- a/src/applications/vass/utils/auth.js
+++ b/src/applications/vass/utils/auth.js
@@ -9,12 +9,16 @@ import { decodeJwt } from './jwt-utils';
  * @returns {boolean} True if the token is expired or invalid, false otherwise
  */
 export const isTokenExpired = token => {
-  const { payload } = decodeJwt(token);
-  if (!payload || !payload.exp) return true;
+  try {
+    const { payload } = decodeJwt(token) || {};
+    if (!payload || !payload.exp) return true;
 
-  // exp is in seconds, Date.now() is in milliseconds
-  const now = Math.floor(Date.now() / 1000);
-  return payload.exp <= now;
+    // exp is in seconds, Date.now() is in milliseconds
+    const now = Math.floor(Date.now() / 1000);
+    return payload.exp <= now;
+  } catch (error) {
+    return true;
+  }
 };
 
 /**
@@ -25,7 +29,7 @@ export const getVassToken = () => Cookies.get(VASS_TOKEN_COOKIE_NAME);
 
 export const setVassToken = token => {
   if (!token) return;
-  const { payload } = decodeJwt(token);
+  const { payload } = decodeJwt(token) || {};
   if (!payload || !payload.exp) return;
 
   // Convert the expiration time from seconds to milliseconds and create a Date object

--- a/src/applications/vass/utils/auth.unit.spec.jsx
+++ b/src/applications/vass/utils/auth.unit.spec.jsx
@@ -2,48 +2,16 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import Cookies from 'js-cookie';
 import {
-  decodeJwt,
   isTokenExpired,
   getVassToken,
   getValidVassToken,
   removeVassToken,
+  setVassToken,
 } from './auth';
 import { createMockJwt } from './mock-helpers';
 import { VASS_TOKEN_COOKIE_NAME } from './constants';
 
 describe('VASS Utils: auth', () => {
-  describe('decodeJwt', () => {
-    it('should decode a valid JWT and return the payload', () => {
-      const token = createMockJwt('test-uuid-123');
-      const payload = decodeJwt(token);
-
-      expect(payload).to.be.an('object');
-      expect(payload.sub).to.equal('test-uuid-123');
-      expect(payload.jti).to.equal('mock-jti');
-      expect(payload).to.have.property('iat');
-      expect(payload).to.have.property('exp');
-    });
-
-    it('should return null for null or undefined token', () => {
-      expect(decodeJwt(null)).to.be.null;
-      expect(decodeJwt(undefined)).to.be.null;
-    });
-
-    it('should return null for empty string', () => {
-      expect(decodeJwt('')).to.be.null;
-    });
-
-    it('should return null for invalid JWT format (not 3 parts)', () => {
-      expect(decodeJwt('invalid-token')).to.be.null;
-      expect(decodeJwt('only.two')).to.be.null;
-      expect(decodeJwt('too.many.parts.here')).to.be.null;
-    });
-
-    it('should return null for malformed base64 payload', () => {
-      expect(decodeJwt('header.!!!invalid!!!.signature')).to.be.null;
-    });
-  });
-
   describe('isTokenExpired', () => {
     it('should return false for a valid non-expired token', () => {
       const token = createMockJwt('test-uuid', 3600); // expires in 1 hour
@@ -163,6 +131,15 @@ describe('VASS Utils: auth', () => {
       removeVassToken();
 
       expect(cookiesRemoveStub.calledWith(VASS_TOKEN_COOKIE_NAME)).to.be.true;
+    });
+  });
+
+  describe('setVassToken', () => {
+    it('should set the VASS token in cookies', () => {
+      const token = createMockJwt('test-uuid');
+      setVassToken(token);
+
+      expect(Cookies.get(VASS_TOKEN_COOKIE_NAME)).to.equal(token);
     });
   });
 });

--- a/src/applications/vass/utils/auth.unit.spec.jsx
+++ b/src/applications/vass/utils/auth.unit.spec.jsx
@@ -1,0 +1,168 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Cookies from 'js-cookie';
+import {
+  decodeJwt,
+  isTokenExpired,
+  getVassToken,
+  getValidVassToken,
+  removeVassToken,
+} from './auth';
+import { createMockJwt } from './mock-helpers';
+import { VASS_TOKEN_COOKIE_NAME } from './constants';
+
+describe('VASS Utils: auth', () => {
+  describe('decodeJwt', () => {
+    it('should decode a valid JWT and return the payload', () => {
+      const token = createMockJwt('test-uuid-123');
+      const payload = decodeJwt(token);
+
+      expect(payload).to.be.an('object');
+      expect(payload.sub).to.equal('test-uuid-123');
+      expect(payload.jti).to.equal('mock-jti');
+      expect(payload).to.have.property('iat');
+      expect(payload).to.have.property('exp');
+    });
+
+    it('should return null for null or undefined token', () => {
+      expect(decodeJwt(null)).to.be.null;
+      expect(decodeJwt(undefined)).to.be.null;
+    });
+
+    it('should return null for empty string', () => {
+      expect(decodeJwt('')).to.be.null;
+    });
+
+    it('should return null for invalid JWT format (not 3 parts)', () => {
+      expect(decodeJwt('invalid-token')).to.be.null;
+      expect(decodeJwt('only.two')).to.be.null;
+      expect(decodeJwt('too.many.parts.here')).to.be.null;
+    });
+
+    it('should return null for malformed base64 payload', () => {
+      expect(decodeJwt('header.!!!invalid!!!.signature')).to.be.null;
+    });
+  });
+
+  describe('isTokenExpired', () => {
+    it('should return false for a valid non-expired token', () => {
+      const token = createMockJwt('test-uuid', 3600); // expires in 1 hour
+      expect(isTokenExpired(token)).to.be.false;
+    });
+
+    it('should return true for an expired token', () => {
+      const token = createMockJwt('test-uuid', -3600); // expired 1 hour ago
+      expect(isTokenExpired(token)).to.be.true;
+    });
+
+    it('should return true for a token that expired exactly now', () => {
+      const token = createMockJwt('test-uuid', 0); // expires now
+      expect(isTokenExpired(token)).to.be.true;
+    });
+
+    it('should return true for null or undefined token', () => {
+      expect(isTokenExpired(null)).to.be.true;
+      expect(isTokenExpired(undefined)).to.be.true;
+    });
+
+    it('should return true for invalid token', () => {
+      expect(isTokenExpired('invalid-token')).to.be.true;
+    });
+
+    it('should return true for token without exp claim', () => {
+      // Create a token-like string without exp
+      const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+      const payload = btoa(JSON.stringify({ sub: 'test', iat: 123 })); // no exp
+      const signature = btoa('signature');
+      const tokenWithoutExp = `${header}.${payload}.${signature}`;
+
+      expect(isTokenExpired(tokenWithoutExp)).to.be.true;
+    });
+  });
+
+  describe('getVassToken', () => {
+    let cookiesGetStub;
+
+    beforeEach(() => {
+      cookiesGetStub = sinon.stub(Cookies, 'get');
+    });
+
+    afterEach(() => {
+      cookiesGetStub.restore();
+    });
+
+    it('should return the VASS token from cookies', () => {
+      const mockToken = createMockJwt('test-uuid');
+      cookiesGetStub.withArgs(VASS_TOKEN_COOKIE_NAME).returns(mockToken);
+
+      const token = getVassToken();
+
+      expect(cookiesGetStub.calledWith(VASS_TOKEN_COOKIE_NAME)).to.be.true;
+      expect(token).to.equal(mockToken);
+    });
+
+    it('should return undefined when no token exists', () => {
+      cookiesGetStub.withArgs(VASS_TOKEN_COOKIE_NAME).returns(undefined);
+
+      const token = getVassToken();
+
+      expect(token).to.be.undefined;
+    });
+  });
+
+  describe('getValidVassToken', () => {
+    let cookiesGetStub;
+
+    beforeEach(() => {
+      cookiesGetStub = sinon.stub(Cookies, 'get');
+    });
+
+    afterEach(() => {
+      cookiesGetStub.restore();
+    });
+
+    it('should return the token when it exists and is not expired', () => {
+      const validToken = createMockJwt('test-uuid', 3600);
+      cookiesGetStub.withArgs(VASS_TOKEN_COOKIE_NAME).returns(validToken);
+
+      const token = getValidVassToken();
+
+      expect(token).to.equal(validToken);
+    });
+
+    it('should return null when token does not exist', () => {
+      cookiesGetStub.withArgs(VASS_TOKEN_COOKIE_NAME).returns(undefined);
+
+      const token = getValidVassToken();
+
+      expect(token).to.be.null;
+    });
+
+    it('should return null when token is expired', () => {
+      const expiredToken = createMockJwt('test-uuid', -3600);
+      cookiesGetStub.withArgs(VASS_TOKEN_COOKIE_NAME).returns(expiredToken);
+
+      const token = getValidVassToken();
+
+      expect(token).to.be.null;
+    });
+  });
+
+  describe('removeVassToken', () => {
+    let cookiesRemoveStub;
+
+    beforeEach(() => {
+      cookiesRemoveStub = sinon.stub(Cookies, 'remove');
+    });
+
+    afterEach(() => {
+      cookiesRemoveStub.restore();
+    });
+
+    it('should call Cookies.remove with the correct cookie name', () => {
+      removeVassToken();
+
+      expect(cookiesRemoveStub.calledWith(VASS_TOKEN_COOKIE_NAME)).to.be.true;
+    });
+  });
+});

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -27,3 +27,12 @@ export const AUTH_LEVELS = {
 };
 
 export const VASS_TOKEN_COOKIE_NAME = 'VASS_TOKEN';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export const VASS_COOKIE_OPTIONS = {
+  secure: isProduction,
+  sameSite: isProduction ? 'strict' : undefined,
+  path: '/',
+  ...(isProduction ? { domain: 'va.gov' } : {}),
+};

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -25,3 +25,5 @@ export const AUTH_LEVELS = {
   /** Requires a valid authentication token */
   TOKEN: 'token',
 };
+
+export const VASS_TOKEN_COOKIE_NAME = 'VASS_TOKEN';

--- a/src/applications/vass/utils/jwt-utils.js
+++ b/src/applications/vass/utils/jwt-utils.js
@@ -1,0 +1,69 @@
+/**
+ * Base64 URL encode a string (for mock JWT creation)
+ * @param {string} data - The string to encode
+ * @returns {string} Base64 URL encoded string
+ */
+function base64UrlEncode(data) {
+  if (!data) {
+    return null;
+  }
+
+  const base64 = Buffer.from(data, 'utf8').toString('base64');
+
+  return base64
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/**
+ * Base64 URL decode a string (browser-compatible)
+ * @param {string} data - The base64url encoded string to decode
+ * @returns {string} Decoded string
+ */
+function base64UrlDecode(data) {
+  if (!data) return null;
+
+  // Convert base64url to base64
+  let base64 = data.replace(/-/g, '+').replace(/_/g, '/');
+
+  // Add padding if needed
+  const padding = base64.length % 4;
+  if (padding) {
+    base64 += '='.repeat(4 - padding);
+  }
+
+  // TODO: use Buffer.from(base64, 'base64').toString('utf-8') instead of atob
+  return Buffer.from(base64, 'base64').toString('utf-8');
+}
+
+/**
+ * Decodes a JWT token and extracts the payload.
+ * Note: This does NOT verify the signature.
+ *
+ * @param {string} token - The JWT token to decode
+ * @returns {Object|null} The decoded payload, or null if invalid
+ */
+function decodeJwt(token) {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid JWT format');
+  }
+
+  const decode = str => {
+    const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(Buffer.from(base64, 'base64').toString('utf-8'));
+  };
+
+  return {
+    header: decode(parts[0]),
+    payload: decode(parts[1]),
+    signature: parts[2],
+  };
+}
+
+module.exports = {
+  base64UrlEncode,
+  base64UrlDecode,
+  decodeJwt,
+};

--- a/src/applications/vass/utils/jwt-utils.js
+++ b/src/applications/vass/utils/jwt-utils.js
@@ -45,6 +45,7 @@ function base64UrlDecode(data) {
  * @returns {Object|null} The decoded payload, or null if invalid
  */
 function decodeJwt(token) {
+  if (!token || typeof token !== 'string') return null;
   const parts = token.split('.');
   if (parts.length !== 3) {
     throw new Error('Invalid JWT format');

--- a/src/applications/vass/utils/jwt-utils.unit.spec.jsx
+++ b/src/applications/vass/utils/jwt-utils.unit.spec.jsx
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { base64UrlEncode, base64UrlDecode, decodeJwt } from './jwt-utils';
+import { createMockJwt } from './mock-helpers';
+
+describe('VASS Utils: jwt-utils', () => {
+  describe('base64UrlEncode', () => {
+    it('should encode a string to base64url format', () => {
+      const input = 'Hello, World!';
+      const encoded = base64UrlEncode(input);
+
+      expect(encoded).to.be.a('string');
+      // base64url should not contain +, /, or = characters
+      expect(encoded).to.not.include('+');
+      expect(encoded).to.not.include('/');
+      expect(encoded).to.not.include('=');
+    });
+
+    it('should return null for empty or falsy input', () => {
+      expect(base64UrlEncode(null)).to.be.null;
+      expect(base64UrlEncode(undefined)).to.be.null;
+      expect(base64UrlEncode('')).to.be.null;
+    });
+  });
+
+  describe('base64UrlDecode', () => {
+    it('should decode a base64url encoded string', () => {
+      const original = 'Hello, World!';
+      const encoded = base64UrlEncode(original);
+      const decoded = base64UrlDecode(encoded);
+
+      expect(decoded).to.equal(original);
+    });
+
+    it('should return null for empty or falsy input', () => {
+      expect(base64UrlDecode(null)).to.be.null;
+      expect(base64UrlDecode(undefined)).to.be.null;
+      expect(base64UrlDecode('')).to.be.null;
+    });
+
+    it('should handle strings that need padding', () => {
+      // Test with a string that produces base64 without padding
+      const testData = 'test';
+      const encoded = base64UrlEncode(testData);
+      const decoded = base64UrlDecode(encoded);
+
+      expect(decoded).to.equal(testData);
+    });
+  });
+
+  describe('decodeJwt', () => {
+    it('should decode a valid JWT and return header, payload, and signature', () => {
+      const token = createMockJwt('test-uuid-123');
+      const result = decodeJwt(token);
+
+      expect(result).to.be.an('object');
+      expect(result).to.have.property('header');
+      expect(result).to.have.property('payload');
+      expect(result).to.have.property('signature');
+
+      // Check header
+      expect(result.header).to.deep.include({ alg: 'HS256', typ: 'JWT' });
+
+      // Check payload
+      expect(result.payload.sub).to.equal('test-uuid-123');
+      expect(result.payload.jti).to.equal('mock-jti');
+      expect(result.payload).to.have.property('iat');
+      expect(result.payload).to.have.property('exp');
+    });
+
+    it('should throw an error for invalid JWT format (not 3 parts)', () => {
+      expect(() => decodeJwt('invalid-token')).to.throw('Invalid JWT format');
+      expect(() => decodeJwt('only.two')).to.throw('Invalid JWT format');
+      expect(() => decodeJwt('too.many.parts.here')).to.throw(
+        'Invalid JWT format',
+      );
+    });
+
+    it('should throw an error for malformed base64 payload', () => {
+      expect(() => decodeJwt('header.!!!invalid!!!.signature')).to.throw();
+    });
+  });
+});

--- a/src/applications/vass/utils/mock-helpers.js
+++ b/src/applications/vass/utils/mock-helpers.js
@@ -1,5 +1,6 @@
 const { addDays, addMinutes, format } = require('date-fns');
 const { zonedTimeToUtc } = require('date-fns-tz');
+const { base64UrlEncode } = require('./jwt-utils');
 
 const TZ_ET = 'America/New_York';
 const TZ_PT = 'America/Los_Angeles';
@@ -78,22 +79,6 @@ const generateSlots = (numberOfDays = 14, slotsPerDay = 12) => {
     return slots;
   });
 };
-
-/**
- * Base64 URL encode a string (for mock JWT creation)
- * @param {string} data - The string to encode
- * @returns {string} Base64 URL encoded string
- */
-function base64UrlEncode(data) {
-  if (!data) return null;
-
-  const base64 = Buffer.from(data, 'utf8').toString('base64');
-
-  return base64
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-}
 
 /**
  * Creates a mock JWT token for testing purposes.

--- a/src/applications/vass/utils/mock-helpers.js
+++ b/src/applications/vass/utils/mock-helpers.js
@@ -96,47 +96,6 @@ function base64UrlEncode(data) {
 }
 
 /**
- * Base64 URL decode a string
- * @param {string} data - The base64url encoded string to decode
- * @returns {string} Decoded string
- */
-function base64UrlDecode(data) {
-  if (!data) return null;
-
-  // Convert base64url to base64
-  let base64 = data.replace(/-/g, '+').replace(/_/g, '/');
-
-  // Add padding if needed
-  const padding = base64.length % 4;
-  if (padding) {
-    base64 += '='.repeat(4 - padding);
-  }
-
-  return Buffer.from(base64, 'base64').toString('utf8');
-}
-
-/**
- * Decodes a JWT token and extracts the uuid from the payload.
- * Note: This does NOT verify the signature - for mock/testing purposes only.
- *
- * @param {string} token - The JWT token to decode
- * @returns {string|null} The uuid from the token payload, or null if not found
- */
-function decodeJwtUuid(token) {
-  if (!token) return null;
-
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-
-    const payload = JSON.parse(base64UrlDecode(parts[1]));
-    return payload.uuid || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Creates a mock JWT token for testing purposes.
  *
  * @param {string} uuid - The UUID of the start schedule url param
@@ -144,13 +103,14 @@ function decodeJwtUuid(token) {
  * @returns {string} The mock JWT token
  */
 function createMockJwt(uuid, expiresIn = 3600) {
+  const now = Math.floor(Date.now() / 1000);
   const header = { alg: 'HS256', typ: 'JWT' };
   // TODO: confirm the payload structure
   const defaultPayload = {
-    sub: '1234567890',
-    iat: Math.floor(Date.now() / 1000),
-    exp: Math.floor(Date.now() / 1000) + expiresIn,
-    uuid,
+    sub: uuid,
+    jti: 'mock-jti',
+    iat: now,
+    exp: now + expiresIn,
   };
 
   const encodedHeader = base64UrlEncode(JSON.stringify(header));
@@ -160,4 +120,4 @@ function createMockJwt(uuid, expiresIn = 3600) {
   return `${encodedHeader}.${encodedPayload}.${mockSignature}`;
 }
 
-module.exports = { generateSlots, createMockJwt, decodeJwtUuid };
+module.exports = { generateSlots, createMockJwt };

--- a/src/applications/vass/utils/test-utils.js
+++ b/src/applications/vass/utils/test-utils.js
@@ -4,7 +4,11 @@
  * This module provides shared test helpers to avoid duplicating redux state
  * configuration across multiple test files.
  */
+import { combineReducers, applyMiddleware, createStore } from 'redux';
+import thunk from 'redux-thunk';
+import { commonReducer } from 'platform/startup/store';
 import reducers from '../redux/reducers';
+
 import { vassApi } from '../redux/api/vassApi';
 
 /**
@@ -17,7 +21,6 @@ import { vassApi } from '../redux/api/vassApi';
  * @property {string | null} selectedDate - The selected appointment date (ISO 8601 string)
  * @property {Topic[]} selectedTopics - Array of selected discussion topics
  * @property {string | null} obfuscatedEmail - Partially hidden email for display
- * @property {string | null} token - Authentication token
  * @property {string | null} uuid - Unique identifier from the appointment URL
  * @property {string | null} lastname - User's last name for verification
  * @property {string | null} dob - User's date of birth for verification (YYYY-MM-DD)
@@ -33,7 +36,6 @@ export const defaultVassFormState = {
   selectedDate: null,
   selectedTopics: [],
   obfuscatedEmail: null,
-  token: null,
   uuid: null,
   lastname: null,
   dob: null,
@@ -66,7 +68,6 @@ export const defaultScheduledDowntimeState = {
  * @example
  * // With vassForm state overrides
  * const options = getDefaultRenderOptions({
- *   token: 'test-token',
  *   hydrated: true,
  *   uuid: 'test-uuid-1234',
  * });
@@ -74,7 +75,7 @@ export const defaultScheduledDowntimeState = {
  * @example
  * // Spreading with additional options
  * const options = {
- *   ...getDefaultRenderOptions({ token: 'test-token' }),
+ *   ...getDefaultRenderOptions({ uuid: 'test-uuid-1234' }),
  *   initialEntries: ['/some-path'],
  * };
  *
@@ -99,6 +100,36 @@ export const getDefaultRenderOptions = (
   reducers,
   additionalMiddlewares: [vassApi.middleware],
 });
+
+export const getHydratedFormRenderOptions = (vassFormOverrides = {}) => {
+  const defaultOptions = getDefaultRenderOptions(vassFormOverrides);
+  const initialState = {
+    ...defaultOptions.initialState,
+    vassForm: {
+      hydrated: true,
+      selectedDate: '2025-01-01',
+      obfuscatedEmail: 's***@example.com',
+      selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
+      uuid: 'test-uuid',
+      lastname: 'Smith',
+      dob: '1935-04-07',
+      ...vassFormOverrides,
+    },
+  };
+
+  const store = createStore(
+    combineReducers({ ...commonReducer, ...reducers }),
+    initialState,
+    applyMiddleware(thunk, vassApi.middleware),
+  );
+  return {
+    ...defaultOptions,
+    initialState,
+    reducers,
+    additionalMiddlewares: [vassApi.middleware],
+    store,
+  };
+};
 
 // Re-export commonly used items for convenience
 export { reducers, vassApi };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Migrated VASS authentication token storage from Redux state (with sessionStorage persistence)
  to browser cookies using the `js-cookie` library
  - Created new `auth.js` utility module with functions for JWT decoding, token expiration
  checking, and cookie management (`getVassToken`, `getValidVassToken`, `removeVassToken`,
  `isTokenExpired`, `decodeJwt`)
  - Updated `withAuthorization.jsx` HOC to read token from cookies instead of Redux selector, with
  added token expiration validation
  - Updated `vassApi.js` to retrieve token from cookies via `getValidVassToken()` for all
  authenticated API endpoints
  - Removed `token` from Redux state in `formSlice.js`, including removal of `setToken` action and
  `selectToken` selector
  - Added `VASS_TOKEN_COOKIE_NAME` constant to `constants.js`
  - No flipper/feature toggle used

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#130253

  ## Testing done

  - **Old behavior:** Token was stored in Redux state (`vassForm.token`) and persisted to
  sessionStorage. API calls retrieved token via `getState().vassForm.token`. Route protection in
  `withAuthorization.jsx` used `useSelector(selectToken)` to check authentication status.
  - **New behavior:** Token is stored in a browser cookie (`vass_token`). API calls retrieve token
  via `getValidVassToken()` which also validates expiration. Route protection reads token directly
  from cookies and validates expiration before granting access.
  - **Verification steps:**
    1. Start local dev server and navigate to VASS application
    2. Complete low-auth flow (enter last name, DOB, UUID)
    3. Enter OTC code - verify token cookie is set (check DevTools > Application > Cookies)
    4. Navigate through protected routes (DateTimeSelection, TopicSelection, Review) - verify
  access is granted
    5. Refresh page - verify session persists via cookie
    6. Clear cookie manually - verify redirect to Verify page
    7. Test with expired token - verify redirect to Verify page and token removal
  - **Unit tests:**
    - All new unit tests passing for `auth.js` (168 lines of new test coverage)
    - Updated `withAuthorization.unit.spec.jsx` tests (248 lines modified)
    - Updated `formSlice.unit.spec.jsx` tests (103 lines removed for token-related tests)
    - Updated `withFormData.unit.spec.jsx` tests

  ## Screenshots

  N/A - No UI changes. This is a storage mechanism refactor with no visual impact.

  ## What areas of the site does it impact?

  This change is scoped entirely to `/src/applications/vass`. No other areas of the site are
  impacted.

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
  hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [ ] Documentation has been updated
  - [x] Screenshot of the developed feature is added - N/A, no UI changes
  - [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-c
  ycle/prepare-for-an-accessibility-staging-review) has been performed - N/A, no UI changes

  ### Error Handling

  - [x] Browser console contains no warnings or errors.
  - [x] Events are being sent to the appropriate logging solution
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A for this
  refactor

  ### Authentication

  - [x] Did you login to a local build and verify all authenticated routes work as expected with a
  test user

  ## Requested Feedback

  - Please review the cookie security configuration. Currently using `js-cookie` defaults. Consider
   whether `Secure` and `SameSite` attributes should be explicitly set for production.
  - The `withAuthorization.jsx` now checks token expiration on every render. Please verify this
  doesn't cause performance concerns with rapid re-renders.