### PR TITLE
Fix: Update wording in sign-in E2E test to match actual link text

### DIFF
--- a/src/applications/login/tests/sign-in-page.cypress.spec.js
+++ b/src/applications/login/tests/sign-in-page.cypress.spec.js
@@ -8,7 +8,7 @@ describe('Unified Sign-in Page', () => {
     cy.get('body').should('be.visible');
     cy.get('H1').contains('Sign in or create an account');
     cy.get('H2').contains('Help and support');
-    cy.get('a').contains('Learn about creating a Login.gov or ID.me account');
+    cy.get('a').contains('Learn about creating an ID.me or Login.gov account');
     cy.injectAxeThenAxeCheck();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updated the Cypress E2E test assertion to match the actual link text on the sign-in page
- The link text on the page reads 'Learn about creating an ID.me or Login.gov account' (ID.me first), but the test was checking for 'Login.gov or ID.me' (Login.gov first)
- This is a minor test fix to ensure the test assertion matches the actual UI text order

## Related issue(s)

- N/A - This is a test correction to match existing UI text

## Testing done

- Reviewed the change in the sign-in page Cypress spec
- The test now correctly checks for the link text in the order it appears on the actual page: 'ID.me or Login.gov' instead of 'Login.gov or ID.me'
- This is a one-line change in a test assertion

## Screenshots

N/A - This is a test file change only, no UI changes

## What areas of the site does it impact?

This only impacts the sign-in page E2E test. No functional code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A for test fix)
- [ ] Screenshot of the developed feature is added (N/A for test change)
- [x] Accessibility testing has been performed (N/A for test change)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A for test assertion fix)

## Requested Feedback

This is a straightforward fix to align the test assertion with the actual link text on the page.