### PR TITLE
add refill request button to med cards

### DIFF
--- a/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
+++ b/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
@@ -11,6 +11,7 @@ import {
   DISPENSE_STATUS,
 } from '../../util/constants';
 import CallPharmacyPhone from './CallPharmacyPhone';
+import RefillNavButton from './RefillNavButton';
 import SendRxRenewalMessage from './SendRxRenewalMessage';
 import { pageType } from '../../util/dataDogConstants';
 import {
@@ -18,7 +19,7 @@ import {
   selectV2StatusMappingFlag,
 } from '../../util/selectors';
 
-const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
+const ExtraDetails = ({ showRenewalLink = false, page, ...rx }) => {
   const { dispStatus, refillRemaining, isRenewable } = rx;
   const pharmacyPhone = pharmacyPhoneNumber(rx);
   const noRefillRemaining =
@@ -27,6 +28,9 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
   const isCernerPilot = useSelector(selectCernerPilotFlag);
   const isV2StatusMapping = useSelector(selectV2StatusMappingFlag);
   const useV2Status = isCernerPilot && isV2StatusMapping;
+
+  const refillNavButton =
+    page === pageType.LIST ? <RefillNavButton rx={rx} /> : null;
 
   const renderV2Content = () => {
     switch (dispStatus) {
@@ -109,9 +113,12 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
           );
         }
         return (
-          <p className="vads-u-margin-y--0" data-testid="active">
-            You can request this prescription when you need it.
-          </p>
+          <div>
+            <p className="vads-u-margin-y--0" data-testid="active">
+              You can request this prescription when you need it.
+            </p>
+            {refillNavButton}
+          </div>
         );
 
       case dispStatusObjV2.inactive:
@@ -247,9 +254,12 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
 
       case dispStatusObj.activeParked:
         return (
-          <p className="vads-u-margin-y--0" data-testid="active-parked">
-            You can request this prescription when you need it.
-          </p>
+          <div>
+            <p className="vads-u-margin-y--0" data-testid="active-parked">
+              You can request this prescription when you need it.
+            </p>
+            {refillNavButton}
+          </div>
         );
 
       case dispStatusObj.expired:
@@ -334,7 +344,7 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
             </div>
           );
         }
-        return null;
+        return refillNavButton;
 
       default:
         return null;
@@ -369,12 +379,18 @@ const ExtraDetails = ({ showRenewalLink = false, ...rx }) => {
     return renderV1Content();
   };
 
+  const content = renderContent();
+
+  if (!content) {
+    return null;
+  }
+
   return (
     <div
       className="shipping-info"
       id={`status-description-${rx.prescriptionId}`}
     >
-      {renderContent()}
+      {content}
     </div>
   );
 };

--- a/src/applications/mhv-medications/components/shared/RefillNavButton.jsx
+++ b/src/applications/mhv-medications/components/shared/RefillNavButton.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { dataDogActionNames } from '../../util/dataDogConstants';
+import { medicationsUrls } from '../../util/constants';
+
+/**
+ * A button that navigates to the refill page with a prescription preselected.
+ * Note: dispStatus checks are handled by the parent component (ExtraDetails).
+ */
+const RefillNavButton = ({ rx }) => {
+  const navigate = useNavigate();
+  const { prescriptionId, isRefillable } = rx;
+
+  if (!isRefillable) {
+    return null;
+  }
+
+  const handleClick = () => {
+    navigate(
+      `${medicationsUrls.subdirectories.REFILL}?refillId=${prescriptionId}`,
+    );
+  };
+
+  return (
+    <VaButton
+      secondary
+      uswds
+      className="vads-u-margin-top--2"
+      id={`refill-nav-button-${prescriptionId}`}
+      aria-describedby={`card-header-${prescriptionId}`}
+      data-dd-action-name={
+        dataDogActionNames.medicationsListPage.REQUEST_REFILL_CARD_LINK
+      }
+      data-testid="refill-nav-button"
+      onClick={handleClick}
+      text="Request a refill"
+    />
+  );
+};
+
+RefillNavButton.propTypes = {
+  rx: PropTypes.shape({
+    prescriptionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+      .isRequired,
+    isRefillable: PropTypes.bool,
+  }).isRequired,
+};
+
+export default RefillNavButton;

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -255,9 +255,9 @@ const RefillPrescriptions = () => {
         );
         if (prescriptionToSelect) {
           setSelectedRefillList([prescriptionToSelect]);
-          setHasPreselected(true);
-          setSearchParams({}, { replace: true });
         }
+        setHasPreselected(true);
+        setSearchParams({}, { replace: true });
       }
     },
     [searchParams, setSearchParams, fullRefillList, isLoading, hasPreselected],

--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link, useSearchParams } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 import {
   VaButton,
@@ -108,6 +108,8 @@ const RefillPrescriptions = () => {
   );
   const [selectedRefillList, setSelectedRefillList] = useState([]);
   const [refillStatus, setRefillStatus] = useState(REFILL_STATUS.NOT_STARTED);
+  const [hasPreselected, setHasPreselected] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Handle API errors from RTK Query
   const prescriptionsApiError = refillableError || bulkRefillError;
@@ -236,6 +238,29 @@ const RefillPrescriptions = () => {
       updatePageTitle('Refill prescriptions - Medications | Veterans Affairs');
     },
     [selectedSortOption],
+  );
+
+  // Handle preselection from URL parameter (e.g., from medication card link)
+  useEffect(
+    () => {
+      const refillId = searchParams.get('refillId');
+      if (
+        refillId &&
+        !isLoading &&
+        fullRefillList?.length > 0 &&
+        !hasPreselected
+      ) {
+        const prescriptionToSelect = fullRefillList.find(
+          rx => String(rx.prescriptionId) === String(refillId),
+        );
+        if (prescriptionToSelect) {
+          setSelectedRefillList([prescriptionToSelect]);
+          setHasPreselected(true);
+          setSearchParams({}, { replace: true });
+        }
+      }
+    },
+    [searchParams, setSearchParams, fullRefillList, isLoading, hasPreselected],
   );
 
   useEffect(

--- a/src/applications/mhv-medications/tests/components/shared/ExtraDetails.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/ExtraDetails.unit.spec.jsx
@@ -6,6 +6,7 @@ import reducers from '../../../reducers';
 import prescriptionsListItem from '../../fixtures/prescriptionsListItem.json';
 import ExtraDetails from '../../../components/shared/ExtraDetails';
 import { dispStatusObj, dispStatusObjV2 } from '../../../util/constants';
+import { pageType } from '../../../util/dataDogConstants';
 
 describe('Medications List Card Extra Details', () => {
   const FLAG_COMBINATIONS = [
@@ -263,6 +264,93 @@ describe('Medications List Card Extra Details', () => {
       ).to.contain.text(
         'You can’t refill this prescription. If you need more, send a secure message to your care team',
       );
+    });
+  });
+  describe('RefillLinkButton rendering based on page prop', () => {
+    it('renders refill button on list page for active prescription with refills', async () => {
+      const screen = setup({
+        ...prescription,
+        dispStatus: dispStatusObj.active,
+        isRefillable: true,
+        refillRemaining: 3,
+        page: pageType.LIST,
+      });
+      expect(await screen.findByTestId('refill-nav-button')).to.exist;
+    });
+
+    it('renders refill button on list page for active parked prescription with refills', async () => {
+      const screen = setup({
+        ...prescription,
+        dispStatus: dispStatusObj.activeParked,
+        isRefillable: true,
+        refillRemaining: 3,
+        page: pageType.LIST,
+      });
+      expect(await screen.findByTestId('refill-nav-button')).to.exist;
+    });
+
+    it('does not render refill button on details page for active parked prescription', async () => {
+      const screen = setup({
+        ...prescription,
+        dispStatus: dispStatusObj.activeParked,
+        isRefillable: true,
+        refillRemaining: 3,
+        page: pageType.DETAILS,
+      });
+      expect(screen.queryByTestId('refill-nav-button')).to.not.exist;
+    });
+
+    it('does not render refill button when page prop is not provided', async () => {
+      const screen = setup({
+        ...prescription,
+        dispStatus: dispStatusObj.activeParked,
+        isRefillable: true,
+        refillRemaining: 3,
+      });
+      expect(screen.queryByTestId('refill-nav-button')).to.not.exist;
+    });
+
+    it('does not render refill button when prescription is not refillable', async () => {
+      const screen = setup({
+        ...prescription,
+        dispStatus: dispStatusObj.activeParked,
+        isRefillable: false,
+        refillRemaining: 3,
+        page: pageType.LIST,
+      });
+      expect(screen.queryByTestId('refill-nav-button')).to.not.exist;
+    });
+
+    it('renders refill button for V2 Active status on list page', async () => {
+      const screen = setup(
+        {
+          ...prescription,
+          dispStatus: dispStatusObjV2.active,
+          isRefillable: true,
+          refillRemaining: 3,
+          page: pageType.LIST,
+        },
+        {},
+        true,
+        true,
+      );
+      expect(await screen.findByTestId('refill-nav-button')).to.exist;
+    });
+
+    it('does not render refill button for V2 Active status on details page', async () => {
+      const screen = setup(
+        {
+          ...prescription,
+          dispStatus: dispStatusObjV2.active,
+          isRefillable: true,
+          refillRemaining: 3,
+          page: pageType.DETAILS,
+        },
+        {},
+        true,
+        true,
+      );
+      expect(screen.queryByTestId('refill-nav-button')).to.not.exist;
     });
   });
 });

--- a/src/applications/mhv-medications/tests/components/shared/ExtraDetails.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/ExtraDetails.unit.spec.jsx
@@ -266,7 +266,7 @@ describe('Medications List Card Extra Details', () => {
       );
     });
   });
-  describe('RefillLinkButton rendering based on page prop', () => {
+  describe('RefillNavButton rendering based on page prop', () => {
     it('renders refill button on list page for active prescription with refills', async () => {
       const screen = setup({
         ...prescription,

--- a/src/applications/mhv-medications/tests/components/shared/RefillLinkButton.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/RefillLinkButton.unit.spec.jsx
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import React from 'react';
+import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import RefillNavButton from '../../../components/shared/RefillNavButton';
+import reducers from '../../../reducers';
+import { dataDogActionNames } from '../../../util/dataDogConstants';
+
+describe('RefillLinkButton component', () => {
+  const defaultRx = {
+    prescriptionId: 12345,
+    isRefillable: true,
+  };
+
+  const setup = (rx = defaultRx) => {
+    return renderWithStoreAndRouterV6(<RefillNavButton rx={rx} />, {
+      initialState: {},
+      reducers,
+      initialEntries: ['/'],
+    });
+  };
+
+  it('renders without errors when prescription is refillable', () => {
+    const screen = setup();
+    expect(screen.getByTestId('refill-nav-button')).to.exist;
+  });
+
+  it('displays "Request a refill" button text', () => {
+    const screen = setup();
+    const button = screen.getByTestId('refill-nav-button');
+    expect(button).to.have.attribute('text', 'Request a refill');
+  });
+
+  it('does not render when isRefillable is false', () => {
+    const rx = { ...defaultRx, isRefillable: false };
+    const screen = setup(rx);
+    expect(screen.queryByTestId('refill-nav-button')).to.not.exist;
+  });
+
+  it('does not render when isRefillable is undefined', () => {
+    const rx = { prescriptionId: 12345 };
+    const screen = setup(rx);
+    expect(screen.queryByTestId('refill-nav-button')).to.not.exist;
+  });
+
+  it('has correct id attribute with prescription ID', () => {
+    const screen = setup();
+    const button = screen.getByTestId('refill-nav-button');
+    expect(button).to.have.attribute('id', 'refill-nav-button-12345');
+  });
+
+  it('has correct aria-describedby attribute', () => {
+    const screen = setup();
+    const button = screen.getByTestId('refill-nav-button');
+    expect(button).to.have.attribute('aria-describedby', 'card-header-12345');
+  });
+
+  it('has correct data-dd-action-name for analytics', () => {
+    const screen = setup();
+    const button = screen.getByTestId('refill-nav-button');
+    expect(button).to.have.attribute(
+      'data-dd-action-name',
+      dataDogActionNames.medicationsListPage.REQUEST_REFILL_CARD_LINK,
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/components/shared/RefillNavButton.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/RefillNavButton.unit.spec.jsx
@@ -5,7 +5,7 @@ import RefillNavButton from '../../../components/shared/RefillNavButton';
 import reducers from '../../../reducers';
 import { dataDogActionNames } from '../../../util/dataDogConstants';
 
-describe('RefillLinkButton component', () => {
+describe('RefillNavButton component', () => {
   const defaultRx = {
     prescriptionId: 12345,
     isRefillable: true,

--- a/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -843,4 +843,64 @@ describe('Refill Prescriptions Component', () => {
       });
     });
   });
+
+  describe('URL param preselection', () => {
+    it('preselects prescription when refillId URL param matches a refillable prescription', async () => {
+      const targetPrescriptionId = refillablePrescriptions[0].prescriptionId;
+
+      const screen = renderWithStoreAndRouterV6(<RefillPrescriptions />, {
+        initialState,
+        reducers: reducer,
+        initialEntries: [`/refill?refillId=${targetPrescriptionId}`],
+        additionalMiddlewares: [
+          allergiesApiModule.allergiesApi.middleware,
+          prescriptionsApiModule.prescriptionsApi.middleware,
+        ],
+      });
+
+      await waitFor(() => {
+        const button = screen.queryByTestId('request-refill-button');
+        expect(button).to.exist;
+        expect(button).to.have.property('text', 'Request 1 refill');
+      });
+    });
+
+    it('does not preselect when refillId does not match any prescription', async () => {
+      const screen = renderWithStoreAndRouterV6(<RefillPrescriptions />, {
+        initialState,
+        reducers: reducer,
+        initialEntries: ['/refill?refillId=nonexistent-id'],
+        additionalMiddlewares: [
+          allergiesApiModule.allergiesApi.middleware,
+          prescriptionsApiModule.prescriptionsApi.middleware,
+        ],
+      });
+
+      await waitFor(() => {
+        const button = screen.queryByTestId('request-refill-button');
+        expect(button).to.exist;
+        expect(button.text).to.include('refills');
+        expect(button.text).to.not.include('1 refill');
+      });
+    });
+
+    it('does not preselect when no refillId param is provided', async () => {
+      const screen = renderWithStoreAndRouterV6(<RefillPrescriptions />, {
+        initialState,
+        reducers: reducer,
+        initialEntries: ['/refill'],
+        additionalMiddlewares: [
+          allergiesApiModule.allergiesApi.middleware,
+          prescriptionsApiModule.prescriptionsApi.middleware,
+        ],
+      });
+
+      await waitFor(() => {
+        const button = screen.queryByTestId('request-refill-button');
+        expect(button).to.exist;
+        expect(button.text).to.include('refills');
+        expect(button.text).to.not.include('1 refill');
+      });
+    });
+  });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-request-button-on-card-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-request-button-on-card-list-page.cypress.spec.js
@@ -1,0 +1,58 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import rxList from './fixtures/listOfPrescriptions.json';
+import refillablePrescriptions from './fixtures/list-refillable-prescriptions.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+import MedicationsRefillPage from './pages/MedicationsRefillPage';
+
+describe('Medications List Page - Request Refill Button on Card', () => {
+  it('displays Request a refill button on card for refillable prescription', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+
+    site.login();
+    listPage.visitMedicationsListPageURL(rxList);
+    cy.injectAxe();
+    cy.axeCheck('main');
+
+    listPage.verifyRequestRefillButtonExistsOnCard();
+    listPage.verifyRequestRefillButtonText();
+  });
+
+  it('does not display Request a refill button for non-refillable prescriptions', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+
+    const nonRefillableList = {
+      data: rxList.data.filter(rx => !rx.attributes.isRefillable).slice(0, 5),
+      meta: rxList.meta,
+    };
+
+    site.login();
+    listPage.visitMedicationsListPageURL(nonRefillableList);
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.verifyRequestRefillButtonNotExistsOnCard();
+  });
+
+  it('navigates to refill page when clicking Request a refill button', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const refillPage = new MedicationsRefillPage();
+
+    site.login();
+    listPage.visitMedicationsListPageURL(rxList);
+    cy.injectAxe();
+    cy.axeCheck('main');
+
+    cy.intercept(
+      'GET',
+      '/my_health/v1/prescriptions/list_refillable_prescriptions',
+      refillablePrescriptions,
+    ).as('refillList');
+
+    listPage.clickRequestRefillButtonOnFirstCard();
+    cy.url().should('include', '/refill');
+    cy.wait('@refillList');
+    refillPage.verifyRefillPageTitle();
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-request-button-on-card-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-request-button-on-card-list-page.cypress.spec.js
@@ -16,6 +16,7 @@ describe('Medications List Page - Request Refill Button on Card', () => {
 
     listPage.verifyRequestRefillButtonExistsOnCard();
     listPage.verifyRequestRefillButtonText();
+    listPage.verifyRequestRefillButtonHasAriaDescribedBy();
   });
 
   it('does not display Request a refill button for non-refillable prescriptions', () => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -1168,6 +1168,38 @@ class MedicationsListPage {
         "If you need a medication immediately, you should call your VA pharmacy's automated refill line",
       );
   };
+
+  // Request Refill Button on Card methods
+  verifyRequestRefillButtonExistsOnCard = () => {
+    cy.get('[data-testid="refill-nav-button"]')
+      .first()
+      .should('exist');
+  };
+
+  verifyRequestRefillButtonNotExistsOnCard = () => {
+    cy.get('[data-testid="refill-nav-button"]').should('not.exist');
+  };
+
+  verifyRequestRefillButtonText = () => {
+    cy.get('[data-testid="refill-nav-button"]')
+      .first()
+      .shadow()
+      .find('button')
+      .should('contain', 'Request a refill');
+  };
+
+  clickRequestRefillButtonOnFirstCard = () => {
+    cy.get('[data-testid="refill-nav-button"]')
+      .first()
+      .click();
+  };
+
+  verifyRequestRefillButtonHasAriaDescribedBy = () => {
+    cy.get('[data-testid="refill-nav-button"]')
+      .first()
+      .should('have.attr', 'aria-describedby')
+      .and('match', /card-header-\d+/);
+  };
 }
 
 export default MedicationsListPage;

--- a/src/applications/mhv-medications/util/dataDogConstants.js
+++ b/src/applications/mhv-medications/util/dataDogConstants.js
@@ -16,6 +16,7 @@ export const pageType = {
 export const dataDogActionNames = {
   medicationsListPage: {
     FILL_OR_REFILL_BUTTON: `Fill or Refill Button - ${pageType.LIST}`,
+    REQUEST_REFILL_CARD_LINK: `Request Refill Card Link - ${pageType.LIST}`,
     MEDICATION_NAME_LINK_IN_CARD: `Medication Name Link In Card - ${
       pageType.LIST
     }`,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request introduces a "Request a refill" button to medication cards on the medications list page, improving user experience by allowing users to initiate a refill directly from the list. It also ensures that if a user navigates to the refill page with a prescription preselected via a URL parameter, the corresponding prescription is automatically selected. Comprehensive unit and end-to-end tests are added to verify this behavior and ensure accessibility and analytics coverage.

**Feature: Add "Request a refill" button to medication cards**

- Added a new `RefillNavButton` component that renders a "Request a refill" button for refillable prescriptions, visible only on the medications list page (`pageType.LIST`). The button navigates to the refill page with the prescription preselected via a URL parameter.
- Updated the `ExtraDetails` component to render `RefillNavButton` for eligible prescriptions on the list page, and adjusted logic to ensure the button only appears in the correct contexts.

**Feature: Preselect prescription on refill page via URL param**

- Modified the `RefillPrescriptions` container to check for a `refillId` URL parameter and preselect the corresponding prescription if present and refillable. The URL parameter is cleared after use to prevent repeated preselection.

**Testing: Unit and E2E test coverage**

- Added and extended unit tests for `RefillNavButton` and `ExtraDetails` to verify correct rendering based on prescription and page context.
- Added e2e Cypress tests to verify the button's presence, accessibility, navigation, and preselection behavior on the refill page.

**Analytics and constants**

- Added a new DataDog action name constant for the refill card link to support analytics tracking.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130375

## Testing done

- Modified mock data to ensure refill button only appears for the cards that have prescriptions that can be refilled
- Ensured preselection works appropriately

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="517" height="644" alt="before-request-refill-card" src="https://github.com/user-attachments/assets/ea268167-99aa-4b4c-818f-292a875e8093" /> | <img width="530" height="761" alt="after-request-refill-card" src="https://github.com/user-attachments/assets/e6c9487a-ab34-467e-8d43-e2e931e6a5f4" /> |

## What areas of the site does it impact?

Medications List Cards and Refill Page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
