### PR TITLE
Prefill Pattern: Move success alerts out of the card to above the card

### DIFF
--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -111,19 +111,43 @@ export const ContactInfoBase = ({
   // Get the fieldTransactionMap from Redux store
   const { fieldTransactionMap } = useSelector(state => state.vapService) || {};
 
-  // Map editState field names to actual field names
-  const fieldNameMap = {
-    address: FIELD_NAMES.MAILING_ADDRESS,
-    'home-phone': FIELD_NAMES.HOME_PHONE,
-    'mobile-phone': FIELD_NAMES.MOBILE_PHONE,
-    email: FIELD_NAMES.EMAIL,
+  // Unified field configuration mapping
+  const fieldConfig = {
+    address: {
+      id: 'address',
+      fieldName: FIELD_NAMES.MAILING_ADDRESS,
+      key: keys.address,
+      path: 'mailingAddress',
+      text: content.mailingAddress,
+    },
+    'home-phone': {
+      id: 'home-phone',
+      fieldName: FIELD_NAMES.HOME_PHONE,
+      key: keys.homePhone,
+      path: 'homePhone',
+      text: content.homePhone,
+    },
+    'mobile-phone': {
+      id: 'mobile-phone',
+      fieldName: FIELD_NAMES.MOBILE_PHONE,
+      key: keys.mobilePhone,
+      path: 'mobilePhone',
+      text: content.mobilePhone,
+    },
+    email: {
+      id: 'email',
+      fieldName: FIELD_NAMES.EMAIL,
+      key: keys.email,
+      path: 'email',
+      text: content.email,
+    },
   };
 
   // Check if we have a form-only update for the current field
   const [editField] = editState?.split(',') || [];
-  const fieldName = fieldNameMap[editField];
+  const fieldName = fieldConfig[editField]?.fieldName;
   const hasFormOnlyUpdate = fieldName
-    ? fieldTransactionMap?.[fieldName]?.formOnlyUpdate
+    ? !!fieldTransactionMap?.[fieldName]
     : false;
 
   const handlers = {
@@ -163,14 +187,7 @@ export const ContactInfoBase = ({
     const updatedWrapper = { ...wrapper };
     let needsUpdate = false;
 
-    const fields = [
-      { key: keys.email, path: 'email' },
-      { key: keys.homePhone, path: 'homePhone' },
-      { key: keys.mobilePhone, path: 'mobilePhone' },
-      { key: keys.address, path: 'mailingAddress' },
-    ];
-
-    fields.forEach(({ key, path }) => {
+    Object.values(fieldConfig).forEach(({ key, path }) => {
       const profileValue = contactInfo?.[path];
       const formValue = wrapper?.[key];
 
@@ -267,49 +284,49 @@ export const ContactInfoBase = ({
     </span>
   );
 
-  // Extract alert rendering functions
-  const showSuccessAlertInField = (id, text) => (
-    <va-alert
-      id={`updated-${id}`}
-      visible={editState === `${id},updated` && !hasFormOnlyUpdate}
-      class="vads-u-margin-y--1"
-      status="success"
-      slim
-    >
-      {`${text} ${content.updated}`}
-    </va-alert>
-  );
-
-  const showFormOnlyAlert = id => (
-    <va-alert
-      id="form-only-update-alert"
-      visible={
-        hasFormOnlyUpdate &&
-        editState?.includes(`${id}`) &&
-        editState?.includes('updated')
-      }
-      class="vads-u-margin-y--1"
-      status="error"
-      uswds
-      slim
-    >
-      <p>
-        <strong>
-          We couldn’t update your VA.gov profile, but your changes were saved to
-          this form.{' '}
-        </strong>
-        You can try again later to update your profile, or continue with the
-        form using the information you entered.
-      </p>
-    </va-alert>
-  );
-
   // Helper function to render email addresses consistently
   const renderEmail = emailData => {
     if (!emailData) return '';
     return typeof emailData === 'object'
       ? emailData.emailAddress || ''
       : emailData || '';
+  };
+
+  // Render alerts above contact sections
+  const renderContactAlerts = () => {
+    const alerts = [];
+
+    Object.entries(fieldConfig).forEach(([id, { text, key }]) => {
+      if (!key) return; // Skip if this field is not configured
+
+      const isUpdated = editState === `${id},updated`;
+
+      if (isUpdated) {
+        alerts.push(
+          <va-alert
+            key={`success-${id}`}
+            id={`updated-${id}`}
+            visible
+            class="vads-u-margin-y--1"
+            status="success"
+            slim
+            background-only
+            role="alert"
+          >
+            <h2>We’ve updated your {text}</h2>
+            <p className="vads-u-margin-y--0">
+              {hasFormOnlyUpdate
+                ? 'We’ve made these changes to only this form.'
+                : 'We’ve made these changes to this form and your profile.'}
+            </p>
+          </va-alert>,
+        );
+      }
+    });
+
+    return alerts.length > 0 ? (
+      <div className="vads-u-margin-bottom--2">{alerts}</div>
+    ) : null;
   };
 
   // Extract contact section rendering
@@ -326,9 +343,6 @@ export const ContactInfoBase = ({
             {requiredKeys.includes(FIELD_NAMES.MAILING_ADDRESS) &&
               requiredLabel}
           </Headers>
-          {hasFormOnlyUpdate
-            ? showFormOnlyAlert('address')
-            : showSuccessAlertInField('address', content.mailingAddress)}
           <AddressView data={dataWrap[keys.address]} />
           {loggedIn && (
             <p className="vads-u-margin-top--0p5 vads-u-margin-bottom--0">
@@ -378,9 +392,6 @@ export const ContactInfoBase = ({
             {content.homePhone}
             {requiredKeys.includes(FIELD_NAMES.HOME_PHONE) && requiredLabel}
           </Headers>
-          {hasFormOnlyUpdate
-            ? showFormOnlyAlert('home-phone')
-            : showSuccessAlertInField('home-phone', content.homePhone)}
           <span className="dd-privacy-hidden" data-dd-action-name="home phone">
             {renderTelephone(dataWrap[keys.homePhone])}
           </span>
@@ -428,9 +439,6 @@ export const ContactInfoBase = ({
             {content.mobilePhone}
             {requiredKeys.includes(FIELD_NAMES.MOBILE_PHONE) && requiredLabel}
           </Headers>
-          {hasFormOnlyUpdate
-            ? showFormOnlyAlert('mobile-phone')
-            : showSuccessAlertInField('mobile-phone', content.mobilePhone)}
           <span
             className="dd-privacy-hidden"
             data-dd-action-name="mobile phone"
@@ -478,9 +486,6 @@ export const ContactInfoBase = ({
             {content.email}
             {requiredKeys.includes(FIELD_NAMES.EMAIL) && requiredLabel}
           </Headers>
-          {hasFormOnlyUpdate
-            ? showFormOnlyAlert('email')
-            : showSuccessAlertInField('email', content.email)}
           <span className="dd-privacy-hidden" data-dd-action-name="email">
             {renderEmail(dataWrap[keys.email])}
           </span>
@@ -604,6 +609,7 @@ export const ContactInfoBase = ({
           </strong>
         )}
         {renderValidationMessages()}
+        {renderContactAlerts()}
         <div className="vads-u-margin-top--3">
           <div
             className="va-profile-wrapper vads-l-grid-container vads-u-padding-x--0"

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -306,14 +306,11 @@ export const ContactInfoBase = ({
           <va-alert
             key={`success-${id}`}
             id={`updated-${id}`}
-            visible
             class="vads-u-margin-y--1"
             status="success"
-            slim
-            background-only
             role="alert"
           >
-            <h2>We’ve updated your {text}</h2>
+            <h2 slot="headline">We’ve updated your {text}</h2>
             <p className="vads-u-margin-y--0">
               {hasFormOnlyUpdate
                 ? 'We’ve made these changes to only this form.'


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR moves the prefill pattern's ContactInfo success alerts to the top of the content cards, instead of having them displayed inside each card.

This PR also contains a bugfix related to logic for determining whether or not an update took place on just the form or both the form and profile.
`state.vapService.fieldTransactionMap` was expected to have a nested boolean attribute called `formOnlyUpdate`.  However, this attribute did not exist, so I changed the code to instead look for `fieldTransactionMap.[fieldName]`.  `fieldName` is a dynamic string attribute that is the name of the field that was updated (ie - 'mailingAddress').  The field map contains this field name on form only updates, but not when the profile was also updated.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5386

## Testing done

Local validation, but no unit test changes required

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|<img width="781" height="743" alt="image" src="https://github.com/user-attachments/assets/77dabe7c-9c0e-450f-913c-3475520ca4f2" />|<img width="848" height="990" alt="image" src="https://github.com/user-attachments/assets/8ac577a8-76de-4e65-8efb-91df3378abdf" />|

## What areas of the site does it impact?

Prefill pattern in forms-system


