### PR TITLE
Auth Interstitial page asking veterans to confirm email when email was updated

### DIFF
--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -47,40 +47,25 @@ export const emailNeedsConfirmation = ({
   }
 
   // Has no email address
-  const hasNoEmailAddress =
-    !vet360ContactInformation?.email?.emailAddress ||
-    vet360ContactInformation?.email?.emailAddress === '' ||
-    vet360ContactInformation?.email?.emailAddress === undefined ||
-    vet360ContactInformation?.email?.emailAddress === null;
+  const hasNoEmailAddress = !vet360ContactInformation?.email?.emailAddress;
 
-  // Confirmation Date is null
-  const hasNoConfirmationDate =
-    vet360ContactInformation?.email?.confirmationDate === null;
+  // Confirmation Date is null, undefined, or empty
+  const confirmationDate = vet360ContactInformation?.email?.confirmationDate;
+  const hasNoConfirmationDate = !confirmationDate;
 
   // Confirmation Date is before March 1, 2025
-  const confirmationDateIsBefore =
-    hasNoConfirmationDate === false
-      ? isBefore(
-          parseISO(
-            userAttributes.vet360ContactInformation?.email?.confirmationDate,
-          ),
-          beforeDate,
-        )
-      : false;
+  const confirmationDateIsBefore = !hasNoConfirmationDate
+    ? isBefore(parseISO(confirmationDate), beforeDate)
+    : false;
 
-  // Updated Date is null or undefined
-  const hasNoUpdatedDate =
-    vet360ContactInformation?.email?.updatedAt === null ||
-    vet360ContactInformation?.email?.updatedAt === undefined;
+  // Updated Date is null, undefined, or empty
+  const updatedAt = vet360ContactInformation?.email?.updatedAt;
+  const hasNoUpdatedDate = !updatedAt;
 
   // Updated Date is before March 1, 2025
-  const updatedDateIsBefore =
-    hasNoUpdatedDate === false
-      ? isBefore(
-          parseISO(vet360ContactInformation?.email?.updatedAt),
-          beforeDate,
-        )
-      : false;
+  const updatedDateIsBefore = !hasNoUpdatedDate
+    ? isBefore(parseISO(updatedAt), beforeDate)
+    : false;
 
   return (
     [CSP_IDS.LOGIN_GOV, CSP_IDS.ID_ME].includes(loginType) &&

--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -68,12 +68,28 @@ export const emailNeedsConfirmation = ({
         )
       : false;
 
+  // Updated Date is null or undefined
+  const hasNoUpdatedDate =
+    vet360ContactInformation?.email?.updatedAt === null ||
+    vet360ContactInformation?.email?.updatedAt === undefined;
+
+  // Updated Date is before March 1, 2025
+  const updatedDateIsBefore =
+    hasNoUpdatedDate === false
+      ? isBefore(
+          parseISO(vet360ContactInformation?.email?.updatedAt),
+          beforeDate,
+        )
+      : false;
+
   return (
     [CSP_IDS.LOGIN_GOV, CSP_IDS.ID_ME].includes(loginType) &&
     profile?.verified && // Verified User
     vaProfile?.vaPatient && // VA Patient
     vaProfile?.facilities?.length > 0 && // Assigned to a facility
-    (hasNoConfirmationDate || confirmationDateIsBefore || hasNoEmailAddress) // Confirmation Date or email related
+    (hasNoEmailAddress ||
+      ((hasNoConfirmationDate || confirmationDateIsBefore) &&
+        (hasNoUpdatedDate || updatedDateIsBefore))) // Need confirmation if BOTH dates are old/missing
   );
 };
 

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -821,4 +821,80 @@ describe('emailNeedsConfirmation', () => {
       }),
     ).to.be.true;
   });
+
+  it('should return true when confirmationDate is undefined and updatedAt is undefined', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: undefined,
+              updatedAt: undefined,
+            },
+          },
+        },
+      }),
+    ).to.be.true;
+  });
+
+  it('should return true when confirmationDate is undefined and updatedAt is old', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'logingov',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: undefined,
+              updatedAt: '2024-01-01T00:00:00Z',
+            },
+          },
+        },
+      }),
+    ).to.be.true;
+  });
+
+  it('should return false when confirmationDate is undefined but updatedAt is recent', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: undefined,
+              updatedAt: '2025-04-01T00:00:00Z',
+            },
+          },
+        },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return true when confirmationDate is empty string and updatedAt is empty string', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'logingov',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: '',
+              updatedAt: '',
+            },
+          },
+        },
+      }),
+    ).to.be.true;
+  });
 });

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -593,27 +593,232 @@ describe('handleTokenRequest', () => {
 });
 
 describe('emailNeedsConfirmation', () => {
-  it('should return false when conditions are met', () => {
+  const baseAttributes = {
+    profile: { verified: true },
+    vaProfile: { vaPatient: true, facilities: [{ facilityId: '123' }] },
+    vet360ContactInformation: {
+      email: {
+        emailAddress: 'test@example.com',
+      },
+    },
+  };
+
+  it('should return false when feature flag is disabled', () => {
     expect(
       emailNeedsConfirmation({
         isEmailInterstitialEnabled: false,
+        loginType: 'idme',
+        userAttributes: baseAttributes,
+      }),
+    ).to.be.false;
+  });
+
+  it('should return false when profile is missing', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: { profile: null, vaProfile: {} },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return false when vaProfile is missing', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: { profile: {}, vaProfile: null },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return false when user is not verified', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
         userAttributes: {
-          profile: { verified: true },
-          vaProfile: { vaPatient: true },
+          ...baseAttributes,
+          profile: { verified: false },
         },
       }),
     ).to.be.false;
+  });
+
+  it('should return false when user is not a VA patient', () => {
     expect(
       emailNeedsConfirmation({
         isEmailInterstitialEnabled: true,
-        userAttributes: { profile: {} },
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vaProfile: { vaPatient: false, facilities: [] },
+        },
       }),
     ).to.be.false;
+  });
+
+  it('should return false when user has no facilities', () => {
     expect(
       emailNeedsConfirmation({
         isEmailInterstitialEnabled: true,
-        userAttributes: { profile: {} },
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vaProfile: { vaPatient: true, facilities: [] },
+        },
       }),
     ).to.be.false;
+  });
+
+  it('should return false when loginType is not idme or logingov', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'mhv',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: null,
+              updatedAt: null,
+            },
+          },
+        },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return true when email address is missing', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: null,
+            },
+          },
+        },
+      }),
+    ).to.be.true;
+  });
+
+  it('should return true when both confirmationDate and updatedAt are missing', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'logingov',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: null,
+              updatedAt: null,
+            },
+          },
+        },
+      }),
+    ).to.be.true;
+  });
+
+  it('should return true when both confirmationDate and updatedAt are before March 1, 2025', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: '2024-12-01T00:00:00Z',
+              updatedAt: '2024-12-15T00:00:00Z',
+            },
+          },
+        },
+      }),
+    ).to.be.true;
+  });
+
+  it('should return false when confirmationDate is old but updatedAt is recent', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: '2024-01-01T00:00:00Z',
+              updatedAt: '2025-03-15T00:00:00Z',
+            },
+          },
+        },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return false when confirmationDate is null but updatedAt is recent', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'logingov',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: null,
+              updatedAt: '2025-04-01T00:00:00Z',
+            },
+          },
+        },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return false when both confirmationDate and updatedAt are recent', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: '2025-03-15T00:00:00Z',
+              updatedAt: '2025-03-20T00:00:00Z',
+            },
+          },
+        },
+      }),
+    ).to.be.false;
+  });
+
+  it('should return true when confirmationDate is old and updatedAt is null', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        loginType: 'idme',
+        userAttributes: {
+          ...baseAttributes,
+          vet360ContactInformation: {
+            email: {
+              emailAddress: 'test@example.com',
+              confirmationDate: '2024-01-01T00:00:00Z',
+              updatedAt: null,
+            },
+          },
+        },
+      }),
+    ).to.be.true;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The issue is that the interstitial page does not check if the email address was updated. It only checks for confirmation date. So, if the user updates their email only, the interstitial page will still ask for email confirmation.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/128931

## Testing done
- [x] Added/updated unit tests be better cover logic

## Screenshots
No UI changes

## What areas of the site does it impact?
Auth - Redirecting to Interstitial page at `/sign-in-confirm-contact-email`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

