### PR TITLE
10-7959c | Guard prefill metadata return URL

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -7,6 +7,7 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import PreSubmitInfo from '../components/PreSubmitInfo';
 import FormFooter from '../components/FormFooter';
+import prefillTransformer from './prefillTransformer';
 import transformForSubmit from './submitTransformer';
 import { nameWording, privWrapper } from '../../shared/utilities';
 import SubmissionError from '../../shared/components/SubmissionError';
@@ -100,6 +101,7 @@ const formConfig = {
   version: migrations.length,
   migrations,
   prefillEnabled: true,
+  prefillTransformer,
   transformForSubmit,
   savedFormMessages: {
     notFound:

--- a/src/applications/ivc-champva/10-7959C/config/prefillTransformer.js
+++ b/src/applications/ivc-champva/10-7959C/config/prefillTransformer.js
@@ -1,0 +1,14 @@
+const prefillTransformer = (pages, formData, metadata) => {
+  const isFreshPrefill = metadata?.prefill === true;
+  const updatedMetadata = isFreshPrefill
+    ? { ...metadata, returnUrl: undefined }
+    : metadata;
+
+  return {
+    pages,
+    formData: { ...formData },
+    metadata: updatedMetadata,
+  };
+};
+
+export default prefillTransformer;

--- a/src/applications/ivc-champva/10-7959C/tests/unit/config/prefillTransformer.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/unit/config/prefillTransformer.unit.spec.jsx
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import prefillTransformer from '../../../config/prefillTransformer';
+
+describe('10-7959C Prefill Transformer', () => {
+  const runTransformer = (metadata, formData = {}, pages = []) =>
+    prefillTransformer(pages, formData, metadata);
+
+  it('should remove returnUrl for fresh prefill data', () => {
+    const metadata = {
+      version: 0,
+      prefill: true,
+      returnUrl: '/applicant-info',
+    };
+    const result = runTransformer(metadata);
+    expect(result.metadata.returnUrl).to.be.undefined;
+    expect(result.metadata.prefill).to.be.true;
+    expect(result.metadata.version).to.equal(0);
+  });
+
+  it('should preserve returnUrl for saved in-progress data', () => {
+    const metadata = {
+      version: 0,
+      prefill: false,
+      returnUrl: '/applicant-info',
+    };
+    const result = runTransformer(metadata);
+    expect(result.metadata.returnUrl).to.equal('/applicant-info');
+    expect(result.metadata.prefill).to.be.false;
+  });
+
+  it('should preserve returnUrl when prefill is not set', () => {
+    const metadata = {
+      version: 0,
+      returnUrl: '/applicant-info',
+    };
+    const result = runTransformer(metadata);
+    expect(result.metadata.returnUrl).to.equal('/applicant-info');
+  });
+
+  it('should return pages and formData unchanged', () => {
+    const pages = ['page1', 'page2'];
+    const formData = { field1: 'value1', field2: 'value2' };
+    const metadata = { version: 0, prefill: true };
+    const result = runTransformer(metadata, formData, pages);
+    expect(result.pages).to.deep.equal(pages);
+    expect(result.formData).to.deep.equal(formData);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR introduces a new `prefillTransformer` for the app and integrates it into the form configuration. The transformer ensures that the `returnUrl` field is removed from metadata when the form is freshly prefilled, preventing unintended navigation behavior. Comprehensive unit tests have been added to verify the transformer's logic.

Integration of prefill transformer:

* Added the new `prefillTransformer` function to `src/applications/ivc-champva/10-7959C/config/prefillTransformer.js`, which removes the `returnUrl` from metadata if the prefill is fresh, and otherwise leaves metadata unchanged.
* Integrated `prefillTransformer` into the form configuration by importing it and adding it to the `formConfig` object in `form.js`.

Testing:

* Added unit tests in `prefillTransformer.unit.spec.jsx` to ensure that the transformer behaves correctly for both fresh prefill and in-progress/saved data, and that it does not alter unrelated data.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#130396

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Return URL in metadata matches the intended behavior

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user