### PR TITLE
fix(a11y): Fix empty-heading accessibility violation in Resources & Support search results

### DIFF
--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -47,6 +47,7 @@ export const SearchResult = ({
       </div>
       <h3
         aria-describedby={article.entityUrl.path}
+        aria-label={article.title.trim()}
         className="vads-u-margin-top--0 vads-u-font-size--md"
       >
         <va-link


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed an accessibility violation (`empty-heading`) in the Resources & Support search results page
- The `<h3>` elements containing `<va-link>` web components were flagged as empty headings by axe because the link text is rendered inside the shadow DOM and not visible to accessibility tools
- Solution: Added `aria-label` to the `<h3>` element to provide accessible text for screen readers while preserving the design system component usage
- Team: Public Websites

## Related issue(s)

- Accessibility violation detected in Cypress E2E test `resources-and-support-desktop.cypress.spec.js`

## Testing done

- **Old behavior**: Cypress test failed with `empty-heading` accessibility violation - axe detected 6 headings with no discernible text
- **Steps to verify**: Run `yarn cy:run --spec "src/applications/resources-and-support/tests/resources-and-support-desktop.cypress.spec.js"`
- **Tests completed**: 
  - Ran the Cypress E2E test which includes `cy.injectAxeThenAxeCheck()` - test now passes
  - Verified the search results page renders correctly with all 6 results displaying properly

## Screenshots

N/A - No visual changes. This is an accessibility fix that adds an `aria-label` attribute.

## What areas of the site does it impact?

Resources & Support search results page (`/resources/search/`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A - no visual change)
- [x] Accessibility testing has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - public page, no auth required)

## Requested Feedback

This fix adds `aria-label` to the `<h3>` to satisfy the empty-heading rule while keeping the `<va-link>` design system component. An alternative approach would be to use a regular `<a>` tag, but this preserves DS component usage.