### PR TITLE
Add forced retry of request in promise if 403 is returned

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -108,7 +108,13 @@ export function setItf(data) {
   };
 }
 
-export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
+export function submitToUrl(
+  body,
+  submitUrl,
+  trackingPrefix,
+  eventData,
+  hasAttemptedTokenRefresh = false,
+) {
   // This item should have been set in any previous API calls
   const csrfTokenStored = localStorage.getItem('csrfToken');
   return new Promise((resolve, reject) => {
@@ -127,6 +133,34 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
           'response' in req ? req.response : req.responseText;
         const results = JSON.parse(responseBody || '{}');
         resolve(results);
+      } else if (req.status === 403 && !hasAttemptedTokenRefresh) {
+        try {
+          const errorResponse = JSON.parse(req.response);
+          const errorMessage = errorResponse?.errors || '';
+          const isTokenExpired = errorMessage.includes('token has expired');
+
+          if (isTokenExpired && infoTokenExists()) {
+            refresh({ type: sessionStorage.getItem('serviceName') })
+              .then(() => {
+                return submitToUrl(
+                  body,
+                  submitUrl,
+                  trackingPrefix,
+                  eventData,
+                  true,
+                );
+              })
+              .then(resolve)
+              .catch(reject);
+            return;
+          }
+        } catch (e) {
+          // JSON parse error, fall through to reject
+        }
+        // If we couldn't refresh or it wasn't a token expiration, reject with error
+        const error = new Error(`vets_server_error: ${req.statusText}`);
+        error.statusText = req.statusText;
+        reject(error);
       } else {
         let error;
         if (req.status === 429) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130791


## Testing done

- If you allowed token to expire the backend would send a 403 but there is no built in functionality on fe to retry an expired token. submitToUrl promise was using XHR and had no retry. User would get a 403 and not understand why if they had waited on review page for a couple minutes.
- Allow your token to expire on form upload review page. Once expired send the request with network tab open, you should see a 403 and a retry in the tab.

## Screenshots
<img width="1235" height="610" alt="Screenshot 2026-01-23 at 11 23 21 AM" src="https://github.com/user-attachments/assets/abf7eab8-4f1a-469a-8251-36f9b9825fb8" />


