### PR TITLE
Pension | Update disability rating alert content

### DIFF
--- a/src/applications/pensions/components/DisabilityRatingAlert.jsx
+++ b/src/applications/pensions/components/DisabilityRatingAlert.jsx
@@ -6,7 +6,7 @@ import { dataDogLogger } from 'platform/monitoring/Datadog/utilities';
 const VaLink = () => (
   <va-link
     href="https://va.gov/pension/veterans-pension-rates"
-    text="View Veterans Pension rates"
+    text="Review current pension rates for Veterans"
   />
 );
 
@@ -62,13 +62,12 @@ const DisabilityRatingAlert = () => {
     return (
       <va-alert visible>
         <h2 slot="headline">
-          A 100% disability rating pays more than a Veterans Pension
+          Consider your disability rating before you apply
         </h2>
         <p className="vads-u-margin-y--0">
-          Veterans with a 100% disability rating get a higher payment from
-          disability compensation than from a Veterans Pension. If you have this
-          rating, applying for a Veterans Pension won’t increase your monthly
-          payments.
+          If you have a 100% disability rating, applying for Veterans Pension is
+          unlikely to increase your monthly payments. We always pay the higher
+          payment amount.
         </p>
         <p className="vads-u-margin-bottom--0">
           <VaLink />
@@ -102,12 +101,17 @@ const DisabilityRatingAlert = () => {
   return (
     <va-alert status="warning" visible>
       <h2 slot="headline">
-        You’re unlikely to get a higher payment from a Veterans Pension
+        Applying likely won’t increase your monthly payments
       </h2>
       <p className="vads-u-margin-y--0">
-        Our records show you have a 100% disability rating. Your current monthly
-        payment is higher than a Veterans Pension payment. You can still apply,
-        but your payments won’t increase.
+        Our records show you have a 100% disability rating. Your monthly
+        disability compensation payment is higher than a Veterans Pension
+        payment in most cases.
+      </p>
+      <p>
+        We always pay the higher payment amount. So applying for a Veterans
+        Pension will only increase your payment in certain situations, like if
+        you live in a Medicaid-approved nursing home.
       </p>
       <p className="vads-u-margin-bottom--0">
         <VaLink />

--- a/src/applications/pensions/tests/unit/components/DisabilityRatingAlert.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/components/DisabilityRatingAlert.unit.spec.jsx
@@ -46,11 +46,8 @@ describe('DisabilityRatingAlert component', () => {
     const { container, getByText } = render(<DisabilityRatingAlert />);
 
     await waitFor(() => {
-      expect(
-        getByText(
-          /You’re unlikely to get a higher payment from a Veterans Pension/i,
-        ),
-      ).to.exist;
+      expect(getByText(/Applying likely won’t increase your monthly payments/i))
+        .to.exist;
       expect(ddLoggerStub.called).to.be.true;
       expect(ddLoggerStub.args[0][0]).to.deep.equal({
         message: 'Pension disability rating alert visible for 100 rating',
@@ -101,11 +98,8 @@ describe('DisabilityRatingAlert component', () => {
     const { container, getByText } = render(<DisabilityRatingAlert />);
 
     await waitFor(() => {
-      expect(
-        getByText(
-          /A 100% disability rating pays more than a Veterans Pension/i,
-        ),
-      ).to.exist;
+      expect(getByText(/Consider your disability rating before you apply/i)).to
+        .exist;
       expect(ddLoggerStub.args[0][0]).to.deep.equal({
         message: 'Pension disability rating fetch error',
         attributes: {


### PR DESCRIPTION
### Summary of Changes
This PR updates the **Disability Rating Alert** component content for the **Pension Benefits form (VA Form 21P-527EZ)**.  
The change is **text-only** and refines the alert copy to reflect updated guidance and messaging. No logic or behavior changes were introduced.

The alert continues to be conditionally displayed based on the `pension_rating_alert_logging_enabled` feature toggle.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125720
### Screenshot(s)
| No rating | 100% rating |
|--------|--------|
|<img width="1400" height="891" alt="localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_introduction" src="https://github.com/user-attachments/assets/043cd3bb-31f3-48ee-ab25-07ba9df4b8a8" />|<img width="1400" height="1030" alt="localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_introduction (1)" src="https://github.com/user-attachments/assets/d6eb3c8f-94d5-42e6-b5f6-55aee1e09164" />

### How to Set Up in Local Environment
1. Run the local environment
2. Enable the feature toggle:  
   `pension_rating_alert_logging_enabled`  
   http://localhost:3000/flipper/features/pension_rating_alert_logging_enabled
3. Navigate to the Pension Benefits form:  
   http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/

### How to Test
1. Start a new Pension Benefits application.
2. With `pension_rating_alert_logging_enabled` enabled, verify:
   - The **Disability Rating Alert** is displayed.
   - The updated text content matches the expected copy.
3. Disable the feature toggle and verify:
   - The alert is not displayed.
4. Confirm there are no console errors or layout regressions.

### Feature Flag Note
- The Disability Rating Alert content updates are gated behind the  
  `pension_rating_alert_logging_enabled` feature toggle.

### Acceptance Criteria
- [x] Disability Rating Alert text is updated as expected.
- [x] Alert displays only when the feature toggle is enabled.
- [x] No logic or behavior changes introduced.
- [x] No accessibility or console errors.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggle enabled and disabled.
- [ ] No regressions introduced.
- [ ] Tests verified passing.