### PR TITLE
feat(ci): add deployment concurrency groups for isolated deployments

### DIFF
--- a/.github/workflows/continuous-deploy-production.yml
+++ b/.github/workflows/continuous-deploy-production.yml
@@ -6,6 +6,10 @@ on:
 
 run-name: "Triggered by: ${{ github.event.client_payload.entry_app }} commit: ${{ github.event.client_payload.github_sha }}"
 
+concurrency:
+  group: deploy-${{ github.event.client_payload.concurrency_group }}
+  cancel-in-progress: true
+
 jobs:
   notify-pending-deployment:
     name: Notify of Pending Deployment

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -150,6 +150,13 @@ jobs:
           delimiter: ','
           output-type: 'entry_name, continuous_deployment, deployment_concurrency_group'
 
+      - name: Log changed apps info
+        if: ${{ matrix.buildtype == 'vagovprod' }}
+        run: |
+          echo "Entry names: ${{ steps.get-changed-apps.outputs.entry_names }}"
+          echo "Continuous deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}"
+          echo "Deployment concurrency group: ${{ steps.get-changed-apps.outputs.deployment_concurrency_group }}"
+
       - name: Get Mapbox Token
         if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -113,6 +113,7 @@ jobs:
     outputs:
       entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
       continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
+      deployment_concurrency_group: ${{ steps.get-changed-apps.outputs.deployment_concurrency_group }}
 
     strategy:
       fail-fast: false
@@ -147,7 +148,7 @@ jobs:
         uses: ./.github/workflows/get-changed-apps
         with:
           delimiter: ','
-          output-type: 'entry_name, continuous_deployment'
+          output-type: 'entry_name, continuous_deployment, deployment_concurrency_group'
 
       - name: Get Mapbox Token
         if: ${{ matrix.buildtype == 'vagovprod' }}
@@ -2007,7 +2008,8 @@ jobs:
           --arg ref "${{ github.ref }}" \
           --arg entry "${{ needs.build.outputs.entry_names }}" \
           --arg slack_channel "${{ steps.determine-channel.outputs.channel }}" \
-          '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, entry_app: $entry, slack_channel: $slack_channel}}')"
+          --arg concurrency_group "${{ needs.build.outputs.deployment_concurrency_group }}" \
+          '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, entry_app: $entry, slack_channel: $slack_channel, concurrency_group: $concurrency_group}}')"
 
       - name: Cancel CD dispatch due to holiday
         if: steps.holiday-check.outputs.is_holiday == 'true'

--- a/.github/workflows/get-changed-apps/action.yml
+++ b/.github/workflows/get-changed-apps/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: ' '
 
   output-type:
-    description: 'Comma delimited list of changed application details to retrieve. Output types include: `entry_name`, `folder`, `slack_group`, `slack_channel`, `url`, `continuous_deployment`.'
+    description: 'Comma delimited list of changed application details to retrieve. Output types include: `entry_name`, `folder`, `deployment_concurrency_group`, `slack_group`, `slack_channel`, `url`, `continuous_deployment`.'
     required: false
     default: ''
 
@@ -40,6 +40,10 @@ outputs:
   urls:
     description: 'Root URLs of changed applications.'
     value: ${{ steps.get-urls.outputs.urls }}
+
+  deployment_concurrency_group:
+    description: 'Concurrency group identifier for deployments, derived from sorted parent folder names.'
+    value: ${{ steps.get-concurrency-group.outputs.deployment_concurrency_group }}
 
 runs:
   using: 'composite'
@@ -99,5 +103,13 @@ runs:
       if: contains(inputs.output-type, 'continuous_deployment')
       shell: bash
       run: echo is_enabled=$(node script/github-actions/get-changed-apps.js --continuous-deployment) >> $GITHUB_OUTPUT
+      env:
+        CHANGED_FILE_PATHS: ${{ steps.get-changed-files.outputs.changed_files }}
+
+    - name: Get deployment concurrency group
+      id: get-concurrency-group
+      if: contains(inputs.output-type, 'deployment_concurrency_group')
+      shell: bash
+      run: echo deployment_concurrency_group=$(node script/github-actions/get-changed-apps.js --output-type concurrency-group -d "-") >> $GITHUB_OUTPUT
       env:
         CHANGED_FILE_PATHS: ${{ steps.get-changed-files.outputs.changed_files }}

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -75,6 +75,7 @@ const getAllowedApps = (filePath, allowedApps) => {
       entryName,
       rootUrl,
       rootPath: path.join(appsDirectory, rootAppFolderName),
+      rootFolder: rootAppFolderName,
       slackGroup,
       slackChannel,
       continuousDeployment,
@@ -112,6 +113,8 @@ const getChangedAppsString = (
           appStrings.push(app.entryName);
         } else if (outputType === 'folder') {
           appStrings.push(app.rootPath);
+        } else if (outputType === 'concurrency-group') {
+          appStrings.push(app.rootFolder);
         } else if (outputType === 'slack-group') {
           if (app.slackGroup) appStrings.push(app.slackGroup);
         } else if (outputType === 'slack-channel') {
@@ -123,7 +126,7 @@ const getChangedAppsString = (
     } else return '';
   }
 
-  return [...new Set(appStrings)].join(delimiter);
+  return [...new Set(appStrings)].sort().join(delimiter);
 };
 
 /**
@@ -168,6 +171,7 @@ if (process.env.CHANGED_FILE_PATHS) {
     // Use the --output-type option to specify one of the following outputs:
     // 'entry': The entry names of the changed apps.
     // 'folder': The relative path of the changed apps root folders.
+    // 'concurrency-group': The root folder names for deployment concurrency groups.
     // 'url': The root URLs of the changed apps.
     // 'slack-group': The Slack group of the app's team, specified in the config.
     { name: 'output-type', type: String, defaultValue: 'entry' },

--- a/script/github-actions/get-changed-apps.unit.spec.jsx
+++ b/script/github-actions/get-changed-apps.unit.spec.jsx
@@ -233,6 +233,70 @@ describe('getChangedAppsString', () => {
     });
   });
 
+  context('when the concurrency-group output type is specified', () => {
+    it('should return a single root folder name for a single app', () => {
+      const config = createChangedAppsConfig([{ rootFolder: 'app1' }]);
+      const changedFiles = ['src/applications/app1/some-file.js'];
+
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'concurrency-group',
+      );
+      expect(appString).to.equal('app1');
+    });
+
+    it('should return sorted root folder names for multiple apps', () => {
+      const config = createChangedAppsConfig([
+        { rootFolder: 'app2' },
+        { rootFolder: 'app1' },
+      ]);
+      const changedFiles = ['src/applications/app2', 'src/applications/app1'];
+
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'concurrency-group',
+      );
+      expect(appString).to.equal('app1 app2');
+    });
+
+    it('should return the root folder name when files are changed in a grouped app folder', () => {
+      const config = createChangedAppsConfig([{ rootFolder: 'groupedApps' }]);
+      const changedFiles = [
+        'src/applications/groupedApps/grouped-app-1/some-file.js',
+      ];
+
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'concurrency-group',
+      );
+      expect(appString).to.equal('groupedApps');
+    });
+
+    it('should return hyphen-delimited sorted root folder names when using hyphen delimiter', () => {
+      const config = createChangedAppsConfig([
+        { rootFolder: 'app2' },
+        { rootFolder: 'app1' },
+        { rootFolder: 'app3' },
+      ]);
+      const changedFiles = [
+        'src/applications/app3',
+        'src/applications/app1',
+        'src/applications/app2',
+      ];
+
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'concurrency-group',
+        '-',
+      );
+      expect(appString).to.equal('app1-app2-app3');
+    });
+  });
+
   context('when the delimiter is specified', () => {
     it('should return a string delimited by the delimiter', () => {
       const config = createChangedAppsConfig([

--- a/src/applications/_mock-form/config/form.js
+++ b/src/applications/_mock-form/config/form.js
@@ -1,4 +1,3 @@
-// Test change to verify deployment concurrency group generation in CI
 // In a real app this would be imported from `vets-json-schema`:
 // import fullSchema from 'vets-json-schema/dist/00-1234-schema.json';
 

--- a/src/applications/_mock-form/config/form.js
+++ b/src/applications/_mock-form/config/form.js
@@ -1,3 +1,4 @@
+// Test change to verify deployment concurrency group generation in CI
 // In a real app this would be imported from `vets-json-schema`:
 // import fullSchema from 'vets-json-schema/dist/00-1234-schema.json';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Adds concurrency control to prevent race conditions in isolated app deployments. When multiple deployments for the same parent app directory are queued, only the most recent deployment proceeds, cancelling older pending deployments.

**Changes:**
- Add `deployment_concurrency_group` output type to `get-changed-apps.js` (derives sorted parent folder names)
- Add corresponding output and step to `get-changed-apps` action
- Pass concurrency group through CI dispatch payload to production deploy workflow
- Add workflow-level concurrency block to `continuous-deploy-production.yml`
- Add logging step to CI for visibility into changed apps info

**How it works:**
- When apps change, the concurrency group is derived from their parent folder names (e.g., `appeals-claims-status`)
- The production deploy workflow uses this as its concurrency group with `cancel-in-progress: true`
- If a newer deployment for the same parent folder(s) is triggered, it cancels any pending older deployment

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#129539

## Testing done

- Linting passes
- Unit tests added for the new `concurrency-group` output type
- End-to-end verification of concurrency group generation and deployment behavior will be done in a separate PR with changes only to allowlisted apps

## Screenshots

N/A - CI/workflow changes only, no UI impact

## What areas of the site does it impact?

No site impact. This affects the deployment pipeline only.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, internal CI change
- [ ] Screenshot of the developed feature is added - N/A, no UI changes
- [ ] Accessibility testing has been performed - N/A, no UI changes

### Error Handling

- [x] Browser console contains no warnings or errors. - N/A, no frontend changes
- [ ] Events are being sent to the appropriate logging solution - N/A
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A, no frontend changes

## Requested Feedback

This PR implements Approach 3 (Deployment Concurrency Control) from the nested app deployments analysis. Looking for feedback on:
1. Whether the concurrency group naming strategy is appropriate
2. Any edge cases that may have been missed