### PR TITLE
[ARC/130292] Fix form focus between pages

### DIFF
--- a/src/applications/representative-form-upload/helpers/index.js
+++ b/src/applications/representative-form-upload/helpers/index.js
@@ -3,6 +3,7 @@ import { srSubstitute } from '~/platform/forms-system/src/js/utilities/ui/mask-s
 import { focusElement } from 'platform/utilities/ui';
 import { waitForShadowRoot } from 'platform/utilities/ui/webComponents';
 import { scrollTo } from 'platform/utilities/scroll';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import { differenceInDays } from 'date-fns';
 import { timeFromNow } from 'platform/utilities/date/index';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
@@ -77,7 +78,7 @@ export const getFileSize = num => {
 
 export const scrollAndFocusTarget = () => {
   scrollTo('va-segmented-progress-bar');
-  focusElement('h2', {}, 'va-segmented-progress-bar');
+  focusElement('h2', {}, $('va-segmented-progress-bar')?.shadowRoot);
 };
 
 // separate each number so the screenreader reads "number ending with 1 2 3 4"

--- a/src/applications/representative-form-upload/helpers/index.js
+++ b/src/applications/representative-form-upload/helpers/index.js
@@ -76,8 +76,8 @@ export const getFileSize = num => {
 };
 
 export const scrollAndFocusTarget = () => {
-  scrollTo('topScrollElement');
-  focusElement('va-segmented-progress-bar');
+  scrollTo('va-segmented-progress-bar');
+  focusElement('h2', {}, 'va-segmented-progress-bar');
 };
 
 // separate each number so the screenreader reads "number ending with 1 2 3 4"

--- a/src/applications/representative-form-upload/tests/unit/helpers/index.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/helpers/index.unit.spec.jsx
@@ -103,7 +103,7 @@ describe('Helpers', () => {
 
     it('calls scrollTo', () => {
       scrollAndFocusTarget();
-      expect(scrollToSpy.calledWith('topScrollElement')).to.be.true;
+      expect(scrollToSpy.calledWith('va-segmented-progress-bar')).to.be.true;
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Summary

- Updates `scrollAndFocusTarget` to focus to the `h2` within the `va-segmented-progress-bar` instead of the progress bar itself. This aligns with [focus management guidelines for forms](https://design.va.gov/templates/forms/accessibility-guidelines) ("If the page does not have a unique page heading, set focus on the step indicator header. This header is usually an H2.") and should ensure that VoiceOver announces the heading.
- **This change applies to all ARP forms.**

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130292

## Testing done

- Tested 526EZ, 686c, and ITF on MacOS with Safari/VoiceOver.
- Tested 526EZ, 686c, and ITF on MacOS with Google Chrome and zoom up to 400%.
- Ran axe DevTools, no new accessibility issues added.
- Additional testing needed:
  - iOS/Safari/VoiceOver to confirm fix
  - Regression testing on Windows/Edge/JAWS and Android/Chrome/Talkback
  - Testing on other devices will need to be completed after the change goes to staging. The intent is to do all additional testing before the next deployment on Monday to allow time to rollback if necessary.

## Screenshots
MacOS VoiceOver behavior before change:
https://github.com/user-attachments/assets/a509b5f3-836d-43bf-934b-f5da51ed6ee7

MacOS VoiceOver behavior after change:
https://github.com/user-attachments/assets/b3030c10-7347-430c-81ce-653e4e3d1efa

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
Since this change applies to **all ARP forms**, please pull the code down and test them each. Focus should be shifted to the `h2` within the `va-segmented-progress-bar` on each new form page, _except_ the ITF check error page, where focus should be shifted to the heading within the `va-alert`.
