### PR TITLE
fix(mhv-secure-messaging): Move success alert below H1 heading for accessibility

### DIFF
--- a/src/applications/mhv-secure-messaging/components/shared/AlertBackgroundBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/AlertBackgroundBox.jsx
@@ -240,6 +240,7 @@ const AlertBackgroundBox = props => {
       <VaAlert
         uswds
         ref={alertRef}
+        role="status"
         background-only
         closeable={props.closeable}
         className="vads-u-margin-bottom--1 va-alert"

--- a/src/applications/mhv-secure-messaging/containers/FolderThreadListView.jsx
+++ b/src/applications/mhv-secure-messaging/containers/FolderThreadListView.jsx
@@ -335,7 +335,7 @@ const FolderThreadListView = () => {
   return (
     <div className="vads-u-padding--0">
       <div className="main-content vads-u-display--flex vads-u-flex-direction--column">
-        <AlertBackgroundBox closeable />
+        {folder === null && <AlertBackgroundBox closeable />}
         {folder === null ? (
           <></>
         ) : (
@@ -348,7 +348,7 @@ const FolderThreadListView = () => {
               threadCount={threadList?.length}
               searchProps={{ searchResults, awaitingResults, keyword, query }}
             />
-
+            <AlertBackgroundBox closeable />
             {content}
             <Footer />
           </>


### PR DESCRIPTION
Ignore this. It was used for demo purposes