### PR TITLE
Burail | PDF form alignment - update in-progress form alert content

### DIFF
--- a/src/applications/burials-ez/components/IntroductionPage.jsx
+++ b/src/applications/burials-ez/components/IntroductionPage.jsx
@@ -9,6 +9,8 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+import { formatDateLong } from 'platform/utilities/date';
+import { showPdfFormAlignment } from '../utils/helpers';
 
 const IntroductionPage = ({ route }) => {
   useEffect(() => {
@@ -28,6 +30,25 @@ const IntroductionPage = ({ route }) => {
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const pbbFormsRequireLoa3 = useToggleValue(TOGGLE_NAMES.pbbFormsRequireLoa3);
+
+  const launchDate = '2026-02-19';
+
+  const FormUpdateText = () => (
+    <>
+      <p>
+        You should know that we updated our online form.{' '}
+        <strong>
+          If you started applying online before {formatDateLong(launchDate)}
+        </strong>
+        , we have some new questions for you to answer. And we changed some
+        questions, so you may need to provide certain information again.
+      </p>
+      <p>
+        Select <strong>Continue your application</strong> to use our updated
+        form. Or come back later to finish your application.
+      </p>
+    </>
+  );
 
   return (
     <div className="schemaform-intro vads-u-margin-bottom--6">
@@ -140,6 +161,7 @@ const IntroductionPage = ({ route }) => {
           pageList={route.pageList}
           downtime={route.formConfig.downtime}
           startText="Start the burial allowance and transportation benefits application"
+          continueMsg={showPdfFormAlignment() ? <FormUpdateText /> : null}
         />
       )}
 

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -432,7 +432,7 @@ SaveInProgressIntro.propTypes = {
   buttonAriaDescribedby: PropTypes.string,
   buttonOnly: PropTypes.bool,
   children: PropTypes.any,
-  continueMsg: PropTypes.string,
+  continueMsg: PropTypes.node,
   customLink: PropTypes.any,
   devOnly: PropTypes.shape({
     forceShowFormControls: PropTypes.bool,


### PR DESCRIPTION
### Summary of Changes
This PR updates the **In-progress form alert** content for the **Burial Benefits form (VA Form 21P-530EZ)** as part of **PDF form alignment** work.  
The updated messaging better reflects the PDF-aligned experience and is **only shown when the PDF form alignment feature toggle is enabled**.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130181

### How to Set Up in Local Environment
1. Run the local environment
2. Enable the required feature toggles:
   - `burial_form_enabled`  
     http://localhost:3000/flipper/features/burial_form_enabled
   - `burial_pdf_form_alignment`  
     http://localhost:3000/flipper/features/burial_pdf_form_alignment
3. Navigate to the Burial Benefits form:  
   http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/

### How to Test
1. Start a new **21P-530EZ** application and save progress.
2. Return to the form while it is **in progress**.
3. With `burial_pdf_form_alignment` enabled, verify:
   - The updated **in-progress form alert** content is displayed.
   - The messaging matches the PDF-aligned content requirements.
4. Disable `burial_pdf_form_alignment` and verify:
   - The legacy in-progress alert content is displayed.
5. Confirm there are no console errors or accessibility regressions.

### Feature Flag Note
- This update is gated behind the `burial_pdf_form_alignment` feature toggle.

### Screenshots
| Before | After |
| ------ | ----- |
|<img width="1400" height="2808" alt="localhost_3001_burials-memorials_veterans-burial-allowance_apply-for-allowance-form-21p-530ez_introduction (2)" src="https://github.com/user-attachments/assets/69a61db8-c566-4f3f-8f3d-fa190bc06301" />|<img width="1400" height="2952" alt="localhost_3001_burials-memorials_veterans-burial-allowance_apply-for-allowance-form-21p-530ez_introduction (1)" src="https://github.com/user-attachments/assets/afca7f08-13c1-4bee-8de5-11daf5ecef77" />|

### Acceptance Criteria
- [x] In-progress form alert content updates display when `burial_pdf_form_alignment` is enabled.
- [x] Legacy alert content remains unchanged when the toggle is disabled.
- [x] Content aligns with PDF form alignment requirements.
- [x] No regressions in accessibility or form flow.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggles enabled and disabled.
- [ ] No console errors or accessibility issues.
- [ ] Tests updated or verified passing.