### PR TITLE
fixes empty groups being announced on screen reader on confirmation p…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.jsx
@@ -79,10 +79,10 @@ export const ConfirmationPage = ({ route }) => {
         </p>
         <p>Mail any supporting documents to this address: </p>
         <p className="va-address-block">
-          Department of Veterans Affairs <br />
-          Pension Claims Intake Center <br />
-          PO Box 5365 <br />
-          Janesville, WI 53547-5365 <br />
+          Department of Veterans Affairs <br role="presentation" />
+          Pension Claims Intake Center <br role="presentation" />
+          PO Box 5365 <br role="presentation" />
+          Janesville, WI 53547-5365 <br role="presentation" />
         </p>
         <p>
           <strong>Note:</strong> Mail us copies of your documents only. Don’t


### PR DESCRIPTION
…age address block

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Adding role="presentation" to br elements on confirmation page to prevent screen reader from reading them as empty groups

### Issue
The address block on the confirmation page had br elements that were being read by the screen reader as empty groups

### Solution
Added role="presentation" attribute to these elements to prevent screen readers from picking them up

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21p-530aform
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 128528](https://github.com/department-of-veterans-affairs/va.gov-team/issues/128528)

## Testing done

### Old behavior
* Screen readers would read "Empty Group" when going through the text of the address block on the confirmation page

### New behavior
* Screen readers no longer read "Empty Group" when going through the text of the address block on the confirmation page

### Verification Steps
*  Unit tests: verified existing unit tests still pass (no test modifications needed)
*  Manual testing in local environment verified that screen readers no longer read an empty group when going through the text of the confirmation page
* E2E tests: all existing tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

No visual changes in this commit

## What areas of the site does it impact?

This change affects form 21p-530a, specifically on the Confirmation page that shows after submitting a form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user