### PR TITLE
[129215] Fix makePdf generation error handling

### DIFF
--- a/src/applications/mhv-medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
+++ b/src/applications/mhv-medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
@@ -57,13 +57,17 @@ const AdmissionAndDischargeDetails = props => {
       ...generateDischargeSummaryContent(record),
     };
     const pdfName = `VA-summaries-and-notes-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Admission/discharge details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Admission/discharge details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateCareNotesTxt = () => {

--- a/src/applications/mhv-medical-records/components/CareSummaries/ProgressNoteDetails.jsx
+++ b/src/applications/mhv-medical-records/components/CareSummaries/ProgressNoteDetails.jsx
@@ -57,13 +57,17 @@ const ProgressNoteDetails = props => {
       ...generateProgressNoteContent(record),
     };
     const pdfName = `VA-summaries-and-notes-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Progress note details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Progress note details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateCareNotesTxt = () => {

--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -24,7 +24,6 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import { selectHoldTimeMessagingUpdate } from '../../util/selectors';
 import NeedHelpSection from './NeedHelpSection';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import DownloadSuccessAlert from '../shared/DownloadSuccessAlert';
 import {
   generateTextFile,
   focusOnErrorField,
@@ -94,7 +93,6 @@ const DownloadFileType = props => {
   const dateFilter = useSelector(state => state.mr.downloads?.dateFilter);
   const refreshStatus = useSelector(state => state.mr.refresh.status);
   const holdTimeMessagingUpdate = useSelector(selectHoldTimeMessagingUpdate);
-  const [downloadStarted, setDownloadStarted] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
 
   const { fromDate, toDate, option: dateFilterOption } = dateFilter;
@@ -358,7 +356,6 @@ const DownloadFileType = props => {
       if (isGenerating) return; // Prevent double-clicks
       setIsGenerating(true);
       try {
-        setDownloadStarted(true);
         dispatch(clearAlerts());
 
         if (isDataFetched) {
@@ -426,7 +423,6 @@ const DownloadFileType = props => {
       if (isGenerating) return; // Prevent double-clicks
       setIsGenerating(true);
       try {
-        setDownloadStarted(true);
         dispatch(clearAlerts());
         if (isDataFetched) {
           const title = 'Blue Button report';
@@ -582,7 +578,13 @@ const DownloadFileType = props => {
                   checked={fileType === 'txt'}
                 />
               </VaRadio>
-              {downloadStarted && <DownloadSuccessAlert />}
+              {isGenerating && (
+                <va-loading-indicator
+                  message="Downloading report..."
+                  set-focus
+                  data-testid="downloading-indicator"
+                />
+              )}
               <div className="vads-u-margin-top--1">
                 <DownloadingRecordsInfo description="Blue Button Report" />
               </div>

--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -65,13 +65,17 @@ const ChemHemDetails = props => {
       ...generateChemHemContent(record),
     };
     const pdfName = `VA-labs-and-tests-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Chem/Hem details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Chem/Hem details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateChemHemTxt = async () => {

--- a/src/applications/mhv-medical-records/components/LabsAndTests/GenerateRadiologyPdf.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/GenerateRadiologyPdf.jsx
@@ -18,13 +18,17 @@ const GenerateRadiologyPdf = async (record, user, runningUnitTest) => {
     ...generateRadiologyContent(record),
   };
   const pdfName = `VA-labs-and-tests-details-${getNameDateAndTime(user)}`;
-  makePdf(
-    pdfName,
-    pdfData,
-    'medicalRecords',
-    'Medical Records - Radiology details - PDF generation error',
-    runningUnitTest,
-  );
+  try {
+    await makePdf(
+      pdfName,
+      pdfData,
+      'medicalRecords',
+      'Medical Records - Radiology details - PDF generation error',
+      runningUnitTest,
+    );
+  } catch {
+    // makePdf handles error logging to Datadog/Sentry
+  }
 };
 
 export default GenerateRadiologyPdf;

--- a/src/applications/mhv-medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -60,13 +60,17 @@ const MicroDetails = props => {
       ...generateMicrobioContent(record),
     };
     const pdfName = `VA-labs-and-tests-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Microbiology details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Microbiology details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateMicroTxt = async () => {

--- a/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -58,13 +58,17 @@ const PathologyDetails = props => {
       ...generatePathologyContent(record),
     };
     const pdfName = `VA-labs-and-tests-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Pathology details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Pathology details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generatePathologyTxt = async () => {

--- a/src/applications/mhv-medical-records/components/LabsAndTests/UnifiedLabAndTest.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/UnifiedLabAndTest.jsx
@@ -52,7 +52,17 @@ const UnifiedLabsAndTests = props => {
   const generatePdf = async () => {
     setDownloadStarted(true);
     const data = pdfPrinter({ record, user });
-    makePdf(data.title, data.body, 'medicalRecords', runningUnitTest);
+    try {
+      await makePdf(
+        data.title,
+        data.body,
+        'medicalRecords',
+        'Medical Records - Unified Lab/Test details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateTxt = async () => {

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -136,13 +136,17 @@ const Allergies = props => {
       ),
     };
     const pdfName = `VA-allergies-list-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Allergies - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Allergies - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateAllergyListItemTxt = item => {

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -150,7 +150,6 @@ const Allergies = props => {
   };
 
   const generateAllergyListItemTxt = item => {
-    setDownloadStarted(true);
     if (isCerner) {
       return `
 ${txtLine}\n\n
@@ -173,6 +172,7 @@ Provider notes: ${item.notes}\n`;
   };
 
   const generateAllergiesTxt = async () => {
+    setDownloadStarted(true);
     // Conditional content based on whether user has Meds by Mail facility
     const additionalInfo = hasMedsByMailFacility
       ? `

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -229,7 +229,9 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
         </div>
       )}
 
-      {downloadStarted && <DownloadSuccessAlert />}
+      {downloadStarted && (
+        <DownloadSuccessAlert className="vads-u-margin-bottom--3" />
+      )}
       <RecordListSection
         accessAlert={activeAlert && activeAlert.type === ALERT_TYPE_ERROR}
         accessAlertType={accessAlertTypes.ALLERGY}

--- a/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
@@ -126,13 +126,17 @@ const AllergyDetails = props => {
     const scaffold = generatePdfScaffold(user, title, subject);
     const pdfData = { ...scaffold, details: generateAllergyItem(allergyData) };
     const pdfName = `VA-allergies-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Allergy details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Allergy details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateAllergyTextContent = () => {

--- a/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
@@ -106,13 +106,17 @@ const ConditionDetails = props => {
     const scaffold = generatePdfScaffold(user, title, subject);
     const pdfData = { ...scaffold, ...generateConditionContent(record) };
     const pdfName = `VA-conditions-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Condition details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Condition details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateConditionTxt = async () => {

--- a/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
@@ -94,13 +94,17 @@ const VaccineDetails = props => {
     const scaffold = generatePdfScaffold(user, title, subject);
     const pdfData = { ...scaffold, details: generateVaccineItem(record) };
     const pdfName = `VA-Vaccines-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Vaccine details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Vaccine details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateVaccineTxt = async () => {

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -178,7 +178,6 @@ const Vaccines = props => {
   };
 
   const generateVaccineListItemTxt = item => {
-    setDownloadStarted(true);
     const content = [
       `${txtLine}\n\n`,
       `${item.name}\n`,
@@ -203,6 +202,7 @@ const Vaccines = props => {
     return content.join('');
   };
   const generateVaccinesTxt = async () => {
+    setDownloadStarted(true);
     const content = [
       `${crisisLineHeader}\n\n`,
       `Vaccines\n`,

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -164,13 +164,17 @@ const Vaccines = props => {
       ...generateVaccinesContent(vaccines),
     };
     const pdfName = `VA-vaccines-list-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Vaccines - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Vaccines - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateVaccineListItemTxt = item => {

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -257,7 +257,9 @@ const Vaccines = props => {
           Go to your allergy records
         </Link>
       </div>
-      {downloadStarted && <DownloadSuccessAlert />}
+      {downloadStarted && (
+        <DownloadSuccessAlert className="vads-u-margin-bottom--3" />
+      )}
       <RecordListSection
         accessAlert={activeAlert && activeAlert.type === ALERT_TYPE_ERROR}
         accessAlertType={accessAlertTypes.VACCINE}

--- a/src/applications/mhv-medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VitalDetails.jsx
@@ -225,13 +225,17 @@ const VitalDetails = props => {
       ...generateVitalContent(records, true),
     };
     const pdfName = `VA-vital-details-${getNameDateAndTime(user)}`;
-    makePdf(
-      pdfName,
-      pdfData,
-      'medicalRecords',
-      'Medical Records - Vital details - PDF generation error',
-      runningUnitTest,
-    );
+    try {
+      await makePdf(
+        pdfName,
+        pdfData,
+        'medicalRecords',
+        'Medical Records - Vital details - PDF generation error',
+        runningUnitTest,
+      );
+    } catch {
+      // makePdf handles error logging to Datadog/Sentry
+    }
   };
 
   const generateVitalsTxt = async () => {

--- a/src/applications/mhv-medical-records/tests/components/DownloadFileType.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/DownloadFileType.unit.spec.jsx
@@ -317,4 +317,34 @@ describe('DownloadFileType — AAL logging', () => {
   // `if (isGenerating) return;` in generateTxt, but the state change completes
   // too quickly to be observed in a unit test. The PDF test above verifies the
   // shared isGenerating mechanism works correctly.
+
+  it('does not show loading indicator initially', async () => {
+    const screen = renderWithFormat('pdf');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('downloading-indicator')).to.not.exist;
+    });
+  });
+
+  it('shows loading indicator during PDF generation', async () => {
+    // Make makePdf return a promise that doesn't resolve immediately
+    // so we can observe the loading state
+    makePdfStub.returns(new Promise(() => {})); // Never resolves
+
+    const screen = renderWithFormat('pdf');
+    const btn = await screen.findByTestId('download-report-button');
+
+    // Loading indicator should not exist initially
+    expect(screen.queryByTestId('downloading-indicator')).to.not.exist;
+
+    // Click the button to start generation
+    await userEvent.click(btn);
+
+    // Loading indicator should now appear
+    await waitFor(() => {
+      const loadingIndicator = screen.queryByTestId('downloading-indicator');
+      expect(loadingIndicator).to.exist;
+      expect(loadingIndicator).to.have.attr('message', 'Downloading report...');
+    });
+  });
 });

--- a/src/platform/mhv/util/helpers.js
+++ b/src/platform/mhv/util/helpers.js
@@ -219,5 +219,7 @@ export const makePdf = async (
     pdfModulePromise = null;
     datadogRum.addError(error, { feature: sentryErrorLabel });
     sendErrorToSentry(error, sentryErrorLabel);
+    // Re-throw so callers can handle the error appropriately
+    throw error;
   }
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This pull request improves the reliability and user experience of PDF generation across the medical records application by adding catch error handling and enhancing user feedback during downloads. The major changes include wrapping all `makePdf` calls in try/catch blocks to ensure errors are properly surfaced and handled, updating the UI to show a loading indicator during file generation, and adding corresponding unit tests. Additionally, some unused code related to download state was removed for clarity.

**PDF Generation Error Handling:**
* All calls to `makePdf` in medical records feature components are now wrapped in `try/catch` blocks, ensuring that errors during PDF creation are properly caught and that error logging (to Datadog/Sentry) is consistently handled. [[1]](diffhunk://#diff-23ed528413553c9327b11e5a5952fe0d83d6850cf36f653fa1f8e66a6fc76f89L60-R70) [[2]](diffhunk://#diff-51cac08703be31afbd1ed335fe7b86689713c6f72384e577dd3e59f607acceabL60-R70) [[3]](diffhunk://#diff-121b2103c4015a764bc397537aa110ca39347f15512367fd6770eb990c17a45fL68-R78) [[4]](diffhunk://#diff-339510be6eb567b90686feb022063b3b0bc0e1b4d40af2fc957efdf40405d9afL21-R31) [[5]](diffhunk://#diff-d04623ea52bb6006d1f31d818796dc4b7573bb7940dd87694e383a00b86d1fa7L63-R73) [[6]](diffhunk://#diff-188aadbdb62fea5aefb5c37e0e07a3b4c1b41d0fbfb5318b1b12a2aef7cfb6ceL61-R71) [[7]](diffhunk://#diff-42cbffa61cd05581de63383e38887b6870f523ab4fbfadd2a01c95ecdf8dec1dL55-R65) [[8]](diffhunk://#diff-1fced19b340db24fef6c4ecbab0bb667da1d4e886ed98f085f42b81312a587e0L139-R149) [[9]](diffhunk://#diff-9c5b618fdd2222d66e777ba465167266450dd05f0235b4c08955180e2ad0fefdL129-R139) [[10]](diffhunk://#diff-a5e13febcb25e47ea0e2e8e7c1f27f7a5cc708c537cfc5f792113aec9654ece9L109-R119) [[11]](diffhunk://#diff-6649db8a04b08f366eaa23bde74624d61deb8f5280f48df4cc503ba28ddc7d19L97-R107) [[12]](diffhunk://#diff-356bd5388bfda255441fd0ae6cd3daeb1e0ba35687e02c5c28d77071ff2eb07dL167-R177) [[13]](diffhunk://#diff-a89a73db3be36834ec0d9c15f2501c3bcedb489e19e0b508c2bb889aa0f59b79L228-R238)
* The `makePdf` helper now re-throws errors after logging, allowing calling components to react appropriately if PDF generation fails.

**Download UI Feedback Improvements:**
* The download success alert and related state (`downloadStarted`) were removed from `DownloadFileType.jsx` in favor of displaying a loading indicator (`va-loading-indicator`) while a download is in progress, providing clearer feedback to users. [[1]](diffhunk://#diff-7466f9e1f666131eed061d7bb6f1e50b0af01b3ebd74d5bf5796f697f8f4b067L27) [[2]](diffhunk://#diff-7466f9e1f666131eed061d7bb6f1e50b0af01b3ebd74d5bf5796f697f8f4b067L97) [[3]](diffhunk://#diff-7466f9e1f666131eed061d7bb6f1e50b0af01b3ebd74d5bf5796f697f8f4b067L361) [[4]](diffhunk://#diff-7466f9e1f666131eed061d7bb6f1e50b0af01b3ebd74d5bf5796f697f8f4b067L429) [[5]](diffhunk://#diff-7466f9e1f666131eed061d7bb6f1e50b0af01b3ebd74d5bf5796f697f8f4b067L585-R587)


## Related issue(s)

- department-of-veterans-affairs/va.gov-team#129215

## Testing done

* New unit tests for download blue button report were added to verify that the loading indicator appears during PDF generation
* Local testing

## Screenshots

Replaced the alert on File-type page with downloading spinner.


|         | Before | After |
| ------- | ------ | ----- |
| file-type page  |   <img width="804" height="744" alt="Screenshot 2026-01-22 at 10 13 03 AM" src="https://github.com/user-attachments/assets/fd4831f1-ff31-49d8-b351-6c94cd6342db" />     |    <img width="448" height="372" alt="Screenshot 2026-01-26 at 8 52 04 AM" src="https://github.com/user-attachments/assets/90d43f7b-4137-4fef-bccf-a56b555c85a0" />   |
| Allergies - alert  |    <img width="745" height="636" alt="Screenshot 2026-01-26 at 1 16 10 PM" src="https://github.com/user-attachments/assets/f9980715-49de-460e-b281-aa54f5c79355" />  |   <img width="745" height="636" alt="Screenshot 2026-01-26 at 2 04 02 PM" src="https://github.com/user-attachments/assets/3974af4c-5047-443d-9a65-ebe835855642" />    |
| Vaccines - alert  | <img width="745" height="636" alt="Screenshot 2026-01-26 at 1 18 09 PM" src="https://github.com/user-attachments/assets/7ba8f711-0620-4f0d-8e92-10e105883de2" />     |   <img width="745" height="636" alt="Screenshot 2026-01-26 at 1 57 49 PM" src="https://github.com/user-attachments/assets/87793028-9121-41bd-8023-b07d2f053f12" />    |




## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
