### PR TITLE
[ARC/129838] Proof of Concept: Reorganize ITF fields within fieldset

### DIFF
--- a/src/applications/representative-form-upload/pages/itfVeteranInformation.jsx
+++ b/src/applications/representative-form-upload/pages/itfVeteranInformation.jsx
@@ -27,27 +27,30 @@ export const itfVeteranInformationPage = {
   uiSchema: {
     ...ITFClaimantTitleAndDescription,
     'ui:objectViewField': ITFClaimantInfoViewField,
-    veteranFullName: firstNameLastNameNoSuffixUI(),
-    address: addressUI({
-      omit: [
-        'country',
-        'city',
-        'isMilitary',
-        'state',
-        'street',
-        'street2',
-        'street3',
-        'postalCode',
-      ],
-      required: true,
-    }),
-    veteranSsn: ssnUI(),
-    veteranDateOfBirth: dateOfBirthUI(),
-    vaFileNumber: {
-      ...vaFileNumberUI,
-      'ui:title': 'VA file number',
-      'ui:errorMessages': {
-        pattern: 'Your VA file number must be 8 or 9 digits',
+    veteranInformation: {
+      'ui:title': 'Veteran information',
+      veteranFullName: firstNameLastNameNoSuffixUI(),
+      address: addressUI({
+        omit: [
+          'country',
+          'city',
+          'isMilitary',
+          'state',
+          'street',
+          'street2',
+          'street3',
+          'postalCode',
+        ],
+        required: true,
+      }),
+      veteranSsn: ssnUI(),
+      veteranDateOfBirth: dateOfBirthUI(),
+      vaFileNumber: {
+        ...vaFileNumberUI,
+        'ui:title': 'VA file number',
+        'ui:errorMessages': {
+          pattern: 'Your VA file number must be 8 or 9 digits',
+        },
       },
     },
     benefitType: radioUI({
@@ -64,22 +67,28 @@ export const itfVeteranInformationPage = {
     properties: {
       'view:claimantTitle': emptyObjectSchema,
       'view:claimantDescription': emptyObjectSchema,
-      veteranFullName: firstNameLastNameNoSuffixSchema,
-      veteranSsn: ssnSchema,
-      veteranDateOfBirth: dateOfBirthSchema,
-      address: addressSchema({
-        omit: [
-          'country',
-          'city',
-          'isMilitary',
-          'state',
-          'street',
-          'street2',
-          'street3',
-          'postalCode',
-        ],
-      }),
-      vaFileNumber: vaFileNumberSchema,
+      veteranInformation: {
+        type: 'object',
+        properties: {
+          veteranFullName: firstNameLastNameNoSuffixSchema,
+          veteranSsn: ssnSchema,
+          veteranDateOfBirth: dateOfBirthSchema,
+          address: addressSchema({
+            omit: [
+              'country',
+              'city',
+              'isMilitary',
+              'state',
+              'street',
+              'street2',
+              'street3',
+              'postalCode',
+            ],
+          }),
+          vaFileNumber: vaFileNumberSchema,
+        },
+      },
+
       benefitType: radioSchema(Object.keys(ITFBenefitTypes.labels)),
     },
     required: [


### PR DESCRIPTION
## Summary

- Reorganizes `itfVeteranInformation` schema to place fields within the appropriate `fieldset` as a proof of concept.
- Remaining work:
  - Remove extra headings
  - Make a similar update to `itfClaimantInformation` schema to match new organization
  - Test form flow and confirm that no regressions were added

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129838

## Testing done

- Brief testing of structure on MacOS/Google Chrome

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user