### PR TITLE
Add API error component

### DIFF
--- a/src/applications/vass/README.md
+++ b/src/applications/vass/README.md
@@ -42,6 +42,47 @@ There are several different mock UUIDs that can be used as a value for the `uuid
 | otc | `123456` |
 | email | `s****@email.com` |
 
+### Error Scenarios
+
+#### OTC Verification - VASS API Error
+**URL:** `http://localhost:3001/service-member/benefits/solid-start/schedule?uuid=authenticate-otc-vass-api-error`
+
+Triggers a VASS API error (500) during OTC verification step.
+
+| Field | Value |
+|-------|-------|
+| uuid | `authenticate-otc-vass-api-error` |
+| lastname | `Smith` |
+| dob | `1935-04-07` |
+| otc | `123456` |
+| email | `s****@email.com` |
+
+#### OTC Verification - Service Error
+**URL:** `http://localhost:3001/service-member/benefits/solid-start/schedule?uuid=authenticate-otc-service-error`
+
+Triggers a service error (500) during OTC verification step.
+
+| Field | Value |
+|-------|-------|
+| uuid | `authenticate-otc-service-error` |
+| lastname | `Smith` |
+| dob | `1935-04-07` |
+| otc | `123456` |
+| email | `s****@email.com` |
+
+#### Not Within Cohort
+**URL:** `http://localhost:3001/service-member/benefits/solid-start/schedule?uuid=not-within-cohort`
+
+User successfully authenticates but is not within the eligible cohort for scheduling. Error occurs when fetching appointment availability.
+
+| Field | Value |
+|-------|-------|
+| uuid | `not-within-cohort` |
+| lastname | `Smith` |
+| dob | `1935-04-07` |
+| otc | `123456` |
+| email | `s****@email.com` |
+
 ### Testing Notes
 - The mock API enforces a **3 attempt limit** for low-auth verification (identity verification with lastname + dob)
 - After 3 failed attempts, a 15-minute lockout is enforced

--- a/src/applications/vass/components/ErrorAlert.jsx
+++ b/src/applications/vass/components/ErrorAlert.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { VASS_PHONE_NUMBER } from '../utils/constants';
+
+const ErrorAlert = () => {
+  return (
+    <va-alert
+      status="error"
+      class="vads-u-margin-top--4"
+      data-testid="api-error-alert"
+    >
+      <h2>We can’t schedule your appointment right now</h2>
+      <p>
+        We’re sorry. There’s a problem with our system. Refresh this page to
+        start over or try again later.{' '}
+      </p>
+      <p>
+        If you need to schedule now, call us at{' '}
+        <va-telephone contact={VASS_PHONE_NUMBER} />.
+      </p>
+    </va-alert>
+  );
+};
+
+export default ErrorAlert;

--- a/src/applications/vass/components/ErrorAlert.unit.spec.jsx
+++ b/src/applications/vass/components/ErrorAlert.unit.spec.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import ErrorAlert from './ErrorAlert';
+import { VASS_PHONE_NUMBER } from '../utils/constants';
+
+describe('VASS Component: ErrorAlert', () => {
+  it('should render component with correct structure', () => {
+    const { container, getByTestId, getByRole } = render(<ErrorAlert />);
+
+    const alert = getByTestId('api-error-alert');
+    expect(alert).to.exist;
+    expect(alert.getAttribute('status')).to.equal('error');
+
+    const heading = getByRole('heading', { level: 2 });
+    expect(heading).to.exist;
+    expect(heading.textContent).to.equal(
+      'We can’t schedule your appointment right now',
+    );
+
+    expect(alert.textContent).to.contain(
+      'There’s a problem with our system. Refresh this page to start over or try again later.',
+    );
+
+    const telephone = container.querySelector('va-telephone');
+    expect(telephone).to.exist;
+    expect(telephone.getAttribute('contact')).to.equal(VASS_PHONE_NUMBER);
+  });
+});

--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -8,6 +8,27 @@ import classNames from 'classnames';
 import { focusElement } from 'platform/utilities/ui';
 
 import NeedHelp from '../components/NeedHelp';
+import ErrorAlert from '../components/ErrorAlert';
+
+// TODO: combine errorAlert and verificationError into a single prop
+
+const getContent = (errorAlert, verificationError, children) => {
+  if (errorAlert) {
+    return <ErrorAlert />;
+  }
+  if (verificationError) {
+    return (
+      <va-alert
+        data-testid="verification-error-alert"
+        class="vads-u-margin-top--4"
+        status="error"
+      >
+        {verificationError}
+      </va-alert>
+    );
+  }
+  return children;
+};
 
 const Wrapper = props => {
   const {
@@ -20,6 +41,7 @@ const Wrapper = props => {
     verificationError,
     loading = false,
     loadingMessage = 'Loading...',
+    errorAlert = false,
   } = props;
   const navigate = useNavigate();
 
@@ -49,6 +71,8 @@ const Wrapper = props => {
     );
   }
 
+  const content = getContent(errorAlert, verificationError, children);
+
   return (
     <div
       className={classNames(`vads-l-grid-container vads-u-padding-x--2p5`, {
@@ -58,49 +82,42 @@ const Wrapper = props => {
       })}
       data-testid={testID}
     >
-      {showBackLink && (
-        <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
-          <nav aria-label="backlink">
-            <va-link
-              back
-              aria-label="Back link"
-              data-testid="back-link"
-              text="Back"
-              href="#"
-              onClick={e => {
-                e.preventDefault();
-                navigate(-1);
-              }}
-            />
-          </nav>
-        </div>
-      )}
+      {!errorAlert &&
+        showBackLink && (
+          <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
+            <nav aria-label="backlink">
+              <va-link
+                back
+                aria-label="Back link"
+                data-testid="back-link"
+                text="Back"
+                href="#"
+                onClick={e => {
+                  e.preventDefault();
+                  navigate(-1);
+                }}
+              />
+            </nav>
+          </div>
+        )}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-          {pageTitle && (
-            <h1 tabIndex="-1" data-testid="header">
-              {pageTitle}
-              {required && (
-                <span className="vass-usa-label--required vads-u-font-family--sans">
-                  (*Required)
-                </span>
-              )}
-            </h1>
-          )}
+          {!errorAlert &&
+            pageTitle && (
+              <h1 tabIndex="-1" data-testid="header">
+                {pageTitle}
+                {required && (
+                  <span className="vass-usa-label--required vads-u-font-family--sans">
+                    (*Required)
+                  </span>
+                )}
+              </h1>
+            )}
           <DowntimeNotification
             appTitle="VA Solid Start"
             dependencies={[externalServices.vass]}
           >
-            {!verificationError && children}
-            {verificationError && (
-              <va-alert
-                data-testid="verification-error-alert"
-                class="vads-u-margin-top--4"
-                status="error"
-              >
-                {verificationError}
-              </va-alert>
-            )}
+            {content}
           </DowntimeNotification>
           <NeedHelp />
         </div>
@@ -112,8 +129,9 @@ const Wrapper = props => {
 export default Wrapper;
 
 Wrapper.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   className: PropTypes.string,
+  errorAlert: PropTypes.bool,
   loading: PropTypes.bool,
   loadingMessage: PropTypes.string,
   pageTitle: PropTypes.string,

--- a/src/applications/vass/pages/AlreadyScheduled.jsx
+++ b/src/applications/vass/pages/AlreadyScheduled.jsx
@@ -7,12 +7,17 @@ import { setFlowType } from '../redux/slices/formSlice';
 import { FLOW_TYPES, URLS, VASS_PHONE_NUMBER } from '../utils/constants';
 import { useGetAppointmentQuery } from '../redux/api/vassApi';
 import { getBrowserTimezone } from '../utils/timezone';
+import { isServerError } from '../utils/errors';
 
 const AlreadyScheduled = () => {
   const { appointmentId } = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { data: appointmentData, isLoading } = useGetAppointmentQuery({
+  const {
+    data: appointmentData,
+    isLoading,
+    error: appointmentError,
+  } = useGetAppointmentQuery({
     appointmentId,
   });
 
@@ -43,6 +48,7 @@ const AlreadyScheduled = () => {
       pageTitle="You already scheduled your appointment with VA Solid Start"
       loading={isLoading}
       loadingMessage="Loading appointment details. This may take up to 30 seconds. Please don’t refresh the page."
+      errorAlert={isServerError(appointmentError)}
     >
       <p id="appointment-date-time" data-testid="already-scheduled-date-time">
         Your VA Solid Start appointment is scheduled for {appointmentDate} at{' '}

--- a/src/applications/vass/pages/Confirmation.jsx
+++ b/src/applications/vass/pages/Confirmation.jsx
@@ -10,6 +10,7 @@ import AppointmentCard from '../components/AppointmentCard';
 import { useGetAppointmentQuery } from '../redux/api/vassApi';
 import { selectSelectedTopics, setFlowType } from '../redux/slices/formSlice';
 import { FLOW_TYPES, URLS } from '../utils/constants';
+import { isServerError, isAppointmentNotFoundError } from '../utils/errors';
 
 const Confirmation = () => {
   const { appointmentId } = useParams();
@@ -18,7 +19,11 @@ const Confirmation = () => {
   const selectedTopics = useSelector(selectSelectedTopics);
   const detailsCardOnly = searchParams.get('details') === 'true';
   const navigate = useNavigate();
-  const { data: appointmentData, isLoading, isError } = useGetAppointmentQuery({
+  const {
+    data: appointmentData,
+    isLoading,
+    error: appointmentError,
+  } = useGetAppointmentQuery({
     appointmentId,
   });
 
@@ -26,10 +31,6 @@ const Confirmation = () => {
     dispatch(setFlowType(FLOW_TYPES.CANCEL));
     navigate(`${URLS.CANCEL_APPOINTMENT}/${appointmentId}`);
   };
-
-  if (isError) {
-    return <div>Error</div>;
-  }
 
   return (
     <Wrapper
@@ -41,6 +42,10 @@ const Confirmation = () => {
         detailsCardOnly
           ? undefined
           : 'Your VA Solid Start appointment is scheduled'
+      }
+      errorAlert={
+        isServerError(appointmentError) ||
+        isAppointmentNotFoundError(appointmentError)
       }
     >
       {!detailsCardOnly && (

--- a/src/applications/vass/pages/DateTimeSelection.jsx
+++ b/src/applications/vass/pages/DateTimeSelection.jsx
@@ -16,6 +16,7 @@ import {
   getTimezoneDescByTimeZoneString,
   getBrowserTimezone,
 } from '../utils/timezone';
+import { isNotWhithinCohortError, isServerError } from '../utils/errors';
 
 const DateTimeSelection = () => {
   const dispatch = useDispatch();
@@ -25,6 +26,7 @@ const DateTimeSelection = () => {
   const {
     data: appointmentAvailability,
     isLoading: loading,
+    error: appointmentAvailabilityError,
   } = useGetAppointmentAvailabilityQuery(uuid);
   const [{ error, handleSetError }] = useErrorFocus([
     '.vaos-calendar__validation-msg',
@@ -70,6 +72,10 @@ const DateTimeSelection = () => {
       required
       loading={loading}
       loadingMessage="Loading appointment availability. This may take up to 30 seconds. Please don’t refresh the page."
+      errorAlert={
+        isServerError(appointmentAvailabilityError) ||
+        isNotWhithinCohortError(appointmentAvailabilityError)
+      }
     >
       <div data-testid="content">
         <p>

--- a/src/applications/vass/pages/EnterOTC.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTC.unit.spec.jsx
@@ -14,6 +14,10 @@ import {
 import EnterOTC from './EnterOTC';
 import { getDefaultRenderOptions, LocationDisplay } from '../utils/test-utils';
 import { FLOW_TYPES, URLS } from '../utils/constants';
+import {
+  createOTPInvalidError,
+  createOTPAccountLockedError,
+} from '../services/mocks/utils/errors';
 
 const defaultRenderOptions = getDefaultRenderOptions({
   obfuscatedEmail: 't***@test.com',
@@ -82,16 +86,7 @@ describe('VASS Component: EnterOTC', () => {
 
   describe('API error handling', () => {
     it('should display error alert for invalid_otc with multiple attempts remaining', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), {
-        errors: [
-          {
-            code: 'invalid_otc',
-            detail: 'Invalid or expired OTC',
-            attemptsRemaining: 2,
-            status: 401,
-          },
-        ],
-      });
+      setFetchJSONFailure(global.fetch.onCall(0), createOTPInvalidError(2));
       const { container, getByTestId } = renderComponent();
       inputVaTextInput(container, '123456', 'va-text-input[name="otc"]');
       const continueButton = getByTestId('continue-button');
@@ -105,16 +100,7 @@ describe('VASS Component: EnterOTC', () => {
       });
     });
     it('should display specific error message when only 1 attempt remaining', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), {
-        errors: [
-          {
-            code: 'invalid_otc',
-            detail: 'Invalid or expired OTC',
-            attemptsRemaining: 1,
-            status: 401,
-          },
-        ],
-      });
+      setFetchJSONFailure(global.fetch.onCall(0), createOTPInvalidError(1));
       const { container, getByTestId } = renderComponent();
       inputVaTextInput(container, '123456', 'va-text-input[name="otc"]');
       const continueButton = getByTestId('continue-button');
@@ -128,16 +114,10 @@ describe('VASS Component: EnterOTC', () => {
       });
     });
     it('should display account locked error message', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), {
-        errors: [
-          {
-            code: 'account_locked',
-            detail: 'Too many failed attempts',
-            status: 401,
-            retryAfter: 900,
-          },
-        ],
-      });
+      setFetchJSONFailure(
+        global.fetch.onCall(0),
+        createOTPAccountLockedError(900),
+      );
       const { container, getByTestId } = renderComponent();
       inputVaTextInput(container, '123456', 'va-text-input[name="otc"]');
       const continueButton = getByTestId('continue-button');
@@ -151,16 +131,7 @@ describe('VASS Component: EnterOTC', () => {
       });
     });
     it('should hide success alert when error is displayed', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), {
-        errors: [
-          {
-            code: 'invalid_otc',
-            detail: 'Invalid or expired OTC',
-            attemptsRemaining: 2,
-            status: 401,
-          },
-        ],
-      });
+      setFetchJSONFailure(global.fetch.onCall(0), createOTPInvalidError(2));
       const { container, getByTestId, queryByTestId } = renderComponent();
       inputVaTextInput(container, '123456', 'va-text-input[name="otc"]');
       const continueButton = getByTestId('continue-button');
@@ -171,16 +142,7 @@ describe('VASS Component: EnterOTC', () => {
       });
     });
     it('should clear the OTC input after an error', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), {
-        errors: [
-          {
-            code: 'invalid_otc',
-            detail: 'Invalid or expired OTC',
-            attemptsRemaining: 2,
-            status: 401,
-          },
-        ],
-      });
+      setFetchJSONFailure(global.fetch.onCall(0), createOTPInvalidError(2));
       const { container, getByTestId } = renderComponent();
       inputVaTextInput(container, '123456', 'va-text-input[name="otc"]');
       const continueButton = getByTestId('continue-button');
@@ -259,7 +221,7 @@ describe('VASS Component: EnterOTC', () => {
           <Routes>
             <Route path={URLS.ENTER_OTC} element={<EnterOTC />} />
             <Route
-              path="/cancel-appointment/:appointmentId"
+              path={`${URLS.CANCEL_APPOINTMENT}/:appointmentId`}
               element={<div>Cancel Appointment Page</div>}
             />
           </Routes>

--- a/src/applications/vass/pages/Error.jsx
+++ b/src/applications/vass/pages/Error.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Wrapper from '../layout/Wrapper';
+
+export default function Error() {
+  return <Wrapper testID="error-page" errorAlert />;
+}

--- a/src/applications/vass/pages/Error.unit.spec.jsx
+++ b/src/applications/vass/pages/Error.unit.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+
+import Error from './Error';
+import { getDefaultRenderOptions } from '../utils/test-utils';
+
+const defaultRenderOptions = getDefaultRenderOptions();
+
+describe('VASS Component: Error', () => {
+  it('should render component with correct structure', () => {
+    const {
+      getByTestId,
+      queryByTestId,
+      container,
+    } = renderWithStoreAndRouterV6(<Error />, defaultRenderOptions);
+
+    expect(getByTestId('error-page')).to.exist;
+    expect(getByTestId('api-error-alert')).to.exist;
+    expect(queryByTestId('header')).to.not.exist;
+    expect(queryByTestId('back-link')).to.not.exist;
+    const alert = getByTestId('api-error-alert');
+    expect(alert.textContent).to.exist;
+    const telephone = container.querySelector('va-telephone');
+    expect(telephone).to.exist;
+  });
+});

--- a/src/applications/vass/pages/Review.jsx
+++ b/src/applications/vass/pages/Review.jsx
@@ -9,10 +9,14 @@ import {
   selectSelectedDate,
 } from '../redux/slices/formSlice';
 import { URLS } from '../utils/constants';
+import { isServerError, isAppointmentFailedError } from '../utils/errors';
 
 const Review = () => {
   const navigate = useNavigate();
-  const [postAppointment, { isLoading }] = usePostAppointmentMutation();
+  const [
+    postAppointment,
+    { isLoading, error: postAppointmentError },
+  ] = usePostAppointmentMutation();
   const selectedTopics = useSelector(selectSelectedTopics);
   const selectedDate = useSelector(selectSelectedDate);
   const handleConfirmCall = async () => {
@@ -21,6 +25,9 @@ const Review = () => {
       dtStartUtc: selectedDate,
       dtEndUtc: selectedDate,
     });
+    if (res.error) {
+      return;
+    }
     navigate(`${URLS.CONFIRMATION}/${res.data.appointmentId}`);
   };
 
@@ -29,6 +36,10 @@ const Review = () => {
       pageTitle="Review your VA Solid Start appointment details"
       testID="review-page"
       showBackLink
+      errorAlert={
+        isServerError(postAppointmentError) ||
+        isAppointmentFailedError(postAppointmentError)
+      }
     >
       <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-align-items--center">
         <p

--- a/src/applications/vass/pages/Review.unit.spec.jsx
+++ b/src/applications/vass/pages/Review.unit.spec.jsx
@@ -1,32 +1,209 @@
 import React from 'react';
 import { expect } from 'chai';
-import { renderWithStoreAndRouterV6 as renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+import { waitFor } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom-v5-compat';
+import { renderWithStoreAndRouterV6 } from 'platform/testing/unit/react-testing-library-helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 
 import Review from './Review';
-import { getDefaultRenderOptions } from '../utils/test-utils';
+import { getDefaultRenderOptions, LocationDisplay } from '../utils/test-utils';
+import { URLS } from '../utils/constants';
+import {
+  createAppointmentSaveFailedError,
+  createServiceError,
+} from '../services/mocks/utils/errors';
+
+const defaultFormState = {
+  hydrated: true,
+  selectedDate: '2025-01-15T10:00:00.000Z',
+  selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
+  uuid: 'c0ffee-1234-beef-5678',
+  lastname: 'Smith',
+  dob: '1935-04-07',
+  obfuscatedEmail: 's****@email.com',
+};
+
+const appointmentId = 'appt-123456';
+
+// TODO: Add mock appointment success response to fixtures
+const mockAppointmentSuccessResponse = {
+  data: {
+    appointmentId,
+  },
+};
+
+const defaultRenderOptions = getDefaultRenderOptions(defaultFormState);
+
+const renderComponent = () =>
+  renderWithStoreAndRouterV6(<Review />, defaultRenderOptions);
 
 describe('VASS Component: Review', () => {
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  afterEach(() => {
+    resetFetch();
+  });
+
   it('should render review page correctly', () => {
-    const screen = renderWithStoreAndRouter(
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId('review-page')).to.exist;
+    expect(getByTestId('back-link')).to.exist;
+    expect(getByTestId('header')).to.exist;
+    expect(getByTestId('header').textContent).to.contain(
+      'Review your VA Solid Start appointment details',
+    );
+    expect(getByTestId('date-time-title')).to.exist;
+    expect(getByTestId('date-time-edit-link')).to.exist;
+    expect(getByTestId('date-time-description')).to.exist;
+    expect(getByTestId('topic-title')).to.exist;
+    expect(getByTestId('topic-edit-link')).to.exist;
+    expect(getByTestId('topic-description')).to.exist;
+    expect(getByTestId('confirm-call-button')).to.exist;
+  });
+
+  it('should display single topic correctly', () => {
+    const { getByTestId } = renderWithStoreAndRouterV6(
       <Review />,
       getDefaultRenderOptions({
-        hydrated: true,
-        selectedDate: '2025-01-15T10:00:00.000Z',
-        selectedTopics: [{ topicId: '1', topicName: 'Topic 1' }],
-        uuid: 'c0ffee-1234-beef-5678',
-        lastname: 'Smith',
-        dob: '1935-04-07',
+        ...defaultFormState,
+        selectedTopics: [{ topicId: '1', topicName: 'Education Benefits' }],
       }),
     );
-    expect(screen.getByTestId('review-page')).to.exist;
-    expect(screen.getByTestId('back-link')).to.exist;
-    expect(screen.getByTestId('header')).to.exist;
-    expect(screen.getByTestId('date-time-title')).to.exist;
-    expect(screen.getByTestId('date-time-edit-link')).to.exist;
-    expect(screen.getByTestId('date-time-description')).to.exist;
-    expect(screen.getByTestId('topic-title')).to.exist;
-    expect(screen.getByTestId('topic-edit-link')).to.exist;
-    expect(screen.getByTestId('topic-description')).to.exist;
-    expect(screen.getByTestId('confirm-call-button')).to.exist;
+
+    expect(getByTestId('topic-description').textContent).to.equal(
+      'Education Benefits',
+    );
+  });
+
+  it('should display multiple topics as comma-separated list', () => {
+    const { getByTestId } = renderWithStoreAndRouterV6(
+      <Review />,
+      getDefaultRenderOptions({
+        ...defaultFormState,
+        selectedTopics: [
+          { topicId: '1', topicName: 'Education Benefits' },
+          { topicId: '2', topicName: 'Health Care' },
+          { topicId: '3', topicName: 'Housing Assistance' },
+        ],
+      }),
+    );
+
+    expect(getByTestId('topic-description').textContent).to.equal(
+      'Education Benefits, Health Care, Housing Assistance',
+    );
+  });
+
+  it('should have edit links pointing to correct routes', () => {
+    const { getByTestId } = renderComponent();
+
+    const dateTimeEditLink = getByTestId('date-time-edit-link');
+    const topicEditLink = getByTestId('topic-edit-link');
+
+    expect(dateTimeEditLink.getAttribute('href')).to.equal(URLS.DATE_TIME);
+    expect(topicEditLink.getAttribute('href')).to.equal(URLS.TOPIC_SELECTION);
+  });
+
+  describe('successful appointment submission', () => {
+    it('should navigate to confirmation page on successful submission', async () => {
+      setFetchJSONResponse(
+        global.fetch.onCall(0),
+        mockAppointmentSuccessResponse,
+      );
+
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <>
+          <Routes>
+            <Route path={URLS.REVIEW} element={<Review />} />
+            <Route
+              path={`${URLS.CONFIRMATION}/:appointmentId`}
+              element={<div>Confirmation Page</div>}
+            />
+          </Routes>
+          <LocationDisplay />
+        </>,
+        {
+          ...defaultRenderOptions,
+          initialEntries: [URLS.REVIEW],
+        },
+      );
+
+      const confirmButton = getByTestId('confirm-call-button');
+      confirmButton.click();
+
+      await waitFor(() => {
+        expect(getByTestId('location-display').textContent).to.equal(
+          `${URLS.CONFIRMATION}/${appointmentId}`,
+        );
+      });
+    });
+  });
+
+  describe('API error handling', () => {
+    it('should not navigate when API returns an error', async () => {
+      setFetchJSONFailure(
+        global.fetch.onCall(0),
+        createAppointmentSaveFailedError(),
+      );
+
+      const { getByTestId } = renderWithStoreAndRouterV6(
+        <>
+          <Routes>
+            <Route path={URLS.REVIEW} element={<Review />} />
+            <Route
+              path={`${URLS.CONFIRMATION}/:appointmentId`}
+              element={<div>Confirmation Page</div>}
+            />
+          </Routes>
+          <LocationDisplay />
+        </>,
+        {
+          ...defaultRenderOptions,
+          initialEntries: [URLS.REVIEW],
+        },
+      );
+
+      const confirmButton = getByTestId('confirm-call-button');
+      confirmButton.click();
+
+      await waitFor(() => {
+        // Should still be on review page
+        expect(getByTestId('location-display').textContent).to.equal(
+          URLS.REVIEW,
+        );
+      });
+    });
+
+    it('should display error alert when server error occurs', async () => {
+      setFetchJSONFailure(global.fetch.onCall(0), createServiceError());
+
+      const { getByTestId, queryByTestId } = renderWithStoreAndRouterV6(
+        <>
+          <Routes>
+            <Route path={URLS.REVIEW} element={<Review />} />
+          </Routes>
+        </>,
+        {
+          ...defaultRenderOptions,
+          initialEntries: [URLS.REVIEW],
+        },
+      );
+
+      const confirmButton = getByTestId('confirm-call-button');
+      confirmButton.click();
+
+      await waitFor(() => {
+        expect(getByTestId('api-error-alert')).to.exist;
+        expect(queryByTestId('back-link')).to.not.exist;
+        expect(queryByTestId('header')).to.not.exist;
+      });
+    });
   });
 });

--- a/src/applications/vass/pages/TopicSelection.jsx
+++ b/src/applications/vass/pages/TopicSelection.jsx
@@ -13,13 +13,14 @@ import {
 import { useGetTopicsQuery } from '../redux/api/vassApi';
 import { useErrorFocus } from '../hooks/useErrorFocus';
 import { URLS } from '../utils/constants';
+import { isServerError } from '../utils/errors';
 
 const TopicSelection = () => {
   const [{ error, handleSetError }] = useErrorFocus(['va-checkbox-group']);
   const dispatch = useDispatch();
   const selectedTopics = useSelector(selectSelectedTopics);
   const navigate = useNavigate();
-  const { data, isLoading: loading } = useGetTopicsQuery();
+  const { data, isLoading: loading, error: topicsError } = useGetTopicsQuery();
   const topics = useMemo(() => data?.topics || [], [data]);
 
   const handleTopicChange = event => {
@@ -57,6 +58,7 @@ const TopicSelection = () => {
       showBackLink
       required
       loading={loading}
+      errorAlert={isServerError(topicsError)}
     >
       <va-checkbox-group
         data-testid="topic-checkbox-group"

--- a/src/applications/vass/pages/Verify.unit.spec.jsx
+++ b/src/applications/vass/pages/Verify.unit.spec.jsx
@@ -22,8 +22,18 @@ import {
   LocationDisplay,
 } from '../utils/test-utils';
 import { FLOW_TYPES, URLS } from '../utils/constants';
+import { createRateLimitExceededError } from '../services/mocks/utils/errors';
+
+const entryWithUuid = {
+  initialEntries: [`${URLS.VERIFY}?uuid=c0ffee-1234-beef-5678`],
+};
 
 const defaultRenderOptions = getDefaultRenderOptions();
+
+const defaultRenderOptionsWithUuid = {
+  ...defaultRenderOptions,
+  ...entryWithUuid,
+};
 
 describe('VASS Component: Verify', () => {
   beforeEach(() => {
@@ -37,7 +47,7 @@ describe('VASS Component: Verify', () => {
   it('should render all content', () => {
     const { getByTestId, queryByTestId } = renderWithStoreAndRouterV6(
       <Verify />,
-      defaultRenderOptions,
+      defaultRenderOptionsWithUuid,
     );
 
     expect(getByTestId('header')).to.exist;
@@ -46,6 +56,20 @@ describe('VASS Component: Verify', () => {
     expect(getByTestId('dob-input')).to.exist;
     expect(getByTestId('submit-button')).to.exist;
     expect(queryByTestId('verify-error-alert')).to.not.exist;
+  });
+
+  describe('when URL does not have a UUID', () => {
+    it('should display error alert when URL does not have a UUID', () => {
+      const { getByTestId, queryByTestId } = renderWithStoreAndRouterV6(
+        <Verify />,
+        defaultRenderOptions,
+      );
+
+      expect(getByTestId('api-error-alert')).to.exist;
+      expect(queryByTestId('submit-button')).to.not.exist;
+      expect(queryByTestId('last-name-input')).to.not.exist;
+      expect(queryByTestId('dob-input')).to.not.exist;
+    });
   });
 
   describe('when cancellation url parameter is true', () => {
@@ -69,7 +93,7 @@ describe('VASS Component: Verify', () => {
     it('should display the correct page title', () => {
       const { getByTestId } = renderWithStoreAndRouterV6(<Verify />, {
         ...defaultRenderOptions,
-        initialEntries: [`${URLS.VERIFY}?cancel=true`],
+        initialEntries: [`${URLS.VERIFY}?cancel=true&uuid=test-uuid`],
       });
 
       expect(getByTestId('header').textContent).to.contain(
@@ -94,10 +118,7 @@ describe('VASS Component: Verify', () => {
           </Routes>
           <LocationDisplay />
         </>,
-        {
-          ...defaultRenderOptions,
-          initialEntries: [URLS.VERIFY],
-        },
+        defaultRenderOptionsWithUuid,
       );
 
       // Fill in valid credentials
@@ -140,10 +161,7 @@ describe('VASS Component: Verify', () => {
           </Routes>
           <LocationDisplay />
         </>,
-        {
-          ...defaultRenderOptions,
-          initialEntries: ['/?uuid=c0ffee-1234-beef-5678'],
-        },
+        defaultRenderOptionsWithUuid,
       );
 
       // Fill in valid credentials
@@ -190,11 +208,7 @@ describe('VASS Component: Verify', () => {
           </Routes>
           <LocationDisplay />
         </>,
-        {
-          ...defaultRenderOptions,
-          store,
-          initialEntries: ['/?uuid=c0ffee-1234-beef-5678'],
-        },
+        { ...defaultRenderOptionsWithUuid, store },
       );
 
       // Fill in valid credentials
@@ -240,7 +254,7 @@ describe('VASS Component: Verify', () => {
         getByTestId,
         queryByTestId,
         container,
-      } = renderWithStoreAndRouterV6(<Verify />, defaultRenderOptions);
+      } = renderWithStoreAndRouterV6(<Verify />, defaultRenderOptionsWithUuid);
 
       const submitButton = getByTestId('submit-button');
 
@@ -263,21 +277,16 @@ describe('VASS Component: Verify', () => {
     });
 
     it('should display verification error message when rate limit is exceeded', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), {
-        errors: [
-          {
-            code: 'rate_limit_exceeded',
-            detail: 'Too many OTC requests.  Please try again later.',
-            retryAfter: 900,
-          },
-        ],
-      });
+      setFetchJSONFailure(
+        global.fetch.onCall(0),
+        createRateLimitExceededError(900),
+      );
 
       const {
         getByTestId,
         queryByTestId,
         container,
-      } = renderWithStoreAndRouterV6(<Verify />, defaultRenderOptions);
+      } = renderWithStoreAndRouterV6(<Verify />, defaultRenderOptionsWithUuid);
 
       const submitButton = getByTestId('submit-button');
 

--- a/src/applications/vass/redux/api/vassApi.js
+++ b/src/applications/vass/redux/api/vassApi.js
@@ -33,11 +33,13 @@ export const vassApi = createApi({
             dispatch(setObfuscatedEmail(response.data.email));
           }
           return response;
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'post referral appointment');
-          // TODO: do something with error
           return {
-            error: error.errors[0],
+            error: {
+              code: errors?.[0]?.code,
+              detail: errors?.[0]?.detail,
+            },
           };
         }
       },
@@ -58,11 +60,10 @@ export const vassApi = createApi({
               dob,
             }),
           });
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'post referral appointment');
-          // TODO: do something with error
           return {
-            error: error.errors[0],
+            error: errors?.[0],
           };
         }
       },
@@ -93,11 +94,14 @@ export const vassApi = createApi({
               dtEndUtc,
             }),
           });
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'post appointment');
           // TODO: do something with error
           return {
-            error: { status: error.status || 500, message: error?.message },
+            error: {
+              code: errors?.[0]?.code,
+              detail: errors?.[0]?.detail,
+            },
           };
         }
       },
@@ -113,11 +117,14 @@ export const vassApi = createApi({
               Authorization: `Bearer ${token}`,
             },
           });
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'get appointment');
           // TODO: do something with error
           return {
-            error: { status: error.status || 500, message: error?.message },
+            error: {
+              code: errors?.[0]?.code,
+              detail: errors?.[0]?.detail,
+            },
           };
         }
       },
@@ -133,11 +140,14 @@ export const vassApi = createApi({
               Authorization: `Bearer ${token}`,
             },
           });
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'get topics');
           // TODO: do something with error
           return {
-            error: { status: error.status || 500, message: error?.message },
+            error: {
+              code: errors?.[0]?.code,
+              detail: errors?.[0]?.detail,
+            },
           };
         }
       },
@@ -153,11 +163,14 @@ export const vassApi = createApi({
               Authorization: `Bearer ${token}`,
             },
           });
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'get appointment availability');
           // TODO: do something with error
           return {
-            error: { status: error.status || 500, message: error?.message },
+            error: {
+              code: errors?.[0]?.code,
+              detail: errors?.[0]?.detail,
+            },
           };
         }
       },
@@ -173,11 +186,14 @@ export const vassApi = createApi({
               Authorization: `Bearer ${token}`,
             },
           });
-        } catch (error) {
+        } catch ({ errors }) {
           // captureError(error, false, 'cancel appointment');
           // TODO: do something with error
           return {
-            error: { status: error.status || 500, message: error?.message },
+            error: {
+              code: errors?.[0]?.code,
+              detail: errors?.[0]?.detail,
+            },
           };
         }
       },

--- a/src/applications/vass/routes.jsx
+++ b/src/applications/vass/routes.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import withAuthorization from './containers/withAuthorization';
 import withFormData from './containers/withFormData';
 import withFlowGuard from './containers/withFlowGuard';
+import Error from './pages/Error';
 import { routes } from './utils/navigation';
 import { AUTH_LEVELS, FLOW_TYPES } from './utils/constants';
 
@@ -38,8 +39,7 @@ const createRoutes = () => {
 
         return <Route key={index} path={route.path} element={<Component />} />;
       })}
-      {/* TODO: navigate to error page */}
-      <Route path="*" element={<Navigate to="/" replace />} />
+      <Route path="*" element={<Error />} />
     </Routes>
   );
 };

--- a/src/applications/vass/services/mocks/index.js
+++ b/src/applications/vass/services/mocks/index.js
@@ -5,9 +5,37 @@ const mockTopics = require('./utils/topic');
 const { generateSlots, createMockJwt } = require('../../utils/mock-helpers');
 const { decodeJwt } = require('../../utils/jwt-utils');
 const { createAppointmentData } = require('../../utils/appointments');
+const {
+  createOTPInvalidError,
+  createOTPAccountLockedError,
+  createRateLimitExceededError,
+  createVassApiError,
+  createServiceError,
+  createUnauthorizedError,
+  createInvalidCredentialsError,
+  createNotWithinCohortError,
+} = require('./utils/errors');
 
 const mockUUIDs = Object.freeze({
   'c0ffee-1234-beef-5678': {
+    lastname: 'Smith',
+    dob: '1935-04-07',
+    otc: '123456',
+    email: 's****@email.com',
+  },
+  'authenticate-otc-vass-api-error': {
+    lastname: 'Smith',
+    dob: '1935-04-07',
+    otc: '123456',
+    email: 's****@email.com',
+  },
+  'authenticate-otc-service-error': {
+    lastname: 'Smith',
+    dob: '1935-04-07',
+    otc: '123456',
+    email: 's****@email.com',
+  },
+  'not-within-cohort': {
     lastname: 'Smith',
     dob: '1935-04-07',
     otc: '123456',
@@ -29,6 +57,14 @@ const mockAppointments = [createAppointmentData()];
 const responses = {
   'POST /vass/v0/authenticate': (req, res) => {
     const { uuid, lastname, dob } = req.body;
+
+    if (uuid === 'authenticate-vass-api-error') {
+      return res.status(500).json(createVassApiError());
+    }
+    if (uuid === 'authenticate-service-error') {
+      return res.status(500).json(createServiceError());
+    }
+
     let attemptCount = 0;
     const [lastAttempt, attemptCountStr] = lowAuthVerifications
       .get(uuid)
@@ -60,28 +96,19 @@ const responses = {
       });
     }
     if (attemptCount >= maxLowAuthVerifications) {
-      return res.status(401).json({
-        errors: [
-          {
-            code: 'rate_limit_exceeded',
-            detail: 'Too many OTC requests.  Please try again later.',
-            retryAfter: 900,
-          },
-        ],
-      });
+      return res.status(401).json(createRateLimitExceededError(900));
     }
 
-    return res.status(401).json({
-      errors: [
-        {
-          code: 'invalid_credentials',
-          detail: 'Unable to verify identity. Please check your information.',
-        },
-      ],
-    });
+    return res.status(401).json(createInvalidCredentialsError());
   },
   'POST /vass/v0/authenticate-otc': (req, res) => {
     const { otc, uuid, lastname, dob } = req.body;
+    if (uuid === 'authenticate-otc-vass-api-error') {
+      return res.status(500).json(createVassApiError());
+    }
+    if (uuid === 'authenticate-otc-service-error') {
+      return res.status(500).json(createServiceError());
+    }
     const useCount = otcUseCounts.get(uuid) || 0;
     otcUseCounts.set(uuid, useCount + 1);
     const mockUser = mockUUIDs[uuid];
@@ -101,27 +128,11 @@ const responses = {
       });
     }
     if (useCount >= maxOtcUseCount) {
-      return res.status(401).json({
-        errors: [
-          {
-            code: 'account_locked',
-            detail: 'Too many failed attempts.  Please request a new OTC.',
-            status: 401, // TODO: confirm status code
-            retryAfter: 900, // 15 minutes TODO
-          },
-        ],
-      });
+      return res.status(401).json(createOTPAccountLockedError(900));
     }
-    return res.status(401).json({
-      errors: [
-        {
-          code: 'invalid_otc',
-          detail: 'Invalid or expired OTC.  Please try again.',
-          attemptsRemaining: maxOtcUseCount - useCount,
-          status: 401,
-        },
-      ],
-    });
+    return res
+      .status(401)
+      .json(createOTPInvalidError(maxOtcUseCount - useCount));
   },
   'POST /vass/v0/appointment': (req, res) => {
     return res.json({
@@ -153,10 +164,13 @@ const responses = {
 
     const uuid = tokenPayload?.payload?.sub;
     if (!token || !uuid) {
-      return res.status(401).json({
-        errors: [{ code: 'unauthorized', detail: 'Unauthorized' }],
-      });
+      return res.status(401).json(createUnauthorizedError());
     }
+
+    if (uuid === 'not-within-cohort') {
+      return res.status(401).json(createNotWithinCohortError());
+    }
+
     return res.json({
       data: {
         appointmentId: uuid,
@@ -171,9 +185,7 @@ const responses = {
 
     const uuid = tokenPayload?.payload?.sub;
     if (!token || !uuid) {
-      return res.status(401).json({
-        errors: [{ code: 'unauthorized', detail: 'Unauthorized' }],
-      });
+      return res.status(401).json(createUnauthorizedError());
     }
     const { appointmentId } = req.params;
     return res.json({

--- a/src/applications/vass/services/mocks/utils/errors.js
+++ b/src/applications/vass/services/mocks/utils/errors.js
@@ -1,0 +1,117 @@
+const {
+  OTC_ERROR_CODES,
+  AUTH_ERROR_CODES,
+  TOKEN_ERROR_CODES,
+  APPOINTMENT_ERROR_CODES,
+  SERVER_ERROR_CODES,
+  AVAILABILITY_ERROR_CODES,
+} = require('../../../utils/constants');
+
+const createVassApiError = () => {
+  return {
+    errors: [
+      {
+        code: SERVER_ERROR_CODES.VASS_API_ERROR,
+        detail: 'Unable to connect to scheduling service',
+      },
+    ],
+  };
+};
+
+const createUnauthorizedError = () => {
+  return {
+    errors: [{ code: TOKEN_ERROR_CODES.UNAUTHORIZED, detail: 'Unauthorized' }],
+  };
+};
+
+const createOTPInvalidError = (attemptsRemaining = 0) => {
+  return {
+    errors: [
+      {
+        code: OTC_ERROR_CODES.INVALID_OTP,
+        detail: 'Invalid or expired OTP.  Please try again.',
+        attemptsRemaining,
+      },
+    ],
+  };
+};
+
+const createOTPAccountLockedError = (retryAfter = 900) => {
+  return {
+    errors: [
+      {
+        code: OTC_ERROR_CODES.ACCOUNT_LOCKED,
+        detail: 'Too many failed attempts.  Please request a new OTP.',
+        retryAfter,
+      },
+    ],
+  };
+};
+
+const createRateLimitExceededError = (retryAfter = 900) => {
+  return {
+    errors: [
+      {
+        code: AUTH_ERROR_CODES.RATE_LIMIT_EXCEEDED,
+        detail: 'Too many OTP requests.  Please try again later.',
+        retryAfter,
+      },
+    ],
+  };
+};
+
+const createAppointmentSaveFailedError = () => {
+  return {
+    errors: [
+      {
+        code: APPOINTMENT_ERROR_CODES.APPOINTMENT_SAVE_FAILED,
+        detail: 'Failed to save appointment',
+      },
+    ],
+  };
+};
+
+const createServiceError = () => {
+  return {
+    errors: [
+      {
+        code: SERVER_ERROR_CODES.SERVICE_ERROR,
+        detail: 'Service temporarily unavailable',
+      },
+    ],
+  };
+};
+
+const createInvalidCredentialsError = () => {
+  return {
+    errors: [
+      {
+        code: AUTH_ERROR_CODES.INVALID_CREDENTIALS,
+        detail: 'Unable to verify identity. Please check your information.',
+      },
+    ],
+  };
+};
+
+const createNotWithinCohortError = () => {
+  return {
+    errors: [
+      {
+        code: AVAILABILITY_ERROR_CODES.NOT_WITHIN_COHORT,
+        detail: 'Not within cohort',
+      },
+    ],
+  };
+};
+
+module.exports = {
+  createVassApiError,
+  createOTPInvalidError,
+  createOTPAccountLockedError,
+  createRateLimitExceededError,
+  createUnauthorizedError,
+  createAppointmentSaveFailedError,
+  createServiceError,
+  createInvalidCredentialsError,
+  createNotWithinCohortError,
+};

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -1,6 +1,6 @@
-export const VASS_PHONE_NUMBER = '8008270611';
+const VASS_PHONE_NUMBER = '8008270611';
 
-export const URLS = Object.freeze({
+const URLS = Object.freeze({
   VERIFY: '/',
   ENTER_OTC: '/enter-otc',
   DATE_TIME: '/date-time',
@@ -12,7 +12,7 @@ export const URLS = Object.freeze({
   ALREADY_SCHEDULED: '/already-scheduled',
 });
 
-export const FLOW_TYPES = {
+const FLOW_TYPES = {
   SCHEDULE: 'schedule',
   CANCEL: 'cancel',
   ANY: 'any',
@@ -23,20 +23,81 @@ export const FLOW_TYPES = {
  * @readonly
  * @enum {string}
  */
-export const AUTH_LEVELS = {
+const AUTH_LEVELS = {
   /** No authentication required - public route */
   NONE: 'none',
   /** Requires a valid authentication token */
   TOKEN: 'token',
 };
 
-export const VASS_TOKEN_COOKIE_NAME = 'VASS_TOKEN';
+const VASS_TOKEN_COOKIE_NAME = 'VASS_TOKEN';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-export const VASS_COOKIE_OPTIONS = {
+const VASS_COOKIE_OPTIONS = {
   secure: isProduction,
   sameSite: isProduction ? 'strict' : undefined,
   path: '/',
   ...(isProduction ? { domain: 'va.gov' } : {}),
+};
+
+/**
+ * VASS API Error Codes
+ */
+
+// Authentication errors (POST /vass/v0/request-otp, POST /vass/v0/authenticate)
+const AUTH_ERROR_CODES = Object.freeze({
+  RATE_LIMIT_EXCEEDED: 'rate_limit_exceeded',
+  INVALID_CREDENTIALS: 'invalid_credentials',
+  MISSING_PARAMETER: 'missing_parameter',
+});
+
+// OTP/OTC Verification errors (POST /vass/v0/authenticate-otp)
+const OTC_ERROR_CODES = Object.freeze({
+  INVALID_OTP: 'invalid_otp',
+  ACCOUNT_LOCKED: 'account_locked',
+  OTP_EXPIRED: 'otp_expired',
+  MISSING_PARAMETER: 'missing_parameter',
+});
+
+// Token errors (POST /vass/v0/revoke-token)
+const TOKEN_ERROR_CODES = Object.freeze({
+  INVALID_TOKEN: 'invalid_token',
+  UNAUTHORIZED: 'unauthorized',
+});
+
+// Appointment availability errors (GET /vass/v0/appointment-availablity)
+const AVAILABILITY_ERROR_CODES = Object.freeze({
+  APPOINTMENT_ALREADY_BOOKED: 'appointment_already_booked',
+  NOT_WITHIN_COHORT: 'not_within_cohort',
+  NO_SLOTS_AVAILABLE: 'no_slots_available',
+});
+
+// Appointment errors (POST/GET /vass/v0/appointment)
+const APPOINTMENT_ERROR_CODES = Object.freeze({
+  APPOINTMENT_SAVE_FAILED: 'appointment_save_failed',
+  APPOINTMENT_NOT_FOUND: 'appointment_not_found',
+  CANCELLATION_FAILED: 'cancellation_failed',
+  MISSING_PARAMETER: 'missing_parameter',
+});
+
+// External service / server errors
+const SERVER_ERROR_CODES = Object.freeze({
+  VASS_API_ERROR: 'vass_api_error',
+  SERVICE_ERROR: 'service_error',
+});
+
+module.exports = {
+  VASS_PHONE_NUMBER,
+  URLS,
+  FLOW_TYPES,
+  AUTH_LEVELS,
+  VASS_TOKEN_COOKIE_NAME,
+  VASS_COOKIE_OPTIONS,
+  AUTH_ERROR_CODES,
+  OTC_ERROR_CODES,
+  TOKEN_ERROR_CODES,
+  AVAILABILITY_ERROR_CODES,
+  APPOINTMENT_ERROR_CODES,
+  SERVER_ERROR_CODES,
 };

--- a/src/applications/vass/utils/errors.js
+++ b/src/applications/vass/utils/errors.js
@@ -1,0 +1,68 @@
+import {
+  AUTH_ERROR_CODES,
+  OTC_ERROR_CODES,
+  SERVER_ERROR_CODES,
+  AVAILABILITY_ERROR_CODES,
+  APPOINTMENT_ERROR_CODES,
+} from './constants';
+
+/**
+ * @typedef {Object} Error
+ * @property {string} code
+ * @property {string} detail
+ */
+
+/**
+ * @param {Error Object} error
+ * @returns {boolean}
+ */
+const isInvalidCredentialsError = error => {
+  return error?.code === AUTH_ERROR_CODES.INVALID_CREDENTIALS;
+};
+
+const isRateLimitExceededError = error => {
+  return error?.code === AUTH_ERROR_CODES.RATE_LIMIT_EXCEEDED;
+};
+
+const isMissingParameterError = error => {
+  return (
+    error?.code === AUTH_ERROR_CODES.MISSING_PARAMETER ||
+    error?.code === OTC_ERROR_CODES.MISSING_PARAMETER ||
+    error?.code === AVAILABILITY_ERROR_CODES.MISSING_PARAMETER ||
+    error?.code === APPOINTMENT_ERROR_CODES.MISSING_PARAMETER
+  );
+};
+
+const isAccountLockedError = error => {
+  return error?.code === OTC_ERROR_CODES.ACCOUNT_LOCKED;
+};
+
+const isServerError = error => {
+  return (
+    Object.values(SERVER_ERROR_CODES).includes(error?.code) ||
+    error?.status >= 500
+  );
+};
+
+const isNotWhithinCohortError = error => {
+  return error?.code === AVAILABILITY_ERROR_CODES.NOT_WITHIN_COHORT;
+};
+
+const isAppointmentFailedError = error => {
+  return error?.code === APPOINTMENT_ERROR_CODES.APPOINTMENT_SAVE_FAILED;
+};
+
+const isAppointmentNotFoundError = error => {
+  return error?.code === APPOINTMENT_ERROR_CODES.APPOINTMENT_NOT_FOUND;
+};
+
+export {
+  isInvalidCredentialsError,
+  isRateLimitExceededError,
+  isMissingParameterError,
+  isAccountLockedError,
+  isServerError,
+  isNotWhithinCohortError,
+  isAppointmentFailedError,
+  isAppointmentNotFoundError,
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Adds a new reusable `ErrorAlert` component to display user-friendly error messages when API
  errors occur during the VASS (VA Solid Start) scheduling flow
  - Introduces centralized error handling utilities (`utils/errors.js`) with helper functions to
  detect specific error types (server errors, account locked, not within cohort, appointment not
  found, etc.)
  - Updates multiple pages (AlreadyScheduled, Confirmation, DateTimeSelection, EnterOTC, Review,
  Verify) to gracefully handle API errors by displaying the ErrorAlert component
  - Adds error code constants (`AUTH_ERROR_CODES`, `OTC_ERROR_CODES`, `SERVER_ERROR_CODES`,
  `AVAILABILITY_ERROR_CODES`, `APPOINTMENT_ERROR_CODES`) for consistent error identification
  - Adds mock error scenarios for local testing of error states
  - Team: VASS / VA Solid Start team owns maintenance of this component
  - No flipper/feature toggle used

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#130253

  ## Testing done

  - **Old behavior**: When API errors occurred (500 errors, service unavailable, etc.), the
  application would either show generic error handling
  - **New behavior**: When API errors occur, users see a clear error alert with messaging: "We
  can't schedule your appointment right now" with instructions to refresh or call the VA support
  number
  - **Steps to verify**:
    1. Run local development server: `yarn watch --env entry=vass`
    2. Navigate to `http://localhost:3001/service-member/benefits/solid-start/schedule?uuid=authent
  icate-otc-vass-api-error` to test OTC verification API error
    3. Navigate to `http://localhost:3001/service-member/benefits/solid-start/schedule?uuid=authent
  icate-otc-service-error` to test service error
    4. Navigate to
  `http://localhost:3001/service-member/benefits/solid-start/schedule?uuid=not-within-cohort` to
  test not-within-cohort error scenario
    5. Verify the ErrorAlert component displays correctly with proper messaging and phone number
  - **Tests completed**:
    - Added unit tests for `ErrorAlert` component (`ErrorAlert.unit.spec.jsx`)
    - Added unit tests for `Error` page (`Error.unit.spec.jsx`)
    - Updated unit tests for `EnterOTC`, `Review`, and `Verify` pages to cover error scenarios
    - All 22 affected files have corresponding test coverage

  **Known gaps**: End-to-end (Cypress) tests for error scenarios are not included in this PR.
  Manual testing with actual API error responses in staging would further validate the error
  handling behavior.

  ## Screenshots

  |         | Before | After |
  | ------- | ------ | ----- |
  | Mobile  | N/A - New error state |<img width="1170" height="2532" alt="Screen Shot 2026-01-29 at 12 03 41" src="https://github.com/user-attachments/assets/9d5bb995-680c-4d90-b9d5-f47d7fcf2f86" />|
  | Desktop | N/A - New error state |<img width="1620" height="2160" alt="Screen Shot 2026-01-29 at 12 03 31" src="https://github.com/user-attachments/assets/d64dd5af-2c16-4a71-91dd-42cf3afaa1a7" />|

  ## What areas of the site does it impact?

  This change impacts the VASS (VA Solid Start) application located at
  `/service-member/benefits/solid-start/schedule`. Specifically:
  - OTC verification page (`EnterOTC.jsx`)
  - Date/Time selection page (`DateTimeSelection.jsx`)
  - Review page (`Review.jsx`)
  - Confirmation page (`Confirmation.jsx`)
  - Already Scheduled page (`AlreadyScheduled.jsx`)
  - Verify page (`Verify.jsx`)
  - Error page (`Error.jsx`)
  - Layout Wrapper component (`Wrapper.jsx`)

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
  hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [x] Documentation has been updated (README.md updated with error testing scenarios)
  - [ ] Screenshot of the developed feature is added
  - [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-c
  ycle/prepare-for-an-accessibility-staging-review) has been performed

  ### Error Handling

  - [ ] Browser console contains no warnings or errors.
  - [ ] Events are being sent to the appropriate logging solution
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

  ### Authentication

  - [ ] Did you login to a local build and verify all authenticated routes work as expected with a
  test user

  ## Requested Feedback
  - Consider if additional error scenarios need specific handling beyond the generic ErrorAlert
  - The `Wrapper.jsx` has a TODO comment to combine `errorAlert` and `verificationError` props