### PR TITLE
View Dependents | Add details to Datadog log messages

### DIFF
--- a/src/applications/dependents/shared/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/dependents/shared/tests/utils/utils.unit.spec.jsx
@@ -140,11 +140,22 @@ describe('getIsDependentsWarningHidden', () => {
   });
 
   it('should return true when a valid date is stored', () => {
-    const testDate = '2023-12-01T10:00:00.000Z';
+    const testDate = new Date().toISOString();
     localStorage.setItem('viewDependentsWarningClosedAt', testDate);
 
     const result = getIsDependentsWarningHidden();
     expect(result).to.be.true;
+  });
+
+  it('should return false and clear the stored date when a date is > 6 months old', () => {
+    const testDate = '2025-06-01T10:00:00.000Z';
+    localStorage.setItem('viewDependentsWarningClosedAt', testDate);
+
+    const result = getIsDependentsWarningHidden();
+    expect(result).to.be.false;
+
+    const storedValue = localStorage.getItem('viewDependentsWarningClosedAt');
+    expect(storedValue).to.be.null;
   });
 
   it('should return false when an invalid date string is stored', () => {

--- a/src/applications/dependents/shared/utils/index.js
+++ b/src/applications/dependents/shared/utils/index.js
@@ -1,3 +1,5 @@
+import { parseISO, isValid, differenceInMonths } from 'date-fns';
+
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
 import { getFormatedDate, calculateAge } from './dates';
@@ -85,8 +87,16 @@ export function getIsDependentsWarningHidden() {
     return false;
   }
 
-  const dateClosed = new Date(rawStoredDate);
-  return !Number.isNaN(dateClosed.getTime());
+  const dateClosed = parseISO(rawStoredDate);
+  const monthsSinceClosed = differenceInMonths(new Date(), dateClosed);
+
+  // If it has been more than 6 months since the warning was closed, show it
+  // again
+  if (monthsSinceClosed >= 6) {
+    localStorage.removeItem(VIEW_DEPENDENTS_WARNING_KEY);
+    return false;
+  }
+  return isValid(dateClosed);
 }
 
 /**

--- a/src/applications/dependents/view-dependents/components/ViewDependentsHeader/ViewDependentsHeaderV2.jsx
+++ b/src/applications/dependents/view-dependents/components/ViewDependentsHeader/ViewDependentsHeaderV2.jsx
@@ -27,6 +27,8 @@ const CALLSTATUS = {
 /**
  * @typedef ViewDependentsHeaderProps
  * @property {Boolean} showAlert true if dependent receives compensation and has dependents
+ * @property {Boolean} hasMinimumRating true if disability rating is 30 or higher
+ * @property {Boolean} hasAwardDependents true if Veteran has active dependents
  * @property {String} updateDiariesStatus status of update diaries call
  */
 /**
@@ -35,7 +37,12 @@ const CALLSTATUS = {
  * @returns {JSX.Element} page title, description, and alert if showAlert is true
  */
 function ViewDependentsHeader(props) {
-  const { updateDiariesStatus, showAlert } = props;
+  const {
+    updateDiariesStatus,
+    showAlert,
+    hasAwardDependents,
+    hasMinimumRating,
+  } = props;
 
   const [warningHidden, setWarningHidden] = useState(
     getIsDependentsWarningHidden(),
@@ -48,14 +55,25 @@ function ViewDependentsHeader(props) {
 
   useEffect(
     () => {
-      const state = showAlert && !warningHidden ? 'visible' : 'hidden';
-      // Alert may start hidden if still in the same session
+      let state = showAlert && !warningHidden ? 'visible' : 'hidden';
+      let reason = '';
+      if (warningHidden) {
+        // Alert may start hidden
+        state = 'already hidden';
+        reason = 'user previously closed alert';
+      } else if (!hasAwardDependents) {
+        state = 'hidden because no active dependents';
+        reason = 'no active dependents';
+      } else if (!hasMinimumRating) {
+        state = 'hidden because disability rating below 30%';
+        reason = 'disability rating below 30%';
+      }
       dataDogLogger({
         message: `View dependents 0538 warning alert ${state}`,
-        attributes: { state },
+        attributes: { state, reason },
       });
     },
-    [showAlert, warningHidden],
+    [showAlert, warningHidden, hasAwardDependents, hasMinimumRating],
   );
 
   /**
@@ -66,8 +84,8 @@ function ViewDependentsHeader(props) {
     setWarningHidden(true);
     hideDependentsWarning();
     dataDogLogger({
-      message: 'View dependents 0538 warning alert hidden',
-      attributes: { state: 'hidden' },
+      message: 'View dependents 0538 warning alert hidden by user',
+      attributes: { state: 'hidden by user', reason: 'hidden by user' },
     });
     scrollToTop();
     focusElement('.view-deps-header');
@@ -185,6 +203,8 @@ function ViewDependentsHeader(props) {
 }
 
 ViewDependentsHeader.propTypes = {
+  hasAwardDependents: PropTypes.bool,
+  hasMinimumRating: PropTypes.bool,
   showAlert: PropTypes.bool,
   updateDiariesStatus: PropTypes.string,
 };

--- a/src/applications/dependents/view-dependents/layouts/ViewDependentsLayoutV2.jsx
+++ b/src/applications/dependents/view-dependents/layouts/ViewDependentsLayoutV2.jsx
@@ -58,6 +58,8 @@ function ViewDependentsLayout(props) {
       <ViewDependentsHeader
         updateDiariesStatus={props.updateDiariesStatus}
         showAlert={hasDependents}
+        hasAwardDependents={props.onAwardDependents.length > 0}
+        hasMinimumRating={props.hasMinimumRating}
       />
       {mainContent}
       {showActionLink && (

--- a/src/applications/dependents/view-dependents/tests/components/ViewDependentsHeaderV2.unit.spec.jsx
+++ b/src/applications/dependents/view-dependents/tests/components/ViewDependentsHeaderV2.unit.spec.jsx
@@ -36,7 +36,11 @@ describe('<ViewDependentsHeader />', () => {
   it('Should render', () => {
     const logSpy = sinon.spy();
     window.DD_LOGS = { logger: { log: logSpy } };
-    const { container } = renderWithStore({ showAlert: true });
+    const { container } = renderWithStore({
+      showAlert: true,
+      hasAwardDependents: true,
+      hasMinimumRating: true,
+    });
     expect($('h1', container).textContent).to.equal(PAGE_TITLE);
     expect($('#update-warning-alert', container)).to.exist;
     expect(
@@ -49,17 +53,45 @@ describe('<ViewDependentsHeader />', () => {
     expect(logSpy.args[0][0]).to.eq(
       'View dependents 0538 warning alert visible',
     );
+    expect(logSpy.args[0][1]).to.deep.equal({ state: 'visible', reason: '' });
   });
 
-  it('Should not render alert when showAlert is false', () => {
+  it('Should not render alert when showAlert is false & no dependents', () => {
     const logSpy = sinon.spy();
     window.DD_LOGS = { logger: { log: logSpy } };
-    const { container } = renderWithStore({ showAlert: false });
+    const { container } = renderWithStore({
+      showAlert: false,
+      hasAwardDependents: false,
+      hasMinimumRating: true,
+    });
     expect($('h1', container).textContent).to.equal(PAGE_TITLE);
     expect($('#update-warning-alert', container)).to.not.exist;
     expect(logSpy.args[0][0]).to.eq(
-      'View dependents 0538 warning alert hidden',
+      'View dependents 0538 warning alert hidden because no active dependents',
     );
+    expect(logSpy.args[0][1]).to.deep.equal({
+      state: 'hidden because no active dependents',
+      reason: 'no active dependents',
+    });
+  });
+
+  it('Should not render alert when showAlert is false & below minimum rating', () => {
+    const logSpy = sinon.spy();
+    window.DD_LOGS = { logger: { log: logSpy } };
+    const { container } = renderWithStore({
+      showAlert: false,
+      hasAwardDependents: true,
+      hasMinimumRating: false,
+    });
+    expect($('h1', container).textContent).to.equal(PAGE_TITLE);
+    expect($('#update-warning-alert', container)).to.not.exist;
+    expect(logSpy.args[0][0]).to.eq(
+      'View dependents 0538 warning alert hidden because disability rating below 30%',
+    );
+    expect(logSpy.args[0][1]).to.deep.equal({
+      state: 'hidden because disability rating below 30%',
+      reason: 'disability rating below 30%',
+    });
   });
 
   it('Should not render alert when localStorage indicates that it is hidden', () => {
@@ -67,20 +99,32 @@ describe('<ViewDependentsHeader />', () => {
     window.DD_LOGS = { logger: { log: logSpy } };
     hideDependentsWarning();
 
-    const { container } = renderWithStore({ showAlert: true });
+    const { container } = renderWithStore({
+      showAlert: true,
+      hasAwardDependents: true,
+      hasMinimumRating: true,
+    });
     expect($('h1', container).textContent).to.equal(PAGE_TITLE);
     expect($('#update-warning-alert', container)).to.not.exist;
     expect(logSpy.args[0][0]).to.eq(
-      'View dependents 0538 warning alert hidden',
+      'View dependents 0538 warning alert already hidden',
     );
+    expect(logSpy.args[0][1]).to.deep.equal({
+      state: 'already hidden',
+      reason: 'user previously closed alert',
+    });
   });
 
-  it('Should not close alert and update localStorage', () => {
+  it('Should show alert, then close and update localStorage', () => {
     const logSpy = sinon.spy();
     window.DD_LOGS = { logger: { log: logSpy } };
     localStorage.removeItem(VIEW_DEPENDENTS_WARNING_KEY);
 
-    const { container } = renderWithStore({ showAlert: true });
+    const { container } = renderWithStore({
+      showAlert: true,
+      hasAwardDependents: true,
+      hasMinimumRating: true,
+    });
     expect($('h1', container).textContent).to.equal(PAGE_TITLE);
 
     const alert = $('#update-warning-alert', container);
@@ -93,14 +137,22 @@ describe('<ViewDependentsHeader />', () => {
       'View dependents 0538 warning alert visible',
     );
     expect(logSpy.args[1][0]).to.eq(
-      'View dependents 0538 warning alert hidden',
+      'View dependents 0538 warning alert hidden by user',
     );
+    expect(logSpy.args[1][1]).to.deep.equal({
+      state: 'hidden by user',
+      reason: 'hidden by user',
+    });
   });
 
   it('should log click on verification link', () => {
     const logSpy = sinon.spy();
     window.DD_LOGS = { logger: { log: logSpy } };
-    const { container } = renderWithStore({ showAlert: true });
+    const { container } = renderWithStore({
+      showAlert: true,
+      hasAwardDependents: true,
+      hasMinimumRating: true,
+    });
 
     const link = $('va-link-action', container);
     expect(link).to.exist;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Modified view dependents overflow alert Datadog logging to display reasons why the alert is hidden
  > * Visible:
  >   ```
  >   message: 'View dependents 0538 warning alert visible'
  >   {
  >     state: 'visible',
  >     reason: '',
  >   }
  >   ```
  > * Hidden because of no active dependents:
  >   ```
  >   message: 'View dependents 0538 warning alert hidden because no active dependents'
  >   {
  >     state: 'hidden because no active dependents',
  >     reason: 'no active dependents',
  >   }
  >   ```
  > * Hidden because disability rating < 30%:
  >   ```
  >   message: 'View dependents 0538 warning alert hidden because disability rating below 30%'
  >   {
  >     state: 'hidden because disability rating below 30%',
  >     reason: 'disability rating below 30%',
  >   }
  >   ```
  > * Hidden by user previously:
  >   ```
  >   message: 'View dependents 0538 warning alert already hidden'
  >   {
  >     state: 'already hidden',
  >     reason: 'user previously closed alert',
  >   }
  >   ```
  > * Hidden by user using the close button:
  >   ```
  >   message: 'View dependents 0538 warning alert hidden by user'
  >   {
  >     state: 'hidden by user',
  >     reason: 'hidden by user',
  >   }
  >   ```

- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/121645

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

View Dependents App

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
