### PR TITLE
[ARC/130292] Fix focus for Android/Talkback

### DIFF
--- a/src/applications/representative-form-upload/helpers/index.js
+++ b/src/applications/representative-form-upload/helpers/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { srSubstitute } from '~/platform/forms-system/src/js/utilities/ui/mask-string';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 import { waitForShadowRoot } from 'platform/utilities/ui/webComponents';
 import { scrollTo } from 'platform/utilities/scroll';
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import { differenceInDays } from 'date-fns';
 import { timeFromNow } from 'platform/utilities/date/index';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
@@ -78,7 +77,7 @@ export const getFileSize = num => {
 
 export const scrollAndFocusTarget = () => {
   scrollTo('va-segmented-progress-bar');
-  focusElement('h2', {}, $('va-segmented-progress-bar')?.shadowRoot);
+  waitForRenderThenFocus('va-segmented-progress-bar', document, 250, 'h2');
 };
 
 // separate each number so the screenreader reads "number ending with 1 2 3 4"


### PR DESCRIPTION
- Update 'scrollAndFocusTarget` to use `waitForRenderThenFocus`, allowing time for the shadow dom to render before focusing. Should fix focus issues for Android/TalkBack, and potentially some iPads.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130292#issuecomment-3807543559

## Testing done

- Tested on MacOS with Google Chrome and Safari/VoiceOver.
- Further testing on iOS, Android, and iPadOS will be done on staging.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
