### PR TITLE
Updates display logic for call to schedule on providers page

### DIFF
--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
@@ -25,7 +25,8 @@ export default function ScheduleWithDifferentProvider({
   }
 
   // if request eligibility endpoint returns an error, ELIGIBILITY_REASONS.error
-  if (requestEligibilityError) {
+  // AND one or more providers are returned
+  if (requestEligibilityError && hasProviders) {
     return (
       <>
         <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0 vads-u-margin-top--2">

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
@@ -214,4 +214,41 @@ describe('ScheduleWithDifferentProvider', () => {
 
     dispatchSpy.restore();
   });
+
+  it('should not display call option with facility phone when requestEligibilityError is true and hasProviders is false', () => {
+    const store = createTestStore(defaultState);
+    const selectedFacility = {
+      id: '692',
+      name: 'White City VA Medical Center',
+      telecom: [
+        {
+          system: 'phone',
+          value: '541-987-6543',
+        },
+      ],
+    };
+
+    const screen = renderWithStoreAndRouter(
+      <ScheduleWithDifferentProvider
+        isEligibleForRequest
+        overRequestLimit={false}
+        selectedFacility={selectedFacility}
+        hasProviders={false}
+        requestEligibilityError
+      />,
+      { store },
+    );
+
+    // Should not display the title for scheduling with a different provider
+    expect(
+      screen.queryByText(/If you want to schedule with a different provider/i),
+    ).to.not.exist;
+
+    // Should not display instruction to call the facility
+    expect(
+      screen.queryByText(
+        /Call the facility and ask to schedule with that provider:/i,
+      ),
+    ).to.not.exist;
+  });
 });

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.jsx
@@ -157,7 +157,6 @@ describe('VAOS Page: ProviderSelectPage', () => {
     });
   });
 
-  /* Commenting out for now to unblock OH request test in staging */
   describe('when user is over request limit', () => {
     it('should display correct call a provider text', async () => {
       const store = createTestStore({


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This updates the logic on the providers page for the following scenario:

- **IF** The request eligibility endpoint returns an error 
- **AND** no providers are returned
- **THEN** _do not_ display the phone number and call to schedule messaging

- **IF** The request eligibility endpoint returns an error 
- **AND** providers are returned
- **THEN** display the phone number and call to schedule messaging


## Related issue(s)
This is related to a comment left on the issue [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130366#issuecomment-3806867692)

## Testing done
- Manual testing
- Added unit test coverage

## Screenshots

**Before this fix, if there were no providers returned the phone number messaging was duplicated**

<img width="1108" height="892" alt="CleanShot 2026-01-29 at 16 14 12@2x" src="https://github.com/user-attachments/assets/e4ef31f2-becd-499d-b8f1-8e353a1f8f53" />

**After this fix, the phone number is not displayed when no providers are returned**
<img width="734" height="1270" alt="CleanShot 2026-01-29 at 16 15 24@2x" src="https://github.com/user-attachments/assets/a2bd3a82-3ebf-4002-bafa-edc6a1a0aeb8" />

**...but still is displayed when some providers are returned**
<img width="726" height="1872" alt="CleanShot 2026-01-29 at 16 17 24@2x" src="https://github.com/user-attachments/assets/c90e2ed9-7ad4-4f62-bc5c-17479cee401f" />


## What areas of the site does it impact?
OH new appointment flow

## Acceptance criteria

To test this locally, ensure that the flag is on in the mocks. Then do the following in the browser developer tools:

- Ensure that the eligibility call for requests is blocked
- Either change the `.json` mock or the response within the developer tools for the patient relationship endpoint to:


**No providers returned, the text should not show up**
```json
{
    "data": [
    
    ],
    "meta": {
        "failures": []
    }
}
```

**Providers returned, the text should show up**
```json
{
  "data": [
    {
      "type": "relationship",
      "attributes": {
        "provider": {
          "cernerId": "Practitioner/123456",
          "name": "Doe, John D, MD"
        },
        "location": {
          "vhaFacilityId": "534",
          "name": "Zanesville Primary Care"
        },
        "serviceType": {
          "coding": [
            {
              "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
              "code": "foodAndNutrition",
              "display": "Food and Nutrition"
            }
          ],
          "text": "Food and Nutrition"
        },
        "lastSeen": "2024-11-26T00:32:34.216Z",
        "hasAvailability": false
      }
    },
    {
      "type": "relationship",
      "attributes": {
        "provider": {
          "cernerId": "Practitioner/1111",
          "name": "Doe, Mary D, MD"
        },
        "location": {
          "vhaFacilityId": "534",
          "name": "Zanesville Primary Care"
        },
        "serviceType": {
          "coding": [
            {
              "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
              "code": "foodAndNutrition",
              "display": "Food and Nutrition"
            }
          ],
          "text": "Food and Nutrition"
        },
        "lastSeen": "2024-10-15T00:32:34.216Z",
        "hasAvailability": true
      }
    }
  ],
  "meta": {
    "failures": []
  }
}

```




### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


