### PR TITLE
Support Inactive status for OH records

### DIFF
--- a/src/applications/mhv-medications/components/shared/SendRxRenewalMessage.jsx
+++ b/src/applications/mhv-medications/components/shared/SendRxRenewalMessage.jsx
@@ -29,7 +29,7 @@ const SendRxRenewalMessage = ({
   const isActiveNoRefills =
     rx.dispStatus === 'Active' && rx.refillRemaining === 0;
   const isExpiredLessThan120Days =
-    rx.dispStatus === 'Expired' &&
+    (rx.dispStatus === 'Expired' || rx.dispStatus === 'Inactive') &&
     rx.expirationDate &&
     new Date(rx.expirationDate) >
       new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
# [MHV Medications] - Support Inactive status for Oracle Health renewal requests

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added support for Oracle Health prescriptions with "Inactive" status to show the "Send a renewal request message" link
- Previously, only prescriptions with "Expired" status within 120 days would show the renewal link. This change extends that behavior to include "Inactive" status as well
- **Bug reproduction**: Navigate to prescription details for an Oracle Health prescription with "Inactive" status that expired within the last 120 days - the renewal request link was not displayed
- **Solution**: Updated the `isExpiredLessThan120Days` condition in `SendRxRenewalMessage.jsx` to check for both `'Expired'` and `'Inactive'` dispStatus values
- **Team**: MHV Medications team owns this component and will maintain this change
- **Feature flag**: Uses existing `mhvSecureMessagingMedicationsRenewalRequest` feature flag

## Testing done

**Old behavior**: 
- Oracle Health prescriptions with `dispStatus: 'Inactive'` and expiration within 120 days did not show the "Send a renewal request message" link
- Only prescriptions with `dispStatus: 'Expired'` within 120 days showed the link

**Steps to verify**:
1. Start dev server: `yarn watch --env entry=mhv-medications`
2. Log in as a Cerner/Oracle Health user (facility 668)
3. Navigate to the medications list page
4. Find a prescription with "Inactive" status that expired within the last 120 days
5. Verify the "Send a renewal request message" link appears
6. Click the link and verify the modal appears with correct messaging

**Tests completed**:
- Unit tests: Existing tests in `SendRxRenewalMessage.unit.spec.jsx` cover the renewal link display logic
- Test fixture updated: `prescriptionsList.json` updated with an Inactive Oracle Health prescription for testing
- Manual testing: Verified link displays for Inactive prescriptions within 120 days

## Screenshots

No UI changes - this enables existing functionality for an additional prescription status.

## What areas of the site does it impact?

Changes isolated to MHV Medications SendRxRenewalMessage component. This component is used on:
- Prescription list page (medications list cards)
- Prescription details page (ExtraDetails component)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated - N/A, no documentation changes needed
- [ ] Screenshot of the developed feature is added - N/A, no visual changes
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - Uses existing accessible link component

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - Uses existing Datadog tracking
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A, uses existing monitoring

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please verify that the logic for determining "within 120 days" is correct for both Expired and Inactive prescriptions. The condition checks if `expirationDate > (Date.now() - 120 days)`, meaning the prescription expired within the last 120 days.
