### PR TITLE
Installs appropriate awscli based on system architecture

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,10 +72,19 @@ RUN apt-get install -y --no-install-recommends \
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
 RUN chmod +x /cc-test-reporter
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
-RUN aws --version # Verify AWS CLI installation.
+# Install AWS CLI v2 - detect architecture and download appropriate version
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    aws --version
 
 # Explicitly set CA cert to resolve SSL issues with AWS.
 ENV AWS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Installs the appropriate awscli based on system architecture.
- Prevents docker build errors when verifying awscli on macOS

The following error occurs in local development when doing a fresh build of containers within macOS:

```bash
 => ERROR [dev_container_auto_added_stage_label 11/17] RUN aws --version   0.1s
[2026-01-23T14:25:14.487Z] ------
 > [dev_container_auto_added_stage_label 11/17] RUN aws --version # Verify AWS CLI installation.:
0.071 qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
------
[2026-01-23T14:25:14.490Z] ERROR: failed to build: failed to solve: process "/bin/sh -c aws --version # Verify AWS CLI installation." did not complete successfully: exit code: 255
[2026-01-23T14:25:14.493Z] Stop (736 ms): Run: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /var/folders/w1/bgggy5td1lv3bsmvs80wq2g80000gp/T/devcontainercli/container-features/0.80.1-1769178312066/Dockerfile-with-features -t vsc-vets-website-9284a6c66c8e8a3f3b5e0eb2e541fe0ef11a4983481b6105e24d3fca2b659e5f --target dev_containers_target_stage --build-arg VARIANT=22-bookworm --build-context dev_containers_feature_content_source=/var/folders/w1/bgggy5td1lv3bsmvs80wq2g80000gp/T/devcontainercli/container-features/0.80.1-1769178312066 --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label --build-arg _DEV_CONTAINERS_IMAGE_USER=vets-website --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp /Users/radavis/va/vets-website/.devcontainer
[2026-01-23T14:25:14.494Z] Error: Command failed: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /var/folders/w1/bgggy5td1lv3bsmvs80wq2g80000gp/T/devcontainercli/container-features/0.80.1-1769178312066/Dockerfile-with-features -t vsc-vets-website-9284a6c66c8e8a3f3b5e0eb2e541fe0ef11a4983481b6105e24d3fca2b659e5f --target dev_containers_target_stage --build-arg VARIANT=22-bookworm --build-context dev_containers_feature_content_source=/var/folders/w1/bgggy5td1lv3bsmvs80wq2g80000gp/T/devcontainercli/container-features/0.80.1-1769178312066 --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label --build-arg _DEV_CONTAINERS_IMAGE_USER=vets-website --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp /Users/radavis/va/vets-website/.devcontainer
[2026-01-23T14:25:14.494Z]     at F6 (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:468:1988)
[2026-01-23T14:25:14.494Z]     at async pw (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:467:1886)
[2026-01-23T14:25:14.494Z]     at async ax (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:467:608)
[2026-01-23T14:25:14.494Z]     at async Y6 (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:484:3842)
[2026-01-23T14:25:14.494Z]     at async BC (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:484:4957)
[2026-01-23T14:25:14.494Z]     at async p7 (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:665:202)
[2026-01-23T14:25:14.494Z]     at async d7 (/Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:664:14804)
[2026-01-23T14:25:14.494Z]     at async /Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js:484:1188
[2026-01-23T14:25:14.497Z] Stop (2764 ms): Run: /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /Users/radavis/Library/Application Support/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-6e74edc8-8730-4c7e-9d84-0ef537e39bd81769178311197 --workspace-folder /Users/radavis/va/vets-website --workspace-mount-consistency cached --gpu-availability detect --id-label devcontainer.local_folder=/Users/radavis/va/vets-website --id-label devcontainer.config_file=/Users/radavis/va/vets-website/.devcontainer/devcontainer.json --log-level debug --log-format json --config /Users/radavis/va/vets-website/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root --include-configuration --include-merged-configuration
[2026-01-23T14:25:14.497Z] Exit code 1
[2026-01-23T14:25:14.500Z] Command failed: /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) /Users/radavis/.vscode/extensions/ms-vscode-remote.remote-containers-0.437.0/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /Users/radavis/Library/Application Support/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-6e74edc8-8730-4c7e-9d84-0ef537e39bd81769178311197 --workspace-folder /Users/radavis/va/vets-website --workspace-mount-consistency cached --gpu-availability detect --id-label devcontainer.local_folder=/Users/radavis/va/vets-website --id-label devcontainer.config_file=/Users/radavis/va/vets-website/.devcontainer/devcontainer.json --log-level debug --log-format json --config /Users/radavis/va/vets-website/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root --include-configuration --include-merged-configuration
[2026-01-23T14:25:14.500Z] Exit code 1
```

## Related issue(s)

- n/a

## Testing done

- There are no longer container build errors

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
