### PR TITLE
Fix flaky waitForElementToBeRemoved test for Node 22

### DIFF
--- a/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/ContactInformation.delete-address.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { waitForElementToBeRemoved } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 import { expect } from 'chai';
 import { server } from 'platform/testing/unit/mocha-setup';
@@ -35,7 +35,6 @@ function deleteAddress(addressName) {
   const confirmRemoveModal = view.getByTestId('confirm-remove-modal');
   const dummyEvent = new Event('click');
   confirmRemoveModal.__events.primaryButtonClick(dummyEvent);
-  return { confirmRemoveModal };
 }
 
 // When the update happens but not until after the delete modal has exited and the
@@ -43,10 +42,12 @@ function deleteAddress(addressName) {
 async function testSlowSuccess(addressName) {
   server.use(...mocks.transactionPending);
 
-  const { confirmRemoveModal } = deleteAddress(addressName);
+  deleteAddress(addressName);
 
   // wait for the confirm removal modal to close
-  await waitForElementToBeRemoved(confirmRemoveModal);
+  await waitFor(() => {
+    expect(view.queryByTestId('confirm-remove-modal')).to.be.null;
+  });
 
   // the va-loading-indicator should display
   await view.findByTestId('loading-indicator');


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes a flaky unit test in the personalization profile contact information tests for Node 22 compatibility
- The `waitForElementToBeRemoved` function was unreliable when the element reference could become stale before the check completed
- Replaced `waitForElementToBeRemoved(confirmRemoveModal)` with `waitFor(() => expect(view.queryByTestId('confirm-remove-modal')).to.be.null)` which queries the DOM fresh each time
- Removed the return statement from `deleteAddress()` since the modal reference is no longer needed
- Authenticated Experience team (Profile)

## Related issue(s)

- Node 22 upgrade compatibility work

## Testing done

- Verified the test passes consistently with Node 22
- The old behavior used a stale element reference that could fail intermittently
- The new approach re-queries the DOM on each poll, making it more reliable
- Unit tests pass: `yarn test:unit src/applications/personalization/profile/tests/components/contact-information/ContactInformation.delete-address.unit.spec.jsx`

## Screenshots

_N/A - Test file changes only, no UI modifications_

## What areas of the site does it impact?

This change only impacts unit tests for the personalization profile contact information feature. No production code is affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - test fix only)
- [x] Accessibility testing has been performed (N/A - test fix only)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test fix only)
- [x] Events are being sent to the appropriate logging solution (N/A - test fix only)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A - test fix only)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only, no runtime changes)

## Requested Feedback

This is a straightforward test fix for Node 22 compatibility. The change replaces a potentially flaky element reference check with a more robust DOM query approach.