### PR TITLE
Fixed Identity Google Analytics

### DIFF
--- a/src/applications/auth/containers/AuthMetrics.jsx
+++ b/src/applications/auth/containers/AuthMetrics.jsx
@@ -4,6 +4,8 @@ import recordEvent from 'platform/monitoring/record-event';
 import { CSP_IDS, POLICY_TYPES } from 'platform/user/authentication/constants';
 import { SENTRY_TAGS } from 'platform/user/authentication/errors';
 import get from 'platform/utilities/data/get';
+import environment from 'platform/utilities/environment';
+import environments from 'site/constants/environments';
 import { parseAssuranceLevel } from '../helpers';
 
 export default class AuthMetrics {
@@ -17,6 +19,8 @@ export default class AuthMetrics {
     this.loaCurrent = get('loa.current', this.userProfile, null);
     this.authnContext = get('authnContext', this.userProfile, undefined);
     this.serviceName = get('signIn.serviceName', this.userProfile, null);
+    this.isProduction =
+      environment.getRawBuildtype() === environments.PRODUCTION;
   }
 
   compareLoginPolicy = () => {
@@ -26,7 +30,7 @@ export default class AuthMetrics {
     const attemptedLoginPolicy =
       this.type === CSP_IDS.MHV ? CSP_IDS.MHV_VERBOSE : this.type;
 
-    if (this.serviceName !== attemptedLoginPolicy) {
+    if (this.serviceName !== attemptedLoginPolicy && this.isProduction) {
       recordEvent({
         event: `login-mismatch-${attemptedLoginPolicy}-${this.serviceName}`,
       });
@@ -36,11 +40,13 @@ export default class AuthMetrics {
   recordGAAuthEvents = () => {
     switch (this.type) {
       case POLICY_TYPES.SIGNUP:
-        recordEvent({
-          event: `register-success-${this.serviceName}-${parseAssuranceLevel(
-            this.authnContext,
-          )}`,
-        });
+        if (this.isProduction) {
+          recordEvent({
+            event: `register-success-${this.serviceName}-${parseAssuranceLevel(
+              this.authnContext,
+            )}`,
+          });
+        }
         break;
       case POLICY_TYPES.CUSTOM: /* type=custom is used for SSOe auto login */
       case POLICY_TYPES.MHV_VERIFIED: /* type=mhv_verified */
@@ -48,19 +54,23 @@ export default class AuthMetrics {
       case CSP_IDS.ID_ME:
       case CSP_IDS.LOGIN_GOV:
       case CSP_IDS.VAMOCK:
-        recordEvent({
-          event: `login-success-${this.serviceName}-${parseAssuranceLevel(
-            this.authnContext,
-          )}`,
-        });
+        if (this.isProduction) {
+          recordEvent({
+            event: `login-success-${this.serviceName}-${parseAssuranceLevel(
+              this.authnContext,
+            )}`,
+          });
+        }
         this.compareLoginPolicy();
         break;
       default:
-        recordEvent({
-          event: `login-or-register-success-${
-            this.serviceName
-          }-${parseAssuranceLevel(this.authnContext)}`,
-        });
+        if (this.isProduction) {
+          recordEvent({
+            event: `login-or-register-success-${
+              this.serviceName
+            }-${parseAssuranceLevel(this.authnContext)}`,
+          });
+        }
         Sentry.withScope(scope => {
           scope.setExtra(SENTRY_TAGS.REQUEST_ID, this.requestId);
           scope.setExtra(SENTRY_TAGS.ERROR_CODE, this.errorCode);
@@ -70,7 +80,7 @@ export default class AuthMetrics {
     }
 
     // Report out the current level of assurance for the user.
-    if (this.loaCurrent) {
+    if (this.loaCurrent && this.isProduction) {
       recordEvent({ event: `login-loa-current-${this.loaCurrent}` });
     }
   };

--- a/src/applications/auth/tests/AuthMetrics.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthMetrics.unit.spec.jsx
@@ -2,12 +2,14 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import * as Sentry from '@sentry/browser';
+import * as recordEventModule from 'platform/monitoring/record-event';
 
 import {
   CSP_IDS,
   SIGNUP_TYPES,
   POLICY_TYPES,
 } from 'platform/user/authentication/constants';
+import environments from 'site/constants/environments';
 import AuthMetrics from '../containers/AuthMetrics';
 
 const createPayload = (
@@ -31,9 +33,22 @@ const createPayload = (
 const defaultPayload = createPayload();
 
 describe('AuthMetrics', () => {
+  let sandbox;
+  let recordEventStub;
+  const oldBuildType = __BUILDTYPE__;
+
   beforeEach(() => {
+    __BUILDTYPE__ = environments.PRODUCTION;
+    sandbox = sinon.createSandbox();
     global.window = global.window || {};
     global.window.dataLayer = [];
+    recordEventStub = sandbox.stub(recordEventModule, 'default');
+  });
+
+  afterEach(() => {
+    recordEventStub.restore();
+    sandbox.restore();
+    __BUILDTYPE__ = oldBuildType;
   });
 
   it('should record event using compareLoginPolicy', () => {
@@ -42,37 +57,41 @@ describe('AuthMetrics', () => {
       defaultPayload,
     );
     authMetrics.compareLoginPolicy();
-    const gwData = global.window.dataLayer;
-    const recordedEvent = gwData[gwData.length - 1];
 
-    expect(recordedEvent.event).to.equal('login-mismatch-idme_signup-idme');
+    expect(recordEventStub.called).to.be.true;
+    expect(recordEventStub.firstCall.args[0].event).to.equal(
+      'login-mismatch-idme_signup-idme',
+    );
   });
 
   it('should record `register-success` event using recordGAAuthEvents', () => {
     const authMetrics = new AuthMetrics(POLICY_TYPES.SIGNUP, defaultPayload);
     authMetrics.recordGAAuthEvents();
-    const gwData = global.window.dataLayer;
-    const recordedEvent = gwData[gwData.length - 1];
 
-    expect(recordedEvent.event).to.equal('register-success-idme-ial2');
+    expect(recordEventStub.called).to.be.true;
+    expect(recordEventStub.firstCall.args[0].event).to.equal(
+      'register-success-idme-ial2',
+    );
   });
 
   it('should record `login-success` event using recordGAAuthEvents', () => {
     const authMetrics = new AuthMetrics(CSP_IDS.ID_ME, defaultPayload);
     authMetrics.recordGAAuthEvents();
-    const gwData = global.window.dataLayer;
-    const recordedEvent = gwData[gwData.length - 1];
 
-    expect(recordedEvent.event).to.equal('login-success-idme-ial2');
+    expect(recordEventStub.called).to.be.true;
+    expect(recordEventStub.firstCall.args[0].event).to.equal(
+      'login-success-idme-ial2',
+    );
   });
 
   it('should record `login-or-register-success` event using recordGAAuthEvents', () => {
     const authMetrics = new AuthMetrics('unknownType', defaultPayload);
     authMetrics.recordGAAuthEvents();
-    const gwData = global.window.dataLayer;
-    const recordedEvent = gwData[gwData.length - 1];
 
-    expect(recordedEvent.event).to.equal('login-or-register-success-idme-ial2');
+    expect(recordEventStub.called).to.be.true;
+    expect(recordEventStub.firstCall.args[0].event).to.equal(
+      'login-or-register-success-idme-ial2',
+    );
   });
 
   it('should call reportSentryErrors when userProfile is empty', () => {
@@ -115,10 +134,11 @@ describe('AuthMetrics', () => {
       const payload = createPayload(type);
       const authMetrics = new AuthMetrics(type, payload);
       authMetrics.recordGAAuthEvents();
-      const gwData = global.window.dataLayer;
-      const recordedEvent = gwData[gwData.length - 1];
 
-      expect(recordedEvent.event).to.equal(`login-success-${type}-ial2`);
+      expect(recordEventStub.called).to.be.true;
+      expect(recordEventStub.firstCall.args[0].event).to.equal(
+        `login-success-${type}-ial2`,
+      );
     });
   });
 
@@ -126,26 +146,28 @@ describe('AuthMetrics', () => {
     const payload = createPayload('mhv');
     const authMetrics = new AuthMetrics('mhv', payload);
     authMetrics.recordGAAuthEvents();
-    const [
-      { event: firstEvent },
-      { event: secondEvent },
-    ] = global.window.dataLayer;
 
-    expect(firstEvent).to.eql('login-success-mhv-ial2');
-    expect(secondEvent).to.eql('login-mismatch-myhealthevet-mhv');
+    expect(recordEventStub.called).to.be.true;
+    expect(recordEventStub.firstCall.args[0].event).to.equal(
+      'login-success-mhv-ial2',
+    );
+    expect(recordEventStub.secondCall.args[0].event).to.equal(
+      'login-mismatch-myhealthevet-mhv',
+    );
   });
 
   it('should record the loa.current if exists', () => {
     const payload = createPayload('idme', true, '/loa/3');
     const authMetrics = new AuthMetrics('idme', payload);
     authMetrics.recordGAAuthEvents();
-    const [
-      { event: firstEvent },
-      { event: secondEvent },
-    ] = global.window.dataLayer;
 
-    expect(firstEvent).to.eql('login-success-idme-loa3');
-    expect(secondEvent).to.eql('login-loa-current-3');
+    expect(recordEventStub.called).to.be.true;
+    expect(recordEventStub.firstCall.args[0].event).to.equal(
+      'login-success-idme-loa3',
+    );
+    expect(recordEventStub.secondCall.args[0].event).to.equal(
+      'login-loa-current-3',
+    );
   });
 
   it('should run if no session active', () => {

--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
+import environment from '~/platform/utilities/environment';
 import recordEvent from '~/platform/monitoring/record-event';
 import { fetchMHVAccount } from '~/platform/user/profile/actions';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
@@ -110,6 +111,7 @@ export const CallToActionWidget = ({
   setFocus = true,
   toggleLoginModal: propsToggleLoginModal,
 }) => {
+  const isProduction = environment.isProduction();
   const ctaWidget = ctaWidgetsLookup?.[appId];
   const featureToggle = ctaWidget?.featureToggle;
   const gaPrefix = 'register-mhv';
@@ -252,9 +254,11 @@ export const CallToActionWidget = ({
       if (authenticatedWithSSOe) {
         const errorContent = (() => {
           if (!verifiedProfile) {
-            recordEvent({
-              event: `${gaPrefix}-info-needs-identity-verification`,
-            });
+            if (isProduction) {
+              recordEvent({
+                event: `${gaPrefix}-info-needs-identity-verification`,
+              });
+            }
             return verifyAlert;
           }
           if (mhvAccountIdState === 'DEACTIVATED') {
@@ -348,9 +352,11 @@ export const CallToActionWidget = ({
     }
 
     if (!verifiedProfile) {
-      recordEvent({
-        event: `${gaPrefix}-info-needs-identity-verification`,
-      });
+      if (isProduction) {
+        recordEvent({
+          event: `${gaPrefix}-info-needs-identity-verification`,
+        });
+      }
       return verifyAlert;
     }
 

--- a/src/applications/static-pages/cta-widget/tests/index.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/index.unit.spec.jsx
@@ -401,45 +401,51 @@ describe('<CallToActionWidget>', () => {
     });
 
     it('should show VaAlertSignIn when the mvi status is not authorized', () => {
+      const { mockStore } = getData();
       const tree = mount(
-        <CallToActionWidget
-          isLoggedIn
-          appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
-          profile={{
-            loading: false,
-            verified: true,
-            multifactor: true,
-          }}
-          mhvAccount={{}}
-          mviStatus="NOT_AUTHORIZED"
-          featureToggles={{
-            loading: false,
-            vaOnlineScheduling: true,
-          }}
-        />,
+        <Provider store={mockStore}>
+          <CallToActionWidget
+            isLoggedIn
+            appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
+            profile={{
+              loading: false,
+              verified: true,
+              multifactor: true,
+            }}
+            mhvAccount={{}}
+            mviStatus="NOT_AUTHORIZED"
+            featureToggles={{
+              loading: false,
+              vaOnlineScheduling: true,
+            }}
+          />
+        </Provider>,
       );
       expect(tree.find('VaAlertSignIn').exists()).to.be.true;
       tree.unmount();
     });
 
     it('should show SignInOtherAccount when the mvi status is not authorized and the CSP is MHV', () => {
+      const { mockStore } = getData();
       const tree = mount(
-        <CallToActionWidget
-          isLoggedIn
-          appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
-          profile={{
-            loading: false,
-            verified: true,
-            multifactor: true,
-          }}
-          mhvAccount={{}}
-          mviStatus="NOT_AUTHORIZED"
-          featureToggles={{
-            loading: false,
-            vaOnlineScheduling: true,
-          }}
-          serviceName={CSP_IDS.MHV}
-        />,
+        <Provider store={mockStore}>
+          <CallToActionWidget
+            isLoggedIn
+            appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
+            profile={{
+              loading: false,
+              verified: true,
+              multifactor: true,
+            }}
+            mhvAccount={{}}
+            mviStatus="NOT_AUTHORIZED"
+            featureToggles={{
+              loading: false,
+              vaOnlineScheduling: true,
+            }}
+            serviceName={CSP_IDS.MHV}
+          />
+        </Provider>,
       );
       expect(tree.find('SignInOtherAccount').exists()).to.be.true;
       tree.unmount();
@@ -528,23 +534,26 @@ describe('<CallToActionWidget>', () => {
 
     it('should show VaAlertSignIn if it is a health tool and the mvi status is not authorized', () => {
       const fetchMHVAccount = sinon.spy();
+      const { mockStore } = getData();
       const tree = mount(
-        <CallToActionWidget
-          fetchMHVAccount={fetchMHVAccount}
-          isLoggedIn
-          appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
-          profile={{
-            loading: false,
-            verified: true,
-            multifactor: true,
-          }}
-          mhvAccount={{}}
-          mviStatus="NOT_AUTHORIZED"
-          featureToggles={{
-            loading: false,
-            vaOnlineScheduling: false,
-          }}
-        />,
+        <Provider store={mockStore}>
+          <CallToActionWidget
+            fetchMHVAccount={fetchMHVAccount}
+            isLoggedIn
+            appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
+            profile={{
+              loading: false,
+              verified: true,
+              multifactor: true,
+            }}
+            mhvAccount={{}}
+            mviStatus="NOT_AUTHORIZED"
+            featureToggles={{
+              loading: false,
+              vaOnlineScheduling: false,
+            }}
+          />
+        </Provider>,
       );
       expect(fetchMHVAccount.calledOnce).to.be.true;
       expect(tree.find('VaAlertSignIn').exists()).to.be.true;
@@ -553,23 +562,26 @@ describe('<CallToActionWidget>', () => {
 
     it('should show VaAlertSignIn if it is a health tool authenticated with ssoe', () => {
       const fetchMHVAccount = sinon.spy();
+      const { mockStore } = getData();
       const tree = mount(
-        <CallToActionWidget
-          fetchMHVAccount={fetchMHVAccount}
-          authenticatedWithSSOe
-          isLoggedIn
-          appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
-          profile={{
-            loading: false,
-            verified: false,
-            multifactor: true,
-          }}
-          mhvAccount={{}}
-          featureToggles={{
-            loading: false,
-            vaOnlineScheduling: false,
-          }}
-        />,
+        <Provider store={mockStore}>
+          <CallToActionWidget
+            fetchMHVAccount={fetchMHVAccount}
+            authenticatedWithSSOe
+            isLoggedIn
+            appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
+            profile={{
+              loading: false,
+              verified: false,
+              multifactor: true,
+            }}
+            mhvAccount={{}}
+            featureToggles={{
+              loading: false,
+              vaOnlineScheduling: false,
+            }}
+          />
+        </Provider>,
       );
       expect(fetchMHVAccount.calledOnce).to.be.true;
       expect(tree.find('VaAlertSignIn').exists()).to.be.true;
@@ -797,22 +809,25 @@ describe('<CallToActionWidget>', () => {
 
     it('should show VaAlertSignIn if it is a health tool and the account needs verification', () => {
       const fetchMHVAccount = sinon.spy();
+      const { mockStore } = getData();
       const tree = mount(
-        <CallToActionWidget
-          fetchMHVAccount={fetchMHVAccount}
-          isLoggedIn
-          appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
-          profile={{
-            loading: false,
-            verified: true,
-            multifactor: true,
-          }}
-          mhvAccount={{ accountState: ACCOUNT_STATES.NEEDS_VERIFICATION }}
-          featureToggles={{
-            loading: false,
-            vaOnlineScheduling: false,
-          }}
-        />,
+        <Provider store={mockStore}>
+          <CallToActionWidget
+            fetchMHVAccount={fetchMHVAccount}
+            isLoggedIn
+            appId={CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS}
+            profile={{
+              loading: false,
+              verified: true,
+              multifactor: true,
+            }}
+            mhvAccount={{ accountState: ACCOUNT_STATES.NEEDS_VERIFICATION }}
+            featureToggles={{
+              loading: false,
+              vaOnlineScheduling: false,
+            }}
+          />
+        </Provider>,
       );
       expect(fetchMHVAccount.calledOnce).to.be.true;
       expect(tree.find('VaAlertSignIn').exists()).to.be.true;
@@ -1009,27 +1024,22 @@ describe('<CallToActionWidget>', () => {
       it('should sign out correctly when signOut is called', () => {
         const oldLocation = window.location;
 
-        const recordEventSpy = sinon.spy(recordEvent, 'default');
         const IAMLogoutSpy = sinon.spy(authUtils, 'logout');
         const logoutUrlSiSSpy = sinon.spy(oauthUtils, 'logoutUrlSiS');
         const innerFunc = signOut(true);
         innerFunc();
-        expect(recordEventSpy.calledTwice).to.be.true;
         expect(IAMLogoutSpy.calledOnce).to.be.true;
 
         IAMLogoutSpy.reset();
-        recordEventSpy.reset();
 
         const otherInnerFunc = signOut(false);
         expect(otherInnerFunc).to.be.a('function');
         otherInnerFunc();
-        expect(recordEventSpy.calledOnce).to.be.true;
         expect(IAMLogoutSpy.calledOnce).to.be.false;
         expect(logoutUrlSiSSpy.calledOnce).to.be.true;
         const location = window.location.href || window.location;
         expect(location).to.include(logoutUrlSiSSpy.returnValues[0]);
 
-        recordEventSpy.restore();
         IAMLogoutSpy.restore();
         logoutUrlSiSSpy.restore();
         window.location = oldLocation;

--- a/src/platform/user/authentication/components/LoginButton.jsx
+++ b/src/platform/user/authentication/components/LoginButton.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 import * as authUtilities from 'platform/user/authentication/utilities';
+import environment from 'platform/utilities/environment';
 import { SERVICE_PROVIDERS, OKTA_APPS } from '../constants';
 import { createOktaOAuthRequest } from '../../../utilities/oauth/utilities';
 
 export function loginHandler(loginType, isOAuth, oktaParams = {}) {
   const isOAuthAttempt = isOAuth && '-oauth';
   const { codeChallenge = '', clientId = '', state = '' } = oktaParams;
+  const isProduction = environment.isProduction();
 
   if (OKTA_APPS?.includes(clientId)) {
     const url = createOktaOAuthRequest({
@@ -16,15 +18,19 @@ export function loginHandler(loginType, isOAuth, oktaParams = {}) {
       state,
       loginType,
     });
-    recordEvent({
-      event: `login-attempted-${loginType}${isOAuthAttempt}`,
-    });
+    if (isProduction) {
+      recordEvent({
+        event: `login-attempted-${loginType}${isOAuthAttempt}`,
+      });
+    }
     window.location = url;
     // short-circuit the function
     return;
   }
 
-  recordEvent({ event: `login-attempted-${loginType}${isOAuthAttempt}` });
+  if (isProduction) {
+    recordEvent({ event: `login-attempted-${loginType}${isOAuthAttempt}` });
+  }
   authUtilities.login({ policy: loginType });
 }
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -311,6 +311,7 @@ export function redirect(redirectUrl, clickedEvent, type = '') {
   const { application } = getQueryParams();
   const externalRedirect = isExternalRedirect();
   const existingReturnUrl = sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL);
+  const isProduction = environment.isProduction();
 
   // Keep track of the URL to return to after auth operation.
   // If the user is coming via the standalone sign-in, redirect to the home page.
@@ -322,12 +323,15 @@ export function redirect(redirectUrl, clickedEvent, type = '') {
     createAndStoreReturnUrl();
   }
 
-  recordEvent({ event: type ? `${clickedEvent}-${type}` : clickedEvent });
+  if (isProduction) {
+    recordEvent({ event: type ? `${clickedEvent}-${type}` : clickedEvent });
+  }
 
   // Trigger USiP External Auth Event
   if (
     externalRedirect &&
-    [AUTH_EVENTS.SSO_LOGIN, AUTH_EVENTS.MODAL_LOGIN].includes(clickedEvent)
+    [AUTH_EVENTS.SSO_LOGIN, AUTH_EVENTS.MODAL_LOGIN].includes(clickedEvent) &&
+    isProduction
   ) {
     recordEvent({
       event: `${AUTHN_SETTINGS.REDIRECT_EVENT}-${application}-inbound`,

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -160,7 +160,9 @@ export async function createOAuthRequest({
   );
 
   sessionStorage.setItem('ci', usedClientId);
-  recordEvent({ event: `login-attempted-${type}-oauth-${clientId}` });
+  if (environment.isProduction()) {
+    recordEvent({ event: `login-attempted-${type}-oauth-${clientId}` });
+  }
   return url.toString();
 }
 
@@ -213,11 +215,13 @@ export const requestToken = async ({ code, redirectUri, csp }) => {
     credentials: 'include',
   });
 
-  recordEvent({
-    event: response.ok
-      ? `login-success-${csp}-oauth-tokenexchange`
-      : `login-failure-${csp}-oauth-tokenexchange`,
-  });
+  if (environment.isProduction()) {
+    recordEvent({
+      event: response.ok
+        ? `login-success-${csp}-oauth-tokenexchange`
+        : `login-failure-${csp}-oauth-tokenexchange`,
+    });
+  }
 
   if (response.ok) {
     removeStateAndVerifier();
@@ -347,7 +351,9 @@ export const logoutEvent = async (signInServiceName, wait = {}) => {
   const sleep = time => {
     return new Promise(resolve => setTimeout(resolve, time));
   };
-  recordEvent({ event: `${AUTH_EVENTS.OAUTH_LOGOUT}-${signInServiceName}` });
+  if (environment.isProduction()) {
+    recordEvent({ event: `${AUTH_EVENTS.OAUTH_LOGOUT}-${signInServiceName}` });
+  }
 
   sessionStorage.removeItem('shouldRedirectExpiredSession');
   updateLoggedInStatus(false);
@@ -382,6 +388,8 @@ export function createOktaOAuthRequest({
   );
 
   sessionStorage.setItem('ci', clientId);
-  recordEvent({ event: `login-attempted-${loginType}-oauth-${clientId}` });
+  if (environment.isProduction()) {
+    recordEvent({ event: `login-attempted-${loginType}-oauth-${clientId}` });
+  }
   return url.toString();
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated Identity Google Analytics to be bound to the Production environment.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1039)

## Testing done
- Updated `AuthMetrics.unit.spec.jsx` and `cta-widget/tests/index.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running: 
  - `yarn test:unit src/applications/auth/tests/AuthMetrics.unit.spec.jsx`
  - `yarn test:unit src/applications/static-pages/cta-widget/tests/index.unit.spec.jsx`

## What areas of the site does it impact?
This impacts `AuthMetrics.jsx`, the CTA Widget, and Auth utilities.

## Acceptance criteria
- [x] Fix erroneous GA logs being sent in non-production environments.