### PR TITLE
Prefill Pattern: Back button return to cards

### DIFF
--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/index.js
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/index.js
@@ -86,6 +86,7 @@ const profileContactInfoPages = ({
       depends: () => false, // accessed from contact info page
       uiSchema: {},
       schema: blankSchema,
+      onNavBack: ({ goPath }) => goPath(contactPath),
     };
   }
 
@@ -111,6 +112,7 @@ const profileContactInfoPages = ({
       depends: () => false, // accessed from contact info page
       uiSchema: {},
       schema: blankSchema,
+      onNavBack: ({ goPath }) => goPath(contactPath),
     };
   }
 
@@ -137,6 +139,7 @@ const profileContactInfoPages = ({
       depends: () => false, // accessed from contact info page
       uiSchema: {},
       schema: blankSchema,
+      onNavBack: ({ goPath }) => goPath(contactPath),
     };
   }
 
@@ -161,6 +164,7 @@ const profileContactInfoPages = ({
       depends: () => false, // accessed from contact info page
       uiSchema: {},
       schema: blankSchema,
+      onNavBack: ({ goPath }) => goPath(contactPath),
     };
   }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Clicking the "Back" button on any Edit Details pages now routes back to the main Contact Info page.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5383

## Testing done

Local testing/QA

## What areas of the site does it impact?

Prefill pattern in platform.

## Acceptance criteria

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
