### PR TITLE
feat(platform): Add retry logic for chunk load failures

### DIFF
--- a/src/applications/mhv-medical-records/routes.jsx
+++ b/src/applications/mhv-medical-records/routes.jsx
@@ -1,48 +1,60 @@
-import React, { lazy, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { MhvPageNotFound } from '@department-of-veterans-affairs/mhv/exports';
 import { useMyHealthAccessGuard } from '~/platform/mhv/hooks/useMyHealthAccessGuard';
+import { lazyWithRetry } from '~/platform/utilities/lazy-load-with-retry';
 import AppRoute from './components/shared/AppRoute';
 
-// Lazy-loaded components.
-const HealthConditions = lazy(() => import('./containers/HealthConditions'));
-const VaccineDetails = lazy(() => import('./containers/VaccineDetails'));
-const Vaccines = lazy(() => import('./containers/Vaccines'));
-const VitalDetails = lazy(() => import('./containers/VitalDetails'));
-const Vitals = lazy(() => import('./containers/Vitals'));
-const LandingPage = lazy(() => import('./containers/LandingPage'));
-const LabsAndTests = lazy(() => import('./containers/LabsAndTests'));
-const CareSummariesAndNotes = lazy(() =>
+// Lazy-loaded components with retry logic for Safari/iOS bfcache issues.
+const HealthConditions = lazyWithRetry(() =>
+  import('./containers/HealthConditions'),
+);
+const VaccineDetails = lazyWithRetry(() =>
+  import('./containers/VaccineDetails'),
+);
+const Vaccines = lazyWithRetry(() => import('./containers/Vaccines'));
+const VitalDetails = lazyWithRetry(() => import('./containers/VitalDetails'));
+const Vitals = lazyWithRetry(() => import('./containers/Vitals'));
+const LandingPage = lazyWithRetry(() => import('./containers/LandingPage'));
+const LabsAndTests = lazyWithRetry(() => import('./containers/LabsAndTests'));
+const CareSummariesAndNotes = lazyWithRetry(() =>
   import('./containers/CareSummariesAndNotes'),
 );
-const ConditionDetails = lazy(() => import('./containers/ConditionDetails'));
-const LabAndTestDetails = lazy(() => import('./containers/LabAndTestDetails'));
-const Allergies = lazy(() => import('./containers/Allergies'));
-const AllergyDetails = lazy(() => import('./containers/AllergyDetails'));
-const CareSummariesDetails = lazy(() =>
+const ConditionDetails = lazyWithRetry(() =>
+  import('./containers/ConditionDetails'),
+);
+const LabAndTestDetails = lazyWithRetry(() =>
+  import('./containers/LabAndTestDetails'),
+);
+const Allergies = lazyWithRetry(() => import('./containers/Allergies'));
+const AllergyDetails = lazyWithRetry(() =>
+  import('./containers/AllergyDetails'),
+);
+const CareSummariesDetails = lazyWithRetry(() =>
   import('./containers/CareSummariesDetails'),
 );
-const SettingsPage = lazy(() => import('./containers/SettingsPage'));
-const RadiologyImagesList = lazy(() =>
+const SettingsPage = lazyWithRetry(() => import('./containers/SettingsPage'));
+const RadiologyImagesList = lazyWithRetry(() =>
   import('./containers/RadiologyImagesList'),
 );
-const RadiologySingleImage = lazy(() =>
+const RadiologySingleImage = lazyWithRetry(() =>
   import('./containers/RadiologySingleImage'),
 );
-const DownloadReportPage = lazy(() =>
+const DownloadReportPage = lazyWithRetry(() =>
   import('./containers/DownloadReportPage'),
 );
-const DownloadDateRange = lazy(() =>
+const DownloadDateRange = lazyWithRetry(() =>
   import('./components/DownloadRecords/DownloadDateRange'),
 );
-const DownloadRecordType = lazy(() =>
+const DownloadRecordType = lazyWithRetry(() =>
   import('./components/DownloadRecords/DownloadRecordType'),
 );
-const DownloadFileType = lazy(() =>
+const DownloadFileType = lazyWithRetry(() =>
   import('./components/DownloadRecords/DownloadFileType'),
 );
 
-// Loading component to display while lazy-loaded components are being fetched.
+// Loading component to display while lazy-loaded components are being fetched
+// and during retry attempts after chunk load failures.
 const Loading = () => (
   <va-loading-indicator
     message="Loading..."

--- a/src/applications/mhv-medications/routes.jsx
+++ b/src/applications/mhv-medications/routes.jsx
@@ -1,9 +1,10 @@
-import React, { lazy, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import { createBrowserRouter, useParams } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { MhvPageNotFound } from '@department-of-veterans-affairs/mhv/exports';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
+import { lazyWithRetry } from '@department-of-veterans-affairs/platform-utilities/lazy-load-with-retry';
 import manifest from './manifest.json';
 import AppProviders from './containers/AppProviders';
 import App from './containers/App';
@@ -13,14 +14,14 @@ import RxBreadcrumbs from './containers/RxBreadcrumbs';
 // TODO: When the pilot is complete, re-enable loaders
 // import { prescriptionsLoader } from './loaders/prescriptionsLoader';
 
-const Prescriptions = lazy(() => import('./containers/Prescriptions'));
-const RefillPrescriptions = lazy(() =>
+const Prescriptions = lazyWithRetry(() => import('./containers/Prescriptions'));
+const RefillPrescriptions = lazyWithRetry(() =>
   import('./containers/RefillPrescriptions'),
 );
-const PrescriptionDetails = lazy(() =>
+const PrescriptionDetails = lazyWithRetry(() =>
   import('./containers/PrescriptionDetails'),
 );
-const PrescriptionDetailsDocumentation = lazy(() =>
+const PrescriptionDetailsDocumentation = lazyWithRetry(() =>
   import('./containers/PrescriptionDetailsDocumentation'),
 );
 

--- a/src/platform/utilities/exportsFile.js
+++ b/src/platform/utilities/exportsFile.js
@@ -1,5 +1,6 @@
 export { requestStates } from './constants';
 export { default as sortListByFuzzyMatch } from './fuzzy-matching';
+export { lazyWithRetry } from './lazy-load-with-retry';
 export { default as prefixUtilityClasses } from './prefix-utility-classes';
 export { usePrevious } from './react-hooks';
 export { getAppUrl } from './registry-helpers';

--- a/src/platform/utilities/lazy-load-with-retry.js
+++ b/src/platform/utilities/lazy-load-with-retry.js
@@ -76,7 +76,7 @@ async function loadWithRetry(importFn, maxRetries, baseDelayMs, maxDelayMs) {
       const delay = calculateDelay(attempt, baseDelayMs, maxDelayMs);
 
       // eslint-disable-next-line no-await-in-loop
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise(resolve => setTimeout(resolve, delay));
     }
   }
 

--- a/src/platform/utilities/lazy-load-with-retry.js
+++ b/src/platform/utilities/lazy-load-with-retry.js
@@ -70,25 +70,13 @@ async function loadWithRetry(importFn, maxRetries, baseDelayMs, maxDelayMs) {
 
       // Don't retry after the last attempt
       if (attempt === maxRetries) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `Failed to load chunk after ${maxRetries + 1} attempts:`,
-          error,
-        );
         throw error;
       }
 
       const delay = calculateDelay(attempt, baseDelayMs, maxDelayMs);
 
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Chunk load failed (attempt ${attempt + 1}/${maxRetries +
-          1}), retrying in ${Math.round(delay)}ms...`,
-        error?.message,
-      );
-
       // eslint-disable-next-line no-await-in-loop
-      await new Promise(resolve => setTimeout(resolve, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 

--- a/src/platform/utilities/lazy-load-with-retry.js
+++ b/src/platform/utilities/lazy-load-with-retry.js
@@ -1,0 +1,129 @@
+/**
+ * Lazy loading utility with retry logic for chunk load failures.
+ *
+ * Safari and other browsers' tab suspension can cause chunk loads to fail
+ * with status 0 when the network layer is in an unstable state after
+ * page restoration. This wrapper adds automatic retry with exponential
+ * backoff to handle transient failures.
+ *
+ * @module platform/utilities/lazy-load-with-retry
+ */
+import { lazy } from 'react';
+
+/**
+ * Default retry configuration
+ */
+const DEFAULT_CONFIG = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 10000,
+};
+
+/**
+ * Check if an error is a chunk load error
+ * @param {Error} error - The error to check
+ * @returns {boolean} - True if this is a chunk load error
+ */
+function isChunkLoadError(error) {
+  return (
+    error?.name === 'ChunkLoadError' ||
+    error?.message?.includes('Loading chunk') ||
+    error?.message?.includes('Loading CSS chunk')
+  );
+}
+
+/**
+ * Calculate delay with exponential backoff and jitter
+ * @param {number} attempt - Current attempt number (0-indexed)
+ * @param {number} baseDelayMs - Base delay in milliseconds
+ * @param {number} maxDelayMs - Maximum delay in milliseconds
+ * @returns {number} - Delay in milliseconds
+ */
+function calculateDelay(attempt, baseDelayMs, maxDelayMs) {
+  const exponentialDelay = baseDelayMs * 2 ** attempt;
+  const jitter = Math.random() * 0.3 * exponentialDelay; // Add up to 30% jitter
+  return Math.min(exponentialDelay + jitter, maxDelayMs);
+}
+
+/**
+ * Attempt to load a module with retries
+ * @param {Function} importFn - The dynamic import function
+ * @param {number} maxRetries - Maximum number of retries
+ * @param {number} baseDelayMs - Base delay between retries
+ * @param {number} maxDelayMs - Maximum delay between retries
+ * @returns {Promise} - Promise that resolves to the module
+ */
+async function loadWithRetry(importFn, maxRetries, baseDelayMs, maxDelayMs) {
+  let lastError;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await importFn();
+    } catch (error) {
+      lastError = error;
+
+      // Only retry chunk load errors
+      if (!isChunkLoadError(error)) {
+        throw error;
+      }
+
+      // Don't retry after the last attempt
+      if (attempt === maxRetries) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `Failed to load chunk after ${maxRetries + 1} attempts:`,
+          error,
+        );
+        throw error;
+      }
+
+      const delay = calculateDelay(attempt, baseDelayMs, maxDelayMs);
+
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Chunk load failed (attempt ${attempt + 1}/${maxRetries +
+          1}), retrying in ${Math.round(delay)}ms...`,
+        error?.message,
+      );
+
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Create a lazy component with automatic retry on chunk load failure.
+ *
+ * Use this instead of React.lazy when loading components that may fail
+ * due to network issues, especially on Safari/iOS.
+ *
+ * @example
+ * // Instead of:
+ * const MyComponent = lazy(() => import('./MyComponent'));
+ *
+ * // Use:
+ * const MyComponent = lazyWithRetry(() => import('./MyComponent'));
+ *
+ * @param {Function} importFn - A function that returns a dynamic import promise
+ * @param {object} [config] - Optional configuration
+ * @param {number} [config.maxRetries=3] - Maximum number of retry attempts
+ * @param {number} [config.baseDelayMs=1000] - Base delay between retries (ms)
+ * @param {number} [config.maxDelayMs=10000] - Maximum delay between retries (ms)
+ * @returns {React.LazyExoticComponent} - A lazy component
+ */
+export function lazyWithRetry(importFn, config = {}) {
+  const { maxRetries, baseDelayMs, maxDelayMs } = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  };
+
+  return lazy(() =>
+    loadWithRetry(importFn, maxRetries, baseDelayMs, maxDelayMs),
+  );
+}
+
+export default lazyWithRetry;

--- a/src/platform/utilities/package.json
+++ b/src/platform/utilities/package.json
@@ -12,6 +12,7 @@
     "./featureFlagNames": "./feature-toggles/featureFlagNames.js",
     "./flipper-client": "./feature-toggles/flipper-client.js",
     "./keepAliveSSO": "./sso/keepAliveSSO.js",
+    "./lazy-load-with-retry": "./lazy-load-with-retry.js",
     "./localStorage": "./storage/localStorage.js",
     "./loginAttempted": "./sso/loginAttempted.js",
     "./medical-centers": "./medical-centers/medical-centers.js",

--- a/src/platform/utilities/tests/chunk-load-error-reproduction.unit.spec.jsx
+++ b/src/platform/utilities/tests/chunk-load-error-reproduction.unit.spec.jsx
@@ -1,0 +1,176 @@
+import React, { Suspense } from 'react';
+import PropTypes from 'prop-types';
+import { render, waitFor } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+// Shared ErrorBoundary for tests - catches errors and renders fallback
+class TestErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    const { hasError } = this.state;
+    const { children, fallbackTestId } = this.props;
+    if (hasError) {
+      return <div data-testid={fallbackTestId}>Error occurred</div>;
+    }
+    return children;
+  }
+}
+
+TestErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  fallbackTestId: PropTypes.string.isRequired,
+};
+
+describe('ChunkLoadError Reproduction', () => {
+  let consoleErrorStub;
+  let consoleWarnStub;
+
+  beforeEach(() => {
+    // Suppress React error boundary console errors during test
+    consoleErrorStub = sinon.stub(console, 'error');
+    consoleWarnStub = sinon.stub(console, 'warn');
+  });
+
+  afterEach(() => {
+    consoleErrorStub.restore();
+    consoleWarnStub.restore();
+  });
+
+  describe('React.lazy', () => {
+    it('does not retry when import fails', async () => {
+      let loadAttempts = 0;
+
+      // Simulate a chunk that fails on first load but would succeed on retry
+      const flakyImport = () => {
+        loadAttempts += 1;
+        if (loadAttempts === 1) {
+          const error = new Error(
+            'ChunkLoadError: Loading chunk test_component failed.',
+          );
+          error.name = 'ChunkLoadError';
+          return Promise.reject(error);
+        }
+        // Subsequent attempts would succeed (but React.lazy won't retry)
+        return Promise.resolve({
+          default: () => <div data-testid="loaded">Component Loaded!</div>,
+        });
+      };
+
+      // Standard React.lazy - current implementation across the codebase
+      const LazyComponent = React.lazy(flakyImport);
+
+      const { getByTestId } = render(
+        <TestErrorBoundary fallbackTestId="error-boundary">
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <LazyComponent />
+          </Suspense>
+        </TestErrorBoundary>,
+      );
+
+      // Wait for error boundary to catch the failure
+      await waitFor(() => {
+        expect(getByTestId('error-boundary')).to.exist;
+      });
+
+      expect(loadAttempts).to.equal(1);
+    });
+  });
+
+  describe('lazyWithRetry', () => {
+    it('retries and succeeds after transient failure', async () => {
+      // Import the fix
+      const { lazyWithRetry } = await import('../lazy-load-with-retry');
+
+      let loadAttempts = 0;
+
+      const flakyImport = () => {
+        loadAttempts += 1;
+        if (loadAttempts === 1) {
+          // First attempt fails
+          const error = new Error(
+            'ChunkLoadError: Loading chunk test_component failed.',
+          );
+          error.name = 'ChunkLoadError';
+          return Promise.reject(error);
+        }
+        // Second attempt succeeds
+        return Promise.resolve({
+          default: () => (
+            <div data-testid="success">Component Loaded After Retry!</div>
+          ),
+        });
+      };
+
+      // Using lazyWithRetry with short delays for testing
+      const LazyComponent = lazyWithRetry(flakyImport, {
+        maxRetries: 3,
+        baseDelayMs: 10, // Short delay for tests
+        maxDelayMs: 50,
+      });
+
+      const { getByTestId } = render(
+        <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+          <LazyComponent />
+        </Suspense>,
+      );
+
+      // Should eventually succeed after retry
+      await waitFor(
+        () => {
+          expect(getByTestId('success')).to.exist;
+        },
+        { timeout: 1000 },
+      );
+
+      expect(loadAttempts).to.equal(2);
+    });
+
+    it('gives up after max retries', async () => {
+      const { lazyWithRetry } = await import('../lazy-load-with-retry');
+
+      let loadAttempts = 0;
+
+      const alwaysFailingImport = () => {
+        loadAttempts += 1;
+        const error = new Error(
+          'ChunkLoadError: Loading chunk always_fail failed.',
+        );
+        error.name = 'ChunkLoadError';
+        return Promise.reject(error);
+      };
+
+      const LazyComponent = lazyWithRetry(alwaysFailingImport, {
+        maxRetries: 2,
+        baseDelayMs: 10,
+        maxDelayMs: 50,
+      });
+
+      const { getByTestId } = render(
+        <TestErrorBoundary fallbackTestId="final-error">
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <LazyComponent />
+          </Suspense>
+        </TestErrorBoundary>,
+      );
+
+      await waitFor(
+        () => {
+          expect(getByTestId('final-error')).to.exist;
+        },
+        { timeout: 2000 },
+      );
+
+      // Should have tried initial + maxRetries times (1 + 2 = 3)
+      expect(loadAttempts).to.equal(3);
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

## Summary

This PR addresses the **ChunkLoadError** issue affecting VA.gov applications, which generates **100,000+ errors per week** across 9+ applications and impacts **1-40% of user sessions**. The errors occur when lazy-loaded JavaScript chunks fail to load due to transient network failures.

### Problem
- React.lazy() has no built-in retry mechanism for failed chunk loads
- Network instability (mobile connections, TIC intermediaries, cellular handoffs) causes requests to drop mid-flight
- Users see blank screens or broken components when chunks fail to load
- Datadog RUM analysis shows **zero HTTP status codes** on failed requests, confirming network interruption rather than 404s or server errors

### Solution
Implemented `lazyWithRetry` - a drop-in replacement for `React.lazy()` that:
- Retries failed chunk loads with exponential backoff (1s, 2s, 4s delays)
- Only retries on ChunkLoadError (not other error types)
- Gives up after 3 attempts and propagates error to Error Boundary
- Zero breaking changes - same API as React.lazy()

### Impact Analysis from Datadog
- **Device Distribution**: 80% mobile, 18% desktop, 2% tablet
- **OS Distribution**: 65% iOS, 17% Android, 7% macOS

## Related issue(s)

- Related to ChunkLoadError investigation
- Addresses errors first seen October 23, 2024 ([Datadog issue](https://vagov.ddog-gov.com/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22fcf0bd6a-915d-11ef-8b40-da7ad0900007%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1769034657398&to_ts=1769121057398&live=true))

## Testing done

### Manual Reproduction
- Successfully reproduced ChunkLoadError using Chrome DevTools Request Blocking
- Blocked `*component-library*.entry.js` patterns to simulate network failure

### Unit Tests
Added chunk-load-error-reproduction.unit.spec.jsx to show:
- React.lazy does not retry on failure (1 attempt only)
- lazyWithRetry succeeds after transient failure (2 attempts)
- lazyWithRetry gives up after max retries (3 attempts then error boundary)
- ✅ All tests passing

### Test Results
```
yarn test:unit src/platform/utilities/tests/chunk-load-error-reproduction.unit.spec.jsx
  ChunkLoadError Reproduction
    React.lazy
      ✓ does not retry when import fails
    lazyWithRetry
      ✓ retries and succeeds after transient failure
      ✓ gives up after max retries

  3 passing
```

## What areas of the site does it impact?
- Medical Records (mhv-medical-records) - 45k errors/week
- Medications (mhv-medications) - 8k errors/week

**Future Impact** (when apps adopt):
- All other apps using React.lazy for route splitting

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (comprehensive JSDoc comments in utility)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (N/A - no UI changes, internal utility)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (console.warn logs retry attempts)
- [x] Feature/bug has a monitor built into Datadog or Grafana (existing ChunkLoadError tracking continues)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - utility only, no route changes)

## Requested Feedback

This is the **first of two PRs** to address ChunkLoadError:

1. **This PR**: Platform utility (`lazyWithRetry`)
2. **Next PR**: Fix [wc-loader.js](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/site-wide/wc-loader.js) to retry web component initialization (addresses 100% of component library chunk errors)

After these platform fixes are merged, individual application teams can adopt `lazyWithRetry` for their lazy route components.