### PR TITLE
DMT | Update hideIf to use fullData

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/relationshipType.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/relationshipType.js
@@ -78,7 +78,8 @@ export const relationshipType = {
         </>
       ),
       'ui:options': {
-        hideIf: formData => formData.relationshipType !== 'STEPCHILD',
+        hideIf: (_formData, index, fullData) =>
+          fullData?.childrenToAdd?.[index]?.relationshipType !== 'STEPCHILD',
       },
     },
     'view:adoptedChildInfo': {
@@ -108,7 +109,8 @@ export const relationshipType = {
         </>
       ),
       'ui:options': {
-        hideIf: formData => formData.relationshipType !== 'ADOPTED',
+        hideIf: (_formData, index, fullData) =>
+          fullData?.childrenToAdd?.[index]?.relationshipType !== 'ADOPTED',
       },
     },
   },

--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/relationshipType.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/relationshipType.js
@@ -62,6 +62,26 @@ export const relationshipType = {
         return schema;
       },
     }),
+    'view:biologicalChildInfo': {
+      'ui:description': (
+        <>
+          <p>
+            Based on your answers, you’ll need to submit additional evidence to
+            add this child as your dependent.
+          </p>
+          <p>We’ll ask you to submit this evidence at the end of this form.</p>
+          <p>You’ll need to submit a copy of this child’s birth certificate.</p>
+        </>
+      ),
+      'ui:options': {
+        hideIf: (_formData, index, fullData) =>
+          !(
+            fullData?.veteranContactInformation?.veteranAddress?.country !==
+              'USA' &&
+            fullData?.childrenToAdd?.[index]?.relationshipType === 'BIOLOGICAL'
+          ),
+      },
+    },
     'view:stepchildInfo': {
       'ui:description': (
         <>
@@ -119,6 +139,7 @@ export const relationshipType = {
     required: ['relationshipType'],
     properties: {
       relationshipType: radioSchema(Object.keys(labels)),
+      'view:biologicalChildInfo': { type: 'object', properties: {} },
       'view:stepchildInfo': { type: 'object', properties: {} },
       'view:adoptedChildInfo': { type: 'object', properties: {} },
     },

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/relationshipType.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/relationshipType.unit.spec.jsx
@@ -13,11 +13,16 @@ import formConfig from '../../../../config/form';
 
 const defaultStore = createCommonStore();
 
-const formData = (child = {}) => ({
+const formData = (child = {}, country = 'USA') => ({
   'view:selectable686Options': {
     addChild: true,
   },
   childrenToAdd: [child],
+  veteranContactInformation: {
+    veteranAddress: {
+      country,
+    },
+  },
 });
 
 describe('686 add child relationship type', () => {
@@ -135,5 +140,61 @@ describe('686 add child relationship type', () => {
     expect(testData.childrenToAdd[0].biologicalParentDob).to.equal(
       '2000-01-01',
     );
+  });
+
+  context('biological child info visibility', () => {
+    const { hideIf } = uiSchema.childrenToAdd.items['view:biologicalChildInfo'][
+      'ui:options'
+    ];
+    it('should hide biological child info for US addresses & non-biological children', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'BIOLOGICAL' }, 'USA')))
+        .to.be.true;
+      expect(hideIf({}, 0, formData({ relationshipType: 'ADOPTED' }, 'USA'))).to
+        .be.true;
+      expect(hideIf({}, 0, formData({ relationshipType: 'STEPCHILD' }, 'USA')))
+        .to.be.true;
+    });
+    it('should hide biological child info for non-US addresses & non-biological children', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'ADOPTED' }, 'CAN'))).to
+        .be.true;
+      expect(hideIf({}, 0, formData({ relationshipType: 'STEPCHILD' }, 'CAN')))
+        .to.be.true;
+    });
+    it('should show biological child info for non-US addresses & biological children', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'BIOLOGICAL' }, 'CAN')))
+        .to.be.false;
+    });
+  });
+
+  context('Stepchild info visibility', () => {
+    const { hideIf } = uiSchema.childrenToAdd.items['view:stepchildInfo'][
+      'ui:options'
+    ];
+    it('should hide stepchild info for non-stepchildren', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'BIOLOGICAL' }))).to.be
+        .true;
+      expect(hideIf({}, 0, formData({ relationshipType: 'ADOPTED' }))).to.be
+        .true;
+    });
+    it('should show stepchild info for stepchildren', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'STEPCHILD' }))).to.be
+        .false;
+    });
+  });
+
+  context('Adopted child info visibility', () => {
+    const { hideIf } = uiSchema.childrenToAdd.items['view:adoptedChildInfo'][
+      'ui:options'
+    ];
+    it('should hide adopted child info for non-adopted children', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'BIOLOGICAL' }))).to.be
+        .true;
+      expect(hideIf({}, 0, formData({ relationshipType: 'STEPCHILD' }))).to.be
+        .true;
+    });
+    it('should show adopted child info for adopted children', () => {
+      expect(hideIf({}, 0, formData({ relationshipType: 'ADOPTED' }))).to.be
+        .false;
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > The necessary content was previously only showing while editing a child and was not visible while adding a child. To fix this we switched `hideIf` in array builder list loop to use `fullData` ([see this bug ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/131481)). The content now shows up as expected in both add and edit modes.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130636
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131481

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > No changes - all tests passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Biological selected (no change) | <img width="500" alt="Image" src="https://github.com/user-attachments/assets/92cf4946-90af-4699-bf0a-b7a4b3ff81c9" /> | <img width="500" alt="Image" src="https://github.com/user-attachments/assets/92cf4946-90af-4699-bf0a-b7a4b3ff81c9" /> |
| Stepchild selected | <img width="500" alt="Image" src="https://github.com/user-attachments/assets/92ad0b0f-1dcc-4f9e-9b7f-ff6385e64937" /> | <img width="500" alt="Screenshot 2026-01-29 at 7 54 30 AM" src="https://github.com/user-attachments/assets/85279fe4-864d-4555-b056-b954bb1a71b5" /> |
| Adopted selected | <img width="500" alt="Image" src="https://github.com/user-attachments/assets/ac6398d7-7451-44ec-be6a-d7f4d4414896" /> | <img width="500" alt="Screenshot 2026-01-29 at 7 54 45 AM" src="https://github.com/user-attachments/assets/c6aa312b-09bb-456d-b889-03bf0e8c9662" /> |

## What areas of the site does it impact?

Dependents Management Form (686C-674)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
