### PR TITLE
Consolidate one mock appointment creation

### DIFF
--- a/src/applications/vass/components/AddToCalendarButton.jsx
+++ b/src/applications/vass/components/AddToCalendarButton.jsx
@@ -1,20 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { addMinutes, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { generateICS } from '../utils/calendar';
+import { VASS_PHONE_NUMBER } from '../utils/constants';
 
+/**
+ * @typedef {import('../utils/appointments').Appointment} Appointment
+ */
+
+/**
+ * Renders a button that allows users to download an ICS calendar file for the appointment.
+ * @param {Object} props
+ * @param {Appointment} props.appointment - The appointment data for calendar generation
+ * @returns {JSX.Element}
+ */
 export default function AddToCalendarButton({ appointment }) {
-  const startUtc = parseISO(appointment?.dateTime);
-  const minutesDuration = 30;
-  const endUtc = addMinutes(startUtc, minutesDuration);
+  const startUtc = parseISO(appointment?.startUTC);
+  const endUtc = parseISO(appointment?.endUTC);
 
-  const description = `Your representative will call you from ${
-    appointment.phoneNumber
-  }.`;
   const ics = generateICS(
     'Solid Start Phone Call',
-    description,
+    `Your representative will call you from ${VASS_PHONE_NUMBER}.`,
     startUtc,
     endUtc,
   );
@@ -41,6 +48,7 @@ export default function AddToCalendarButton({ appointment }) {
     </>
   );
 }
+
 AddToCalendarButton.propTypes = {
   appointment: PropTypes.object,
 };

--- a/src/applications/vass/components/AddToCalendarButton.unit.spec.jsx
+++ b/src/applications/vass/components/AddToCalendarButton.unit.spec.jsx
@@ -3,11 +3,10 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import AddToCalendarButton from './AddToCalendarButton';
+import { createAppointmentData } from '../utils/appointments';
 
 describe('VASS Component: AddToCalendarButton', () => {
-  const mockAppointment = {
-    dateTime: '2025-11-17T20:00:00Z',
-  };
+  const mockAppointment = createAppointmentData();
 
   it('should render all content', () => {
     const { getByTestId } = render(

--- a/src/applications/vass/components/AppointmentCard.jsx
+++ b/src/applications/vass/components/AppointmentCard.jsx
@@ -11,9 +11,14 @@ import { VASS_PHONE_NUMBER } from '../utils/constants';
  * @param {Object} props
  * @param {Appointment} props.appointmentData - The appointment data
  * @param {Function} props.handleCancelAppointment - The function to handle canceling the appointment
+ * @param {boolean} props.showAddToCalendarButton - Whether to show the add to calendar button
  * @returns {JSX.Element}
  */
-const AppointmentCard = ({ appointmentData, handleCancelAppointment }) => {
+const AppointmentCard = ({
+  appointmentData,
+  handleCancelAppointment,
+  showAddToCalendarButton,
+}) => {
   return (
     <va-card
       data-testid="appointment-card"
@@ -45,6 +50,7 @@ const AppointmentCard = ({ appointmentData, handleCancelAppointment }) => {
         data-testid="when-section"
         heading="When"
         appointmentData={appointmentData}
+        showAddToCalendarButton={showAddToCalendarButton}
       />
       <CardSection
         data-testid="what-section"
@@ -99,4 +105,5 @@ export default AppointmentCard;
 AppointmentCard.propTypes = {
   appointmentData: PropTypes.object.isRequired,
   handleCancelAppointment: PropTypes.func,
+  showAddToCalendarButton: PropTypes.bool,
 };

--- a/src/applications/vass/components/AppointmentCard.jsx
+++ b/src/applications/vass/components/AppointmentCard.jsx
@@ -2,9 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CardSection from './CardSection';
 import { VASS_PHONE_NUMBER } from '../utils/constants';
+/**
+ * @typedef {import('../utils/appointments').Appointment} Appointment
+ */
 
+/**
+ * Renders a card for an appointment.
+ * @param {Object} props
+ * @param {Appointment} props.appointmentData - The appointment data
+ * @param {Function} props.handleCancelAppointment - The function to handle canceling the appointment
+ * @returns {JSX.Element}
+ */
 const AppointmentCard = ({ appointmentData, handleCancelAppointment }) => {
-  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return (
     <va-card
       data-testid="appointment-card"
@@ -35,12 +44,7 @@ const AppointmentCard = ({ appointmentData, handleCancelAppointment }) => {
       <CardSection
         data-testid="when-section"
         heading="When"
-        dateContent={{
-          dateTime: appointmentData?.startUTC,
-          timezone: browserTimezone,
-          phoneNumber: VASS_PHONE_NUMBER,
-          showAddToCalendarButton: appointmentData?.showAddToCalendarButton,
-        }}
+        appointmentData={appointmentData}
       />
       <CardSection
         data-testid="what-section"

--- a/src/applications/vass/components/AppointmentCard.unit.spec.jsx
+++ b/src/applications/vass/components/AppointmentCard.unit.spec.jsx
@@ -3,22 +3,13 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import AppointmentCard from './AppointmentCard';
+import { createAppointmentData } from '../utils/appointments';
 
 describe('VASS Component: AppointmentCard', () => {
   it('renders card sections and actions', () => {
-    const appointmentData = {
-      appointmentId: '123',
-      startUTC: '2025-05-01T16:00:00.000Z',
-      endUTC: '2025-05-01T16:30:00.000Z',
-      agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
-      agentNickname: 'Bill Brasky',
-      appointmentStatusCode: 1,
-      appointmentStatus: 'Confirmed',
-      cohortStartUtc: '2025-01-01T00:00:00.000Z',
-      cohortEndUtc: '2025-12-31T23:59:59.999Z',
+    const appointmentData = createAppointmentData({
       topics: [{ topicName: 'Benefits' }, { topicName: 'Health care' }],
-      showAddToCalendarButton: true,
-    };
+    });
 
     const { getByTestId } = render(
       <AppointmentCard
@@ -48,44 +39,20 @@ describe('VASS Component: AppointmentCard', () => {
   });
 
   it('omits calendar and cancel actions when not provided', () => {
-    const appointmentData = {
-      appointmentId: '456',
-      phoneNumber: '8005551212',
-      startUTC: '2025-06-01T16:00:00.000Z',
-      endUTC: '2025-06-01T16:30:00.000Z',
-      agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
-      agentNickname: 'Bill Brasky',
-      appointmentStatusCode: 1,
-      appointmentStatus: 'Confirmed',
-      cohortStartUtc: '2025-01-01T00:00:00.000Z',
-      cohortEndUtc: '2025-12-31T23:59:59.999Z',
-      topics: [{ topicName: 'Benefits' }],
-      showAddToCalendarButton: false,
-    };
+    const appointmentData = createAppointmentData();
 
     const { getByTestId, queryByTestId } = render(
       <AppointmentCard appointmentData={appointmentData} />,
     );
 
     expect(getByTestId('appointment-card')).to.exist;
-    expect(queryByTestId('add-to-calendar-button')).to.not.exist;
     expect(queryByTestId('print-button')).to.not.exist;
     expect(queryByTestId('cancel-button')).to.not.exist;
   });
 
   it('omits topics section when no topics are provided', () => {
-    const appointmentData = {
-      appointmentId: '789',
-      startUTC: '2025-07-01T16:00:00.000Z',
-      endUTC: '2025-07-01T16:30:00.000Z',
-      agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
-      agentNickname: 'Bill Brasky',
-      appointmentStatusCode: 1,
-      appointmentStatus: 'Confirmed',
-      cohortStartUtc: '2025-01-01T00:00:00.000Z',
-      cohortEndUtc: '2025-12-31T23:59:59.999Z',
-      topics: [],
-    };
+    const appointmentData = createAppointmentData({ topics: [] });
+
     const { queryByTestId } = render(
       <AppointmentCard appointmentData={appointmentData} />,
     );

--- a/src/applications/vass/components/AppointmentCard.unit.spec.jsx
+++ b/src/applications/vass/components/AppointmentCard.unit.spec.jsx
@@ -15,6 +15,7 @@ describe('VASS Component: AppointmentCard', () => {
       <AppointmentCard
         appointmentData={appointmentData}
         handleCancelAppointment={() => {}}
+        showAddToCalendarButton
       />,
     );
 
@@ -48,6 +49,19 @@ describe('VASS Component: AppointmentCard', () => {
     expect(getByTestId('appointment-card')).to.exist;
     expect(queryByTestId('print-button')).to.not.exist;
     expect(queryByTestId('cancel-button')).to.not.exist;
+  });
+
+  it('omits add to calendar button when showAddToCalendarButton is false', () => {
+    const appointmentData = createAppointmentData();
+
+    const { queryByTestId } = render(
+      <AppointmentCard
+        appointmentData={appointmentData}
+        showAddToCalendarButton={false}
+      />,
+    );
+
+    expect(queryByTestId('add-to-calendar-button')).not.to.exist;
   });
 
   it('omits topics section when no topics are provided', () => {

--- a/src/applications/vass/components/CardSection.jsx
+++ b/src/applications/vass/components/CardSection.jsx
@@ -1,10 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import DateTime from './DateTime';
 import AddToCalendarButton from './AddToCalendarButton';
 
+/**
+ * Renders a card section.
+ * @param {Object} props
+ * @param {import('../utils/appointments').Appointment} props.appointmentData - The appointment data
+ * @param {string} props.textContent - The text content
+ * @param {string} props.heading - The heading
+ * @param {number} props.level - The level
+ * @param {React.ReactNode} props.customBodyElement - The custom body element
+ * @returns {JSX.Element}
+ */
 export default function CardSection({
-  dateContent,
+  appointmentData,
   textContent,
   heading,
   level = 2,
@@ -23,12 +34,10 @@ export default function CardSection({
           {textContent}
         </p>
       )}
-      {dateContent && (
+      {appointmentData && (
         <>
-          <DateTime dateTime={dateContent.dateTime} />
-          {dateContent.showAddToCalendarButton && (
-            <AddToCalendarButton appointment={dateContent} />
-          )}
+          <DateTime dateTime={appointmentData.startUTC} />
+          <AddToCalendarButton appointment={appointmentData} />
         </>
       )}
       {customBodyElement}
@@ -37,8 +46,8 @@ export default function CardSection({
 }
 
 CardSection.propTypes = {
+  appointmentData: PropTypes.object,
   customBodyElement: PropTypes.node,
-  dateContent: PropTypes.object,
   heading: PropTypes.string,
   level: PropTypes.number,
   textContent: PropTypes.string,

--- a/src/applications/vass/components/CardSection.jsx
+++ b/src/applications/vass/components/CardSection.jsx
@@ -11,6 +11,7 @@ import AddToCalendarButton from './AddToCalendarButton';
  * @param {string} props.textContent - The text content
  * @param {string} props.heading - The heading
  * @param {number} props.level - The level
+ * @param {boolean} props.showAddToCalendarButton - Whether to show the add to calendar button if appointmentData is provided
  * @param {React.ReactNode} props.customBodyElement - The custom body element
  * @returns {JSX.Element}
  */
@@ -20,6 +21,7 @@ export default function CardSection({
   heading,
   level = 2,
   customBodyElement,
+  showAddToCalendarButton,
   ...props
 }) {
   const Heading = `h${level}`;
@@ -37,7 +39,9 @@ export default function CardSection({
       {appointmentData && (
         <>
           <DateTime dateTime={appointmentData.startUTC} />
-          <AddToCalendarButton appointment={appointmentData} />
+          {showAddToCalendarButton && (
+            <AddToCalendarButton appointment={appointmentData} />
+          )}
         </>
       )}
       {customBodyElement}
@@ -50,5 +54,6 @@ CardSection.propTypes = {
   customBodyElement: PropTypes.node,
   heading: PropTypes.string,
   level: PropTypes.number,
+  showAddToCalendarButton: PropTypes.bool,
   textContent: PropTypes.string,
 };

--- a/src/applications/vass/components/CardSection.unit.spec.jsx
+++ b/src/applications/vass/components/CardSection.unit.spec.jsx
@@ -24,6 +24,19 @@ describe('VASS Component: CardSection', () => {
 
     expect(getByText('When')).to.exist;
     expect(getByTestId('date-time-description')).to.exist;
-    expect(getByTestId('add-to-calendar-button')).to.exist;
+  });
+
+  it('should not render add to calendar button when showAddToCalendarButton is false', () => {
+    const mockAppointmentData = createAppointmentData();
+
+    const { queryByTestId } = render(
+      <CardSection
+        heading="When"
+        appointmentData={mockAppointmentData}
+        showAddToCalendarButton={false}
+      />,
+    );
+
+    expect(queryByTestId('add-to-calendar-button')).not.to.exist;
   });
 });

--- a/src/applications/vass/components/CardSection.unit.spec.jsx
+++ b/src/applications/vass/components/CardSection.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import CardSection from './CardSection';
+import { createAppointmentData } from '../utils/appointments';
 
 describe('VASS Component: CardSection', () => {
   it('should render all content with text content', () => {
@@ -15,30 +16,14 @@ describe('VASS Component: CardSection', () => {
   });
 
   it('should render with date content', () => {
-    const mockDateContent = {
-      dateTime: '2025-11-17T20:00:00Z',
-      showAddToCalendarButton: true,
-    };
+    const mockAppointmentData = createAppointmentData();
 
     const { getByText, getByTestId } = render(
-      <CardSection heading="When" dateContent={mockDateContent} />,
+      <CardSection heading="When" appointmentData={mockAppointmentData} />,
     );
 
     expect(getByText('When')).to.exist;
     expect(getByTestId('date-time-description')).to.exist;
     expect(getByTestId('add-to-calendar-button')).to.exist;
-  });
-
-  it('should hide calendar button when flag is false', () => {
-    const mockDateContent = {
-      dateTime: '2025-11-17T20:00:00Z',
-      showAddToCalendarButton: false,
-    };
-
-    const { queryByTestId } = render(
-      <CardSection heading="When" dateContent={mockDateContent} />,
-    );
-
-    expect(queryByTestId('add-to-calendar-button')).to.not.exist;
   });
 });

--- a/src/applications/vass/components/DateTime.jsx
+++ b/src/applications/vass/components/DateTime.jsx
@@ -2,14 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { formatInTimeZone } from 'date-fns-tz';
 
-const formatDateTime = dateString => {
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+import { getBrowserTimezone } from '../utils/timezone';
+
+const formatInBrowserTimezone = dateString => {
+  const timezone = getBrowserTimezone();
 
   // Format date as "Weekday, Month DD, YYYY"
   const formattedDate = formatInTimeZone(
     dateString,
     timezone,
-    'EEEE, MMMM dd, yyyy',
+    'EEEE, MMMM dd, yyyy', // e.g., "Monday, November 17, 2025"
   );
 
   // Format time as "HH:MM p.m. TZ"
@@ -19,7 +21,7 @@ const formatDateTime = dateString => {
 };
 
 const DateTime = ({ dateTime }) => {
-  const { formattedDate, formattedTime } = formatDateTime(dateTime);
+  const { formattedDate, formattedTime } = formatInBrowserTimezone(dateTime);
   return (
     <p
       className="vads-u-margin-top--0p5 vads-u-margin-bottom--1"

--- a/src/applications/vass/pages/AlreadyScheduled.jsx
+++ b/src/applications/vass/pages/AlreadyScheduled.jsx
@@ -3,21 +3,17 @@ import { format } from 'date-fns';
 
 import Wrapper from '../layout/Wrapper';
 import { VASS_PHONE_NUMBER } from '../utils/constants';
+import { createAppointmentData } from '../utils/appointments';
 
 // TODO: replace with actual data
-const appointmentData = {
-  appointmentId: '123',
-  phoneNumber: '8005551212',
-  dtStartUtc: '2025-05-01T16:00:00.000Z',
-  providerName: 'Bill Brasky',
-  topics: [
-    { topicName: 'Benefits', topicId: '123' },
-    { topicName: 'Health care', topicId: '456' },
-  ],
-};
+const appointmentData = createAppointmentData({
+  startUTC: '2025-05-01T16:00:00.000Z',
+  endUTC: '2025-05-01T16:30:00.000Z',
+  topics: [{ topicName: 'Benefits' }, { topicName: 'Health care' }],
+});
 
 const AlreadyScheduled = () => {
-  const appointmentDate = new Date(appointmentData.dtStartUtc);
+  const appointmentDate = new Date(appointmentData.startUTC);
   return (
     <Wrapper
       testID="already-scheduled-page"

--- a/src/applications/vass/pages/AlreadyScheduled.unit.spec.jsx
+++ b/src/applications/vass/pages/AlreadyScheduled.unit.spec.jsx
@@ -5,13 +5,16 @@ import { renderWithStoreAndRouterV6 } from '~/platform/testing/unit/react-testin
 
 import AlreadyScheduled from './AlreadyScheduled';
 import { getDefaultRenderOptions } from '../utils/test-utils';
+import { createAppointmentData } from '../utils/appointments';
 
 describe('VASS Component: AlreadyScheduled', () => {
   it('should render all content', () => {
     // Use the same UTC timestamp as the component to compute expected values
     // This ensures the test works regardless of the timezone it runs in
-    const appointmentDateUtc = '2025-05-01T16:00:00.000Z';
-    const appointmentDate = new Date(appointmentDateUtc);
+    const appointmentData = createAppointmentData({
+      startUTC: '2025-05-01T16:00:00.000Z',
+    });
+    const appointmentDate = new Date(appointmentData.startUTC);
     const expectedDate = format(appointmentDate, 'MM/dd/yyyy');
     const expectedTime = format(appointmentDate, 'hh:mm a');
 

--- a/src/applications/vass/pages/CancelAppointment.jsx
+++ b/src/applications/vass/pages/CancelAppointment.jsx
@@ -25,7 +25,10 @@ const CancelAppointment = () => {
       pageTitle="Would you like to cancel this appointment?"
     >
       <div className="vads-u-margin-top--6">
-        <AppointmentCard appointmentData={appointmentData} />
+        <AppointmentCard
+          appointmentData={appointmentData}
+          showAddToCalendarButton={false}
+        />
       </div>
       <VaButtonPair
         data-testid="cancel-confirm-button-pair"

--- a/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
@@ -69,6 +69,7 @@ describe('VASS Page: CancelAppointment', () => {
     );
     expect(screen.getByTestId('appointment-card')).to.exist;
     expect(screen.getByTestId('cancel-confirm-button-pair')).to.exist;
+    expect(screen.queryByTestId('add-to-calendar-link')).not.to.exist;
   });
 
   describe('navigation', () => {

--- a/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
@@ -6,6 +6,7 @@ import { renderWithStoreAndRouterV6 as renderWithStoreAndRouter } from 'platform
 
 import CancelAppointment from './CancelAppointment';
 import { getDefaultRenderOptions } from '../utils/test-utils';
+import { createAppointmentData } from '../utils/appointments';
 
 // Helper component to display current location for testing navigation
 const LocationDisplay = () => {
@@ -19,17 +20,7 @@ const LocationDisplay = () => {
 };
 
 const appointmentId = 'abcdef123456';
-const appointmentData = {
-  appointmentId,
-  startUTC: '2025-12-24T10:00:00Z',
-  endUTC: '2025-12-24T10:30:00Z',
-  agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
-  agentNickname: 'Bill Brasky',
-  appointmentStatusCode: 1,
-  appointmentStatus: 'Confirmed',
-  cohortStartUtc: '2025-12-01T00:00:00Z',
-  cohortEndUtc: '2026-02-28T23:59:59Z',
-};
+const appointmentData = createAppointmentData({ appointmentId });
 
 // Pre-populate the RTK Query cache with the appointment data
 const vassApiState = {

--- a/src/applications/vass/pages/Confirmation.jsx
+++ b/src/applications/vass/pages/Confirmation.jsx
@@ -55,9 +55,9 @@ const Confirmation = () => {
         appointmentData={{
           ...appointmentData,
           topics: appointmentData?.topics || selectedTopics,
-          showAddToCalendarButton: true,
         }}
         handleCancelAppointment={handleCancelAppointment}
+        showAddToCalendarButton
       />
     </Wrapper>
   );

--- a/src/applications/vass/pages/Confirmation.unit.spec.jsx
+++ b/src/applications/vass/pages/Confirmation.unit.spec.jsx
@@ -5,19 +5,10 @@ import { renderWithStoreAndRouterV6 as renderWithStoreAndRouter } from 'platform
 
 import Confirmation from './Confirmation';
 import { getDefaultRenderOptions } from '../utils/test-utils';
+import { createAppointmentData } from '../utils/appointments';
 
 const appointmentId = '123';
-const appointmentData = {
-  appointmentId,
-  startUTC: '2025-05-01T16:00:00.000Z',
-  endUTC: '2025-05-01T16:30:00.000Z',
-  agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
-  agentNickname: 'Bill Brasky',
-  appointmentStatusCode: 1,
-  appointmentStatus: 'Confirmed',
-  cohortStartUtc: '2025-01-01T00:00:00.000Z',
-  cohortEndUtc: '2025-12-31T23:59:59.999Z',
-};
+const appointmentData = createAppointmentData({ appointmentId });
 
 // Pre-populate the RTK Query cache with the appointment data
 const getVassApiState = () => ({

--- a/src/applications/vass/pages/Confirmation.unit.spec.jsx
+++ b/src/applications/vass/pages/Confirmation.unit.spec.jsx
@@ -46,6 +46,7 @@ describe('VASS Component: Confirmation', () => {
     expect(getByTestId('confirmation-page')).to.exist;
     expect(getByTestId('confirmation-message')).to.exist;
     expect(getByTestId('appointment-card')).to.exist;
+    expect(getByTestId('add-to-calendar-button')).to.exist;
   });
 
   describe('when the details url parameter is true', () => {

--- a/src/applications/vass/pages/DateTimeSelection.jsx
+++ b/src/applications/vass/pages/DateTimeSelection.jsx
@@ -12,7 +12,10 @@ import {
 import { useGetAppointmentAvailabilityQuery } from '../redux/api/vassApi';
 
 import { mapAppointmentAvailabilityToSlots } from '../utils/slots';
-import { getTimezoneDescByTimeZoneString } from '../utils/timezone';
+import {
+  getTimezoneDescByTimeZoneString,
+  getBrowserTimezone,
+} from '../utils/timezone';
 
 const DateTimeSelection = () => {
   const dispatch = useDispatch();
@@ -24,8 +27,7 @@ const DateTimeSelection = () => {
     isLoading: loading,
   } = useGetAppointmentAvailabilityQuery(uuid);
 
-  // TODO: determine what timezone to use
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const timezone = getBrowserTimezone();
 
   const slots = mapAppointmentAvailabilityToSlots(appointmentAvailability);
 

--- a/src/applications/vass/services/mocks/index.js
+++ b/src/applications/vass/services/mocks/index.js
@@ -4,6 +4,7 @@ const delay = require('mocker-api/lib/delay');
 const mockTopics = require('./utils/topic');
 const { generateSlots, createMockJwt } = require('../../utils/mock-helpers');
 const { decodeJwt } = require('../../utils/jwt-utils');
+const { createAppointmentData } = require('../../utils/appointments');
 
 const mockUUIDs = Object.freeze({
   'c0ffee-1234-beef-5678': {
@@ -23,27 +24,7 @@ const lowAuthVerificationTimeout = 15 * 60 * 1000; // 15 minutes
 const otcUseCounts = new Map(); // uuid -> count
 const maxOtcUseCount = 5;
 
-const mockAppointments = [
-  {
-    appointmentId: 'abcdef123456',
-    // Currently the appointment GET api does not return topics, so we are not mocking them
-    // ideally VASS adds these values to the appointment GET api response
-    // topics: [
-    //   {
-    //     topicId: '123',
-    //     topicName: 'General Health',
-    //   },
-    // ],
-    startUTC: '2025-12-24T10:00:00Z',
-    endUTC: '2025-12-24T10:30:00Z',
-    agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
-    agentNickname: 'Bill Brasky',
-    appointmentStatusCode: 1,
-    appointmentStatus: 'Confirmed',
-    cohortStartUtc: '2025-12-01T00:00:00Z',
-    cohortEndUtc: '2026-02-28T23:59:59Z',
-  },
-];
+const mockAppointments = [createAppointmentData()];
 
 const responses = {
   'POST /vass/v0/authenticate': (req, res) => {

--- a/src/applications/vass/utils/appointments.js
+++ b/src/applications/vass/utils/appointments.js
@@ -1,0 +1,49 @@
+/**
+ * @typedef {Object} Topic
+ * @property {string} topicId - Unique identifier for the topic
+ * @property {string} topicName - Display name of the topic
+ */
+
+/**
+ * @typedef {Object} Appointment
+ * @property {string} appointmentId - Unique identifier for the appointment
+ * @property {string} startUTC - Start date/time in ISO 8601 format (UTC)
+ * @property {string} endUTC - End date/time in ISO 8601 format (UTC)
+ * @property {string} agentId - Unique identifier for the assigned agent
+ * @property {string} agentNickname - Display name of the assigned agent
+ * @property {number} appointmentStatusCode - Numeric status code (e.g., 1 = Confirmed)
+ * @property {string} appointmentStatus - Human-readable status (e.g., 'Confirmed')
+ * @property {string} cohortStartUtc - Cohort start date/time in ISO 8601 format (UTC)
+ * @property {string} cohortEndUtc - Cohort end date/time in ISO 8601 format (UTC)
+ * @property {Topic[]} [topics] - Optional array of topics for the appointment
+ */
+
+/**
+ * Creates a mock appointment data object for testing purposes.
+ * @param {Partial<Appointment>} [appointmentData={}] - Optional partial appointment data to override defaults
+ * @returns {Appointment} A complete appointment object with default values merged with overrides
+ */
+function createAppointmentData(appointmentData = {}) {
+  return {
+    appointmentId: 'abcdef123456',
+    // Currently the appointment GET api does not return topics, so we are not mocking them
+    // ideally VASS adds these values to the appointment GET api response
+    // topics: [
+    //   {
+    //     topicId: '123',
+    //     topicName: 'General Health',
+    //   },
+    // ],
+    startUTC: '2025-12-24T10:00:00Z',
+    endUTC: '2025-12-24T10:30:00Z',
+    agentId: '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
+    agentNickname: 'Bill Brasky',
+    appointmentStatusCode: 1,
+    appointmentStatus: 'Confirmed',
+    cohortStartUtc: '2025-12-01T00:00:00Z',
+    cohortEndUtc: '2026-02-28T23:59:59Z',
+    ...appointmentData,
+  };
+}
+
+module.exports = { createAppointmentData };

--- a/src/applications/vass/utils/timezone.js
+++ b/src/applications/vass/utils/timezone.js
@@ -82,3 +82,13 @@ export function getTimezoneDescByTimeZoneString(timezone) {
 
   return abbreviation;
 }
+
+/**
+ * Function to return browser timezone
+ *
+ * @export
+ * @returns {string} - Browser timezone in IANA format (e.g., 'America/New_York')
+ */
+export const getBrowserTimezone = () => {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Created a centralized `createAppointmentData()` test utility function in
  `src/applications/vass/utils/appointments.js` to consolidate mock appointment creation across
  tests
  - Added JSDoc type definitions (`Appointment`, `Topic`) for better code documentation and IDE
  support
  - Added `getBrowserTimezone()` utility function in `utils/timezone.js` to centralize browser
  timezone retrieval
  - Refactored 6 test files and 1 mock file to use the new utility, reducing code duplication
  - Updated components (`AddToCalendarButton`, `AppointmentCard`, `CardSection`, `DateTime`) to use
   consistent appointment data structure

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#130258

  ## Testing done

  - **Old behavior**: Each test file defined its own mock appointment data object with varying
  property names and values, leading to inconsistency and maintenance burden
  - **New behavior**: All tests use `createAppointmentData()` which provides consistent default
  values and allows selective overrides via spread operator
  - **Steps to verify**:
    1. Run unit tests: `yarn test:unit src/applications/vass`
    2. Verify all tests pass with the consolidated mock data
    3. Review that `createAppointmentData()` returns expected default values
    4. Confirm components render correctly with the standardized appointment structure
  - **Tests completed**: Unit tests for `AddToCalendarButton`, `AppointmentCard`, `CardSection`,
  `AlreadyScheduled`, `CancelAppointment`, and `Confirmation` pages all pass using the new utility

  ## Screenshots

  _N/A - This is a test utility refactor with no UI changes._

  |         | Before | After |
  | ------- | ------ | ----- |
  | Mobile  | N/A    | N/A   |
  | Desktop | N/A    | N/A   |

  ## What areas of the site does it impact?

  This change impacts only the VASS application located in
   `src/applications/vass`. No other areas of the site are affected. The changes are primarily
  internal refactoring of test utilities and do not modify production behavior.

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
  hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [ ] Documentation has been updated ([link to documentation](#)) - *JSDoc comments added inline;
   no external docs needed*
  - [ ] Screenshot of the developed feature is added - *N/A - No UI changes*
  - [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-c
  ycle/prepare-for-an-accessibility-staging-review) has been performed - *N/A - No UI changes*

  ### Error Handling

  - [x] Browser console contains no warnings or errors.
  - [ ] Events are being sent to the appropriate logging solution - *N/A - Test utility only*
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - *N/A - Test
  utility only*

  ### Authentication

  - [ ] Did you login to a local build and verify all authenticated routes work as expected with a
  test user - *N/A - No changes to authenticated routes, only test utilities refactored*

  ## Requested Feedback

  This PR consolidates duplicated mock appointment data across multiple test files into a single
  reusable utility. Please verify:
  1. The `createAppointmentData()` function provides sensible defaults
  2. The JSDoc type definitions accurately reflect the appointment data structure
  3. The refactored tests maintain equivalent coverage

  **Known gaps**: The `showAddToCalendarButton` flag logic was removed from `CardSection` - the
  calendar button now always renders when `appointmentData` is provided