### PR TITLE
Fixed flaky test by adding tabindex

### DIFF
--- a/src/platform/mhv/components/MhvAlertConfirmEmail/AlertConfirmAddContactEmailError.jsx
+++ b/src/platform/mhv/components/MhvAlertConfirmEmail/AlertConfirmAddContactEmailError.jsx
@@ -23,6 +23,7 @@ const AlertConfirmAddContactEmailError = ({
       role="alert"
       dataTestid="mhv-alert--confirm-error"
       className="vads-u-margin-y--2"
+      tabIndex={-1}
     >
       <h2 slot="headline">
         <span className="usa-sr-only">error</span>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed a flaky unit test in `MhvAlertConfirmEmail.unit.spec.jsx` that was failing intermittently in CI but passing locally
- **Root cause**: The `AlertConfirmAddContactEmailError` component was missing `tabIndex={-1}` on its `<VaAlert>` element, which is required for the element to be programmatically focusable
- **Why it was flaky**: The `focusElement` utility (used by `waitForRenderThenFocus`) dynamically adds `tabindex="-1"` before focusing. The test's `waitFor` would retry until this happened, but in CI with different timing, the assertion could check before the attribute was added
- **Solution**: Add `tabIndex={-1}` directly to the `<VaAlert>` component, matching the pattern used in `AlertSystemResponse.jsx` for success alerts
- Team: MHV on VA.gov - Secure Messaging / Medical Records

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#0000 _(replace with actual ticket if available)_

## Testing done

- **Old behavior**: The test "focuses the error alert after failed confirmation" would pass locally but fail intermittently in CI with `AssertionError: expected null to equal '-1'`
- **Steps to verify**:
  1. To reproduce the failure locally, modify the test to check `tabindex` immediately after the error alert renders (before `waitForRenderThenFocus` has time to add it):
     ```javascript
     await waitFor(() => {
       expect(getByTestId('mhv-alert--confirm-error')).to.exist;
     });
     const errorAlert = getByTestId('mhv-alert--confirm-error');
     expect(errorAlert.getAttribute('tabindex')).to.equal('-1'); // This would fail without the fix
     ```
  2. With the fix applied, the component now has `tabIndex={-1}` directly, so the assertion passes immediately
- **Tests completed**:
  - Ran `yarn test:unit src/platform/mhv/tests/components/MhvAlertConfirmEmail.unit.spec.jsx` - 25 tests passing
  - Verified the error alert now has `tabindex="-1"` attribute immediately upon render
  - Confirmed the success alert (`AlertSystemResponse.jsx`) already had this pattern, so this change makes the error alert consistent

## Screenshots

_N/A - No UI changes. This is a fix for a flaky test caused by a missing HTML attribute._

## What areas of the site does it impact?

- MHV Landing Page (`/my-health`)
- My VA Dashboard (`/my-va`)  
- Profile Contact Information (`/profile/contact-information`)

These are the areas where the email confirmation alert can appear, but the visual behavior is unchanged. The fix ensures the error alert is properly focusable for accessibility.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - no documentation needed for this fix)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - This fix improves accessibility by ensuring the error alert can receive programmatic focus

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A - no new logging)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - this is a test fix with no runtime behavior change)

## Requested Feedback

This is a one-line fix adding `tabIndex={-1}` to the `<VaAlert>` in `AlertConfirmAddContactEmailError.jsx`. The fix aligns with the existing pattern in `AlertSystemResponse.jsx` (the success alert component). The root cause was a race condition between the test's `waitFor` and the `waitForRenderThenFocus` utility which dynamically adds the tabindex attribute.