### PR TITLE
Pension | Add new simplified marriage information

### DIFF
--- a/src/applications/pensions/config/chapters/04-household-information/currentMarriageInformation.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentMarriageInformation.js
@@ -1,0 +1,64 @@
+import get from 'platform/utilities/data/get';
+import {
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+  radioUI,
+  radioSchema,
+  textUI,
+  textSchema,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { marriageTypeLabels } from '../../../labels';
+import { requiresSpouseInfo } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
+
+const otherExplanationRequired = formData =>
+  get(['marriageType'], formData) === 'OTHER';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Marriage Information',
+  path: 'household/current-marriage/information',
+  depends: formData =>
+    showMultiplePageResponse() && requiresSpouseInfo(formData),
+  uiSchema: {
+    ...titleUI('Marriage Information'),
+    marriageType: radioUI({
+      title: 'How did you get married?',
+      labels: marriageTypeLabels,
+      classNames: 'vads-u-margin-bottom--2',
+    }),
+    otherExplanation: {
+      ...textUI({
+        title: 'Tell us how you got married',
+        hint:
+          'You can enter common law, proxy (someone else represented you or your spouse at your marriage ceremony), tribal ceremony, or another way.',
+      }),
+      'ui:options': {
+        expandUnder: 'marriageType',
+        expandUnderCondition: 'OTHER',
+      },
+      'ui:required': otherExplanationRequired,
+    },
+    dateOfMarriage: {
+      ...currentOrPastDateUI({
+        title: 'Date of marriage',
+        dataDogHidden: true,
+      }),
+    },
+    locationOfMarriage: textUI({
+      title: 'Place of marriage',
+      hint: 'City and state or foreign country',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['marriageType', 'dateOfMarriage', 'locationOfMarriage'],
+    properties: {
+      marriageType: radioSchema(Object.keys(marriageTypeLabels)),
+      otherExplanation: textSchema,
+      dateOfMarriage: currentOrPastDateSchema,
+      locationOfMarriage: textSchema,
+    },
+  },
+};

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseAddressV2.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseAddressV2.js
@@ -1,20 +1,23 @@
+import get from 'platform/utilities/data/get';
 import {
   addressUI,
   addressSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import createHouseholdMemberTitle from '../../../components/DisclosureTitle';
-import { showSpouseAddress } from './helpers';
+import { generateSpouseTitle, showSpouseAddress } from './helpers';
 import { showMultiplePageResponse } from '../../../helpers';
 
 /** @type {PageSchema} */
 export default {
   title: 'Spouse address',
-  path: 'household/marital-status/separated/spouse-address',
+  path: 'household/current-marriage/spouse-address',
   depends: formData =>
-    !showMultiplePageResponse() && showSpouseAddress(formData),
+    showMultiplePageResponse() &&
+    showSpouseAddress(formData) &&
+    (formData.maritalStatus === 'SEPARATED' ||
+      get(['view:liveWithSpouse'], formData) === false),
   uiSchema: {
-    ...titleUI(createHouseholdMemberTitle('spouseFullName', 'address')),
+    ...titleUI(generateSpouseTitle('address')),
     spouseAddress: addressUI({
       omit: ['isMilitary', 'street3'],
     }),

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseFormerMarriages.jsx
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseFormerMarriages.jsx
@@ -15,7 +15,7 @@ import {
   ContactWarningAlert,
   ContactWarningMultiAlert,
 } from '../../../components/FormAlerts';
-import { formatFullName } from '../../../helpers';
+import { formatFullName, showMultiplePageResponse } from '../../../helpers';
 import ListItemView from '../../../components/ListItemView';
 import SpouseMarriageTitle from '../../../components/SpouseMarriageTitle';
 import { separationTypeLabels } from '../../../labels';
@@ -52,7 +52,9 @@ export default {
   title: 'Spouse’s former marriages',
   path: 'household/marital-status/spouse-marriages',
   depends: formData =>
-    requiresSpouseInfo(formData) && currentSpouseHasFormerMarriages(formData),
+    !showMultiplePageResponse() &&
+    requiresSpouseInfo(formData) &&
+    currentSpouseHasFormerMarriages(formData),
   uiSchema: {
     ...titleUI(SpouseMarriageTitle),
     'view:contactWarning': {

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseInformation.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseInformation.js
@@ -1,0 +1,47 @@
+import merge from 'lodash/merge';
+import {
+  dateOfBirthUI,
+  dateOfBirthSchema,
+  ssnUI,
+  ssnSchema,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  generateSpouseLabel,
+  generateSpouseTitle,
+  requiresSpouseInfo,
+} from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Spouse Information',
+  path: 'household/current-marriage/spouse-information',
+  depends: formData =>
+    showMultiplePageResponse() && requiresSpouseInfo(formData),
+  uiSchema: {
+    ...titleUI(generateSpouseTitle('information')),
+    spouseDateOfBirth: merge({}, dateOfBirthUI({ dataDogHidden: true }), {
+      'ui:title': '',
+      'ui:options': {
+        updateSchema: formData =>
+          generateSpouseLabel(formData, 'date of birth'),
+      },
+    }),
+    spouseSocialSecurityNumber: merge({}, ssnUI(), {
+      'ui:title': '',
+      'ui:options': {
+        updateSchema: formData =>
+          generateSpouseLabel(formData, 'Social Security number'),
+      },
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['spouseDateOfBirth', 'spouseSocialSecurityNumber'],
+    properties: {
+      spouseDateOfBirth: dateOfBirthSchema,
+      spouseSocialSecurityNumber: ssnSchema,
+    },
+  },
+};

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseMaritalHistory.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseMaritalHistory.js
@@ -4,6 +4,7 @@ import {
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { requiresSpouseInfo } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 
 const radioOptions = {
   YES: 'Yes',
@@ -15,7 +16,8 @@ const radioOptions = {
 export default {
   title: 'Current spouse marital history',
   path: 'household/marital-status/spouse-marital-history',
-  depends: requiresSpouseInfo,
+  depends: formData =>
+    !showMultiplePageResponse() && requiresSpouseInfo(formData),
   uiSchema: {
     ...titleUI('Current spouse’s marital history'),
     currentSpouseMaritalHistory: radioUI({

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseName.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseName.js
@@ -1,0 +1,26 @@
+import {
+  fullNameUI,
+  fullNameSchema,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { requiresSpouseInfo } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Spouse Name',
+  path: 'household/current-marriage/spouse-name',
+  depends: formData =>
+    showMultiplePageResponse() && requiresSpouseInfo(formData),
+  uiSchema: {
+    ...titleUI('Spouse’s Name'),
+    spouseFullName: fullNameUI(title => `Spouse’s ${title}`),
+  },
+  schema: {
+    type: 'object',
+    required: ['spouseFullName'],
+    properties: {
+      spouseFullName: fullNameSchema,
+    },
+  },
+};

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseVeteranInformation.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseVeteranInformation.js
@@ -1,0 +1,47 @@
+import get from 'platform/utilities/data/get';
+import {
+  yesNoUI,
+  yesNoSchema,
+  titleUI,
+  vaFileNumberUI,
+  vaFileNumberSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { generateSpouseTitle, requiresSpouseInfo } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
+
+const generateSpouseLabel = formData => {
+  const spouseName = get('spouseFullName', formData);
+  return {
+    title: `Is ${spouseName.first} ${spouseName.last} also a Veteran?`,
+  };
+};
+
+/** @type {PageSchema} */
+export default {
+  title: 'Spouse Veteran Information',
+  path: 'household/current-marriage/spouse-veteran-information',
+  depends: formData =>
+    showMultiplePageResponse() && requiresSpouseInfo(formData),
+  uiSchema: {
+    ...titleUI(generateSpouseTitle('additional information')),
+    spouseIsVeteran: yesNoUI({
+      updateSchema: formData => generateSpouseLabel(formData),
+    }),
+    spouseVaFileNumber: {
+      ...vaFileNumberUI(
+        'Enter their VA file number if it does not match their SSN',
+      ),
+      'ui:options': {
+        expandUnder: 'spouseIsVeteran',
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['spouseIsVeteran'],
+    properties: {
+      spouseIsVeteran: yesNoSchema,
+      spouseVaFileNumber: vaFileNumberSchema,
+    },
+  },
+};

--- a/src/applications/pensions/config/chapters/04-household-information/helpers.jsx
+++ b/src/applications/pensions/config/chapters/04-household-information/helpers.jsx
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { Title } from 'platform/forms-system/src/js/web-component-patterns';
 import React from 'react';
 import { isWithinInterval, parseISO, startOfDay, subYears } from 'date-fns';
-import { showPdfFormAlignment } from '../../../helpers';
+import { formatPossessiveString, showPdfFormAlignment } from '../../../helpers';
 
 /**
  * Checks if the marital status is 'SEPARATED'
@@ -208,3 +208,21 @@ export function createSpouseLabelSelector(nameTemplate) {
 }
 
 export const MarriageTitle = title => <Title title={title} />;
+
+const SpouseTitle = (spouseName, title) =>
+  `${spouseName.first} ${formatPossessiveString(spouseName.last)} ${title}`;
+
+export const generateSpouseLabel = (formData, label) => {
+  const spouseName = get('spouseFullName', formData) || {};
+  return {
+    title: SpouseTitle(spouseName, label),
+  };
+};
+
+export const generateSpouseTitle = title => {
+  return ({ formData }) => {
+    const spouseName = get('spouseFullName', formData) || {};
+
+    return SpouseTitle(spouseName, title);
+  };
+};

--- a/src/applications/pensions/config/chapters/04-household-information/index.js
+++ b/src/applications/pensions/config/chapters/04-household-information/index.js
@@ -3,7 +3,13 @@ import marriageInfo from './marriageInfo';
 import marriageHistory from './marriageHistory';
 import spouseInfo from './spouseInfo';
 import reasonForCurrentSeparation from './reasonForCurrentSeparation';
+import currentMarriageInformation from './currentMarriageInformation';
+import currentSpouseInformation from './currentSpouseInformation';
+import currentSpouseVeteranInformation from './currentSpouseVeteranInformation';
 import currentSpouseAddress from './currentSpouseAddress';
+import currentSpouseName from './currentSpouseName';
+import livesWithCurrentSpouse from './livesWithCurrentSpouse';
+import currentSpouseAddressV2 from './currentSpouseAddressV2';
 import currentSpouseMonthlySupport from './currentSpouseMonthlySupport';
 import currentSpouseMaritalHistory from './currentSpouseMaritalHistory';
 import currentSpouseFormerMarriages from './currentSpouseFormerMarriages';
@@ -17,20 +23,59 @@ import { dependentChildrenPages } from './dependentChildrenPages';
 export default {
   title: 'Household information',
   pages: {
-    maritalStatus,
-    marriageInfo,
-    marriageHistory,
-    spouseInfo,
-    reasonForCurrentSeparation,
-    currentSpouseAddress,
-    currentSpouseMonthlySupport,
-    currentSpouseMaritalHistory,
-    currentSpouseFormerMarriages,
-    ...dependentChildrenPages,
-    hasDependents,
-    dependentChildren,
-    dependentChildInformation,
-    dependentChildInHousehold,
-    dependentChildAddress,
+    // -------------------------------------------------------------------------
+    // Marriages
+    // Legacy and simplified marriage flows toggled by showMultiplePageResponse
+    // Note: Order matters: later pages assume earlier formData exists.
+    // -------------------------------------------------------------------------
+    maritalStatus, // Shared entry point (always included)
+
+    // -------------------------------------------------------------------------
+    // Legacy marriage flow (showMultiplePageResponse = false)
+    // -------------------------------------------------------------------------
+    marriageInfo, // legacy-only
+    marriageHistory, // legacy-only
+    spouseInfo, // legacy-only
+
+    // -------------------------------------------------------------------------
+    // New simplified marriage flow (showMultiplePageResponse = true)
+    // These pages replace the legacy marriageInfo/marriageHistory/spouseInfo set.
+    // -------------------------------------------------------------------------
+    currentMarriageInformation,
+    currentSpouseName,
+    currentSpouseInformation,
+    currentSpouseVeteranInformation,
+    livesWithCurrentSpouse,
+    currentSpouseAddressV2,
+
+    // -------------------------------------------------------------------------
+    // Shared pages that apply after either marriage flow completes
+    // -------------------------------------------------------------------------
+    reasonForCurrentSeparation, // shared (both flows): only relevant when separated
+    currentSpouseAddress, // legacy-only: spouse address page used by the legacy flow
+    currentSpouseMonthlySupport, // shared (both flows): only relevant when not living together
+
+    // -------------------------------------------------------------------------
+    // Downstream marriage history (currently legacy-aligned)
+    // Consider later: whether these become shared/new once the simplified flow expands.
+    // -------------------------------------------------------------------------
+    currentSpouseMaritalHistory, // legacy-aligned for now
+    currentSpouseFormerMarriages, // legacy-aligned for now
+
+    // -------------------------------------------------------------------------
+    // Dependents
+    // Legacy and simplified dependents flows toggled by showMultiplePageResponse
+    // -------------------------------------------------------------------------
+    ...dependentChildrenPages, // New simplified dependents flow (showMultiplePageResponse = true)
+
+    // -------------------------------------------------------------------------
+    // Legacy dependents flow (showMultiplePageResponse = false)
+    // Order matters: later pages assume earlier formData exists.
+    // -------------------------------------------------------------------------
+    hasDependents, // legacy-only
+    dependentChildren, // legacy-only
+    dependentChildInformation, // legacy-only
+    dependentChildInHousehold, // legacy-only
+    dependentChildAddress, // legacy-only
   },
 };

--- a/src/applications/pensions/config/chapters/04-household-information/livesWithCurrentSpouse.js
+++ b/src/applications/pensions/config/chapters/04-household-information/livesWithCurrentSpouse.js
@@ -1,0 +1,36 @@
+import get from 'platform/utilities/data/get';
+import {
+  yesNoUI,
+  yesNoSchema,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { requiresSpouseInfo } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
+
+const generateSpouseLabel = formData => {
+  const spouseName = get('spouseFullName', formData);
+  return {
+    title: `Do you live with ${spouseName.first} ${spouseName.last}?`,
+  };
+};
+
+/** @type {PageSchema} */
+export default {
+  title: 'Spouse Name',
+  path: 'household/current-marriage/lives-with-spouse',
+  depends: formData =>
+    showMultiplePageResponse() && requiresSpouseInfo(formData),
+  uiSchema: {
+    ...titleUI('Additional marriage information'),
+    'view:liveWithSpouse': yesNoUI({
+      updateSchema: formData => generateSpouseLabel(formData),
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['view:liveWithSpouse'],
+    properties: {
+      'view:liveWithSpouse': yesNoSchema,
+    },
+  },
+};

--- a/src/applications/pensions/config/chapters/04-household-information/marriageHistory.js
+++ b/src/applications/pensions/config/chapters/04-household-information/marriageHistory.js
@@ -16,6 +16,7 @@ import {
   isCurrentMarriage,
   hasMarriageHistory,
 } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 
 const dateSchema = {
   pattern: '^\\d{4}-\\d{2}-\\d{2}$',
@@ -27,7 +28,8 @@ export default {
   title: (form, { pagePerItemIndex } = { pagePerItemIndex: 0 }) =>
     getMarriageTitleWithCurrent(form, pagePerItemIndex),
   path: 'household/marriages/:index',
-  depends: hasMarriageHistory,
+  depends: formData =>
+    !showMultiplePageResponse() && hasMarriageHistory(formData),
   showPagePerItem: true,
   arrayPath: 'marriages',
   uiSchema: {

--- a/src/applications/pensions/config/chapters/04-household-information/marriageInfo.js
+++ b/src/applications/pensions/config/chapters/04-household-information/marriageInfo.js
@@ -2,11 +2,13 @@ import { hasMarriageHistory } from './helpers';
 import { marriages } from '../../definitions';
 import MarriageCount from '../../../components/MarriageCount';
 import MarriageCountReview from '../../../components/MarriageCountReview';
+import { showMultiplePageResponse } from '../../../helpers';
 
 export default {
   title: 'Marriage history',
   path: 'household/marriage-info',
-  depends: hasMarriageHistory,
+  depends: formData =>
+    !showMultiplePageResponse() && hasMarriageHistory(formData),
   CustomPage: MarriageCount,
   CustomPageReview: MarriageCountReview,
   uiSchema: {},

--- a/src/applications/pensions/config/chapters/04-household-information/spouseInfo.js
+++ b/src/applications/pensions/config/chapters/04-household-information/spouseInfo.js
@@ -12,6 +12,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 import { createSpouseLabelSelector, requiresSpouseInfo } from './helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 import createHouseholdMemberTitle from '../../../components/DisclosureTitle';
 
 const { spouseIsVeteran } = fullSchemaPensions.properties;
@@ -20,7 +21,8 @@ const { spouseIsVeteran } = fullSchemaPensions.properties;
 export default {
   title: 'Spouse information',
   path: 'household/spouse-info',
-  depends: requiresSpouseInfo,
+  depends: formData =>
+    !showMultiplePageResponse() && requiresSpouseInfo(formData),
   uiSchema: {
     ...titleUI(createHouseholdMemberTitle('spouseFullName', 'information')),
     spouseDateOfBirth: merge({}, dateOfBirthUI({ dataDogHidden: true }), {

--- a/src/applications/pensions/tests/e2e/pagePaths.js
+++ b/src/applications/pensions/tests/e2e/pagePaths.js
@@ -51,6 +51,19 @@ export default {
   marriageInfo: formChapters.householdInformation.pages.marriageInfo.path,
   marriageHistory: formChapters.householdInformation.pages.marriageHistory.path,
   spouseInfo: formChapters.householdInformation.pages.spouseInfo.path,
+  currentMarriageInformation:
+    formChapters.householdInformation.pages.currentMarriageInformation.path,
+  currentSpouseName:
+    formChapters.householdInformation.pages.currentSpouseName.path,
+  currentSpouseInformation:
+    formChapters.householdInformation.pages.currentSpouseInformation.path,
+  currentSpouseVeteranInformation:
+    formChapters.householdInformation.pages.currentSpouseVeteranInformation
+      .path,
+  livesWithCurrentSpouse:
+    formChapters.householdInformation.pages.livesWithCurrentSpouse.path,
+  currentSpouseAddressV2:
+    formChapters.householdInformation.pages.currentSpouseAddressV2.path,
   reasonForCurrentSeparation:
     formChapters.householdInformation.pages.reasonForCurrentSeparation.path,
   currentSpouseAddress:


### PR DESCRIPTION
### Summary of Changes
This PR updates the **Household information** chapter in the **Pension Benefits form (VA Form 21P-527EZ)** to support a new, simplified **marriage information** flow behind the `showMultiplePageResponse` feature toggle.

When `showMultiplePageResponse` is enabled, the chapter uses the simplified marriage information pages and updated page order. When disabled, the legacy marriage flow remains available. This allows us to support both experiences during the transition period.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103928

### How to Set Up in Local Environment
1. Run the local environment
2. Enable or disable the feature toggle as needed:
   - Enable simplified flow:  
     http://localhost:3000/flipper/features/showMultiplePageResponse
   - Disable for legacy flow (toggle off)
3. Navigate to the Pension Benefits form:  
   http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/

### How to Test
1. With `showMultiplePageResponse` **disabled** (legacy flow):
   - Navigate to the **Household information** chapter.
   - Verify the legacy marriage pages and page order render as expected.
   - Complete the marriage section and confirm Review & Submit displays the correct data.

2. With `showMultiplePageResponse` **enabled** (simplified flow):
   - Navigate to the **Household information** chapter.
   - Verify the simplified marriage information pages render and follow the updated page order.
   - Complete the simplified flow and confirm Review & Submit displays the correct data.

3. For both toggle states:
   - Verify conditional pages (separation, spouse info, marriage history) appear/skip correctly based on user responses.
   - Confirm no console errors and no accessibility regressions.

### Feature Flag Note
- `showMultiplePageResponse` controls whether the chapter uses the legacy flow or the simplified marriage information flow.

### Acceptance Criteria
- [ ] Legacy marriage information flow remains unchanged when `showMultiplePageResponse` is disabled.
- [ ] Simplified marriage information flow is used when `showMultiplePageResponse` is enabled.
- [ ] Page order and conditional logic behave correctly for both flows.
- [ ] Review & Submit displays accurate data for both flows.
- [ ] No regressions in navigation, validation, or accessibility.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggle enabled and disabled.
- [ ] No console errors or accessibility issues.
- [ ] Tests updated or verified passing.