### PR TITLE
534ez transform and text updates

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/incomeAndAssets/grossMonthlyIncomePages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/incomeAndAssets/grossMonthlyIncomePages.js
@@ -20,7 +20,7 @@ const grossDescription = () => (
   <div>
     <p>
       Next we’ll ask you the gross monthly income you and your dependents
-      receive. You’ll need to add at least 1 income source and can add up to 4.
+      receive. You can add up to 4 income sources.
     </p>
 
     <p>

--- a/src/applications/survivors-benefits/config/chapters/07-additional-information/supportingDocuments.js
+++ b/src/applications/survivors-benefits/config/chapters/07-additional-information/supportingDocuments.js
@@ -90,9 +90,9 @@ const Documents = () => (
             </span>
           </li>
           <li>
-            <strong>Royalties</strong> require a Statement in Support of Claim
-            for Pension or Parents’ Dependency and Indemnity Compensation (DIC)
-            (VA Form 21P-0969)
+            <strong>Royalties</strong> require an Income and Asset Statement in
+            Support of Claim for Pension or Parents' Dependency and Indemnity
+            Compensation (DIC) (VA Form 21P-0969)
             <span className="vads-u-display--block">
               <va-link
                 href="https://www.va.gov/find-forms/about-form-21p-0969/"

--- a/src/applications/survivors-benefits/config/submit-transformer.js
+++ b/src/applications/survivors-benefits/config/submit-transformer.js
@@ -10,6 +10,7 @@ import {
   updateFullNames,
   combineUnitNameAddress,
   chapter4Transform,
+  checkForHowMarriageEnded,
 } from '../utils/transformers';
 
 export const transform = (formConfig, form) => {
@@ -23,6 +24,7 @@ export const transform = (formConfig, form) => {
   transformedData = updateFullNames(transformedData);
   transformedData = combineUnitNameAddress(transformedData);
   transformedData = chapter4Transform(transformedData);
+  transformedData = checkForHowMarriageEnded(transformedData);
   return JSON.stringify({
     survivorsBenefitsClaim: {
       form: transformedData,

--- a/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/grossMonthlyIncomePages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/grossMonthlyIncomePages.unit.spec.jsx
@@ -52,7 +52,7 @@ describe('Gross Monthly Income Pages', () => {
     const vaOtherTypeExplanationText =
       'va-text-input[label*="Tell us the type of income"]';
     expect($(vaOtherTypeExplanationText, formDOM)).to.not.exist;
-    expect(vaOptions.length).to.equal(9);
+    expect(vaOptions.length).to.equal(7);
     Object.keys({
       ...incomeRecipientTypeLabels,
       ...typeOfIncomeLabels,

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -77,8 +77,6 @@ export const recipientTypeLabels = {
 export const incomeRecipientTypeLabels = {
   SURVIVING_SPOUSE: 'Surviving spouse',
   CHILD: 'Veteran’s child',
-  CUSTODIAN: 'Custodian',
-  CUSTODIAN_SPOUSE: 'Custodian’s spouse',
 };
 
 export const medicalExpenseRecipientLabels = {

--- a/src/applications/survivors-benefits/utils/transformers/checkForHowMarriageEnded.js
+++ b/src/applications/survivors-benefits/utils/transformers/checkForHowMarriageEnded.js
@@ -1,0 +1,11 @@
+export function checkForHowMarriageEnded(formData) {
+  const parsedFormData = JSON.parse(formData);
+  const transformedValue = parsedFormData;
+  if (parsedFormData?.howMarriageEnded) {
+    JSON.stringify(transformedValue);
+  }
+  if (parsedFormData?.marriedToVeteranAtTimeOfDeath) {
+    transformedValue.howMarriageEnded = 'death';
+  }
+  return JSON.stringify(transformedValue);
+}

--- a/src/applications/survivors-benefits/utils/transformers/combineUnitNameAddress.js
+++ b/src/applications/survivors-benefits/utils/transformers/combineUnitNameAddress.js
@@ -1,3 +1,21 @@
+const buildAddress = unitAddress => {
+  const { street, street2, city, state, postalCode } = unitAddress;
+  let address = street || '';
+  if (street2) {
+    address += `, ${street2}`;
+  }
+  if (city) {
+    address += `, ${city}`;
+  }
+  if (state) {
+    address += `, ${state}`;
+  }
+  if (postalCode) {
+    address += ` ${postalCode}`;
+  }
+  return address;
+};
+
 export function combineUnitNameAddress(formData) {
   const parsedFormData = JSON.parse(formData);
   const transformedValue = parsedFormData;
@@ -7,10 +25,9 @@ export function combineUnitNameAddress(formData) {
     transformedValue.unitNameAndAddress = unitName;
   }
   if (parsedFormData?.unitAddress) {
-    const { street, city, state, postalCode } = parsedFormData.unitAddress;
     transformedValue.unitNameAndAddress += unitName
-      ? `, ${street}, ${city}, ${state} ${postalCode}`
-      : `${street}, ${city}, ${state} ${postalCode}`;
+      ? `, ${buildAddress(parsedFormData.unitAddress)}`
+      : `${buildAddress(parsedFormData.unitAddress)}`;
   }
   delete transformedValue.unitName;
   delete transformedValue.unitAddress;

--- a/src/applications/survivors-benefits/utils/transformers/index.js
+++ b/src/applications/survivors-benefits/utils/transformers/index.js
@@ -1,5 +1,6 @@
 export * from './calculateSeparationDuration';
 export * from './chapter4Transform';
+export * from './checkForHowMarriageEnded';
 export * from './combineTreatmentFacility';
 export * from './combineUnitNameAddress';
 export * from './splitSsn';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add check to mark death for how veteran died if lived with veteran until death, as the form page is now skipped
- Add address 2 to unit name and address string
- update text on gross monthly income and additional forms page
- Remove 2 options from gross monthly income recipients that were for the 2025 version of the form but are not available on the current version

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131561
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131727
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131729
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131728

## Testing done

- Manual testing with local pdf filler
- updated tests

## Screenshots
| Before | After |
| ------ | ----- |
| <img width="607" height="731" alt="Screenshot 2026-02-02 at 10 20 09 AM" src="https://github.com/user-attachments/assets/d50157ab-aae4-45fd-aea7-12a9cdab393a" /> <img width="634" height="504" alt="Screenshot 2026-02-02 at 10 15 12 AM" src="https://github.com/user-attachments/assets/0210ecd8-a23e-415a-8b00-4fc62f834dcc" /> | <img width="658" height="774" alt="Screenshot 2026-02-02 at 10 20 20 AM" src="https://github.com/user-attachments/assets/216a90c5-a16f-4fbc-86d6-4b9fccc4497a" /> <img width="644" height="483" alt="Screenshot 2026-02-02 at 10 15 25 AM" src="https://github.com/user-attachments/assets/d4463ad0-f16d-4b0d-bedf-c7af57900705" /> |



## What areas of the site does it impact?

534ez form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
