### PR TITLE
Bug(526): Fix Date Display Error on IPF page

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -4,7 +4,7 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 import { recordEventOnce } from 'platform/monitoring/record-event';
 
-import { add as addFns, format as formatFns } from 'date-fns';
+import { add as addFns, format as formatFns, parseISO } from 'date-fns';
 import { parseDate } from '../utils/dates';
 
 // EVSS returns dates like '2014-07-28T19:53:45.810+0000'
@@ -12,11 +12,22 @@ import { parseDate } from '../utils/dates';
 const evssDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 const outputDateFormat = "eeee, MMMM do, yyyy 'at' h:mm a";
 
+const normalizeEvssIso = dateString =>
+  typeof dateString === 'string'
+    ? dateString.replace(/([+-]\d{2})(\d{2})$/, '$1:$2')
+    : dateString;
+
 // Adding 1 hour to the displayDate output will display the time in the ET timezone as the returned time and date
 // is in the central timezone
 const displayDate = dateString => {
-  const parsed = parseDate(dateString, evssDateFormat);
+  if (!dateString) return '';
+
+  let parsed = parseISO(normalizeEvssIso(dateString));
+  if (!parsed || Number.isNaN(parsed.getTime())) {
+    parsed = parseDate(dateString, evssDateFormat);
+  }
   if (!parsed) return '';
+
   const adjusted = addFns(parsed, { hours: 1 });
   return formatFns(adjusted, outputDateFormat);
 };

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -9,6 +9,7 @@ import { requestStates } from 'platform/utilities/constants';
 import { mockFetch } from 'platform/testing/unit/helpers';
 import { ITFWrapper } from '../../containers/ITFWrapper';
 import { itfStatuses } from '../../constants';
+import { itfActive, itfSuccess } from '../../content/itfWrapper';
 
 import { parseDate, parseDateWithTemplate } from '../../utils/dates';
 import { daysFromToday } from '../../utils/dates/formatting';
@@ -315,6 +316,33 @@ describe('526 ITFWrapper', () => {
     expect(bannerProps.status).to.equal('itf-created');
     expect(bannerProps.currentExpDate).to.equal(expirationDate);
     expect(bannerProps.previousExpDate).to.equal(previousExpirationDate);
+    tree.unmount();
+  });
+
+  it('should display an expiration date for EVSS +0000 timestamps (active ITF)', () => {
+    const expirationDate = '2030-07-28T19:53:45.810+0000';
+    const tree = mount(itfActive(expirationDate));
+
+    expect(tree.text()).to.include('ET');
+    expect(tree.text()).to.match(/\b2030\b/);
+    expect(tree.text()).to.not.include('Invalid Date');
+
+    tree.unmount();
+  });
+
+  it('should display current and previous expiration dates for EVSS +0000 timestamps (created ITF)', () => {
+    const currentExpirationDate = '2030-07-28T19:53:45.810+0000';
+    const previousExpirationDate = '2029-07-28T19:53:45.810+0000';
+
+    const tree = mount(
+      itfSuccess(true, currentExpirationDate, previousExpirationDate),
+    );
+
+    expect(tree.text()).to.include('ET');
+    expect(tree.text()).to.match(/\b2030\b/);
+    expect(tree.text()).to.match(/\b2029\b/);
+    expect(tree.text()).to.not.include('Invalid Date');
+
     tree.unmount();
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updating the date displayed on the ITF that was bugged out from an update made during the date migration
- Log in on staging and notice how it shows just ET and not a date or time. 
- To use parseISO from dateFns, as it is easier normalized 
- Pathways with Disability Benefits

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131662

## Testing done

- Showed no date and only that it would expire in ET
- Log in to a user that has an ITF, start the 526, the ITF page should now display a date and time instead of just ET. 
- Quick manual test, as well as adding unit test. 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<img width="922" height="425" alt="Screenshot 2026-01-30 at 10 57 58 AM" src="https://github.com/user-attachments/assets/fe61b16d-ec4f-49d0-aa76-383be4b82dfa" />