### PR TITLE
Update schema to accept EZR Military Service data

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#050a914937ac65272deaba404a5c01f429206aa9",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25027,9 +25027,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c":
-  version "25.2.43"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#050a914937ac65272deaba404a5c01f429206aa9":
+  version "25.2.44"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#050a914937ac65272deaba404a5c01f429206aa9"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- bumps vets-json-schema dependency to latest version (25.2.44)
- The schema change adds Service History fields to EZR schema.
- Health Applications 10-10EZR team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113983
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1104
- https://github.com/department-of-veterans-affairs/vets-api/pull/26206
