### PR TITLE
Throw error on duplicate page path

### DIFF
--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { dropRight, merge } from 'lodash';
 import { getDefaultFormState } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
+import environment from 'platform/utilities/environment';
 import dataGet from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
 import unset from '../../../../utilities/data/unset';
@@ -855,6 +856,8 @@ export function createInitialState(formConfig) {
     formErrors: {},
   };
 
+  const uniquePaths = new Set();
+
   const pageAndDataState = createFormPageList(formConfig).reduce(
     (state, page) => {
       const definitions = {
@@ -864,6 +867,12 @@ export function createInitialState(formConfig) {
       let schema = replaceRefSchemas(page.schema, definitions, page.pageKey);
       // Throw an error if the new schema is invalid
       checkValidSchema(schema);
+      if (!environment.isProduction() && uniquePaths.has(page.path)) {
+        throw new Error(
+          `Duplicate page path found: ${page.path}. Page paths must be unique.`,
+        );
+      }
+      uniquePaths.add(page.path);
       schema = updateItemsSchema(schema);
       const isArrayPage = page.showPagePerItem;
       const data = getDefaultFormState(

--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -867,15 +867,17 @@ export function createInitialState(formConfig) {
       let schema = replaceRefSchemas(page.schema, definitions, page.pageKey);
       // Throw an error if the new schema is invalid
       checkValidSchema(schema);
-      if (!environment.isProduction() && uniquePaths.has(page.path)) {
-        throw new Error(
-          `Duplicate page path found: ${page.path}. Page paths must be unique.
-          Paths must be unique because usually the side effects are unintentional,
-          such as going to the route you didn't expect to go to. (router.push will
-          go to the first path it finds, even if its "depends" is false)`,
-        );
+      if (page.path) {
+        if (!environment.isProduction() && uniquePaths.has(page.path)) {
+          throw new Error(
+            `Duplicate page path found: ${page.path}. Page paths must be unique.
+            Paths must be unique because usually the side effects are unintentional,
+            such as going to the route you didn't expect to go to. (router.push will
+            go to the first path it finds, even if its "depends" is false)`,
+          );
+        }
+        uniquePaths.add(page.path);
       }
-      uniquePaths.add(page.path);
       schema = updateItemsSchema(schema);
       const isArrayPage = page.showPagePerItem;
       const data = getDefaultFormState(

--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -869,7 +869,10 @@ export function createInitialState(formConfig) {
       checkValidSchema(schema);
       if (!environment.isProduction() && uniquePaths.has(page.path)) {
         throw new Error(
-          `Duplicate page path found: ${page.path}. Page paths must be unique.`,
+          `Duplicate page path found: ${page.path}. Page paths must be unique.
+          Paths must be unique because usually the side effects are unintentional,
+          such as going to the route you didn't expect to go to. (router.push will
+          go to the first path it finds, even if its "depends" is false)`,
         );
       }
       uniquePaths.add(page.path);


### PR DESCRIPTION
## Summary

- Throw error on duplicate page path

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5531

## Testing done

- Full unit test suite
(1 failure on `static-pages` - Unrelated, as it also fails on `main`)

## Screenshots

<img width="440" height="517" alt="image" src="https://github.com/user-attachments/assets/a9f0d0ac-b5b5-48e7-bf82-50795b939967" />
<img width="511" height="320" alt="image" src="https://github.com/user-attachments/assets/e0ee2322-0a99-4f96-8c32-964466d979f0" />
<img width="861" height="262" alt="image" src="https://github.com/user-attachments/assets/1053af62-907e-45e4-ada8-ccac1e7808fe" />


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
