### PR TITLE
fix: remove redundant aria-labelledby via prop override

### DIFF
--- a/src/applications/facility-locator/components/search-form/autosuggest/InputWithClear.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/InputWithClear.jsx
@@ -41,6 +41,7 @@ function InputWithClear({
         <input
           className="input-with-clear vads-u-width--full"
           {...getInputProps({ ref: inputRef, ...downshiftInputProps })}
+          aria-labelledby={undefined}
           data-testid={`${inputId}-input-with-clear`}
           aria-expanded={dropdownIsOpen}
           role="combobox"

--- a/src/applications/facility-locator/tests/components/search-form/autosuggest/Autosuggest.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-form/autosuggest/Autosuggest.unit.spec.jsx
@@ -79,4 +79,10 @@ describe('<Autosuggest inputId="any">', () => {
     fireEvent.blur(input);
     expect(input).to.have.value('any input'); // clear on tab
   });
+
+  it('Autosuggest input should NOT have aria-labelledby attribute', async () => {
+    const screen = render(<AutosuggestTestComponent />);
+    const input = await screen.findByRole('combobox');
+    expect(input.hasAttribute('aria-labelledby')).to.equal(false);
+  });
 });


### PR DESCRIPTION
Addresses issue #22891 - removes unnecessary aria-labelledby attribute from location and service type autosuggest inputs.

Override placed AFTER spread to guarantee it takes precedence over whatever Downshift's getInputProps() returns.
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

-  A attribute for the `aria-labelledby` attribute was declared on the location input, preventing the assignment of a redundant `aria-labelledby` attribute by the Downshift component (thank you @bryan-thompsoncodes)
- Steps to reproduce the behavior:
  - Go to [staging facility locator prototype](https://staging.va.gov/find-locations/)
  - Check out the HTML with devtools.
  - Note the label with the for attribute referencing the input id. Note the aria-labelledby on the input referencing that same label.
- Solution: remove the aria-labelledby by defining it as undefined on the input 
- I work for Facilities team
- Behind the autosuggest updates flipper

## Related issue(s)

- [Unnecessary aria-labelledby on Location and Va Health > Service type autosuggest inputs](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22891)

## Testing done

- Prior to the change, the arira-labelledby attribute could be seen on the location input on the facility locator prototype in staging

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  <img width="1267" height="215" alt="Screenshot 2026-01-21 at 2 41 11 PM" src="https://github.com/user-attachments/assets/482741e3-45d8-4259-99bb-c656f4d4ab4b" />  | <img width="1173" height="192" alt="Screenshot 2026-01-21 at 2 40 50 PM" src="https://github.com/user-attachments/assets/cc9cbd87-bf33-4562-8f7e-e53d1ee1e63b" /> |

## What areas of the site does it impact?

-Facility Locator // Location Input Field

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [NA]  Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [NA] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [NA] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
[NA] 