### PR TITLE
8416 update ssn transform

### DIFF
--- a/src/applications/medical-expense-report/config/submit-transformer.js
+++ b/src/applications/medical-expense-report/config/submit-transformer.js
@@ -63,15 +63,16 @@ function swapNames(formData) {
 
 function splitVaSsnField(formData) {
   const parsedFormData = JSON.parse(formData);
-  const transformedValue = parsedFormData;
+  const transformedValue = { ...parsedFormData };
   if (parsedFormData?.veteranSocialSecurityNumber?.ssn) {
     transformedValue.veteranSocialSecurityNumber =
       parsedFormData?.veteranSocialSecurityNumber?.ssn;
+  } else {
+    delete transformedValue.veteranSocialSecurityNumber;
   }
   if (parsedFormData?.veteranSocialSecurityNumber?.vaFileNumber) {
     transformedValue.vaFileNumber =
       parsedFormData?.veteranSocialSecurityNumber?.vaFileNumber;
-    transformedValue.veteranSocialSecurityNumber = undefined;
   }
   return JSON.stringify(transformedValue);
 }

--- a/src/applications/medical-expense-report/tests/unit/utils/transform.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/utils/transform.unit.spec.jsx
@@ -190,6 +190,7 @@ describe('submit transformer', () => {
     expect(parsedResult.medicalExpenseReportsClaim).to.have.property('form');
     expect(parsedForm).to.deep.equal({
       veteranSocialSecurityNumber: '123-45-6789',
+      vaFileNumber: '987654321',
     });
     expect(parsedResult).to.have.property('localTime');
   });

--- a/src/applications/survivors-benefits/utils/transformers/splitSsn.js
+++ b/src/applications/survivors-benefits/utils/transformers/splitSsn.js
@@ -4,6 +4,8 @@ export function splitVaSsnField(formData) {
   if (parsedFormData?.veteranSocialSecurityNumber?.ssn) {
     transformedValue.veteranSocialSecurityNumber =
       parsedFormData?.veteranSocialSecurityNumber?.ssn;
+  } else {
+    delete transformedValue.veteranSocialSecurityNumber;
   }
   if (parsedFormData?.veteranSocialSecurityNumber?.vaFileNumber) {
     transformedValue.vaFileNumber =


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update 8416 ssn transform to keep both fields when filled in
- Update 8416 if veteran ssn is blank but va file number isn't, remove veteranSocialSecurityNumber object to validate correctly against the schema as it expects a string not object
- Add same conditional to to remove veteran ssn object to 534ez so it doesn't run into the same schema issue when implemented


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132024

## Testing done

- Updated unit tests
- Manual testing against vets-api locally with pdf fill tests

## Screenshots

N/A

## What areas of the site does it impact?

534ez and 8416 submission transforms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
