### PR TITLE
[Disability Benefits] Add evidenceRequest & medicalRecords pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -23,6 +23,7 @@ import {
   capitalizeEachWord,
   getPageTitle,
   hasGuardOrReservePeriod,
+  hasMedicalRecords,
   hasNewPtsdDisability,
   hasOtherEvidence,
   hasPrivateEvidence,
@@ -32,6 +33,7 @@ import {
   isAnswering781aQuestions,
   isAnswering781Questions,
   isBDD,
+  isEvidenceEnhancement,
   isNewConditionsOn,
   isNewConditionsOff,
   isNotUploadingPrivateMedical,
@@ -67,6 +69,7 @@ import {
   choosePtsdType,
   claimExamsInfo,
   contactInformation,
+  evidenceRequest,
   evidenceTypes,
   evidenceTypesBDD,
   federalOrders,
@@ -74,6 +77,7 @@ import {
   fullyDevelopedClaim,
   homelessOrAtRisk,
   individualUnemployability,
+  medicalRecords,
   mentalHealthChanges,
   militaryHistory,
   newPTSDFollowUp,
@@ -609,9 +613,30 @@ const formConfig = {
         evidenceTypes: {
           title: 'Types of supporting evidence',
           path: 'supporting-evidence/evidence-types',
-          depends: formData => !isBDD(formData),
+          depends: formData =>
+            !isBDD(formData) && !isEvidenceEnhancement(formData),
+          updateFormData: evidenceTypes.updateFormData,
           uiSchema: evidenceTypes.uiSchema,
           schema: evidenceTypes.schema,
+        },
+        evidenceRequest: {
+          title: 'Medical records that support your disability claim',
+          path: 'supporting-evidence/evidence-request',
+          depends: formData =>
+            !isBDD(formData) && isEvidenceEnhancement(formData),
+          uiSchema: evidenceRequest.uiSchema,
+          schema: evidenceRequest.schema,
+        },
+        medicalRecords: {
+          title: 'Types of medical records',
+          path: 'supporting-evidence/medical-records',
+          depends: formData =>
+            !isBDD(formData) &&
+            isEvidenceEnhancement(formData) &&
+            hasMedicalRecords(formData),
+          updateFormData: medicalRecords.updateFormData,
+          uiSchema: medicalRecords.uiSchema,
+          schema: medicalRecords.schema,
         },
         evidenceTypesBDD: {
           title: 'Types of supporting evidence for BDD',

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -119,6 +119,8 @@ export const SERVICE_CONNECTION_TYPES = {
 };
 
 export const DATA_PATHS = {
+  hasMedicalRecords: 'view:hasMedicalRecords',
+  hasEvidence: 'view:hasEvidence',
   hasVAEvidence: 'view:selectableEvidenceTypes.view:hasVaMedicalRecords',
   hasPrivateEvidence:
     'view:selectableEvidenceTypes.view:hasPrivateMedicalRecords',

--- a/src/applications/disability-benefits/all-claims/pages/evidenceRequest.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceRequest.js
@@ -1,0 +1,22 @@
+import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { standardTitle } from '../content/form0781';
+
+export const uiSchema = {
+  'ui:title': standardTitle(
+    'Medical records that support your disability claim',
+  ),
+  'view:hasMedicalRecords': yesNoUI({
+    title: 'Are there medical records from VA or private?',
+  }),
+};
+
+export const schema = {
+  type: 'object',
+  required: ['view:hasMedicalRecords'],
+  properties: {
+    'view:hasMedicalRecords': yesNoSchema,
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -10,6 +10,25 @@ import { standardTitle } from '../content/form0781';
 
 import { evidenceTypeHelp } from '../content/evidenceTypes';
 
+/**
+ * Map view:hasMedicalRecords from enhancement flow to view:hasEvidence for legacy flow
+ * This ensures compatibility when transitioning from enhancement to legacy flow
+ */
+export const updateFormData = (oldFormData, formData) => {
+  const hasMedicalRecords = get('view:hasMedicalRecords', oldFormData);
+  const hasEvidence = get('view:hasEvidence', formData);
+
+  // Only map if enhancement field exists and legacy field doesn't
+  if (hasMedicalRecords !== undefined && hasEvidence === undefined) {
+    return {
+      ...formData,
+      'view:hasEvidence': hasMedicalRecords,
+    };
+  }
+
+  return formData;
+};
+
 export const uiSchema = {
   'ui:title': standardTitle('Types of supporting evidence'),
   'view:hasEvidence': yesNoUI({

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -13,6 +13,7 @@ import * as claimExamsInfo from './claimExamsInfo';
 import * as claimType from './claimType';
 import * as contactInformation from './contactInformation';
 import * as employmentHistory from './employmentHistory';
+import * as evidenceRequest from './evidenceRequest';
 import * as evidenceTypes from './evidenceTypes';
 import * as evidenceTypesBDD from './evidenceTypesBDD';
 import * as federalOrders from './federalOrders';
@@ -44,6 +45,7 @@ import * as instructionalPart2 from './instructionalPart2';
 import * as instructionalPart3 from './instructionalPart3';
 import * as medals from './medals';
 import * as medicalCare from './medicalCare';
+import * as medicalRecords from './medicalRecords';
 import * as mentalHealthChanges from './mentalHealthChanges';
 import * as militaryDutyImpact from './militaryDutyImpact';
 import * as militaryHistory from './militaryHistory';
@@ -132,6 +134,7 @@ export {
   claimType,
   contactInformation,
   employmentHistory,
+  evidenceRequest,
   evidenceTypes,
   evidenceTypesBDD,
   federalOrders,
@@ -163,6 +166,7 @@ export {
   instructionalPart3,
   medals,
   medicalCare,
+  medicalRecords,
   mentalHealthChanges,
   militaryDutyImpact,
   militaryHistory,

--- a/src/applications/disability-benefits/all-claims/pages/medicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/medicalRecords.js
@@ -1,0 +1,66 @@
+import get from 'platform/utilities/data/get';
+import VaCheckboxGroupField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField';
+import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
+import { validateIfHasEvidence } from '../validations';
+import { standardTitle } from '../content/form0781';
+
+/**
+ * Preserve hasOtherEvidence value when this page updates.
+ * This ensures compatibility when transitioning between legacy and enhancement flows.
+ */
+export const updateFormData = (oldFormData, formData) => {
+  // Preserve the hasOtherEvidence value from either:
+  // 1. The old formData (if it existed before)
+  // 2. Or keep it undefined if it never existed
+  const hasOtherEvidence = get(
+    'view:selectableEvidenceTypes.view:hasOtherEvidence',
+    oldFormData,
+  );
+
+  return {
+    ...formData,
+    'view:selectableEvidenceTypes': {
+      ...(formData['view:selectableEvidenceTypes'] || {}),
+      'view:hasOtherEvidence': hasOtherEvidence,
+    },
+  };
+};
+
+export const uiSchema = {
+  'ui:title': standardTitle('Types of medical records'),
+  'view:selectableEvidenceTypes': {
+    'ui:title':
+      'What type of medical records would you like us to access on your behalf?',
+    'ui:webComponentField': VaCheckboxGroupField,
+    'ui:options': {
+      showFieldLabel: true,
+    },
+    'ui:required': () => true,
+    'ui:validations': [
+      {
+        validator: validateIfHasEvidence,
+        options: { wrappedValidator: validateBooleanGroup },
+      },
+    ],
+    'ui:errorMessages': {
+      atLeastOne: 'Please select at least one type of supporting evidence',
+    },
+    'view:hasVaMedicalRecords': { 'ui:title': 'VA medical records' },
+    'view:hasPrivateMedicalRecords': {
+      'ui:title': 'Private medical records',
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    'view:selectableEvidenceTypes': {
+      type: 'object',
+      properties: {
+        'view:hasVaMedicalRecords': { type: 'boolean' },
+        'view:hasPrivateMedicalRecords': { type: 'boolean' },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/tests/config/supportingEvidencePages.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/config/supportingEvidencePages.unit.spec.jsx
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import { add, format } from 'date-fns';
+import { DATE_TEMPLATE } from '../../utils/dates/formatting';
+import formConfig from '../../config/form';
+
+const formatDate = date => format(date, DATE_TEMPLATE);
+const daysFromToday = days => formatDate(add(new Date(), { days }));
+
+const createBDDFormData = (overrides = {}) => ({
+  'view:isBddData': true,
+  serviceInformation: {
+    servicePeriods: [
+      {
+        dateRange: {
+          to: daysFromToday(90),
+        },
+      },
+    ],
+  },
+  ...overrides,
+});
+
+const createEnhancementFlowFormData = (overrides = {}) => ({
+  disability526SupportingEvidenceEnhancement: true,
+  ...overrides,
+});
+
+const createLegacyFlowFormData = (overrides = {}) => ({
+  disability526SupportingEvidenceEnhancement: false,
+  ...overrides,
+});
+
+describe('Supporting Evidence Pages - Conditional Rendering', () => {
+  const {
+    evidenceTypes,
+    evidenceRequest,
+    medicalRecords,
+  } = formConfig.chapters.supportingEvidence.pages;
+
+  describe('evidenceTypes depends', () => {
+    it('should return true for non-BDD legacy flow', () => {
+      const formData = createLegacyFlowFormData();
+      expect(evidenceTypes.depends(formData)).to.be.true;
+    });
+
+    it('should return false for BDD users', () => {
+      const formData = createBDDFormData();
+      expect(evidenceTypes.depends(formData)).to.be.false;
+    });
+
+    it('should return false for enhancement flow users', () => {
+      const formData = createEnhancementFlowFormData();
+      expect(evidenceTypes.depends(formData)).to.be.false;
+    });
+  });
+
+  describe('evidenceRequest depends', () => {
+    it('should return true for non-BDD enhancement flow users', () => {
+      const formData = createEnhancementFlowFormData();
+      expect(evidenceRequest.depends(formData)).to.be.true;
+    });
+
+    it('should return false for BDD users', () => {
+      const formData = createBDDFormData(createEnhancementFlowFormData());
+      expect(evidenceRequest.depends(formData)).to.be.false;
+    });
+
+    it('should return false for legacy flow users', () => {
+      const formData = createLegacyFlowFormData();
+      expect(evidenceRequest.depends(formData)).to.be.false;
+    });
+  });
+
+  describe('medicalRecords depends', () => {
+    it('should return true for non-BDD enhancement flow users with medical records', () => {
+      const formData = createEnhancementFlowFormData({
+        'view:hasMedicalRecords': true,
+      });
+      expect(medicalRecords.depends(formData)).to.be.true;
+    });
+
+    it('should return false for non-BDD enhancement flow users without medical records', () => {
+      const formData = createEnhancementFlowFormData({
+        'view:hasMedicalRecords': false,
+      });
+      expect(medicalRecords.depends(formData)).to.be.false;
+    });
+
+    it('should return false for BDD users', () => {
+      const formData = createBDDFormData(
+        createEnhancementFlowFormData({ 'view:hasMedicalRecords': true }),
+      );
+      expect(medicalRecords.depends(formData)).to.be.false;
+    });
+
+    it('should return false for legacy flow users', () => {
+      const formData = createLegacyFlowFormData({
+        'view:hasEvidence': true,
+      });
+      expect(medicalRecords.depends(formData)).to.be.false;
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx
@@ -35,10 +35,8 @@ describe('evidenceRequest', () => {
       'Are there medical records from VA or private?',
     );
 
-    expect(container.querySelector('va-radio-option[label="Yes"', container)).to
-      .exist;
-    expect(container.querySelector('va-radio-option[label="No"', container)).to
-      .exist;
+    expect(container.querySelector('va-radio-option[label="Yes"]')).to.exist;
+    expect(container.querySelector('va-radio-option[label="No"]')).to.exist;
   });
 
   it('should submit when no medical records selected', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  $,
+  $$,
+} from '@department-of-veterans-affairs/platform-forms-system/ui';
+import formConfig from '../../config/form';
+
+describe('evidenceRequest', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.supportingEvidence.pages.evidenceRequest;
+
+  it('should render', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect($$('va-radio-option').length).to.equal(2);
+
+    const question = container.querySelector('va-radio');
+    expect(question).to.have.attribute(
+      'label',
+      'Are there medical records from VA or private?',
+    );
+
+    expect(container.querySelector('va-radio-option[label="Yes"', container)).to
+      .exist;
+    expect(container.querySelector('va-radio-option[label="No"', container)).to
+      .exist;
+  });
+
+  it('should submit when no medical records selected', () => {
+    const onSubmit = sinon.spy();
+    const { getByText, container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    $('va-radio', container).__events.vaValueChange({
+      detail: { value: 'N' },
+    });
+    const submitButton = getByText(/submit/i);
+    userEvent.click(submitButton);
+    expect($('va-radio').error).to.be.null;
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+
+  it('should submit when medical records selected', () => {
+    const onSubmit = sinon.spy();
+    const { getByText, container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    $('va-radio', container).__events.vaValueChange({
+      detail: { value: 'Y' },
+    });
+    const submitButton = getByText(/submit/i);
+    userEvent.click(submitButton);
+    expect($('va-radio').error).to.be.null;
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+
+  it('should require a response before submitting', () => {
+    const onSubmit = sinon.spy();
+    const { getByText } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const submitButton = getByText(/submit/i);
+    userEvent.click(submitButton);
+    expect(onSubmit.called).to.be.false;
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
@@ -10,6 +10,7 @@ import {
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
+import { updateFormData } from '../../pages/evidenceTypes';
 
 describe('evidenceTypes', () => {
   const {
@@ -117,5 +118,67 @@ describe('evidenceTypes', () => {
     expect(onSubmit.calledOnce).to.be.true;
     // Check for absence of an error message.
     expect($('va-radio').error).to.be.null;
+  });
+
+  describe('updateFormData', () => {
+    it('should map view:hasMedicalRecords to view:hasEvidence when legacy field missing', () => {
+      [true, false].forEach(value => {
+        const oldFormData = { 'view:hasMedicalRecords': value };
+        const formData = {};
+        const result = updateFormData(oldFormData, formData);
+        expect(result).to.deep.equal({
+          'view:hasEvidence': value,
+        });
+      });
+    });
+
+    it('should not map when both enhancement and legacy fields exist', () => {
+      const oldFormData = {
+        'view:hasMedicalRecords': true,
+      };
+      const formData = {
+        'view:hasEvidence': false,
+      };
+      const result = updateFormData(oldFormData, formData);
+      expect(result).to.deep.equal({
+        'view:hasEvidence': false,
+      });
+    });
+
+    it('should not map when enhancement field does not exist', () => {
+      const oldFormData = {};
+      const formData = {
+        'view:hasEvidence': true,
+      };
+      const result = updateFormData(oldFormData, formData);
+      expect(result).to.deep.equal({
+        'view:hasEvidence': true,
+      });
+    });
+
+    it('should return formData unchanged when no mapping is needed', () => {
+      const oldFormData = {};
+      const formData = {
+        someOtherField: 'value',
+      };
+      const result = updateFormData(oldFormData, formData);
+      expect(result).to.deep.equal({
+        someOtherField: 'value',
+      });
+    });
+
+    it('should preserve existing formData fields when mapping', () => {
+      const oldFormData = {
+        'view:hasMedicalRecords': true,
+      };
+      const formData = {
+        existingField: 'existingValue',
+      };
+      const result = updateFormData(oldFormData, formData);
+      expect(result).to.deep.equal({
+        existingField: 'existingValue',
+        'view:hasEvidence': true,
+      });
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/medicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/medicalRecords.unit.spec.jsx
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+import { updateFormData } from '../../pages/medicalRecords';
+
+describe('medicalRecords updateFormData', () => {
+  it('should preserve hasOtherEvidence from oldFormData', () => {
+    const oldFormData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasOtherEvidence': true,
+      },
+    };
+    const formData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+      },
+    };
+    const result = updateFormData(oldFormData, formData);
+    expect(result).to.deep.equal({
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+        'view:hasOtherEvidence': true,
+      },
+    });
+  });
+
+  it('should preserve false hasOtherEvidence value from oldFormData', () => {
+    const oldFormData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasOtherEvidence': false,
+      },
+    };
+    const formData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+      },
+    };
+    const result = updateFormData(oldFormData, formData);
+    expect(result).to.deep.equal({
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+        'view:hasOtherEvidence': false,
+      },
+    });
+  });
+
+  it('should set hasOtherEvidence to undefined when not in oldFormData', () => {
+    const oldFormData = {};
+    const formData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+      },
+    };
+    const result = updateFormData(oldFormData, formData);
+    expect(result).to.deep.equal({
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+        'view:hasOtherEvidence': undefined,
+      },
+    });
+  });
+
+  it('should initialize selectableEvidenceTypes if missing in formData', () => {
+    const oldFormData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasOtherEvidence': true,
+      },
+    };
+    const formData = {};
+    const result = updateFormData(oldFormData, formData);
+    expect(result).to.deep.equal({
+      'view:selectableEvidenceTypes': {
+        'view:hasOtherEvidence': true,
+      },
+    });
+  });
+
+  it('should preserve existing formData fields when preserving hasOtherEvidence', () => {
+    const oldFormData = {
+      'view:selectableEvidenceTypes': {
+        'view:hasOtherEvidence': true,
+      },
+    };
+    const formData = {
+      existingField: 'value',
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+        'view:hasPrivateMedicalRecords': false,
+      },
+    };
+    const result = updateFormData(oldFormData, formData);
+    expect(result).to.deep.equal({
+      existingField: 'value',
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+        'view:hasPrivateMedicalRecords': false,
+        'view:hasOtherEvidence': true,
+      },
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
@@ -4,6 +4,8 @@ import {
   isCompletingModern4142,
   baseDoNew4142Logic,
   onFormLoaded,
+  redirectLegacyToEnhancement,
+  redirectEnhancementToLegacy,
 } from '../../utils';
 
 describe('utils', () => {
@@ -63,6 +65,92 @@ describe('utils', () => {
       expect(
         router.push.calledWith('/supporting-evidence/private-medical-records'),
       ).to.be.true;
+    });
+
+    it('should redirect to evidence-request when legacy to enhancement transition needed', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+      };
+      onFormLoaded({
+        returnUrl: '/supporting-evidence/evidence-types',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/supporting-evidence/evidence-request')).to
+        .be.true;
+    });
+
+    it('should redirect to evidence-types when enhancement to legacy transition needed', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        disability526SupportingEvidenceEnhancement: false,
+      };
+      onFormLoaded({
+        returnUrl: '/supporting-evidence/evidence-request',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/supporting-evidence/evidence-types')).to
+        .be.true;
+    });
+  });
+
+  describe('redirectLegacyToEnhancement', () => {
+    it('should return true when returnUrl matches and formData indicates enhancement flow', () => {
+      expect(
+        redirectLegacyToEnhancement({
+          returnUrl: '/supporting-evidence/evidence-types',
+          formData: { disability526SupportingEvidenceEnhancement: true },
+        }),
+      ).to.be.true;
+    });
+
+    it('should return false otherwise', () => {
+      expect(
+        redirectLegacyToEnhancement({
+          returnUrl: '/supporting-evidence/evidence-request',
+          formData: { disability526SupportingEvidenceEnhancement: true },
+        }),
+      ).to.be.false;
+      expect(
+        redirectLegacyToEnhancement({
+          returnUrl: '/supporting-evidence/evidence-types',
+          formData: { disability526SupportingEvidenceEnhancement: false },
+        }),
+      ).to.be.false;
+    });
+  });
+
+  describe('redirectEnhancementToLegacy', () => {
+    it('should return true when returnUrl matches enhancement pages and formData indicates legacy flow', () => {
+      expect(
+        redirectEnhancementToLegacy({
+          returnUrl: '/supporting-evidence/evidence-request',
+          formData: { disability526SupportingEvidenceEnhancement: false },
+        }),
+      ).to.be.true;
+      expect(
+        redirectEnhancementToLegacy({
+          returnUrl: '/supporting-evidence/medical-records',
+          formData: { disability526SupportingEvidenceEnhancement: false },
+        }),
+      ).to.be.true;
+    });
+
+    it('should return false otherwise', () => {
+      expect(
+        redirectEnhancementToLegacy({
+          returnUrl: '/supporting-evidence/evidence-request',
+          formData: { disability526SupportingEvidenceEnhancement: true },
+        }),
+      ).to.be.false;
+      expect(
+        redirectEnhancementToLegacy({
+          returnUrl: '/supporting-evidence/evidence-types',
+          formData: { disability526SupportingEvidenceEnhancement: false },
+        }),
+      ).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -16,6 +16,7 @@ import {
   formatFullName,
   hasGuardOrReservePeriod,
   hasHospitalCare,
+  hasMedicalRecords,
   hasNewPtsdDisability,
   hasOtherEvidence,
   increaseOnly,
@@ -211,6 +212,66 @@ describe('526 helpers', () => {
         },
       };
       expect(hasOtherEvidence(formData)).to.equal(true);
+    });
+  });
+
+  describe('hasMedicalRecords', () => {
+    it('should return true in enhancement flow when view:hasMedicalRecords is true', () => {
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasMedicalRecords': true,
+      };
+      expect(hasMedicalRecords(formData)).to.equal(true);
+    });
+
+    it('should return false in enhancement flow when view:hasMedicalRecords is false', () => {
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasMedicalRecords': false,
+      };
+      expect(hasMedicalRecords(formData)).to.equal(false);
+    });
+
+    it('should derive from legacy data in enhancement flow when enhancement field is undefined', () => {
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasEvidence': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasVaMedicalRecords': true,
+        },
+      };
+      expect(hasMedicalRecords(formData)).to.equal(true);
+    });
+
+    it('should return false in enhancement flow when legacy data indicates no medical records', () => {
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasEvidence': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasVaMedicalRecords': false,
+          'view:hasPrivateMedicalRecords': false,
+        },
+      };
+      expect(hasMedicalRecords(formData)).to.equal(false);
+    });
+
+    it('should return true in legacy flow when view:hasEvidence is true', () => {
+      const formData = {
+        'view:hasEvidence': true,
+      };
+      expect(hasMedicalRecords(formData)).to.equal(true);
+    });
+
+    it('should return false in legacy flow when view:hasEvidence is false', () => {
+      const formData = {
+        'view:hasEvidence': false,
+      };
+      expect(hasMedicalRecords(formData)).to.equal(false);
+    });
+
+    it('should return false in legacy flow when view:hasEvidence is undefined', () => {
+      const formData = {};
+      expect(hasMedicalRecords(formData)).to.equal(false);
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -232,6 +232,18 @@ describe('526 helpers', () => {
       expect(hasMedicalRecords(formData)).to.equal(false);
     });
 
+    it('should return false when view:hasMedicalRecords is false even if legacy data exists', () => {
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasMedicalRecords': false,
+        'view:hasEvidence': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasVaMedicalRecords': true,
+        },
+      };
+      expect(hasMedicalRecords(formData)).to.equal(false);
+    });
+
     it('should derive from legacy data in enhancement flow when enhancement field is undefined', () => {
       const formData = {
         disability526SupportingEvidenceEnhancement: true,

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx
@@ -20,6 +20,7 @@ import {
   oneDisabilityRequired,
   validateDisabilityName,
   validateBooleanGroup,
+  validateIfHasEvidence,
   validateAge,
   validateSeparationDate,
   isInFuture,
@@ -790,6 +791,115 @@ describe('526 All Claims validations', () => {
       validateBooleanGroup(errors, { tests: false }, null, {});
 
       expect(errors.addError.called).to.be.true;
+    });
+  });
+
+  describe('validateIfHasEvidence', () => {
+    const createTestFixtures = () => ({
+      errors: { addError: sinon.spy() },
+      wrappedValidator: sinon.spy(),
+      fieldData: {},
+      schema: {},
+      messages: {},
+    });
+
+    const callValidateIfHasEvidence = (formData, fixtures) => {
+      validateIfHasEvidence(
+        fixtures.errors,
+        fixtures.fieldData,
+        formData,
+        fixtures.schema,
+        fixtures.messages,
+        { wrappedValidator: fixtures.wrappedValidator },
+        0,
+      );
+      return fixtures;
+    };
+
+    it('should call wrappedValidator in enhancement flow when view:hasMedicalRecords is true', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasMedicalRecords': true,
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.calledOnce).to.be.true;
+      expect(
+        fixtures.wrappedValidator.calledWith(
+          fixtures.errors,
+          fixtures.fieldData,
+          formData,
+          fixtures.schema,
+          fixtures.messages,
+          0,
+        ),
+      ).to.be.true;
+    });
+
+    it('should not call wrappedValidator in enhancement flow when view:hasMedicalRecords is false', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasMedicalRecords': false,
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.called).to.be.false;
+    });
+
+    it('should call wrappedValidator in legacy flow when view:hasEvidence is true', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        'view:hasEvidence': true,
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.calledOnce).to.be.true;
+      expect(
+        fixtures.wrappedValidator.calledWith(
+          fixtures.errors,
+          fixtures.fieldData,
+          formData,
+          fixtures.schema,
+          fixtures.messages,
+          0,
+        ),
+      ).to.be.true;
+    });
+
+    it('should not call wrappedValidator in legacy flow when view:hasEvidence is false', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        'view:hasEvidence': false,
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.called).to.be.false;
+    });
+
+    it('should call wrappedValidator in enhancement flow when view:hasMedicalRecords is undefined (defaults to true)', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        disability526SupportingEvidenceEnhancement: true,
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.calledOnce).to.be.true;
+    });
+
+    it('should call wrappedValidator in legacy flow when view:hasEvidence is undefined (defaults to true)', () => {
+      const fixtures = createTestFixtures();
+      const formData = {};
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.calledOnce).to.be.true;
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -271,8 +271,8 @@ export const hasPrivateEvidence = formData =>
 export const hasMedicalRecords = formData => {
   if (isEvidenceEnhancement(formData)) {
     // Enhancement flow: check new field name, with fallback to legacy data for transition compatibility
-    const hasRecords = _.get(DATA_PATHS.hasMedicalRecords, formData, false);
-    if (hasRecords !== false) {
+    const hasRecords = _.get(DATA_PATHS.hasMedicalRecords, formData);
+    if (hasRecords !== undefined) {
       return hasRecords;
     }
     // Transition compatibility: derive from legacy data if switching from legacy flow

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -257,12 +257,33 @@ const regexNonWord = /[^\w]/g;
 export const sippableId = str =>
   (str || 'blank').replace(regexNonWord, '').toLowerCase();
 
+// Helper to check if user is in evidence enhancement flow
+export const isEvidenceEnhancement = formData =>
+  !!formData?.disability526SupportingEvidenceEnhancement;
+
 export const hasVAEvidence = formData =>
   _.get(DATA_PATHS.hasVAEvidence, formData, false);
 export const hasOtherEvidence = formData =>
   _.get(DATA_PATHS.hasAdditionalDocuments, formData, false);
 export const hasPrivateEvidence = formData =>
   _.get(DATA_PATHS.hasPrivateEvidence, formData, false);
+
+export const hasMedicalRecords = formData => {
+  if (isEvidenceEnhancement(formData)) {
+    // Enhancement flow: check new field name, with fallback to legacy data for transition compatibility
+    const hasRecords = _.get(DATA_PATHS.hasMedicalRecords, formData, false);
+    if (hasRecords !== false) {
+      return hasRecords;
+    }
+    // Transition compatibility: derive from legacy data if switching from legacy flow
+    const hasLegacyEvidence = _.get(DATA_PATHS.hasEvidence, formData, false);
+    const hasVA = hasVAEvidence(formData);
+    const hasPrivate = hasPrivateEvidence(formData);
+    return hasLegacyEvidence && (hasVA || hasPrivate);
+  }
+  // Legacy flow: use the existing path
+  return _.get(DATA_PATHS.hasEvidence, formData, false);
+};
 
 /**
  * Inspects all given paths in the formData object for presence of values
@@ -983,6 +1004,34 @@ export const redirectWhenNoEvidence = props => {
   );
 };
 
+/**
+ * Determines if user should be redirected from legacy evidence page to enhancement page
+ * @param {Object} props - { returnUrl, formData }
+ * @returns {boolean} true if redirect needed
+ */
+export const redirectLegacyToEnhancement = props => {
+  const { returnUrl, formData } = props;
+  return (
+    returnUrl === '/supporting-evidence/evidence-types' &&
+    isEvidenceEnhancement(formData)
+  );
+};
+
+/**
+ * Determines if user should be redirected from enhancement evidence pages to legacy page
+ * @param {Object} props - { returnUrl, formData }
+ * @returns {boolean} true if redirect needed
+ */
+export const redirectEnhancementToLegacy = props => {
+  const { returnUrl, formData } = props;
+  const isEnhancement = isEvidenceEnhancement(formData);
+  return (
+    !isEnhancement &&
+    (returnUrl === '/supporting-evidence/evidence-request' ||
+      returnUrl === '/supporting-evidence/medical-records')
+  );
+};
+
 export const isNewConditionsOn = formData =>
   !!formData?.disabilityCompNewConditionsWorkflow;
 
@@ -993,6 +1042,8 @@ export const onFormLoaded = props => {
   const shouldRedirectToModern4142Choice = baseDoNew4142Logic(formData);
   const shouldRevertWhenFlipperOff = redirectWhenFlipperOff(props);
   const shouldRevertWhenNoEvidence = redirectWhenNoEvidence(props);
+  const shouldRedirectLegacyToEnhancement = redirectLegacyToEnhancement(props);
+  const shouldRedirectEnhancementToLegacy = redirectEnhancementToLegacy(props);
   const redirectUrl = legacy4142AuthURL;
 
   if (shouldRedirectToModern4142Choice === true) {
@@ -1013,6 +1064,12 @@ export const onFormLoaded = props => {
     shouldRedirectToModern4142Choice === false &&
     shouldRevertWhenNoEvidence === true
   ) {
+    router.push('/supporting-evidence/evidence-types');
+  } else if (shouldRedirectLegacyToEnhancement === true) {
+    // Handle evidence enhancement flow transition: legacy → enhancement
+    router.push('/supporting-evidence/evidence-request');
+  } else if (shouldRedirectEnhancementToLegacy === true) {
+    // Handle evidence enhancement flow transition: enhancement → legacy
     router.push('/supporting-evidence/evidence-types');
   } else {
     // otherwise, we just redirect to the returnUrl as usual when resuming a form

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -19,6 +19,7 @@ import {
   claimingRated,
   showSeparationLocation,
   sippableId,
+  isEvidenceEnhancement,
 } from './utils';
 
 import {
@@ -227,7 +228,11 @@ export const validateIfHasEvidence = (
   index,
 ) => {
   const { wrappedValidator } = options;
-  if (_.get('view:hasEvidence', formData, true)) {
+  // In enhancement flow, check view:hasMedicalRecords; otherwise check view:hasEvidence
+  const hasEvidence = isEvidenceEnhancement(formData)
+    ? _.get('view:hasMedicalRecords', formData, true)
+    : _.get('view:hasEvidence', formData, true);
+  if (hasEvidence) {
     wrappedValidator(errors, fieldData, formData, schema, messages, index);
   }
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Introduces a new evidence enhancement flow that splits a single `evidenceTypes` collection page into two pages:
    - an initial yes/no question about medical records (`evidenceRequest`)
    - and a follow-up page to select medical record types (`medicalRecords`)
  - Implements flow-aware helper functions and redirect logic to handle transitions between legacy and enhancement flows
  - Updates validation logic to work with both flows using different field names
- _(If bug, how to reproduce)_
  - n/a
- _(What is the solution, why is this the solution)_
  - presents one question per page
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - 🌊 Disability Benefits Pathways team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `disability526SupportingEvidenceEnhancement` toggle used to safely test and roll out content and design enhancements

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129612

## Testing done

- _Describe what the old behavior was prior to the change_
  - the legacy flow combined into a single page (`evidenceTypes`)
- _Describe the steps required to verify your changes are working as expected_
  1. Enable Feature Toggle
      - Set `disability526SupportingEvidenceEnhancement` to `true` in feature toggles
  2. Test Enhancement Flow (Non-BDD User)
      - Start a new form and navigate to supporting evidence section
      - Verify `evidenceRequest` page appears (not `evidenceTypes`)
      - Answer "Yes" to medical records question
      - Verify `medicalRecords` page appears
      - Select medical record type(s) and continue
  3. Test "No" Path
      - Answer "No" on `evidenceRequest` page
      - Verify `medicalRecords` page is skipped
      - Verify flow continues to summary
  4. Test Legacy Flow
      - Disable the feature toggle
      - Verify `evidenceTypes` page appears (not `evidenceRequest`)
      - Verify legacy flow works as before
  5. Test Data Compatibility
      - Start in enhancement flow, answer questions, then disable toggle
      - Resume form and verify data maps correctly to legacy format
  6. Test BDD Users
      - Verify BDD users see `evidenceTypesBDD` (not enhancement pages) regardless of toggle
  7. Run Tests
      - Execute the new unit tests to verify all logic works
- _Describe the tests completed and the results_
  - **Helper functions**: enhancement/legacy flow logic
  - **Data mapping**: `updateFormData` hooks
  - **Validation**: flow-aware validation logic
  - **Page rendering**: page UI and interactions
  - **Form configuration**: conditional page rendering based on feature toggle and user type

## Screenshots

|         | Before (`/evidence-types`) | Before ('Yes' response) | After (`/evidence-request`) | After (`/medical-records`) |
| ------- | ------ | ----- | ----- | ----- |
|  | <img width="394" height="342" alt="Screenshot 2026-01-23 at 5 42 21 PM" src="https://github.com/user-attachments/assets/292b084f-46b1-4bb9-b399-6ca6257c2bd8" /> | <img width="394" height="506" alt="Screenshot 2026-01-23 at 5 46 36 PM" src="https://github.com/user-attachments/assets/2f37afe1-132d-4256-af22-536894a938e9" /> | <img width="394" height="316" alt="Screenshot 2026-01-23 at 5 35 27 PM" src="https://github.com/user-attachments/assets/7676434a-1e61-4021-bc03-08406834fdcf" /> | <img width="394" height="332" alt="Screenshot 2026-01-23 at 5 36 59 PM" src="https://github.com/user-attachments/assets/e874f0ca-2a6b-4df4-bbfc-548486643fa0" />
| error state | <img width="394" height="342" alt="Screenshot 2026-01-23 at 5 42 54 PM" src="https://github.com/user-attachments/assets/7267137c-63f8-4b9f-b947-60f00a6677ff" /> | <img width="394" height="520" alt="Screenshot 2026-01-23 at 5 47 16 PM" src="https://github.com/user-attachments/assets/d876f78e-79b4-47df-a9d0-d8872009f02d" /> | <img width="394" height="342" alt="Screenshot 2026-01-23 at 5 40 48 PM" src="https://github.com/user-attachments/assets/52ef7e33-5c43-4870-bc74-7b7ac1527e6a" /> | <img width="394" height="342" alt="Screenshot 2026-01-23 at 5 39 03 PM" src="https://github.com/user-attachments/assets/54e1f03c-7115-449f-b191-b3025f4a688f" /> |

## What areas of the site does it impact?

Supporting Evidence section of Form 526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I ~fixed~|~updated~|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback


