### PR TITLE
fix: resolve get-changed-apps unit test failures on Node 22

### DIFF
--- a/script/github-actions/get-changed-apps.unit.spec.jsx
+++ b/script/github-actions/get-changed-apps.unit.spec.jsx
@@ -1,10 +1,12 @@
+import path from 'path';
 import { expect } from 'chai';
-import mockFs from 'mock-fs';
 
 import {
   getChangedAppsString,
   isContinuousDeploymentEnabled,
 } from './get-changed-apps';
+
+const root = process.cwd();
 
 const createManifest = name => {
   return JSON.stringify({
@@ -19,45 +21,110 @@ const createChangedAppsConfig = (apps = []) => {
   return { apps };
 };
 
-describe('getChangedAppsString', () => {
-  before(() => {
-    mockFs({
-      'src/applications/app1': {
-        'manifest.json': createManifest('app1'),
-        'some-file.js': '',
-        'other-file.js': '',
-      },
-      'src/applications/app2': {
-        'manifest.json': createManifest('app2'),
-        'some-file.js': '',
-      },
-      'src/applications/app3': {
-        'manifest.json': createManifest('app3'),
-        'some-file.js': '',
-      },
-      'src/applications/app4': {
-        'some-file.js': '',
-      },
-      'src/applications/app5': {
-        'manifest.json': JSON.stringify({
-          appName: 'APP5',
-          entryFile: './app5-entry.jsx',
-          entryName: 'app5',
-        }),
-        'some-file.js': '',
-      },
-      'src/applications/groupedApps': {
-        'grouped-app-1': {
-          'manifest.json': createManifest('groupedApp1'),
-          'some-file.js': '',
-        },
-        'grouped-app-2': {
-          'manifest.json': createManifest('groupedApp2'),
-          'some-file.js': '',
-        },
-        'grouped-apps-utils.js': '',
-      },
+/**
+ * Creates a mock file system structure for testing.
+ * Returns a mock fs module that can be injected into the functions.
+ */
+const createMockFs = fileStructure => {
+  // Normalize all paths to use the current working directory
+  const normalizedStructure = {};
+  Object.entries(fileStructure).forEach(([key, value]) => {
+    const normalizedKey = key.startsWith('/') ? key : path.join(root, key);
+    normalizedStructure[normalizedKey] = value;
+  });
+
+  // Helper to check if a path exists in the structure
+  const pathExists = targetPath => {
+    // Check exact match
+    if (normalizedStructure[targetPath] !== undefined) return true;
+
+    // Check if it's a parent directory of any file
+    const normalizedTarget = targetPath.endsWith('/')
+      ? targetPath
+      : `${targetPath}/`;
+    return Object.keys(normalizedStructure).some(
+      p => p.startsWith(normalizedTarget) || p === targetPath,
+    );
+  };
+
+  // Helper to get directory entries
+  const getDirectoryEntries = dirPath => {
+    const normalizedDir = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
+    const entries = new Set();
+
+    Object.keys(normalizedStructure).forEach(p => {
+      if (p.startsWith(normalizedDir)) {
+        const relativePath = p.slice(normalizedDir.length);
+        const firstPart = relativePath.split('/')[0];
+        if (firstPart) {
+          entries.add(firstPart);
+        }
+      }
     });
+
+    return Array.from(entries);
+  };
+
+  // Helper to check if path is a directory
+  const isDirectory = targetPath => {
+    const normalizedTarget = targetPath.endsWith('/')
+      ? targetPath
+      : `${targetPath}/`;
+    return Object.keys(normalizedStructure).some(p =>
+      p.startsWith(normalizedTarget),
+    );
+  };
+
+  return {
+    existsSync: targetPath => pathExists(targetPath),
+    readFileSync: filePath => {
+      if (normalizedStructure[filePath] !== undefined) {
+        return normalizedStructure[filePath];
+      }
+      throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    },
+    readdirSync: (dirPath, options) => {
+      const entries = getDirectoryEntries(dirPath);
+      if (options && options.withFileTypes) {
+        return entries.map(name => {
+          const fullPath = path.join(dirPath, name);
+          return {
+            name,
+            isDirectory: () => isDirectory(fullPath),
+            isFile: () => !isDirectory(fullPath),
+          };
+        });
+      }
+      return entries;
+    },
+  };
+};
+
+describe('getChangedAppsString', () => {
+  const mockFs = createMockFs({
+    'src/applications/app1/manifest.json': createManifest('app1'),
+    'src/applications/app1/some-file.js': '',
+    'src/applications/app1/other-file.js': '',
+    'src/applications/app2/manifest.json': createManifest('app2'),
+    'src/applications/app2/some-file.js': '',
+    'src/applications/app3/manifest.json': createManifest('app3'),
+    'src/applications/app3/some-file.js': '',
+    'src/applications/app4/some-file.js': '',
+    'src/applications/app5/manifest.json': JSON.stringify({
+      appName: 'APP5',
+      entryFile: './app5-entry.jsx',
+      entryName: 'app5',
+    }),
+    'src/applications/app5/some-file.js': '',
+    'src/applications/groupedApps/grouped-app-1/manifest.json': createManifest(
+      'groupedApp1',
+    ),
+    'src/applications/groupedApps/grouped-app-1/some-file.js': '',
+    'src/applications/groupedApps/grouped-app-2/manifest.json': createManifest(
+      'groupedApp2',
+    ),
+    'src/applications/groupedApps/grouped-app-2/some-file.js': '',
+    'src/applications/groupedApps/grouped-apps-utils.js': '',
   });
 
   context('when the entry output type is specified', () => {
@@ -68,7 +135,13 @@ describe('getChangedAppsString', () => {
         'src/applications/app2/some-file.js',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config, 'folder');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'folder',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.be.empty;
     });
 
@@ -82,7 +155,13 @@ describe('getChangedAppsString', () => {
         'src/applications/app2',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config);
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'entry',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('app1 app2');
     });
 
@@ -93,7 +172,13 @@ describe('getChangedAppsString', () => {
         'src/applications/app1/other-file.js',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config);
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'entry',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('app1');
     });
 
@@ -103,7 +188,13 @@ describe('getChangedAppsString', () => {
         'src/applications/groupedApps/grouped-app-1/some-file.js',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config);
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'entry',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('groupedApp1 groupedApp2');
     });
   });
@@ -116,7 +207,13 @@ describe('getChangedAppsString', () => {
       ]);
       const changedFiles = ['src/applications/app1', 'src/applications/app2'];
 
-      const appString = getChangedAppsString(changedFiles, config, 'folder');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'folder',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('src/applications/app1 src/applications/app2');
     });
 
@@ -126,7 +223,13 @@ describe('getChangedAppsString', () => {
         'src/applications/groupedApps/grouped-app-1/some-file.js',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config, 'folder');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'folder',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('src/applications/groupedApps');
     });
   });
@@ -143,6 +246,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'slack-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.equal('@appTeam1 @appTeam2');
     });
@@ -155,6 +260,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'slack-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.be.empty;
     });
@@ -170,6 +277,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'slack-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.equal('@appTeam1');
     });
@@ -186,6 +295,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'slack-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.equal('@appTeamGrouped');
     });
@@ -199,7 +310,13 @@ describe('getChangedAppsString', () => {
       ]);
       const changedFiles = ['src/applications/app1', 'src/applications/app2'];
 
-      const appString = getChangedAppsString(changedFiles, config, 'url');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'url',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('/app1 /app2');
     });
 
@@ -207,7 +324,13 @@ describe('getChangedAppsString', () => {
       const config = createChangedAppsConfig([{ rootFolder: 'app5' }]);
       const changedFiles = ['src/applications/app5'];
 
-      const appString = getChangedAppsString(changedFiles, config, 'url');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'url',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.be.empty;
     });
 
@@ -218,7 +341,13 @@ describe('getChangedAppsString', () => {
       ]);
       const changedFiles = ['src/applications/app1', 'src/applications/app5'];
 
-      const appString = getChangedAppsString(changedFiles, config, 'url');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'url',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('/app1');
     });
 
@@ -228,7 +357,13 @@ describe('getChangedAppsString', () => {
         'src/applications/groupedApps/grouped-app-1/some-file.js',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config, 'url');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'url',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.equal('/groupedApp1 /groupedApp2');
     });
   });
@@ -242,6 +377,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'concurrency-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.equal('app1');
     });
@@ -257,6 +394,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'concurrency-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.equal('app1 app2');
     });
@@ -271,6 +410,8 @@ describe('getChangedAppsString', () => {
         changedFiles,
         config,
         'concurrency-group',
+        ' ',
+        mockFs,
       );
       expect(appString).to.equal('groupedApps');
     });
@@ -292,6 +433,7 @@ describe('getChangedAppsString', () => {
         config,
         'concurrency-group',
         '-',
+        mockFs,
       );
       expect(appString).to.equal('app1-app2-app3');
     });
@@ -314,6 +456,7 @@ describe('getChangedAppsString', () => {
         config,
         'entry',
         delimiter,
+        mockFs,
       );
       expect(appString).to.equal(`app1${delimiter}app2`);
     });
@@ -328,7 +471,7 @@ describe('getChangedAppsString', () => {
       const changedFiles = ['src/applications/app1', 'src/applications/app2'];
 
       expect(() => {
-        getChangedAppsString(changedFiles, config, 'unknown');
+        getChangedAppsString(changedFiles, config, 'unknown', ' ', mockFs);
       }).to.throw('Invalid output type specified.');
     });
   });
@@ -341,7 +484,13 @@ describe('getChangedAppsString', () => {
       ]);
       const changedFiles = ['src/applications/app3/some-file.js'];
 
-      const appString = getChangedAppsString(changedFiles, config, 'folder');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'folder',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.be.empty;
     });
   });
@@ -354,7 +503,13 @@ describe('getChangedAppsString', () => {
       ]);
       const changedFiles = ['src/applications/app4/some-file.js'];
 
-      const appString = getChangedAppsString(changedFiles, config, 'folder');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'folder',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.be.empty;
     });
   });
@@ -371,28 +526,26 @@ describe('getChangedAppsString', () => {
         'src/platform',
       ];
 
-      const appString = getChangedAppsString(changedFiles, config, 'folder');
+      const appString = getChangedAppsString(
+        changedFiles,
+        config,
+        'folder',
+        ' ',
+        mockFs,
+      );
       expect(appString).to.be.empty;
     });
   });
-
-  after(() => mockFs.restore());
 });
 
 describe('isContinuousDeploymentEnabled', () => {
-  before(() => {
-    mockFs({
-      'src/applications/app1': {
-        'manifest.json': createManifest('app1'),
-        'some-file.js': '',
-        'other-file.js': '',
-      },
-      'src/applications/app2': {
-        'manifest.json': createManifest('app2'),
-        'some-file.js': '',
-        'other-file.js': '',
-      },
-    });
+  const mockFs = createMockFs({
+    'src/applications/app1/manifest.json': createManifest('app1'),
+    'src/applications/app1/some-file.js': '',
+    'src/applications/app1/other-file.js': '',
+    'src/applications/app2/manifest.json': createManifest('app2'),
+    'src/applications/app2/some-file.js': '',
+    'src/applications/app2/other-file.js': '',
   });
 
   it('should return true when an app does not specify continuous deployment option', () => {
@@ -402,6 +555,7 @@ describe('isContinuousDeploymentEnabled', () => {
     const continuousDeployment = isContinuousDeploymentEnabled(
       changedFiles,
       config,
+      mockFs,
     );
     expect(continuousDeployment).to.be.true;
   });
@@ -415,6 +569,7 @@ describe('isContinuousDeploymentEnabled', () => {
     const continuousDeployment = isContinuousDeploymentEnabled(
       changedFiles,
       config,
+      mockFs,
     );
     expect(continuousDeployment).to.be.false;
   });
@@ -432,6 +587,7 @@ describe('isContinuousDeploymentEnabled', () => {
     const continuousDeployment = isContinuousDeploymentEnabled(
       changedFiles,
       config,
+      mockFs,
     );
     expect(continuousDeployment).to.be.false;
   });
@@ -449,6 +605,7 @@ describe('isContinuousDeploymentEnabled', () => {
     const continuousDeployment = isContinuousDeploymentEnabled(
       changedFiles,
       config,
+      mockFs,
     );
     expect(continuousDeployment).to.be.true;
   });
@@ -460,7 +617,7 @@ describe('isContinuousDeploymentEnabled', () => {
     const changedFiles = ['src/applications/app1/some-file.js'];
 
     expect(() => {
-      isContinuousDeploymentEnabled(changedFiles, config);
+      isContinuousDeploymentEnabled(changedFiles, config, mockFs);
     }).to.throw(Error);
   });
 
@@ -473,9 +630,8 @@ describe('isContinuousDeploymentEnabled', () => {
     const continuousDeployment = isContinuousDeploymentEnabled(
       changedFiles,
       config,
+      mockFs,
     );
     expect(continuousDeployment).to.be.false;
   });
-
-  after(() => mockFs.restore());
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Resolves 20 failing unit tests in `script/github-actions/get-changed-apps.unit.spec.jsx` when running on Node 22
- The `mock-fs` library has compatibility issues with Node 22 where `fs.existsSync` returns `false` even for mocked paths
- Solution: Replace `mock-fs` with dependency injection pattern - added optional `fsModule` parameter to functions that interact with the filesystem, allowing tests to inject a custom mock implementation
- Platform team owns this CI script

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#122537

## Testing done

- Before: 20 tests failing with `AssertionError: expected '' to equal 'app1 app2'` type errors because `mock-fs` wasn't properly mocking the filesystem on Node 22
- After: All 29 tests passing
- Ran `yarn test:unit --path "script/github-actions/get-changed-apps.unit.spec.jsx"` locally to verify fix
- The fix uses dependency injection to pass a mock fs object to the functions under test, avoiding the `mock-fs` Node 22 compatibility issues

## Screenshots

N/A - This is a CI script with no UI changes.

## What areas of the site does it impact?

This change only affects the `get-changed-apps` CI script used for determining which apps have changed in a PR. No user-facing functionality is impacted.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- N/A - Documentation has been updated (no documentation changes needed for this fix)
- N/A - Screenshot of the developed feature is added (CI script, no UI)
- N/A - Accessibility testing has been performed (CI script, no UI)

### Error Handling

- N/A - Browser console contains no warnings or errors (CI script, not browser-based)
- N/A - Events are being sent to the appropriate logging solution (existing script behavior unchanged)
- N/A - Feature/bug has a monitor built into Datadog or Grafana (existing CI script)

### Authentication

- N/A - Did you login to a local build and verify all authenticated routes work as expected with a test user (CI script, no authentication involved)

## Requested Feedback

None - straightforward test fix for Node 22 compatibility.