### PR TITLE
Add click to close to all DR OMB modals

### DIFF
--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -149,6 +149,7 @@ const IntroductionPage = props => {
           exp-date={
             decisionReviewNodFeb2025PdfEnabled ? '4/30/2028' : '2/28/2022'
           }
+          modal-click-to-close
         />
       </div>
     </div>

--- a/src/applications/appeals/995/content/OmbInfo.jsx
+++ b/src/applications/appeals/995/content/OmbInfo.jsx
@@ -6,7 +6,12 @@ import { titleFormDetails } from './title';
 const OmbInfo = () => (
   <>
     <p>{FORM_ID}</p>
-    <va-omb-info res-burden="15" omb-number="2900-0886" exp-date="5/31/2027">
+    <va-omb-info
+      res-burden="15"
+      omb-number="2900-0886"
+      exp-date="5/31/2027"
+      modal-click-to-close
+    >
       <p>
         <strong>Respondent Burden:</strong> We need this information to
         determine entitlement to benefits (38 U.S.C. 501). Title 38, United
@@ -63,7 +68,12 @@ const OmbInfo = () => (
       (VA)
     </h3>
     <p>{FORM_IDS_4142}</p>
-    <va-omb-info res-burden="10" omb-number="2900-0858" exp-date="7/31/2024">
+    <va-omb-info
+      res-burden="10"
+      omb-number="2900-0858"
+      exp-date="7/31/2024"
+      modal-click-to-close
+    >
       <PrivacyActStatementContent />
     </va-omb-info>
   </>

--- a/src/applications/appeals/996/content/introduction.jsx
+++ b/src/applications/appeals/996/content/introduction.jsx
@@ -91,7 +91,12 @@ export const ProcessList = () => (
 
 export const OmbBlock = () => (
   <div className="omb-info--container vads-u-padding-left--0 vads-u-margin-y--4">
-    <va-omb-info res-burden="15" omb-number="2900-0862" exp-date="03/31/2027">
+    <va-omb-info
+      res-burden="15"
+      omb-number="2900-0862"
+      exp-date="03/31/2027"
+      modal-click-to-close
+    >
       <>
         <h2 className="vads-u-font-size--h3">Respondent Burden:</h2>
         <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Earlier in our contract, we received feedback from a11y that our modals should close when someone clicks outside of them. We added this functionality to all of the modals except the ones that were built into `<va-omb-info>`. That required a [Design System update](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5014). That update has since been completed, so now we can implement it on the last few modals that do not support this behavior.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/126909

## Testing done

Screen recording of all 3 DR apps' introduction pages and the OMB modals' new click to close behavior.

https://github.com/user-attachments/assets/5f9ae666-e29b-42a8-9273-d19f95fe03a0