### PR TITLE
Burials - Update service period labels

### DIFF
--- a/src/applications/burials-ez/config/chapters/03-military-history/servicePeriod.js
+++ b/src/applications/burials-ez/config/chapters/03-military-history/servicePeriod.js
@@ -14,7 +14,9 @@ const { placeOfSeparation } = fullSchemaPensions.properties;
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'ui:title': generateTitle('Service period'),
+    'ui:title': generateTitle('Military service information'),
+    'ui:description':
+      'Start by adding the Veteran’s most recent period of active service.',
     serviceBranch: selectUI({
       title: 'Branch of service',
       labels: serviceBranchLabels,
@@ -23,11 +25,11 @@ export default {
       },
     }),
     serviceDateRange: currentOrPastDateRangeUI(
-      { title: 'Service start date', dataDogHidden: true },
-      { title: 'Service end date', dataDogHidden: true },
+      { title: 'Date first entered active duty', dataDogHidden: true },
+      { title: 'Date separated from active duty', dataDogHidden: true },
     ),
     placeOfSeparation: {
-      'ui:title': 'Place of separation',
+      'ui:title': 'Place separated from active duty',
       'ui:options': {
         hint: 'Enter the city and state or name of the military base',
       },


### PR DESCRIPTION
### Summary of Changes
This PR updates the **Service period** field labels in the **Burial Benefits form (VA Form 21P-530EZ)** to align with the **PDF form alignment** requirements.  
The label updates improve clarity and ensure consistency between the online form and the PDF version. This is a **content-only** update and does not change validation or form behavior.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129182

### How to Set Up in Local Environment
1. Run the local environment
2. Enable the required feature toggles:
   - `burial_form_enabled`  
     http://localhost:3000/flipper/features/burial_form_enabled
   - `burial_pdf_form_alignment`  
     http://localhost:3000/flipper/features/burial_pdf_form_alignment
3. Navigate to the Burial Benefits form:  
   http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/

### How to Test
1. Start a new **21P-530EZ** application.
2. Navigate to the **Military history** chapter.
3. With `burial_pdf_form_alignment` enabled, verify:
   - Updated Service period labels display as expected.
   - Labels match the PDF-aligned wording.
4. Complete the Service period page and continue through the flow.
5. Disable `burial_pdf_form_alignment` and verify:
   - Legacy labels continue to display.
6. Confirm there are no console errors or accessibility regressions.

### Feature Flag Note
- Service period label updates are gated behind the `burial_pdf_form_alignment` feature toggle.

### Screenshot
<img width="701" height="1149" alt="localhost_3001_burials-memorials_veterans-burial-allowance_apply-for-allowance-form-21p-530ez_introduction (1)" src="https://github.com/user-attachments/assets/b0616240-2fd8-4b06-b482-9de7100c54f3" />

### Acceptance Criteria
- [x] Service period labels match updated design spec.
- [x] Label updates apply only when `burial_pdf_form_alignment` is enabled.
- [x] No functional regressions introduced.
- [x] No accessibility or console errors.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with feature toggles enabled and disabled.
- [ ] Tests verified passing.