### PR TITLE
Removed active styling from links in evidence requests.

### DIFF
--- a/src/applications/claims-status/utils/evidenceDictionary.jsx
+++ b/src/applications/claims-status/utils/evidenceDictionary.jsx
@@ -29,7 +29,6 @@ export const evidenceDictionary = {
           upload or mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4142"
             text="VA Form 21-4142"
             href="/find-forms/about-form-21-4142/"
@@ -52,7 +51,6 @@ export const evidenceDictionary = {
           us your employment information.
           <br />
           <va-link
-            active
             text="VA Form 21-4192"
             data-testid="VA Form 21-4192"
             href="/find-forms/about-form-21-4192/"
@@ -76,7 +74,6 @@ export const evidenceDictionary = {
           by phone, or by mail.
           <br />
           <va-link
-            active
             text="Add or change direct deposit information"
             data-testid="Add or change direct deposit information"
             href="/profile/direct-deposit"
@@ -87,21 +84,13 @@ export const evidenceDictionary = {
           If you don’t already have a bank account, the Veterans Benefits
           Banking Program (VBBP) can connect you with a bank that will help you
           set up an account.
-          <a
-            className="external-active-link vads-u-margin-top--0"
-            rel="noopener noreferrer"
-            target="_blank"
-            data-testid="Set up a bank account through VBBP (opens in new tab)"
+          <br />
+          <va-link
+            external
+            data-testid="Set up a bank account through VBBP"
             href="https://veteransbenefitsbanking.org/"
-          >
-            Set up a bank account through VBBP (opens in new tab)
-            <va-icon
-              icon="chevron_right"
-              class="active-link-icon"
-              size={2}
-              aria-hidden="true"
-            />
-          </a>
+            text="Set up a bank account through VBBP"
+          />
         </p>
       </>
     ),
@@ -235,7 +224,6 @@ export const evidenceDictionary = {
           mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-8940"
             text="VA Form 21-8940"
             href="/find-forms/about-form-21-8940/"
@@ -246,7 +234,6 @@ export const evidenceDictionary = {
           ask them to mail us your employment information.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4192"
             text="VA Form 21-4192"
             href="/find-forms/about-form-21-4192/"
@@ -311,7 +298,6 @@ export const evidenceDictionary = {
           mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4142a"
             text="VA Form 21-4142a"
             href="/find-forms/about-form-21-4142a/"
@@ -365,7 +351,6 @@ export const evidenceDictionary = {
           it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-10210"
             text="VA Form 21-10210"
             href="/find-forms/about-form-21-10210/"
@@ -415,7 +400,6 @@ export const evidenceDictionary = {
           After completing and signing the form, you can upload or mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4138"
             text="VA Form 21-4138"
             href="/find-forms/about-form-21-4138/"
@@ -453,7 +437,6 @@ export const evidenceDictionary = {
           After completing and signing the form, you can upload or mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4138"
             text="VA Form 21-4138"
             href="/find-forms/about-form-21-4138/"
@@ -506,7 +489,6 @@ export const evidenceDictionary = {
           upload or mail it.
           <br />
           <va-link
-            active
             text="VA Form 21-526EZ"
             data-testid="VA Form 21-526EZ"
             href="/find-forms/about-form-21-526ez/"
@@ -611,7 +593,6 @@ export const evidenceDictionary = {
           upload or mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4142"
             text="VA Form 21-4142"
             href="/find-forms/about-form-21-4142/"
@@ -646,7 +627,6 @@ export const evidenceDictionary = {
           upload or mail it.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4142a"
             text="VA Form 21-4142a"
             href="/find-forms/about-form-21-4142a/"
@@ -717,7 +697,6 @@ export const evidenceDictionary = {
           or use VA Form 21-4138, Statement in Support of Claim.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4138"
             text="VA Form 21-4138"
             href="/find-forms/about-form-21-4138/"
@@ -773,7 +752,6 @@ export const evidenceDictionary = {
           authorize VA to request your medical records.
           <br />
           <va-link
-            active
             data-testid="VA Form 21-4142"
             text="VA Form 21-4142"
             href="/find-forms/about-form-21-4142/"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed active pseudo-class styling from links in evidence request content within the claims status tool
- This affects links displayed in the evidence dictionary that provides content for document request pages
- The change improves the visual presentation of links by removing the default active state styling
- Team: Benefits Management Tools 2 (Bee's Knees)
- This team owns the maintenance of the claims status application

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131148

## Testing done

**Old behavior:**
- Links in evidence request content had active state styling applied, which could cause visual issues when clicked

**Steps to verify:**
1. Navigate to the claims status tool on localhost
2. View a claim with document requests/evidence requests
4. Verify that links no longer show unwanted active styling

**Tests completed:**
- Manual testing of links in evidence request pages
- Verified visual appearance of links in various evidence request scenarios
- Confirmed no regression in link functionality

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="884" height="286" alt="Screenshot 2026-01-27 at 8 47 34 AM" src="https://github.com/user-attachments/assets/fdfa2cba-3858-46c3-894f-91b25ac7fd79" /> | <img width="866" height="261" alt="Screenshot 2026-01-27 at 8 18 07 AM" src="https://github.com/user-attachments/assets/c8a1beeb-a30b-4ca2-99cd-2cf3cd400bef" /> |
| <img width="789" height="213" alt="Screenshot 2026-01-27 at 8 47 21 AM" src="https://github.com/user-attachments/assets/c01bfb8f-448a-4b05-bed4-4eef7feecc8e" /> | <img width="791" height="201" alt="Screenshot 2026-01-27 at 8 18 44 AM" src="https://github.com/user-attachments/assets/c87111fd-5a82-46a1-955e-6b432e363a96" /> |


## What areas of the site does it impact?


This change impacts the claims status tool, specifically the evidence request/document request pages where additional information and links are displayed to veterans.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (link to documentation) \*if necessary
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please review the visual changes to ensure the link styling meets accessibility standards and design system guidelines.
