### PR TITLE
Fixed Auth Metrics GA Environment Bug

### DIFF
--- a/src/applications/auth/containers/AuthMetrics.jsx
+++ b/src/applications/auth/containers/AuthMetrics.jsx
@@ -20,7 +20,7 @@ export default class AuthMetrics {
     this.authnContext = get('authnContext', this.userProfile, undefined);
     this.serviceName = get('signIn.serviceName', this.userProfile, null);
     this.isProduction =
-      environment.getRawBuildtype() === environments.PRODUCTION;
+      environment.getRawBuildtype() === environments.VAGOVPROD;
   }
 
   compareLoginPolicy = () => {

--- a/src/applications/auth/tests/AuthMetrics.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthMetrics.unit.spec.jsx
@@ -38,7 +38,7 @@ describe('AuthMetrics', () => {
   const oldBuildType = __BUILDTYPE__;
 
   beforeEach(() => {
-    __BUILDTYPE__ = environments.PRODUCTION;
+    __BUILDTYPE__ = environments.VAGOVPROD;
     sandbox = sinon.createSandbox();
     global.window = global.window || {};
     global.window.dataLayer = [];


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed a bug in `AuthMetrics.jsx` which caused Google Analytics to not properly fire in production.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1079)

## Testing done
- Updated `AuthMetrics.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/applications/auth/tests/AuthMetrics.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts `AuthMetrics.jsx` and the related tests.

## Acceptance criteria
- [x] Fix GA environment bug in `AuthMetrics.jsx`