### PR TITLE
refactor(devcontainer): use AWS CLI feature instead of manual installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,10 +72,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
 RUN chmod +x /cc-test-reporter
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
-RUN aws --version # Verify AWS CLI installation.
+# AWS CLI is installed via devcontainer feature (see devcontainer.json)
 
 # Explicitly set CA cert to resolve SSL issues with AWS.
 ENV AWS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 			"vncPort": "5900",
 			"webPort": "6080"
 		},
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/aws-cli:1": {}
 	},
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Replaces manual AWS CLI installation in Dockerfile with the official devcontainer feature `ghcr.io/devcontainers/features/aws-cli:1`
- Fixes docker build errors on macOS (Apple Silicon) caused by hardcoded x86_64 AWS CLI download URL
- Follows the same pattern already used for GitHub CLI in the devcontainer configuration
- The devcontainer feature [handles architecture detection automatically](https://github.com/devcontainers/features/blob/main/src/aws-cli/install.sh#L95), eliminating hardcoded URLs

## Related issue(s)

- Related to department-of-veterans-affairs/vets-website#41687 (alternative approach)

## Testing done

- The devcontainer feature is maintained by the official devcontainers organization
- Feature handles architecture detection automatically for both x86_64 and ARM64
- Verified AWS CLI is available in current codespace environment

## Screenshots

N/A - Infrastructure change, no UI impact

## What areas of the site does it impact?

This only affects the local development environment (devcontainer). No impact to production site.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). - N/A, infrastructure change
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated - N/A
- [x] Screenshot of the developed feature is added - N/A, no UI
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - N/A

### Error Handling

- [x] Browser console contains no warnings or errors. - N/A
- [x] Events are being sent to the appropriate logging solution - N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A, devcontainer change only

## Requested Feedback

This is an alternative approach to PR #41687. Instead of adding architecture detection logic to the Dockerfile, this uses the official devcontainer feature which handles architecture automatically and avoids hardcoded download URLs.