### PR TITLE
Fix skipped CurrencyWidget test for blank value onChange

### DIFF
--- a/src/platform/forms-system/test/js/widgets/CurrencyWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/CurrencyWidget.unit.spec.jsx
@@ -65,13 +65,14 @@ describe('Schemaform <CurrencyWidget>', () => {
     fireEvent.change(input, { target: { value: '10.000' } });
     expect(onChange.calledWith('10.000')).to.be.true;
   });
-  it.skip('should call onChange with undefined if the value is blank', () => {
+  it('should call onChange with undefined if the value is blank', () => {
     const onChange = sinon.spy();
     const { container } = render(
-      <CurrencyWidget options={{}} onChange={onChange} />,
+      <CurrencyWidget options={{}} value="100" onChange={onChange} />,
     );
     const input = container.querySelector('input');
     fireEvent.change(input, { target: { value: '' } });
-    expect(onChange.calledWith()).to.be.true;
+    expect(onChange.called).to.be.true;
+    expect(onChange.firstCall.args.length).to.equal(0);
   });
 });


### PR DESCRIPTION
**Note**: This is a small follow-up fix to #41948.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
- [x] No

## Summary

- Fixes a skipped test in CurrencyWidget that was missed during the skin-deep to RTL migration in #41948
- The test `should call onChange with undefined if the value is blank` was changed to `it.skip` but not properly fixed
- Root cause: The test needed an initial `value` prop so that clearing the input would trigger the onChange handler
- Updated assertion to explicitly verify onChange is called with no arguments

## Related issue(s)

- Follow-up to department-of-veterans-affairs/vets-website#41948

## Testing done

- Ran unit tests: `yarn test:unit src/platform/forms-system/test/js/widgets/CurrencyWidget.unit.spec.jsx`
- All 8 tests passing including the previously skipped test
- Verified the CurrencyWidget component calls `onChange()` with no args when input is cleared

## Screenshots

N/A - Unit test fix only, no UI changes.

## What areas of the site does it impact?

None - test file only.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A - test only)
- [x] Accessibility testing has been performed (N/A - test only)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test only)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test only)

## Requested Feedback

This is a straightforward test fix. The original test was skipped because `onChange.calledWith()` doesn't work as expected when verifying a function was called with no arguments - sinon requires checking `args.length === 0` instead.