### PR TITLE
534 Blocker Updates - Rename and update dependents alert components

### DIFF
--- a/src/applications/survivors-benefits/components/FormAlerts/index.jsx
+++ b/src/applications/survivors-benefits/components/FormAlerts/index.jsx
@@ -189,7 +189,7 @@ export const handleSpouseMaxMarriagesAlert = () => (
   </div>
 );
 
-export const VaForm214138Alert = () => (
+export const AdditionalDependentsAlert = () => (
   <va-alert-expandable
     status="warning"
     trigger="You’ll need to submit a VA Form 21-4138"
@@ -197,12 +197,12 @@ export const VaForm214138Alert = () => (
   >
     <p>
       You’ll need to submit a Statement in Support of Claim (VA Form 21-4138)
-      with the name of the person the child is currently living with and the
-      full address of where the child resides.
+      with the name of the person each child is currently living with and the
+      full address of where each child resides.
     </p>
     <p>
       We’ll ask you to upload these documents at the end of this application. Or
-      you can send them to us by mail.
+      you can send it to us by mail.
     </p>
     <p>
       <span className="vads-u-display--block">
@@ -211,7 +211,7 @@ export const VaForm214138Alert = () => (
           external
           text="Get VA Form 21-4138 to download"
         >
-          Get VA Form 21-4138 to download (opens in new tab)
+          Get VA Form 21-4138 to download
         </va-link>
       </span>
     </p>

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
@@ -30,7 +30,7 @@ import {
   COUNTRY_VALUES,
 } from '../../../utils/labels';
 import { seriouslyDisabledDescription } from '../../../utils/helpers';
-import { VaForm214138Alert } from '../../../components/FormAlerts';
+import { AdditionalDependentsAlert } from '../../../components/FormAlerts';
 
 const updatedFullNameSchema = fullNameSchema;
 updatedFullNameSchema.properties.first.maxLength = 12;
@@ -97,10 +97,21 @@ const introPage = {
     }),
     'ui:description': () => (
       <div>
-        <p className="vads-u-margin-top--0">
+        <p className="vads-u-margin-top--0 vads-u-margin-bottom--5">
           Next we’ll ask you about the Veteran’s dependent children. You may add
           up to 3 dependents.
         </p>
+        <va-additional-info trigger="If you have more than 3 dependents">
+          <p>
+            Additional children can be added using VA Form 686c and uploaded at
+            the end of this application.
+          </p>
+          <va-link
+            href="https://www.va.gov/find-forms/about-form-21-686c/"
+            external
+            text="Get VA Form 21-686c to download"
+          />
+        </va-additional-info>
       </div>
     ),
   },
@@ -329,8 +340,8 @@ const householdPage = {
       title: 'Does the child live with you?',
       'ui:required': true,
     }),
-    vaForm214138Alert: {
-      'ui:description': VaForm214138Alert,
+    additionalDependentsAlert: {
+      'ui:description': AdditionalDependentsAlert,
       'ui:options': {
         hideIf: (formData, index) => {
           const item = formData?.veteransChildren?.[index];
@@ -346,7 +357,7 @@ const householdPage = {
     required: ['livesWith'],
     properties: {
       livesWith: yesNoSchema,
-      vaForm214138Alert: {
+      additionalDependentsAlert: {
         type: 'object',
         properties: {},
       },
@@ -358,7 +369,7 @@ const childSupportPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Child support payment'),
     childSupport: currencyUI(
-      "How much did the Veteran contribute per month to their child's support?",
+      "How much did you contribute per month to the child's support?",
     ),
   },
   schema: {

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsResidence.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsResidence.js
@@ -4,7 +4,7 @@ import {
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { isYes } from '../../../utils/helpers';
-import { VaForm214138Alert } from '../../../components/FormAlerts';
+import { AdditionalDependentsAlert } from '../../../components/FormAlerts';
 
 /** @type {PageSchema} */
 export default {
@@ -15,7 +15,7 @@ export default {
         'Do the children who don’t live with you reside at the same address?',
     }),
     residenceAlert: {
-      'ui:description': VaForm214138Alert,
+      'ui:description': AdditionalDependentsAlert,
       'ui:options': {
         hideIf: formData =>
           isYes(formData?.childrenLiveTogetherButNotWithSpouse),

--- a/src/applications/survivors-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/survivors-benefits/containers/IntroductionPage.jsx
@@ -86,9 +86,9 @@ const ProcessList = () => {
           </p>
           <p>
             We may request more information from you to make a decision about
-            your medical expense reimbursement. If we request more information,
+            your claim for survivors benefits. If we request more information,
             you’ll need to respond within 30 days. If you don’t, we may decide
-            your expenses with the evidence that’s available to us.
+            your claim with the evidence that’s available to us.
           </p>
         </va-additional-info>
       </va-process-list-item>

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
@@ -234,10 +234,11 @@ describe('Dependents Pages', () => {
     expect(text.getItemName(itemWithoutName)).to.equal('Dependent');
   });
 
-  it('VaForm214138Alert only displays when livesWith is explicitly false', () => {
+  it('AdditionalDependentsAlert only displays when livesWith is explicitly false', () => {
     const householdItemUi = findItemUi(dependentHousehold);
     expect(householdItemUi, 'dependentHousehold item UI not found').to.exist;
-    const alertOptions = householdItemUi.vaForm214138Alert['ui:options'];
+    const alertOptions =
+      householdItemUi.additionalDependentsAlert['ui:options'];
 
     // explicit false at item => alert visible (hideIf returns false)
     const itemFalse = { veteransChildren: [{ livesWith: false }] };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Renamed VaForm214138Alert to AdditionalDependentsAlert and updated references throughout the dependents pages and residence config. 
- Improved alert messaging for dependents, clarified instructions for adding more than 3 dependents, and updated test cases to reflect the new component name. 
- Also revised introduction page text for accuracy regarding survivors benefits claims.

## Related issue(s)

- [[534EZ - Chapter 4 - Dependents - Content updates #131558]](https://github.com/department-of-veterans-affairs/va.gov-team/issues/131558)
- [[534EZ - Chapter 1 - Content updates #131556]](https://github.com/department-of-veterans-affairs/va.gov-team/issues/131556)
- [[534ez: Chapter 4 > Dependents > Update custodian flow - Adjust alert message to reference "each" child #130560]](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130560)


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |<img width="546" height="477" alt="image" src="https://github.com/user-attachments/assets/8a65f139-41ae-4778-a0db-22ae52063530" /><img width="588" height="395" alt="image" src="https://github.com/user-attachments/assets/45b70a9e-6169-4424-a491-69f70e7e89aa" />|

## What areas of the site does it impact?

*(534 EZ Survivors Benefits Form -- Chapters 1 & 4)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
