### PR TITLE
Feature Toggle Infinite loop Investigation

### DIFF
--- a/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
@@ -72,13 +72,10 @@ StatusTabLink.propTypes = {
 
 const POARequestSearchPage = title => {
   const [searchParams] = useSearchParams();
-  useEffect(
-    () => {
-      focusElement('h1');
-      document.title = title.title;
-    },
-    [title],
-  );
+  useEffect(() => {
+    focusElement('h1');
+    document.title = title.title;
+  }, [title]);
   const loaderData = useLoaderData() || {};
   const poaRequests = loaderData.data || [];
   const meta =
@@ -308,10 +305,13 @@ POARequestSearchPage.loader = async ({ request }) => {
     );
   } catch (err) {
     if (err instanceof Response && err.status === 403) {
-      // Try authorization endpoint
+      // Try authorization endpoint to distinguish between:
+      // 1. User is authorized as rep but POA feature not enabled (show alert)
+      // 2. User is not authorized at all (redirect to dashboard)
       try {
         await api.checkAuthorized({
           signal: request.signal,
+          skip403Redirect: true, // FIXED: Add this flag
         });
         // If authorized as a representative, show alert and empty data
         return { data: [], meta: {}, showPOA403Alert: true };


### PR DESCRIPTION
***THIS PR IS ONLY TO SHOW AREAS WHERE INFINITE LOOPS EXIST***
***PLEASE DO NOT MERGE THIS PR***


Prevent infinite redirect / polling loops on auth failures (ARP + platform utilities)

This PR hardens several frontend “auth failure” paths (mostly 403s) to prevent infinite loops (repeated redirects and repeated requests), with updates in the Accredited Representative Portal (ARP) and shared platform utilities.

List of Priorities:
Yep — here’s the same prioritized list, now with **specific file names** (from your PR patch) and what each area is doing + impact.

---

## 1) **Critical: Infinite feature-toggle polling on auth failure (403)**

**File**

* `src/platform/utilities/feature-toggles/flipper-client.js`

**What’s happening**

* The flipper/feature-toggle client can keep polling `/v0/feature_toggles` even after a **403**, causing repeated requests and repeated failures.
* Your changes introduce a “stop polling after auth failure” behavior and prevent restarting refreshes once auth failure is detected.

**Impact**

* **vets-api:** sustained traffic + 403 log spam on `/v0/feature_toggles` (multiplied by users, tabs, SPA navigation).
* **External services:** even if the endpoint is cheap, auth/session validation can still touch backing stores/infra; aggregate pressure can spill into system stability and observability noise.

---

## 2) **Critical: Redirect loops on 403 (ARP unauthorized redirect behavior)**

**File**

* `src/applications/accredited-representative-portal/utilities/api.js`

**What’s happening**

* A 403 handler redirects to the dashboard with an unauthorized flag. If the dashboard then triggers the same 403 logic again, you get a **redirect loop** (dashboard → unauthorized → dashboard…).
* Your change adds a guard to avoid redirecting again if already on the dashboard.

**Impact**

* **vets-api:** repeated “auth check” traffic and any ARP bootstrapping calls that happen on page init.
* **External services:** depending on the ARP endpoint, this can cascade into downstream calls if any backend authorization/bootstrapping touches external dependencies.

---

## 3) **Critical: ARP dashboard continues calls after unauthorized (loop fuel)**

**File**

* `src/applications/accredited-representative-portal/containers/DashboardPage.jsx`

**What’s happening**

* If the dashboard doesn’t “settle” into a terminal unauthorized state, other components/services can keep attempting requests.
* Your PR adds an unauthorized state + dispatches an `auth:unauthorized` event so the rest of the app can stop making calls, and it uses `checkAuthorized({ skip403Redirect: true })` to prevent redirect churn.

**Impact**

* **vets-api:** repeated auth checks + repeated initialization requests (higher baseline load).
* **External services:** same “amplifier” risk—if any of those endpoints fan out to downstream systems, loops multiply that load.

---

## 4) **High: Form upload retry loop on auth failure (token refresh recursion)**

**File**

* `src/platform/forms-system/src/js/actions.js`

**What’s happening**

* Upload code can attempt refresh+retry on 403. Without a guard, this can repeat indefinitely.
* Your PR adds a `hasAttemptedTokenRefresh` guard so the refresh path runs once and then fails cleanly.

**Impact**

* **vets-api:** repeated upload endpoint hits are expensive (payload handling, storage integration paths, possibly scanning flows).
* **External services:** upload flows often touch storage/scanning/processing pipelines; retries amplify side effects and operational noise.

---

## 5) **Medium: POA request search 403 classification and loader behavior**

**File**

* `src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx`

**What’s happening**

* A **403** can mean “feature gated / not enabled” *or* “not authorized”.
* If FE treats all 403s the same, it can keep re-running effects, re-checking, or bouncing users incorrectly.
* Your change re-checks authorization with `skip403Redirect: true` to distinguish cases and stabilize the UI path.

**Impact**

* **vets-api:** reduced repeated calls to the same failing endpoints.
* **External services:** reduces fan-out risk if those endpoints trigger downstream work.

---

## 6) **Lower: Lifecycle cleanup / stop polling when no subscribers**

**File**

* `src/platform/utilities/feature-toggles/flipper-client.js` (same file as #1)

**What’s happening**

* Polling/refresh timers should stop when nobody is subscribed and on unmount/navigation.
* Your PR strengthens “stop when nobody is listening” behavior.

**Impact**

* **vets-api:** smaller baseline load reduction (but meaningful at scale).
* **External services:** mostly indirect (infra churn reduction).

---


**Acceptance Criteria**
- [ ] The browser network tab goes quiet (no repeated requests for the failing endpoint)
- [ ] Refreshing the page doesn’t re-trigger the same failure loop
- [ ] The UI is stable (no redirect ping-pong)
- [ ] There’s a clear next action (sign in / request access / try again)