### PR TITLE
updates texts with hospitalization to hospital care, updates tests to…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.js
@@ -237,7 +237,7 @@ const formConfig = {
 
     // Step 4 of 5: Hospitalization
     hospitalizationChapter: {
-      title: 'Hospitalization',
+      title: 'Hospital care',
       pages: {
         hospitalizationStatus: {
           path: 'hospitalization-status',
@@ -253,9 +253,9 @@ const formConfig = {
               const fullName = `${firstName} ${lastName}`.trim();
 
               if (fullName) {
-                return `Is ${fullName} hospitalized?`;
+                return `Is ${fullName} receiving hospital care?`;
               }
-              return 'Is the Veteran hospitalized?';
+              return 'Is the Veteran receiving hospital care?';
             }
 
             const firstName =
@@ -265,9 +265,9 @@ const formConfig = {
             const fullName = `${firstName} ${lastName}`.trim();
 
             if (fullName) {
-              return `Is ${fullName} hospitalized?`;
+              return `Is ${fullName} receiving hospital care?`;
             }
-            return 'Is the claimant hospitalized?';
+            return 'Is the claimant receiving hospital care?';
           },
           uiSchema: hospitalizationStatusUiSchema,
           schema: hospitalizationStatusSchema,

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/config/form/form.unit.spec.jsx
@@ -66,7 +66,7 @@ describe('Form Configuration', () => {
     it('should have hospitalizationChapter', () => {
       expect(formConfig.chapters.hospitalizationChapter).to.exist;
       expect(formConfig.chapters.hospitalizationChapter.title).to.include(
-        'Hospitalization',
+        'Hospital care',
       );
     });
   });
@@ -370,7 +370,7 @@ describe('Form Configuration', () => {
           },
         };
         expect(page.title(formData)).to.equal(
-          'Is Anakin Skywalker hospitalized?',
+          'Is Anakin Skywalker receiving hospital care?',
         );
       });
 
@@ -379,7 +379,9 @@ describe('Form Configuration', () => {
           claimantRelationship: { relationship: 'veteran' },
           veteranInformation: { veteranFullName: {} },
         };
-        expect(page.title(formData)).to.equal('Is the Veteran hospitalized?');
+        expect(page.title(formData)).to.equal(
+          'Is the Veteran receiving hospital care?',
+        );
       });
 
       it('should use claimant name when claimant is not veteran', () => {
@@ -389,7 +391,9 @@ describe('Form Configuration', () => {
             claimantFullName: { first: 'Padmé', last: 'Amidala' },
           },
         };
-        expect(page.title(formData)).to.equal('Is Padmé Amidala hospitalized?');
+        expect(page.title(formData)).to.equal(
+          'Is Padmé Amidala receiving hospital care?',
+        );
       });
 
       it('should use default claimant text when claimant name missing', () => {
@@ -397,7 +401,9 @@ describe('Form Configuration', () => {
           claimantRelationship: { relationship: 'spouse' },
           claimantInformation: { claimantFullName: {} },
         };
-        expect(page.title(formData)).to.equal('Is the claimant hospitalized?');
+        expect(page.title(formData)).to.equal(
+          'Is the claimant receiving hospital care?',
+        );
       });
     });
 

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/hospitalization-status.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/pages/hospitalization-status.js
@@ -17,7 +17,7 @@ import { getHospitalizationStatusTitle } from '../utils';
 export const hospitalizationStatusUiSchema = {
   hospitalizationStatus: {
     isCurrentlyHospitalized: yesNoUI({
-      title: 'Is the claimant hospitalized?',
+      title: 'Is the claimant receiving hospital care?',
     }),
   },
   'ui:options': {

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/utils/dynamic-title-helpers.js
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/utils/dynamic-title-helpers.js
@@ -19,12 +19,12 @@ export const getHospitalizationStatusTitle = formData => {
     : getClaimantName(formData, '');
 
   if (name) {
-    return `Is ${name} hospitalized?`;
+    return `Is ${name} receiving hospital care?`;
   }
 
   return isVeteran
-    ? 'Is the Veteran hospitalized?'
-    : 'Is the claimant hospitalized?';
+    ? 'Is the Veteran receiving hospital care?'
+    : 'Is the claimant receiving hospital care?';
 };
 
 /**

--- a/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/utils/dynamic-title-helpers.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-2680-house-bound-status/utils/dynamic-title-helpers.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is Anakin Skywalker hospitalized?',
+        'Is Anakin Skywalker receiving hospital care?',
       );
     });
 
@@ -42,7 +42,7 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is Padmé Amidala hospitalized?',
+        'Is Padmé Amidala receiving hospital care?',
       );
     });
 
@@ -56,7 +56,7 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is the Veteran hospitalized?',
+        'Is the Veteran receiving hospital care?',
       );
     });
 
@@ -70,7 +70,7 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is the claimant hospitalized?',
+        'Is the claimant receiving hospital care?',
       );
     });
 
@@ -87,7 +87,7 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is Luke Skywalker hospitalized?',
+        'Is Luke Skywalker receiving hospital care?',
       );
     });
 
@@ -104,14 +104,14 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is Shmi Skywalker hospitalized?',
+        'Is Shmi Skywalker receiving hospital care?',
       );
     });
 
     it('should handle missing relationship', () => {
       const formData = {};
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is the claimant hospitalized?',
+        'Is the claimant receiving hospital care?',
       );
     });
 
@@ -128,7 +128,7 @@ describe('dynamicTitleHelpers', () => {
         },
       };
       expect(getHospitalizationStatusTitle(formData)).to.equal(
-        'Is Yoda hospitalized?',
+        'Is Yoda receiving hospital care?',
       );
     });
   });


### PR DESCRIPTION
… reflect this

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing "Hospitalization" step title to "Hospital care", rewording hospitalization status question to remove the word "hospitalized"

### Issue
VA preferred language is "hospital care" instead of "hospitalization". The form is currently using the word "hospitalization".

### Solution
Changed "hospitalization" to "hospital care" on the page title and question.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-2680 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 124722](https://github.com/department-of-veterans-affairs/va.gov-team/issues/124722)

## Testing done

### Old behavior
* The form was using the words "hospitalization" and "hospitalized"

### New behavior
* The form uses the words "hospital care" and "receiving hospital care"

### Verification Steps
*  Unit tests: verified existing unit tests still pass, modified tests to look for "hospital care" instead of "hospitalization"
*  Manual testing in local environment verified that the page title and question are using "hospital care" instead of "hospitalization"
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="432" height="281" alt="before hospital" src="https://github.com/user-attachments/assets/3bc2aadd-9c83-4b50-b8af-9d328a680188" /> | <img width="487" height="273" alt="after hospital" src="https://github.com/user-attachments/assets/07618c06-f09a-42d6-958a-85d96b844362" /> |

## What areas of the site does it impact?

This change affects form 21-2680 specifically on the Step 4 - Hospitalization

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user