### PR TITLE
eselkin/ Uses user TZ when "GMT" returned for facility that has not set lat/long in VAST

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -53,7 +53,10 @@ function getAtlasLocation(appt) {
 }
 
 function getAppointmentTimezone(appt, featureUseBrowserTimezone) {
-  const timezone = appt.location?.attributes?.timezone?.timeZoneId;
+  let timezone = appt.location?.attributes?.timezone?.timeZoneId;
+  if (timezone === 'GMT' || timezone === 'UTC') {
+    timezone = null;
+  }
 
   return (
     timezone ||

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -52,7 +52,7 @@ function getAtlasLocation(appt) {
   };
 }
 
-function getAppointmentTimezone(appt, featureUseBrowserTimezone) {
+export function getAppointmentTimezone(appt, featureUseBrowserTimezone) {
   let timezone = appt.location?.attributes?.timezone?.timeZoneId;
   if (timezone === 'GMT' || timezone === 'UTC') {
     timezone = null;

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -54,6 +54,9 @@ function getAtlasLocation(appt) {
 
 export function getAppointmentTimezone(appt, featureUseBrowserTimezone) {
   let timezone = appt.location?.attributes?.timezone?.timeZoneId;
+  // GMT/UTC is not a proper timeZoneId - only occurs when facility lat/long is 0,0 (Unset)
+  // and LH resolves that to GMT. "GMT" is the IANA timezone (which LH uses) and UTC is just an alias.
+  // We may want to log when a facility has a GMT/UTC timezone, but that may create a lot of logs
   if (timezone === 'GMT' || timezone === 'UTC') {
     timezone = null;
   }

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -132,7 +132,8 @@ describe('getAppointmentTimezone util', () => {
       },
     };
 
-    getAppointmentTimezone(appointment, true);
+    const result = getAppointmentTimezone(appointment, true);
+    expect(result).to.equal('America/Chicago');
     expect(getTimezoneByFacilityIdStub.calledWith('555', true)).to.be.true;
   });
 

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import MockAppointmentResponse from '../../tests/fixtures/MockAppointmentResponse';
-import { getAppointmentType } from './transformers';
+import { getAppointmentType, getAppointmentTimezone } from './transformers';
+import * as timezoneUtils from '../../utils/timezone';
 
 describe('getAppointmentType util', () => {
   it('should return appointment type as ccAppointment', async () => {
@@ -38,6 +40,110 @@ describe('getAppointmentType util', () => {
     };
     const result = getAppointmentType(appointment);
     expect(result).to.equal('request');
+  });
+});
+
+describe('getAppointmentTimezone util', () => {
+  let getTimezoneByFacilityIdStub;
+
+  beforeEach(() => {
+    getTimezoneByFacilityIdStub = sinon
+      .stub(timezoneUtils, 'getTimezoneByFacilityId')
+      .returns('America/Chicago');
+  });
+
+  afterEach(() => {
+    getTimezoneByFacilityIdStub.restore();
+  });
+
+  it('should return appointment timezone when available', () => {
+    const appointment = {
+      locationId: '123',
+      location: {
+        attributes: {
+          timezone: {
+            timeZoneId: 'America/Los_Angeles',
+          },
+        },
+      },
+    };
+
+    const result = getAppointmentTimezone(appointment);
+    expect(result).to.equal('America/Los_Angeles');
+    expect(getTimezoneByFacilityIdStub.called).to.be.false;
+  });
+
+  it('should return null and fallback when timezone is GMT', () => {
+    const appointment = {
+      locationId: '456',
+      location: {
+        attributes: {
+          timezone: {
+            timeZoneId: 'GMT',
+          },
+        },
+      },
+    };
+
+    const result = getAppointmentTimezone(appointment);
+    expect(result).to.equal('America/Chicago');
+    expect(getTimezoneByFacilityIdStub.calledWith('456')).to.be.true;
+  });
+
+  it('should return null and fallback when timezone is UTC', () => {
+    const appointment = {
+      locationId: '789',
+      location: {
+        attributes: {
+          timezone: {
+            timeZoneId: 'UTC',
+          },
+        },
+      },
+    };
+
+    const result = getAppointmentTimezone(appointment);
+    expect(result).to.equal('America/Chicago');
+    expect(getTimezoneByFacilityIdStub.calledWith('789')).to.be.true;
+  });
+
+  it('should fallback to facility timezone when appointment timezone is unavailable', () => {
+    const appointment = {
+      locationId: '999',
+      location: {
+        attributes: {},
+      },
+    };
+
+    const result = getAppointmentTimezone(appointment);
+    expect(result).to.equal('America/Chicago');
+    expect(getTimezoneByFacilityIdStub.calledWith('999')).to.be.true;
+  });
+
+  it('should pass featureUseBrowserTimezone to getTimezoneByFacilityId', () => {
+    const appointment = {
+      locationId: '555',
+      location: {
+        attributes: {
+          timezone: {
+            timeZoneId: 'UTC',
+          },
+        },
+      },
+    };
+
+    getAppointmentTimezone(appointment, true);
+    expect(getTimezoneByFacilityIdStub.calledWith('555', true)).to.be.true;
+  });
+
+  it('should handle missing location attribute gracefully', () => {
+    const appointment = {
+      locationId: '111',
+    };
+
+    const result = getAppointmentTimezone(appointment);
+    expect(result).to.equal('America/Chicago');
+    expect(getTimezoneByFacilityIdStub.calledWith('111')).to.be.true;
   });
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request updates the logic for determining the appointment timezone in the `getAppointmentTimezone` function. The main change is to treat exact matches of `'GMT'` and `'UTC'` timezones as not set, which will allow the function to fall back to alternative timezone handling.

Timezone handling improvement:

* Modified `getAppointmentTimezone` in `transformers.js` to treat `'GMT'` and `'UTC'` as `null`, ensuring these unset timezone responses do not override the flipper information for using the user's timezone.

Added tests for the function to make sure only situations that require this exact condition are tested. Especially with and with both conditions for the flipper for using the user timezone.

- Find a facility with a timezone that has been set to GMT (has 0,0 lat/long) or override content from a staging response to set the timezone of a facility to "GMT"
- UAE/Appointments

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131202

## Testing done

- Added exhaustive tests for multiple conditions flipper state and "GMT" and specified timezone that is not GMT. Also unspecified timezones.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1333" height="1012" alt="Screenshot 2026-01-27 at 3 53 04 PM" src="https://github.com/user-attachments/assets/9d3423b1-ba34-48bb-9175-6acf15fb618e" />    |<img width="1331" height="1011" alt="Screenshot 2026-01-27 at 3 55 30 PM" src="https://github.com/user-attachments/assets/d53b7126-7f8b-45b5-b7e0-f5315c154a60" />|

## What areas of the site does it impact?

List views of appointments (anything that uses the appointments transformer).

## Acceptance criteria

Adequately handles turning "GMT" (no offest) or "UTC" (no offset) times to user timezones.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
Check with a facility that has "GMT" timezone without an offset (or override your `v2/appointments` call's returned data with facilities that have a timezoneId of "GMT" only, no offset). 