### PR TITLE
Fix DelayedRefillAlert 404 errors by falling back to id

### DIFF
--- a/src/applications/mhv-medications/components/shared/DelayedRefillAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/DelayedRefillAlert.jsx
@@ -14,6 +14,10 @@ const DelayedRefillAlert = props => {
     });
   };
 
+  // Helper to get prescription ID - handles both V1 (prescriptionId) and V2 (id) response formats
+  // TODO: Remove fallback to `id` after vets-api PR #26244 is deployed
+  const getPrescriptionId = rx => rx.prescriptionId ?? rx.id;
+
   const sortedPrescriptions = sortPrescriptionsByName(refillAlertList);
 
   return (
@@ -29,24 +33,27 @@ const DelayedRefillAlert = props => {
       </h2>
       <p>Go to your medication details to find out what to do next:</p>
       <ul className="medications-list-style--none vads-u-padding-left--0">
-        {sortedPrescriptions.map(rx => (
-          <li
-            className="vads-u-margin-bottom--2"
-            key={rx.prescriptionId}
-            data-dd-privacy="mask"
-          >
-            <Link
-              id={`refill-alert-link-${rx.prescriptionId}`}
+        {sortedPrescriptions.map(rx => {
+          const rxId = getPrescriptionId(rx);
+          return (
+            <li
+              className="vads-u-margin-bottom--2"
+              key={rxId}
               data-dd-privacy="mask"
-              data-testid={`refill-alert-link-${rx.prescriptionId}`}
-              className="vads-u-font-weight--bold"
-              to={`/prescription/${rx.prescriptionId}`}
-              data-dd-action-name={dataDogActionName}
             >
-              {rx.prescriptionName}
-            </Link>
-          </li>
-        ))}
+              <Link
+                id={`refill-alert-link-${rxId}`}
+                data-dd-privacy="mask"
+                data-testid={`refill-alert-link-${rxId}`}
+                className="vads-u-font-weight--bold"
+                to={`/prescription/${rxId}`}
+                data-dd-action-name={dataDogActionName}
+              >
+                {rx.prescriptionName}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </VaAlert>
   );
@@ -56,8 +63,9 @@ DelayedRefillAlert.propTypes = {
   dataDogActionName: PropTypes.string,
   refillAlertList: PropTypes.arrayOf(
     PropTypes.shape({
-      prescriptionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-        .isRequired,
+      // prescriptionId is the expected field, id is fallback for V2 API until vets-api PR #26244 is deployed
+      prescriptionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       prescriptionName: PropTypes.string.isRequired,
     }),
   ),

--- a/src/applications/mhv-medications/tests/components/shared/DelayedRefillAlert.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/DelayedRefillAlert.unit.spec.jsx
@@ -16,13 +16,26 @@ const refillAlertList = [
   },
 ];
 
-const setup = () => {
+// Test data for V2 API response format where only `id` is available
+// TODO: Remove this test data after vets-api PR #26244 is deployed
+const refillAlertListWithIdOnly = [
+  {
+    id: '345678',
+    prescriptionName: 'V2 API Test name 1',
+  },
+  {
+    id: '456789',
+    prescriptionName: 'V2 API Test name 2',
+  },
+];
+
+const setup = (alertList = refillAlertList) => {
   return renderWithStoreAndRouterV6(
-    <DelayedRefillAlert refillAlertList={refillAlertList} />,
+    <DelayedRefillAlert refillAlertList={alertList} />,
     {
       initialState: {
         rx: {
-          refillAlertList,
+          refillAlertList: alertList,
           showRefillProgressContent: true,
         },
       },
@@ -59,6 +72,23 @@ describe('Alert if refill is taking longer than expected', () => {
     expect(
       screen.getByTestId(
         `refill-alert-link-${refillAlertList[1].prescriptionId}`,
+      ),
+    );
+  });
+
+  // Test for V2 API fallback where only `id` is available (not `prescriptionId`)
+  // TODO: Remove this test after vets-api PR #26244 is deployed
+  it('falls back to id when prescriptionId is not available (V2 API workaround)', () => {
+    const screen = setup(refillAlertListWithIdOnly);
+
+    expect(
+      screen.getByTestId(
+        `refill-alert-link-${refillAlertListWithIdOnly[0].id}`,
+      ),
+    );
+    expect(
+      screen.getByTestId(
+        `refill-alert-link-${refillAlertListWithIdOnly[1].id}`,
       ),
     );
   });


### PR DESCRIPTION
## Summary

Temporary fix for 404 errors in the Delayed Refill Alert caused by V2 API returning `id` instead of `prescriptionId` in `meta.recentlyRequested`.

## Problem

Users clicking on prescriptions in the "Some refills are taking longer than expected" alert were getting 404 errors because the URLs were being constructed as `/prescription/undefined`.

### Root Cause

The V2 API's `UnifiedHealthData::Prescription` model had `prescription_id` defined as a method alias instead of an attribute:
```ruby
def prescription_id
  id
end
```

Since `Vets::Model#attributes` only serializes declared attributes (not method aliases), `prescription_id` was missing from the API response. The frontend expected `rx.prescriptionId` but only `rx.id` was available.

## Solution

This frontend patch uses a fallback:
```javascript
const getPrescriptionId = rx => rx.prescriptionId ?? rx.id;
```

This handles both:
- **V1 API responses** which have `prescriptionId`
- **V2 API responses** which currently only have `id`

## Related PRs

- **Backend fix:** department-of-veterans-affairs/vets-api#26244 (adds `prescription_id` as a proper attribute)

## TODO

Remove the `id` fallback after vets-api PR #26244 is deployed and verified.

## Testing

- Added unit test for the `id` fallback scenario
- Existing tests continue to pass with `prescriptionId`
