### PR TITLE
fix(tests): wrap React.lazy tests in act() for Node 22 compatibility

### DIFF
--- a/src/platform/utilities/tests/chunk-load-error-reproduction.unit.spec.jsx
+++ b/src/platform/utilities/tests/chunk-load-error-reproduction.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -68,13 +68,17 @@ describe('ChunkLoadError Reproduction', () => {
       // Standard React.lazy - current implementation across the codebase
       const LazyComponent = React.lazy(flakyImport);
 
-      const { getByTestId } = render(
-        <TestErrorBoundary fallbackTestId="error-boundary">
-          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
-            <LazyComponent />
-          </Suspense>
-        </TestErrorBoundary>,
-      );
+      let getByTestId;
+      await act(async () => {
+        const result = render(
+          <TestErrorBoundary fallbackTestId="error-boundary">
+            <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+              <LazyComponent />
+            </Suspense>
+          </TestErrorBoundary>,
+        );
+        getByTestId = result.getByTestId;
+      });
 
       // Wait for error boundary to catch the failure
       await waitFor(() => {
@@ -117,11 +121,15 @@ describe('ChunkLoadError Reproduction', () => {
         maxDelayMs: 50,
       });
 
-      const { getByTestId } = render(
-        <Suspense fallback={<div data-testid="loading">Loading...</div>}>
-          <LazyComponent />
-        </Suspense>,
-      );
+      let getByTestId;
+      await act(async () => {
+        const result = render(
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <LazyComponent />
+          </Suspense>,
+        );
+        getByTestId = result.getByTestId;
+      });
 
       // Should eventually succeed after retry
       await waitFor(
@@ -154,13 +162,17 @@ describe('ChunkLoadError Reproduction', () => {
         maxDelayMs: 50,
       });
 
-      const { getByTestId } = render(
-        <TestErrorBoundary fallbackTestId="final-error">
-          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
-            <LazyComponent />
-          </Suspense>
-        </TestErrorBoundary>,
-      );
+      let getByTestId;
+      await act(async () => {
+        const result = render(
+          <TestErrorBoundary fallbackTestId="final-error">
+            <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+              <LazyComponent />
+            </Suspense>
+          </TestErrorBoundary>,
+        );
+        getByTestId = result.getByTestId;
+      });
 
       await waitFor(
         () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Wrap React.lazy tests in async act() to handle microtask timing differences in Node 22
- Node 22's event loop processes microtasks more efficiently, exposing race conditions in tests that use React.lazy with Suspense
- The tests were stuck in "Loading..." state because Promise rejections weren't propagating to error boundaries before assertions ran
- Platform team owns this test file

## Related issue(s)

- Related to Node 22 upgrade work

## Testing done

- Old behavior: Tests passed in Node 14 but failed in Node 22 with "Unable to find an element by: [data-testid="error-boundary"]"
- The component remained stuck in Suspense fallback state
- After wrapping render() in async act(), React properly processes Promise rejections before assertions
- Verified all 3 tests pass locally with Node 22.22.0

## Screenshots

N/A - test-only changes, no UI impact

## What areas of the site does it impact?

Platform test utilities only - no production code changes

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - test fix only)
- [x] Accessibility testing has been performed (N/A - test fix only)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test fix only)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

This is a prerequisite fix for the Node 22 upgrade. The act() wrapper ensures React has time to process async state updates before assertions run.