### PR TITLE
add units to text input

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
@@ -106,6 +106,7 @@ export const employmentEarningsHoursUiSchema = {
     }),
     timeLost: textUI({
       title: 'Time lost to disability',
+      suffix: 'hours',
       errorMessages: {
         required: 'Time lost is required',
         maxLength: 'Time lost must be less than 100 characters',
@@ -113,6 +114,7 @@ export const employmentEarningsHoursUiSchema = {
     }),
     dailyHours: numberUI({
       title: 'Daily hours worked',
+      suffix: 'hours',
       min: 0,
       max: 24,
       errorMessages: {
@@ -123,6 +125,7 @@ export const employmentEarningsHoursUiSchema = {
     }),
     weeklyHours: numberUI({
       title: 'Weekly hours worked',
+      suffix: 'hours',
       min: 0,
       max: 168,
       errorMessages: {

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
@@ -106,7 +106,7 @@ export const employmentEarningsHoursUiSchema = {
     }),
     timeLost: textUI({
       title: 'Time lost to disability',
-      suffix: 'hours',
+      inputSuffix: 'hours',
       errorMessages: {
         required: 'Time lost is required',
         maxLength: 'Time lost must be less than 100 characters',
@@ -114,7 +114,7 @@ export const employmentEarningsHoursUiSchema = {
     }),
     dailyHours: numberUI({
       title: 'Daily hours worked',
-      suffix: 'hours',
+      inputSuffix: 'hours',
       min: 0,
       max: 24,
       errorMessages: {
@@ -125,7 +125,7 @@ export const employmentEarningsHoursUiSchema = {
     }),
     weeklyHours: numberUI({
       title: 'Weekly hours worked',
-      suffix: 'hours',
+      inputSuffix: 'hours',
       min: 0,
       max: 168,
       errorMessages: {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added `inputSuffix: 'hours'` property to the Time Lost, Daily Hours, and Weekly Hours fields to improve user experience and clarity
- The suffix appears inside the text input box on the right side, making it clear to users that the input values should be in hours
- This enhancement improves form usability by providing inline context for the expected unit of measurement
- This work is for the Benefits Intake Optimization, Aquia team 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124703

## Testing done

- **Old Behavior**: The Time Lost, Daily Hours, and Weekly Hours input fields had no visible suffix indicator
- **Steps to verify**:
  1. Navigate to the Employment Earnings/Hours page in the 21-4192 form
  2. Observe the Time Lost, Daily Hours, and Weekly Hours input fields
  3. Verify that "hours" appears as a suffix inside each input box on the right side
  4. Enter values and verify the suffix remains visible and properly positioned
  5. Test form validation to ensure it still works correctly
- **Testing completed**: 
  - Manual testing in local development environment
  - Verified the suffix appears correctly in all three fields
  - Verified form validation still works as expected
  - Tested across different input states (empty, valid, invalid)
  - Confirmed the suffix provides clear visual indication of the expected unit

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    <img width="516" height="305" alt="image" src="https://github.com/user-attachments/assets/c705ea91-cf10-4b4b-bb67-8d2c466543bb" /> |    <img width="564" height="324" alt="image" src="https://github.com/user-attachments/assets/fe446e81-2144-43c6-8358-3a101f3b7de3" />  |

## What areas of the site does it impact?

This change only impacts the Employment Earnings/Hours page within the 21-4192 Employment Information form application. No other parts of the site are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This enhancement adds visual clarity to the hours input fields by displaying "hours" as an inline suffix within each input box. Please verify the suffix displays correctly in the UI and improves the user experience without impacting form validation or functionality.