### PR TITLE
Update vets-json-schema to 25.2.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0af4632f7fbae51a4faa3d9f96dfb51f36a93618",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#292ebeae984e8fb39b8b1277bdbcd1a5296553c8",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24952,9 +24952,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0af4632f7fbae51a4faa3d9f96dfb51f36a93618":
-  version "25.2.45"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0af4632f7fbae51a4faa3d9f96dfb51f36a93618"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#292ebeae984e8fb39b8b1277bdbcd1a5296553c8":
+  version "25.2.47"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#292ebeae984e8fb39b8b1277bdbcd1a5296553c8"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Bumps vets-json-schema to latest (25.2.47)
- Fixes bug in submission error of 21P-8416 where the schema required a veteran ssn, but the code now accepts a va file number or veteran ssn
- The schema update removes the required ssn field, but the frontend still has validation to make sure one or the other is filled out.
- BIO Huntridge 21P-8416 and 534ez forms

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132024

## Related PRs
- https://github.com/department-of-veterans-affairs/vets-api/pull/26340
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1114

## Testing done

- Tested locally using vets-api and verified the schema no longer blocked submissions

## Screenshots

N/A

## What areas of the site does it impact?

The submission of 21P-8416

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
