### PR TITLE
534ez update value to conditional skip marriage end info

### DIFF
--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -295,7 +295,7 @@ const formConfig = {
           title: 'Marriage to Veteran Details',
           depends: formData =>
             formData.claimantRelationship === 'SURVIVING_SPOUSE' &&
-            !formData.marriedAtDeath,
+            !formData.marriedToVeteranAtTimeOfDeath,
           uiSchema: marriageToVeteranEnd.uiSchema,
           schema: marriageToVeteranEnd.schema,
         },

--- a/src/applications/survivors-benefits/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/survivors-benefits/tests/e2e/fixtures/data/maximal-test.json
@@ -75,7 +75,7 @@
       "from": "2000-01-01",
       "to": "2005-01-01"
     },
-    "marriedAtDeath": true,
+    "marriedToVeteranAtTimeOfDeath": true,
     "marriageToVeteranStartDate": "2010-01-01",
     "marriageToVeteranStartOutsideUS": false,
     "marriageToVeteranStartLocation": {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Change `marriedAtDeath` to `marriedToVeteranAtTimeOfDeath` on form.js

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131594#event-22388214758

## Testing done

- manual testing to make sure flow matches diagram in ticket

## Screenshots

N/A

## What areas of the site does it impact?

Marriage flow of 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A