### PR TITLE
Pension | Update asset information accordion content

### DIFF
--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -50,10 +50,6 @@ export const AssetsInformation = () => (
           marriages)
         </li>
         <li>
-          A parent, if you’re directly caring for them and their income and net
-          worth are below a certain amount
-        </li>
-        <li>
           An unmarried child (including an adopted child or stepchild) who meets
           one of the eligibility requirements listed here
         </li>
@@ -69,8 +65,8 @@ export const AssetsInformation = () => (
           They’re under 18 years old, <strong>or</strong>
         </li>
         <li>
-          They’re between the ages of 18 and 23 years old and enrolled in school
-          full time, <strong>or</strong>
+          They’re between the ages of 18 and 23 years old and enrolled in
+          school, <strong>or</strong>
         </li>
         <li>They became permanently disabled before they turned 18</li>
       </ul>


### PR DESCRIPTION
### Summary of Changes
This PR updates the **asset information accordion content** on the **Total net worth** page for the **Pension Benefits form (VA Form 21P-527EZ)**.  
The copy within the accordion has been revised for clarity and alignment with updated guidance, without changing any underlying logic or behavior.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130596

### How to Set Up in Local Environment
1. Run the local environment
2. Navigate directly to the Total Net Worth page:  
   http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/financial/total-net-worth

### How to Test
1. Load the **Total net worth** page.
2. Expand the **asset information** accordion.
3. Verify the updated accordion content:
   - Text reflects the latest approved copy.
   - Formatting and semantics are correct.
4. Confirm there are no layout, accessibility, or console errors.
5. Continue through the form to ensure no regressions in navigation.

### Feature Flag Note
- No feature flag changes are required for this update.

### Acceptance Criteria
- [x] Asset information accordion content is updated as expected.
- [x] Accordion behavior remains unchanged.
- [x] No accessibility or console errors introduced.
- [x] Page continues to function correctly within the form flow.

### Definition of Done
- [x] Code reviewed and approved.
- [x] Verified locally.
- [x] No regressions introduced.
- [x] Tests verified passing.