### PR TITLE
Fix time zone display for unified vitals

### DIFF
--- a/src/applications/mhv-medical-records/reducers/vitals.js
+++ b/src/applications/mhv-medical-records/reducers/vitals.js
@@ -14,6 +14,7 @@ import {
   macroCase,
   extractContainedResource,
   dateFormatWithoutTimezone,
+  formatDateTimeInUserTimezone,
 } from '../util/helpers';
 
 const initialState = {
@@ -162,7 +163,7 @@ export const convertUnifiedVital = record => {
     id: record.id,
     measurement: record.attributes.measurement || EMPTY_FIELD,
     date: record.attributes.date
-      ? dateFormatWithoutTimezone(record.attributes.date)
+      ? formatDateTimeInUserTimezone(record.attributes.date)
       : EMPTY_FIELD,
     effectiveDateTime: record?.attributes.date,
     location: record.attributes.location || EMPTY_FIELD,

--- a/src/applications/mhv-medical-records/tests/reducers/vitals.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/reducers/vitals.unit.spec.jsx
@@ -371,7 +371,7 @@ describe('getMeasurement', () => {
 });
 
 describe('convertUnifiedVital function', () => {
-  it('should convert a unified vital record to the expected format', () => {
+  it('should convert a unified vital record to the expected format with date in user timezone', () => {
     const record = {
       id: '49c80309-efa0-41fd-84a0-870ed1b38100',
       type: 'observation',
@@ -387,16 +387,18 @@ describe('convertUnifiedVital function', () => {
     };
 
     const converted = convertUnifiedVital(record);
-    expect(converted).to.deep.equal({
-      id: '49c80309-efa0-41fd-84a0-870ed1b38100',
-      type: 'HEIGHT',
-      name: 'Height',
-      measurement: '6 feet, 3.0 inches',
-      date: 'November 14, 2024, 6:19 p.m.',
-      effectiveDateTime: '2024-11-14T18:19:23Z',
-      location: 'FT COLLINS HEALTH SCREENING',
-      notes: 'Patient was calm during measurement.',
-    });
+    expect(converted.id).to.equal('49c80309-efa0-41fd-84a0-870ed1b38100');
+    expect(converted.type).to.equal('HEIGHT');
+    expect(converted.name).to.equal('Height');
+    expect(converted.measurement).to.equal('6 feet, 3.0 inches');
+    expect(converted.effectiveDateTime).to.equal('2024-11-14T18:19:23Z');
+    expect(converted.location).to.equal('FT COLLINS HEALTH SCREENING');
+    expect(converted.notes).to.equal('Patient was calm during measurement.');
+    // Date is formatted in user timezone with timezone abbreviation (UTC 18:19 → local time)
+    expect(converted.date).to.include('November 14, 2024');
+    expect(converted.date).to.match(
+      /\d{1,2}:\d{2} (a\.m\.|p\.m\.) [A-Z]{2,4}$/,
+    );
   });
 });
 

--- a/src/applications/mhv-medical-records/tests/util/dateHelpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/dateHelpers.unit.spec.jsx
@@ -22,6 +22,17 @@ describe('dateHelpers', () => {
       expect(result).to.equal('November 14, 2024, 1:19 p.m. EST');
     });
 
+    it('should format ISO string with timezone offset in given timezone', () => {
+      // 2024-11-14T13:19:23-05:00 is the same instant as 2024-11-14T18:19:23Z
+      // Displayed in America/New_York (EST) = 1:19 p.m. EST
+      const result = formatDateTimeInUserTimezone(
+        '2024-11-14T13:19:23-05:00',
+        'MMMM d, yyyy, h:mm a',
+        'America/New_York',
+      );
+      expect(result).to.equal('November 14, 2024, 1:19 p.m. EST');
+    });
+
     it('should return null for bad input', () => {
       expect(formatDateTimeInUserTimezone(null, undefined, 'America/New_York'))
         .to.be.null;
@@ -29,13 +40,41 @@ describe('dateHelpers', () => {
         .be.null;
     });
 
-    it('should handle date-only string without timezone suffix', () => {
+    it('should handle date-only string (YYYY-MM-DD)', () => {
       const result = formatDateTimeInUserTimezone(
         '2024-11-14',
         'MMMM d, yyyy, h:mm a',
         'America/New_York',
       );
       expect(result).to.equal('November 14, 2024');
+    });
+
+    it('should handle year-only string (YYYY)', () => {
+      const result = formatDateTimeInUserTimezone(
+        '2024',
+        'MMMM d, yyyy, h:mm a',
+        'America/New_York',
+      );
+      expect(result).to.equal('2024');
+    });
+
+    it('should handle year-month string (YYYY-MM)', () => {
+      const result = formatDateTimeInUserTimezone(
+        '2024-11',
+        'MMMM d, yyyy, h:mm a',
+        'America/New_York',
+      );
+      expect(result).to.equal('November 2024');
+    });
+
+    it('should handle datetime with milliseconds', () => {
+      // 2024-11-14T18:19:23.456Z in America/New_York (EST) = 1:19 p.m. EST
+      const result = formatDateTimeInUserTimezone(
+        '2024-11-14T18:19:23.456Z',
+        'MMMM d, yyyy, h:mm a',
+        'America/New_York',
+      );
+      expect(result).to.equal('November 14, 2024, 1:19 p.m. EST');
     });
   });
 

--- a/src/applications/mhv-medical-records/tests/util/dateHelpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/dateHelpers.unit.spec.jsx
@@ -3,6 +3,7 @@ import {
   formatDateYear,
   formatDateMonthDayCommaYear,
   formatDateMonthDayCommaYearHoursMinutes,
+  formatDateTimeInUserTimezone,
   currentDateMinusMinutes,
   currentDateAddHours,
   currentDateAddSecondsForFileDownload,
@@ -10,6 +11,34 @@ import {
 } from '../../util/dateHelpers';
 
 describe('dateHelpers', () => {
+  describe('formatDateTimeInUserTimezone', () => {
+    it('should format UTC ISO string in given timezone with timezone abbreviation', () => {
+      // 2024-11-14T18:19:23Z in America/New_York (EST) = 1:19 p.m. EST
+      const result = formatDateTimeInUserTimezone(
+        '2024-11-14T18:19:23Z',
+        'MMMM d, yyyy, h:mm a',
+        'America/New_York',
+      );
+      expect(result).to.equal('November 14, 2024, 1:19 p.m. EST');
+    });
+
+    it('should return null for bad input', () => {
+      expect(formatDateTimeInUserTimezone(null, undefined, 'America/New_York'))
+        .to.be.null;
+      expect(formatDateTimeInUserTimezone('', undefined, 'America/New_York')).to
+        .be.null;
+    });
+
+    it('should handle date-only string without timezone suffix', () => {
+      const result = formatDateTimeInUserTimezone(
+        '2024-11-14',
+        'MMMM d, yyyy, h:mm a',
+        'America/New_York',
+      );
+      expect(result).to.equal('November 14, 2024');
+    });
+  });
+
   describe('formatDateYear', () => {
     it('should format a date to just the year', () => {
       const result = formatDateYear('2024-11-27T15:30:00.000Z');

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -29,7 +29,10 @@ import {
 } from './constants';
 
 // Re-export from dateHelpers for backwards compatibility
-export { dateFormatWithoutTimezone } from './dateHelpers';
+export {
+  dateFormatWithoutTimezone,
+  formatDateTimeInUserTimezone,
+} from './dateHelpers';
 
 /**
  * @param {*} timestamp


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug fix**: Unified vitals (SCDF/accelerated data) displayed incorrect times because UTC timestamps were being interpreted as local time (e.g., a 2:30 PM appointment showed as 7:30 PM).
- **How to reproduce**: Load vitals with accelerated delivery enabled. Observe that times appear ~5-7 hours off depending on timezone.
- **Solution**: Added `formatDateTimeInUserTimezone` helper that properly parses UTC timestamps and converts them to the user's local timezone, appending the timezone abbreviation (e.g., "12:23 p.m. MDT").
- **Team**: MHV Medical Records team owns this component.
- **Flipper**: Already behind existing `mhv_accelerated_delivery_vital_signs_enabled` feature flag.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#131813

## Testing done

- **Old behavior**: `dateFormatWithoutTimezone` stripped the `Z` from UTC timestamps and parsed the remaining time as local, causing times to display incorrectly (e.g., `2024-11-14T18:19:23Z` showed as "6:19 p.m." instead of "11:19 a.m. MST").
- **Steps to verify**:
  1. Run MR mock server with accelerated vitals enabled
  2. Navigate to Medical Records → Vitals
  3. Verify times display in local timezone with timezone abbreviation (e.g., "July 24, 2025, 12:23 p.m. MDT")
  4. Verify list page and detail page both show correct times with timezone
- **Tests completed**:
  - Unit tests for `formatDateTimeInUserTimezone` (3 new tests)
  - Unit tests for `convertUnifiedVital` (updated to verify timezone format)
  - Manual testing with mock data containing UTC timestamps
  - Verified bug exists on main (brief flash of wrong time before correction)
- **Results**: 57 unit tests passing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="546" height="247" alt="Screenshot 2026-02-03 at 9 45 58 AM" src="https://github.com/user-attachments/assets/50336da0-001f-43fc-9d03-475a54d6a477" /> | <img width="547" height="241" alt="Screenshot 2026-02-03 at 9 46 21 AM" src="https://github.com/user-attachments/assets/967dec79-37ab-40bc-95d9-9f4b3eaf623c" /> |

**Note** 
This is a data formatting fix, not a UI component change. The visible difference is the date string format:
- **Before**: "November 14, 2024, 6:19 p.m." (incorrect - UTC interpreted as local)
- **After**: "November 14, 2024, 11:19 a.m. MST" (correct - UTC converted to local with timezone)

## What areas of the site does it impact?

- MHV Medical Records - Vitals list page
- MHV Medical Records - Vitals detail page
- Only affects unified/accelerated vitals path (behind feature flag)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary) - N/A, no documentation changes needed
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - N/A, no accessibility impact (text content only)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - N/A, no new logging added
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A, existing monitoring sufficient

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user