### PR TITLE
534ez require bank name

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/07-additional-information/directDepositAccount.js
+++ b/src/applications/survivors-benefits/config/chapters/07-additional-information/directDepositAccount.js
@@ -4,6 +4,15 @@ import {
   bankAccountUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+const updatedBankAccountSchema = bankAccountSchema();
+updatedBankAccountSchema.required = [
+  'bankName',
+  'accountType',
+  'accountNumber',
+  'routingNumber',
+];
+updatedBankAccountSchema.properties.bankName.maxLength = 34;
+
 function dependsIfHasBankAccount(formData) {
   return (
     formData?.hasBankAccount === true ||
@@ -27,7 +36,7 @@ export default {
     type: 'object',
     required: ['bankAccount'],
     properties: {
-      bankAccount: bankAccountSchema(),
+      bankAccount: updatedBankAccountSchema,
     },
   },
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Makes bank name required
- Limits bank name to 34 to match pdf limit

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130065

## Testing done

- Manual testing

## Screenshots

| Before | After |
 ------ | ----- |
| <img width="606" height="700" alt="Screenshot 2026-01-22 at 1 50 03 PM" src="https://github.com/user-attachments/assets/f228e546-e905-4da1-95b5-e9a7da539e8b" /> | <img width="579" height="661" alt="Screenshot 2026-01-22 at 1 49 48 PM" src="https://github.com/user-attachments/assets/f88dc8e4-9716-4bf7-a56f-dfc616308e26" /> |

## What areas of the site does it impact?

The direct deposit information page of 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
