### PR TITLE
constrain global mock setting so it doesn't affect other specs

### DIFF
--- a/src/applications/vaos/components/VideoLink.unit.spec.jsx
+++ b/src/applications/vaos/components/VideoLink.unit.spec.jsx
@@ -11,15 +11,15 @@ import {
 import { DATE_FORMATS } from '../utils/constants';
 import VideoLink from './VideoLink';
 
-beforeEach(() => {
-  MockDate.set(getTestDate());
-});
-
-afterEach(() => {
-  MockDate.reset();
-});
-
 describe('VAOS Component: VideoLink', () => {
+  beforeEach(() => {
+    MockDate.set(getTestDate());
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   const initialState = {
     appointments: {
       facilityData: {

--- a/src/applications/vaos/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/utils/appointment.unit.spec.jsx
@@ -1,8 +1,18 @@
 import { expect } from 'chai';
 import { subDays } from 'date-fns';
+import MockDate from 'mockdate';
 import { getRealFacilityId, getDaysRemainingToFileClaim } from './appointment';
+import { getTestDate } from '../tests/mocks/setup';
 
 describe('VAOS appointment helpers', () => {
+  beforeEach(() => {
+    MockDate.set(getTestDate());
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   describe('getRealFacilityId', () => {
     it('should return the real facility id for not production environemnts', () => {
       expect(getRealFacilityId('983')).to.equal('442');


### PR DESCRIPTION
## Summary

- Move date mocking inside the spec's `describe` block so that it doesn't inadvertently affect other specs.
- Previously, running this spec and `src/applications/ezr/tests/unit/utils/helpers/form-config.unit.spec.jsx` together caused multiple failures. With this change, both specs pass.
- This constrains the Date mocking to only affect the one spec.
- Health Applications 10-10 EZR

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131844

## Testing done

- Run both unit tests together:
- `yarn test:unit src/applications/ezr/tests/unit/utils/helpers/form-config.unit.spec.jsx src/applications/vaos/components/VideoLink.unit.spec.jsx`
- Confirm that instead of getting 3 failures in `form-config.unit.spec.jsx`, everything passes.