### PR TITLE
Add some 2680 FE validation to match backend/PDF limits

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-address.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-address.js
@@ -58,6 +58,10 @@ const customAddressSchema = {
       type: 'string',
       maxLength: 5,
     },
+    city: {
+      type: 'string',
+      maxLength: 18,
+    },
     country: {
       ...addressSchema().properties.country,
       default: 'USA',

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-contact.js
@@ -80,7 +80,10 @@ export const claimantContactSchema = {
       type: 'object',
       properties: {
         claimantPhoneNumber: internationalPhoneSchema(),
-        claimantEmail: emailSchema,
+        claimantEmail: {
+          ...emailSchema,
+          maxLength: 70,
+        },
       },
     },
   },

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/hospitalization-facility.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/hospitalization-facility.js
@@ -57,6 +57,10 @@ const customHospitalAddressSchema = {
       type: 'string',
       maxLength: 5,
     },
+    city: {
+      type: 'string',
+      maxLength: 18,
+    },
   },
 };
 

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-address.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/veteran-address.js
@@ -45,6 +45,10 @@ const customVeteranAddressSchema = {
       type: 'string',
       maxLength: 5,
     },
+    city: {
+      type: 'string',
+      maxLength: 18,
+    },
   },
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added frontend validation limits to form 21-2680 (House Bound Status) to match backend field constraints and prevent submission errors
- Backend expects maximum character limits on address city fields (18 chars) and email field (70 chars), but frontend had no validation
- Without these limits, users could enter data that passes FE validation but fails BE validation or gets truncated in the PDF, causing data loss
- Solution: Added maxLength constraints to JSON schemas for city fields in veteran address, claimant address, and hospital address; added maxLength to email field
- Team: Benefits Intake Optimization, Aquia
- Team owns maintenance of the 21-2680 form application

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130372

## Testing done

### Old Behavior
- Users could enter unlimited characters in city fields (veteran address, claimant address, hospital address)
- Users could enter unlimited characters in email field
- Data exceeding backend limits would either be rejected or truncated, causing validation errors or data loss

### Testing Steps
1. Navigate to form 21-2680 on local build
2. Fill out veteran address city field and verify it stops accepting input at 18 characters
3. Fill out claimant address city field (for non-veteran claimants) and verify 18 character limit
4. Fill out hospital facility address city field (if hospitalized) and verify 18 character limit
5. Fill out email field and verify it stops accepting input at 70 characters
6. Verify form validation errors appear if attempting to exceed limits
7. Submit form and verify data is accepted by backend without truncation

### Test Results
- All existing unit tests passing
- Manual testing confirmed:
  - City fields enforce 18 character limit across all three address types
  - Email field enforces 70 character limit
  - Test fixtures (maximal.json, minimal.json, etc.) all remain compliant with new limits
  - Form submission works correctly with fields at or below the limits

## Screenshots

_No visual changes - validation limits are transparent to users unless they attempt to exceed them_

## What areas of the site does it impact?

This change only impacts VA Form 21-2680 (Examination for Housebound Status or Permanent Need for Regular Aid and Attendance) located at `/benefits-optimization-aquia/21-2680-house-bound-status/`. No other areas of the site are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (JSON schemas serve as documentation for field constraints)
- [ ] Screenshot of the developed feature is added (N/A - no visual changes)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (No accessibility impact - maxLength is a native HTML attribute that doesn't affect screen readers or keyboard navigation)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A - validation changes don't require new monitoring)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

These validation limits were added to match backend constraints defined in:
- `vets-json-schema/dist/21-2680-schema.json` (city maxLength: 18, email maxLength: 70)
- `vets-api/lib/pdf_fill/forms/field_mappings/va212680.rb` (PDF field limits)

All test fixtures remain compliant with the new limits, so no breaking changes to existing tests.