### PR TITLE
Micahalconcel/124723 2680 possessive apostrophe fallback

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
@@ -161,7 +161,7 @@ const formConfig = {
               parent: "Veteran's parent's information",
             };
             const relationship = formData?.claimantRelationship?.relationship;
-            return relationshipLabels[relationship] || 'Claimant information';
+            return relationshipLabels[relationship] || "Claimant's information";
           },
           uiSchema: claimantInformationUiSchema,
           schema: claimantInformationSchema,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.unit.spec.jsx
@@ -239,7 +239,7 @@ describe('Form Configuration', () => {
         const formData = {
           claimantRelationship: { relationship: 'other' },
         };
-        expect(page.title(formData)).to.equal('Claimant information');
+        expect(page.title(formData)).to.equal("Claimant's information");
       });
     });
 

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/claimant-information.js
@@ -66,7 +66,7 @@ export const claimantInformationUiSchema = {
       const data = fullData || formData;
       const relationship = data?.claimantRelationship?.relationship;
       const title = `${relationshipLabels[relationship] ||
-        'Claimant'} name and date of birth`;
+        "Claimant's"} name and date of birth`;
 
       return {
         'ui:title': title,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Adding possessive apostrophe to Claimant's Information step title

### Issue
The fallback for the Claimant's Information step title was Claimant name and date of birth, which didn't match the page title (missing the possessive apostrophe)

### Solution
Added the possessive apostrophe to the step title to make it Claimant's name and date of birth

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 124723](https://github.com/department-of-veterans-affairs/va.gov-team/issues/124723)

## Testing done

### Old behavior
* The fallback for the step title displayed as Claimant's name and date of birth
* Not sure how to reliably replicate this... you would need to navigate to the Claimant's Information page without setting a relationship to veteran (e.g. navigate directly to /pension/aid-attendance-housebound/apply-form-21-2680/claimant-relationship through routes menu or save-in-progress menu)

### New behavior
* The fallback for the step title is set to Claimant's name and date of birth to match the page title

### Verification Steps
*  Unit tests: verified existing unit tests still pass, modified page title unit test with possessive apostrophe
*  Manual testing in local environment verified that the fallback step title has the possessive apostrophe
* E2E tests: all existing tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="416" height="190" alt="before possessive" src="https://github.com/user-attachments/assets/dcb8549f-3ac9-4a2f-92b6-e0bdab66f9fc" /> | <img width="394" height="180" alt="after possessive" src="https://github.com/user-attachments/assets/aa39a372-6a60-48a9-9390-19f790fed938" /> |

## What areas of the site does it impact?

This change affects form 21-2680, specifically on the Claimant's Information page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user