### PR TITLE
feat(ci): add Node 22 Docker image option to full-suite-tests workflow

### DIFF
--- a/.github/workflows/full-suite-tests.yml
+++ b/.github/workflows/full-suite-tests.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: ''
+      use_node_22:
+        description: 'Use Node 22 Docker image for E2E tests (for Node 22 upgrade verification)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: full-suite-tests-${{ github.ref }}
@@ -462,10 +467,10 @@ jobs:
       needs.tests-prep.outputs.e2e_count != '0'
 
     container:
-      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
+      image: ${{ inputs.use_node_22 && 'cypress/browsers:node-22.12.0-chrome-131.0.6778.108-1-ff-133.0-edge-131.0.2903.70-1' || '008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge' }}
       credentials:
-        username: ${{ needs.fetch-ecr-credentials.outputs.ecr_user }}
-        password: ${{ needs.fetch-ecr-credentials.outputs.ecr_password }}
+        username: ${{ inputs.use_node_22 && '' || needs.fetch-ecr-credentials.outputs.ecr_user }}
+        password: ${{ inputs.use_node_22 && '' || needs.fetch-ecr-credentials.outputs.ecr_password }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Adds an optional `use_node_22` input to the full-suite-tests workflow that allows running E2E tests with a Node 22 Docker image instead of the default Node 16 image.

- When `use_node_22` is false (default): Uses the existing ECR-hosted Node 16 Cypress image
- When `use_node_22` is true: Uses the public Docker Hub `cypress/browsers:node-22.12.0-chrome-131.0.6778.108-1-ff-133.0-edge-131.0.2903.70-1` image

This enables verification that E2E tests pass on Node 22 as part of the Node 22 upgrade initiative.

## Related issue(s)

- Parent initiative: department-of-veterans-affairs/va.gov-team#122537

## Testing done

- YAML syntax validated
- Will test by running the workflow manually with `use_node_22: true`

## Screenshots

N/A - This is a CI workflow change with no UI components.

## What areas of the site does it impact?

This only impacts the full-suite-tests CI workflow. No application code or site functionality is affected.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - N/A: This is a CI workflow configuration change, not application code
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
  - YAML syntax validated
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
  - N/A: Minor workflow option addition
- [ ] Screenshot of the developed feature is added
  - N/A: No UI changes
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
  - N/A: No UI changes

### Error Handling

- [ ] Browser console contains no warnings or errors.
  - N/A: No UI changes
- [ ] Events are being sent to the appropriate logging solution
  - N/A: CI workflow change
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
  - N/A: Uses existing workflow infrastructure

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
  - N/A: No application code changes

## Requested Feedback

This PR adds an option to test E2E with Node 22. Please verify the conditional image selection logic looks correct.