### PR TITLE
534ez switch field dicType to benefit

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/dicBenefits.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/dicBenefits.js
@@ -109,16 +109,16 @@ export default {
   uiSchema: {
     ...titleUI('DIC benefits', Description),
     'ui:description': DicAccordion,
-    dicType: radioUI({
+    benefit: radioUI({
       title: CHAPTER_5.dicBenefits,
       labels: dicOptions,
     }),
   },
   schema: {
     type: 'object',
-    required: ['dicType'],
+    required: ['benefit'],
     properties: {
-      dicType: radioSchema(Object.keys(dicOptions)),
+      benefit: radioSchema(Object.keys(dicOptions)),
     },
   },
 };

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -11,7 +11,6 @@
   "claimantLivesInANursingHome": false,
   "view:vaMedicalCentersMissingInformation": {},
   "view:isAddingDicBenefits": false,
-  "dicType": "DIC",
   "recognizedAsSpouse": true,
   "hadPreviousMarriages": true,
   "remarriedAfterVeteralDeath": true,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fix mismatched field key for DIC question on pdf

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131096

## Testing done

- Manual testing with pdf filler

## Screenshots

N/A

## What areas of the site does it impact?

The DIC benefit type page of 534ez.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A