### PR TITLE
Updated acrVerify Value for ID.me

### DIFF
--- a/src/applications/verify/tests/e2e/verify.cypress.spec.js
+++ b/src/applications/verify/tests/e2e/verify.cypress.spec.js
@@ -125,7 +125,51 @@ describe('Verify App', () => {
     cy.wait('@verifyRequest');
   });
 
-  it('should have an acr value of "loa3" when the ID.me verify button is clicked', () => {
+  it('should have an acr value of "urn:acr.va.gov:verified-facial-match-required" when the ial2 enforcement feature flag is enabled and the ID.me verify button is clicked', () => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      statusCode: 200,
+      body: {
+        data: {
+          features: [
+            {
+              name: 'identity_idme_ial2_enforcement',
+              value: true,
+            },
+          ],
+        },
+      },
+    }).as('featureToggles');
+
+    cy.intercept('GET', '/v0/sign_in/authorize*', req => {
+      expect(req.query.acr).to.equal(
+        'urn:acr.va.gov:verified-facial-match-required',
+      );
+    }).as('verifyRequest');
+
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+
+    cy.get('.idme-verify-button').should('exist');
+    cy.get('.idme-verify-button').click();
+
+    cy.wait('@verifyRequest');
+  });
+
+  it('should have an acr value of "loa3" when the ial2 enforcement feature flag is disabled and the ID.me verify button is clicked', () => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      statusCode: 200,
+      body: {
+        data: {
+          features: [
+            {
+              name: 'identity_idme_ial2_enforcement',
+              value: false,
+            },
+          ],
+        },
+      },
+    }).as('featureToggles');
+
     cy.intercept('GET', '/v0/sign_in/authorize*', req => {
       expect(req.query.acr).to.equal('loa3');
     }).as('verifyRequest');

--- a/src/platform/user/authentication/components/VerifyButton.jsx
+++ b/src/platform/user/authentication/components/VerifyButton.jsx
@@ -16,7 +16,10 @@ export const verifyHandler = ({
   useOAuth,
 }) => {
   const needsIal2Enforcement =
-    ial2Enforcement && policy === SERVICE_PROVIDERS.logingov.policy;
+    ial2Enforcement &&
+    [SERVICE_PROVIDERS.logingov.policy, SERVICE_PROVIDERS.idme.policy].includes(
+      policy,
+    );
 
   verify({
     policy,
@@ -39,6 +42,10 @@ export const verifyHandler = ({
 export const VerifyIdmeButton = ({ queryParams, useOAuth = false }) => {
   const { altImage, policy } = SERVICE_PROVIDERS.idme;
   const forceOAuth = useSelector(isAuthenticatedWithOAuth) || useOAuth;
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const ial2Enforcement = useToggleValue(
+    TOGGLE_NAMES.identityIdmeIal2Enforcement,
+  );
 
   return (
     <button
@@ -46,7 +53,7 @@ export const VerifyIdmeButton = ({ queryParams, useOAuth = false }) => {
       className="usa-button idme-verify-button"
       onClick={() =>
         verifyHandler({
-          ial2Enforcement: false,
+          ial2Enforcement,
           policy,
           useOAuth: forceOAuth,
           queryParams,

--- a/src/platform/user/tests/authentication/components/VerifyButton.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/VerifyButton.unit.spec.jsx
@@ -17,6 +17,7 @@ const sharedStore = () => ({
   getState: () => ({
     featureToggles: {
       [TOGGLE_NAMES.identityLogingovIal2Enforcement]: false,
+      [TOGGLE_NAMES.identityIdmeIal2Enforcement]: false,
     },
   }),
   dispatch: () => {},

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -143,6 +143,7 @@
   "hcaInsuranceV2Enabled": "hca_insurance_v2_enabled",
   "hcaPerformanceAlertEnabled": "hca_performance_alert_enabled",
   "hcaRegOnlyEnabled": "hca_reg_only_enabled",
+  "identityIdmeIal2Enforcement": "identity_idme_ial2_enforcement",
   "identityLogingovIal2Enforcement": "identity_logingov_ial2_enforcement",
   "incomeAndAssetsFormEnabled": "income_and_assets_form_enabled",
   "incomeAndAssetsContentUpdates": "income_and_assets_content_updates",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated `VerifyButton.jsx` so that ID.me's `acrVerify` is now `urn:acr.va.gov:verified-facial-match-required` (behind feature flag).

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1036)

## Testing done
- Updated `verify.cypress.spec.js` and `VerifyAccountLink.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running: 
  - `yarn cy:run --spec src/applications/verify/tests/e2e/verify.cypress.spec.js`
  - `yarn test:unit src/platform/user/tests/authentication/components/VerifyAccountLink.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts the feature flags, `VerifyButton.jsx`, and the related tests.

## Acceptance criteria
- [x] Update ID.me `acrVerify` value to equal `urn:acr.va.gov:verified-facial-match-required` (behind feature flag)
- [x] Add `identity_idme_ial2_enforcement` feature flag
- [x] Update tests as necessary 