### PR TITLE
[Disability Benefits] Toxic exposure date & utility rendering on review page

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -514,3 +514,21 @@ export function detailsPageBegin(title, subTitle, type = 'locations') {
     </legend>
   );
 }
+
+/**
+ * Review field component for toxic exposure date fields
+ * Handles year-only dates (YYYY-XX) and month/year dates (YYYY-MM) correctly
+ * @param {Object} props - Review field props
+ * @param {Object} props.children - Children object containing formData and uiSchema
+ * @returns {JSX.Element} Review field row
+ */
+export const reviewDateField = ({ children }) => {
+  const { formData, uiSchema: fieldUiSchema } = children.props;
+  const formattedDate = formatMonthYearDate(formData);
+  return (
+    <div className="review-row">
+      <dt>{fieldUiSchema['ui:title']}</dt>
+      <dd>{formattedDate}</dd>
+    </div>
+  );
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -81,6 +81,9 @@ function makeUiSchema(itemId) {
     },
     _forceFieldBlur: {
       'ui:field': ForceFieldBlur,
+      'ui:options': {
+        hideOnReview: true,
+      },
     },
   };
 }

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -9,6 +9,7 @@ import {
   getKeyIndex,
   getSelectedCount,
   notSureHazardDetails,
+  reviewDateField,
   showCheckboxLoopDetailsPage,
   teSubtitle,
 } from '../../content/toxicExposure';
@@ -52,6 +53,7 @@ function makeUiSchema(itemId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           endDate: {
             ...currentOrPastMonthYearDateUI({
@@ -64,6 +66,7 @@ function makeUiSchema(itemId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           'ui:validations': [validateToxicExposureDates],
           'view:notSure': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -8,6 +8,7 @@ import {
   getSelectedCount,
   gulfWar1990PageTitle,
   notSureDatesDetails,
+  reviewDateField,
   showCheckboxLoopDetailsPage,
   startDateApproximate,
   teSubtitle,
@@ -50,6 +51,7 @@ function makeUiSchema(locationId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           endDate: {
             ...currentOrPastMonthYearDateUI({
@@ -62,6 +64,7 @@ function makeUiSchema(locationId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           'ui:validations': [validateToxicExposureGulfWar1990Dates],
           'view:notSure': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -79,6 +79,9 @@ function makeUiSchema(locationId) {
     },
     _forceFieldBlur: {
       'ui:field': ForceFieldBlur,
+      'ui:options': {
+        hideOnReview: true,
+      },
     },
   };
 }

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -8,6 +8,7 @@ import {
   getSelectedCount,
   gulfWar2001PageTitle,
   notSureDatesDetails,
+  reviewDateField,
   showCheckboxLoopDetailsPage,
   startDateApproximate,
   teSubtitle,
@@ -50,6 +51,7 @@ function makeUiSchema(locationId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           endDate: {
             ...currentOrPastMonthYearDateUI({
@@ -62,6 +64,7 @@ function makeUiSchema(locationId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           'ui:validations': [validateToxicExposureGulfWar2001Dates],
           'view:notSure': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -79,6 +79,9 @@ function makeUiSchema(locationId) {
     },
     _forceFieldBlur: {
       'ui:field': ForceFieldBlur,
+      'ui:options': {
+        hideOnReview: true,
+      },
     },
   };
 }

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -8,6 +8,7 @@ import {
   getSelectedCount,
   herbicidePageTitle,
   notSureDatesDetails,
+  reviewDateField,
   showCheckboxLoopDetailsPage,
   startDateApproximate,
   teSubtitle,
@@ -50,6 +51,7 @@ function makeUiSchema(locationId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           endDate: {
             ...currentOrPastMonthYearDateUI({
@@ -62,6 +64,7 @@ function makeUiSchema(locationId) {
               pattern: 'Please enter a valid date',
               required: 'Please enter a date',
             },
+            'ui:reviewField': reviewDateField,
           },
           'ui:validations': [validateToxicExposureDates],
           'view:notSure': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -79,6 +79,9 @@ function makeUiSchema(locationId) {
     },
     _forceFieldBlur: {
       'ui:field': ForceFieldBlur,
+      'ui:options': {
+        hideOnReview: true,
+      },
     },
   };
 }

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -75,6 +75,9 @@ export const uiSchema = {
   },
   _forceFieldBlur: {
     'ui:field': ForceFieldBlur,
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -8,6 +8,7 @@ import {
   getSelectedCount,
   herbicidePageTitle,
   notSureDatesDetails,
+  reviewDateField,
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
@@ -47,6 +48,7 @@ export const uiSchema = {
           pattern: 'Please enter a valid date',
           required: 'Please enter a date',
         },
+        'ui:reviewField': reviewDateField,
       },
       endDate: {
         ...currentOrPastMonthYearDateUI({
@@ -59,6 +61,7 @@ export const uiSchema = {
           pattern: 'Please enter a valid date',
           required: 'Please enter a date',
         },
+        'ui:reviewField': reviewDateField,
       },
       'ui:validations': [validateToxicExposureDates],
       'view:notSure': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -9,6 +9,7 @@ import {
   getOtherFieldDescription,
   getSelectedCount,
   notSureHazardDetails,
+  reviewDateField,
   teSubtitle,
 } from '../../content/toxicExposure';
 import { validateToxicExposureDates } from '../../utils/validations';
@@ -50,6 +51,7 @@ export const uiSchema = {
           pattern: 'Please enter a valid date',
           required: 'Please enter a date',
         },
+        'ui:reviewField': reviewDateField,
       },
       endDate: {
         ...currentOrPastMonthYearDateUI({
@@ -62,6 +64,7 @@ export const uiSchema = {
           pattern: 'Please enter a valid date',
           required: 'Please enter a date',
         },
+        'ui:reviewField': reviewDateField,
       },
       'ui:validations': [validateToxicExposureDates],
       'view:notSure': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -78,6 +78,9 @@ export const uiSchema = {
   },
   _forceFieldBlur: {
     'ui:field': ForceFieldBlur,
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { render } from '@testing-library/react';
 import {
   datesDescription,
   getKeyIndex,
@@ -8,6 +9,7 @@ import {
   isClaimingTECondition,
   makeTEConditionsSchema,
   makeTEConditionsUISchema,
+  reviewDateField,
   showCheckboxLoopDetailsPage,
   showSummaryPage,
   showToxicExposurePages,
@@ -965,6 +967,66 @@ describe('toxicExposure', () => {
       expect(
         getOtherFieldDescription(formData, 'otherHerbicideLocations'),
       ).to.equal('location 1, location 2');
+    });
+  });
+
+  describe('reviewDateField', () => {
+    const createChildren = (formData, uiSchema) => ({
+      props: { formData, uiSchema },
+    });
+
+    it('renders formatted month/year date correctly', () => {
+      const children = createChildren('2023-05', { 'ui:title': 'Start date' });
+      const { container } = render(reviewDateField({ children }));
+
+      expect(container.querySelector('dt').textContent).to.equal('Start date');
+      expect(container.querySelector('dd').textContent).to.equal('May 2023');
+    });
+
+    it('renders year-only date (YYYY-XX) correctly', () => {
+      const children = createChildren('2020-XX', {
+        'ui:title': 'Approximate start date',
+      });
+      const { container } = render(reviewDateField({ children }));
+
+      expect(container.querySelector('dt').textContent).to.equal(
+        'Approximate start date',
+      );
+      expect(container.querySelector('dd').textContent).to.equal('2020');
+    });
+
+    it('handles null formData', () => {
+      const children = createChildren(null, { 'ui:title': 'Date field' });
+      const { container } = render(reviewDateField({ children }));
+
+      expect(container.querySelector('dt').textContent).to.equal('Date field');
+      expect(container.querySelector('dd').textContent).to.equal('');
+    });
+
+    it('handles undefined formData', () => {
+      const children = createChildren(undefined, { 'ui:title': 'Date field' });
+      const { container } = render(reviewDateField({ children }));
+
+      expect(container.querySelector('dt').textContent).to.equal('Date field');
+      expect(container.querySelector('dd').textContent).to.equal('');
+    });
+
+    it('handles empty string formData', () => {
+      const children = createChildren('', { 'ui:title': 'Date field' });
+      const { container } = render(reviewDateField({ children }));
+
+      expect(container.querySelector('dt').textContent).to.equal('Date field');
+      expect(container.querySelector('dd').textContent).to.equal('');
+    });
+
+    it('handles invalid date string', () => {
+      const children = createChildren('invalid-date', {
+        'ui:title': 'Date field',
+      });
+      const { container } = render(reviewDateField({ children }));
+
+      expect(container.querySelector('dt').textContent).to.equal('Date field');
+      expect(container.querySelector('dd').textContent).to.equal('');
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - `hideOnReview` all `_forceFieldBlur` fields in toxic exposure pages to hide on review-and-submit page
  - add `reviewDateField` function to format year-only (YYYY-XX) and month/year dates on the review page
- _(If bug, how to reproduce)_
  - on the review-and-submit page, toxic exposure dates with only a year showed "Invalid Date" instead of the year
- _(What is the solution, why is this the solution)_
  - Added a custom `reviewDateField` function that uses `formatMonthYearDate` instead of the platform's default date formatter, which handles year-only dates (YYYY-XX) by extracting the year, while `new Date()` fails on that format and shows "Invalid Date".
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - 🌊 Disability Benefits Pathways team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - _n/a_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/41319
- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/128641

## Testing done

- _Describe what the old behavior was prior to the change_
  - On the review-and-submit page, the `_forceFieldBlur` utility field appeared for selected toxic exposure locations or hazards, and year-only dates (YYYY-XX) displayed as "Invalid Date" instead of the year.
- _Describe the steps required to verify your changes are working as expected_
  1. Navigate to a toxic exposure section and select at least one location or hazard.
  2. On the details page, enter a year-only date for the start or end date.
  3. Complete the toxic exposure flow and go to the review-and-submit page.
  4. Verify the `_forceFieldBlur` field does not appear in the toxic exposure section.
  5. Verify year-only dates display as the 4-digit year, instead of "Invalid Date".
  6. Verify month/year dates display correctly.
- _Describe the tests completed and the results_
  - Verified the `reviewDateField` function uses `formatMonthYearDate`, which handles year-only dates (YYYY-XX) correctly per its implementation.

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="366" height="957" alt="Screenshot 2026-01-22 at 5 22 36 PM" src="https://github.com/user-attachments/assets/78e5c897-9d6c-474a-b943-5dc065c72c09" /> | <img width="494" height="776" alt="Screenshot 2026-01-22 at 5 23 08 PM" src="https://github.com/user-attachments/assets/677167f0-a5f9-4b49-89ad-aa4a3a91115e" /> |

## What areas of the site does it impact?

Form 526EZ, Conditions chapter, Toxic Exposure section on Review & Submit page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user