### PR TITLE
fix: skip Node 22 compatibility checks on main branch CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1054,6 +1054,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [tests-prep]
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -1132,6 +1133,7 @@ jobs:
     timeout-minutes: 120
     needs: [build, tests-prep, fetch-ecr-credentials]
     if: |
+      github.ref != 'refs/heads/main' &&
       needs.build.result == 'success' &&
       needs.tests-prep.result == 'success' &&
       needs.tests-prep.outputs.e2e_count != '0'


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The Node 22 compatibility check jobs (`node-22-unit-test-compatibility-check` and `node-22-cypress-compatibility-check`) were running on main branch CI runs, which is unnecessary
- These checks are designed to verify feature branch code is compatible with Node 22 before merging to main
- Added `github.ref != 'refs/heads/main'` condition to both jobs to skip them on main branch runs
- This is consistent with other feature-branch-only jobs like `qa-merge-status` and stress test jobs

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#122537

## Testing done

- Verified the condition syntax matches existing patterns in the workflow (e.g., line 526, 1301, 1947)
- The jobs will now only run on feature branches, not on main branch CI

## Screenshots

N/A - CI workflow change, no UI impact.

## What areas of the site does it impact?

CI pipeline only. No user-facing functionality affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- N/A - Documentation has been updated (CI workflow change, no docs needed)
- N/A - Screenshot of the developed feature is added (CI workflow, no UI)
- N/A - Accessibility testing has been performed (CI workflow, no UI)

### Error Handling

- N/A - Browser console contains no warnings or errors (CI workflow)
- N/A - Events are being sent to the appropriate logging solution (CI workflow)
- N/A - Feature/bug has a monitor built into Datadog or Grafana (CI workflow)

### Authentication

- N/A - Did you login to a local build and verify all authenticated routes work as expected with a test user (CI workflow)

## Requested Feedback

None - straightforward conditional addition matching existing patterns.