### PR TITLE
add skip to route so it bypasses the sip check

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -140,7 +140,7 @@ export const OTHER_REASONS = Object.freeze({
 export const ESCAPE_HATCH = Object.freeze(
   <div className="vads-u-margin-y--4">
     If you’d like to use VA Form 21-4138 for your statement instead, you can{' '}
-    <a href="/supporting-forms-for-claims/submit-statement-form-21-4138/personal-information">
+    <a href="/supporting-forms-for-claims/submit-statement-form-21-4138/personal-information?skip">
       go to VA Form 21-4138 now.
     </a>
   </div>,


### PR DESCRIPTION
Fixed the escape hatch link in VA Form 21-4138 that was incorrectly redirecting users to the introduction page instead of the personal-information page
Added ?skip parameter to bypass the RoutedSavableApp redirect logic that sends users to the first form page when landing on a mid-form URL
Team: Forms

Related issue(s)


Testing done

Old behavior: Clicking the escape hatch link to /personal-information redirected users to /introduction (or /statement-type) due to save-in-progress redirect logic in RoutedSavableApp
Root cause: The platform's RoutedSavableApp component redirects users who land on mid-form pages without an active session
Solution: Added ?skip query parameter which the platform recognizes as a bypass flag
Local testing:

Temporarily removed environment.isLocalhost() check in RoutedSavableApp to simulate production behavior
Confirmed /personal-information without ?skip redirects to /statement-type
Confirmed /personal-information?skip stays on the correct page
Reverted temporary change after testing



What areas of the site does it impact?
VA Form 21-4138 escape hatch links on handoff pages
