### PR TITLE
Update text on Form 0781 to show "Note: " instead of "Remember: "

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -112,7 +112,7 @@ export const militarySexualTraumaSupportTextBlob = (
 
 export const rememberTextBlob = (
   <p>
-    <strong>Remember: </strong>
+    <strong>Note: </strong>
     Any information you provide will help us understand your situation and
     identify evidence to support your claim. But you can skip questions you
     can’t or don’t want to answer. And you can save your in-progress online form

--- a/src/applications/disability-benefits/all-claims/tests/utils/form0781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/form0781.unit.spec.jsx
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
 
 import {
   showForm0781Pages,
@@ -12,6 +13,7 @@ import {
   showBehaviorDescriptionsPage,
 } from '../../utils/form0781';
 import { form0781WorkflowChoices } from '../../content/form0781/workflowChoices';
+import { rememberTextBlob } from '../../content/form0781';
 
 describe('showForm0781Pages', () => {
   describe('when the flipper is on and a user is claiming a new condition', () => {
@@ -632,5 +634,22 @@ describe('showBehaviorSummaryPage', () => {
       };
       expect(showBehaviorSummaryPage(formData)).to.eq(false);
     });
+  });
+});
+
+describe('rememberTextBlob', () => {
+  it('should render the text explaining that questions may be skipped and/or the form saved ', () => {
+    const { container } = render(rememberTextBlob);
+
+    const strong = container.querySelector('strong');
+    expect(strong).to.exist;
+    expect(strong.textContent).to.equal('Note: ');
+
+    expect(container.textContent).to.include(
+      'you can skip questions you can’t or don’t want to answer.',
+    );
+    expect(container.textContent).to.include(
+      'you can save your in-progress online form anytime if you need a break.',
+    );
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

### summary of changes

This PR updates the Form 0781 (VA Form 21-0781 - Statement in Support of Claim for Service Connection for PTSD) to use "Note:" instead of "Remember:" in instructional text, aligning with the VA.gov content style guide (while 'Note' is listed in the guide's [word list](https://design.va.gov/content-style-guide/word-list#n, 'Remember' is not).

Changes:
- Updated text markup in the `rememberTextBlob` component to display "Note: " instead of "Remember: "
- Added unit test to verify the correct text is rendered

## Related issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/128758 .

## Testing done

- (visual QA) verified that the form displays "Note: " on the two screens within the Form 0781 flow
- added unit test to verify that "Note: " is displayed

### Steps to view the affected pages
(these steps apply to both the v1 or v2 conditions flow)
1. Start a new disability compensation form.
2. In Chapter 2, add a new condition (for example, "migraines (headaches)")
3. In Chapter 3 (Option to add a statement in support of mental health conditions), select "Yes, and I want to answer the questions online."
4. The text affected by this PR is displayed on follow-up screens "Traumatic events"  and "Behavioral changes" (within Chapter 3).

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="200"  alt="traumaticEventsBeforeMobile" src="https://github.com/user-attachments/assets/e79bbeb3-9161-452d-acbf-ba1217ae3ec6" /> <img width="200" alt="behavioralChangesBeforeMobile" src="https://github.com/user-attachments/assets/c43f55a5-a26d-4ddc-a3ca-5c4489467945" />    | <img width="200"  alt="traumaticEventsMobile" src="https://github.com/user-attachments/assets/4729b15c-966d-4a31-a284-5b4e86eb62f7" /> <img width="200"  alt="behavioralChangesMObile" src="https://github.com/user-attachments/assets/61595ce1-bc66-4559-a62b-7e05dfc44bd6" /> |
| Desktop |   <img width="200"   alt="traumaticEventsBefore" src="https://github.com/user-attachments/assets/e3f7dbbe-6438-404a-8b32-f939e9ec3359" /> <img width="200"  alt="behavioralChangesBefore" src="https://github.com/user-attachments/assets/0c61fe66-4bdd-4ba4-8297-5a6ceaefd054" />  |    <img width="200"   alt="TraumaticEvents" src="https://github.com/user-attachments/assets/f1f498af-b1a1-44cd-a069-e6d1eb7c3f3b" /><img width="200"   alt="BehavioralChanges" src="https://github.com/user-attachments/assets/a688cd63-48b6-4950-bfc5-d1b6596c1fe9" />  |

## What areas of the site does it impact?

The 526 disability compensation form, specifically pages within Chapter 3's Mental health statement.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
