### PR TITLE
Update expandable alert title for content clarity

### DIFF
--- a/src/applications/mhv-secure-messaging/components/EmergencyNote.jsx
+++ b/src/applications/mhv-secure-messaging/components/EmergencyNote.jsx
@@ -42,8 +42,8 @@ const EmergencyNote = props => {
       {dropDownFlag ? (
         <va-alert-expandable
           status="info"
-          trigger="Only use messages for non-urgent needs"
-          data-dd-action-name="Only use messages for non-urgent needs dropdown"
+          trigger="How to get help sooner for urgent needs"
+          data-dd-action-name="How to get help sooner for urgent needs dropdown"
           data-testid="emergency-use-only-expandable"
         >
           <div className="vads-u-padding-x--1 vads-u-padding-bottom--1">

--- a/src/applications/mhv-secure-messaging/tests/components/Reply/ReplyForm.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Reply/ReplyForm.unit.spec.jsx
@@ -116,7 +116,7 @@ describe('Reply form component', () => {
     const { getByText } = screen;
 
     const patientSafetyNotice = document.querySelector(
-      "[trigger='Only use messages for non-urgent needs']",
+      "[trigger='How to get help sooner for urgent needs']",
     );
     const draftToLabel = document.querySelector(
       'span[data-testid=draft-reply-to]',

--- a/src/applications/mhv-secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
@@ -256,7 +256,7 @@ describe('Thread Details container', () => {
 
     expect(
       document.querySelector('va-alert-expandable').getAttribute('trigger'),
-    ).to.equal('Only use messages for non-urgent needs');
+    ).to.equal('How to get help sooner for urgent needs');
 
     expect(
       screen.getByText(

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderManagementPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderManagementPage.js
@@ -100,13 +100,14 @@ class FolderManagementPage {
     cy.findByTestId(Locators.BUTTONS.MOVE_BUTTON_TEST_ID)
       .should('be.visible')
       .click();
-    // Wait for the modal to fully render and radio options to be available
+    // Wait for the modal to appear in DOM first, then check visibility
     cy.findByTestId(Locators.BUTTONS.MOVE_MODAL_TEST_ID)
-      .should('be.visible')
+      .should('exist')
+      .and('be.visible')
       .within(() => {
-        cy.findByLabelText(folderName, { timeout: 10000 })
+        cy.findByLabelText(folderName)
           .should('exist')
-          .should('be.visible')
+          .and('be.visible')
           .click();
       });
   };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I am not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updates the expandable info box title in the MHV Secure Messaging compose flow
- Content change requested during staging review
- MHV Secure Messaging team owns this component
- No flipper involved

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#120577

## Testing done

- Old behavior: "Only use messages for non-urgent needs"
- New behavior: "How to get help sooner for urgent needs"
- Unit test passes, linting passes, E2E tests pass

- fix(e2e): improve move-to-modal assertion chaining to fix flaky test

Use .should('exist').and('be.visible') pattern instead of just
.should('be.visible') to properly wait for the modal to appear in DOM
before checking visibility. This follows Cypress best practices for
assertion chaining without arbitrary timeouts."

## Screenshots

Text-only change - no visual layout changes.

## Acceptance criteria

- [x] Unit tests pass
- [x] Linting addressed
- [x] Accessibility tested
- [x] Datadog tracking updated

## Requested Feedback

Straightforward content update per staging review feedback.
