### PR TITLE
534ez add hint to va file number

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/01-veteran-information/veteranIdentification.js
+++ b/src/applications/survivors-benefits/config/chapters/01-veteran-information/veteranIdentification.js
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import {
   ssnOrVaFileNumberNoHintSchema,
   ssnOrVaFileNumberNoHintUI,
@@ -13,7 +14,11 @@ export default {
       'Veteran’s identification information',
       'You must enter a Social Security number or VA file number',
     ),
-    veteranSocialSecurityNumber: ssnOrVaFileNumberNoHintUI(),
+    veteranSocialSecurityNumber: merge({}, ssnOrVaFileNumberNoHintUI(), {
+      vaFileNumber: {
+        'ui:title': 'VA file number (if known)',
+      },
+    }),
     veteranServiceNumber: serviceNumberUI('Service number'),
   },
   schema: {

--- a/src/applications/survivors-benefits/tests/unit/pages/01-veteran-information/veteranIdentification.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/01-veteran-information/veteranIdentification.unit.spec.jsx
@@ -24,7 +24,10 @@ describe('Claimant Information Page', () => {
     const vaTextInput = $$('va-text-input', formDOM);
 
     const vaSsn = $('va-text-input[label="Social Security number"]', formDOM);
-    const vaFileNumber = $('va-text-input[label="VA file number"]', formDOM);
+    const vaFileNumber = $(
+      'va-text-input[label="VA file number (if known)"]',
+      formDOM,
+    );
     const serviceNumber = $('va-text-input[label="Service number"]', formDOM);
 
     expect(vaTextInput.length).to.equal(3);
@@ -54,7 +57,7 @@ describe('Claimant Information Page', () => {
       'va-text-input[label="Social Security number"]',
     );
     const $vaFileNumber = formDOM.querySelector(
-      'va-text-input[label="VA file number"]',
+      'va-text-input[label="VA file number (if known)"]',
     );
 
     expect($vaSsn.getAttribute('required')).to.equal('false');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add (if known) to the VA File number field title

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128051
- 
## Testing done

- Manual testing
- Updated unit tests

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="571" height="525" alt="Screenshot 2026-01-23 at 9 43 53 AM" src="https://github.com/user-attachments/assets/10aa7ccb-6574-4d87-8657-d77cf29ccd47" /> | <img width="550" height="531" alt="Screenshot 2026-01-23 at 10 07 39 AM" src="https://github.com/user-attachments/assets/978ce494-a386-4ed4-851a-518e3657e294" /> <img width="572" height="525" alt="Screenshot 2026-01-23 at 10 07 49 AM" src="https://github.com/user-attachments/assets/b6f538d7-f06f-4946-88c1-eada6f225d45" /> |

## What areas of the site does it impact?

The veteran identification page of the 534ez.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
