### PR TITLE
[Appoint a Rep] 131821: Add Missing Form Config Key to Form Validator Spec

### DIFF
--- a/src/platform/forms/tests/forms-config-validator.unit.spec.jsx
+++ b/src/platform/forms/tests/forms-config-validator.unit.spec.jsx
@@ -75,6 +75,7 @@ const remapFormId = {
 
 const formConfigKeys = [
   'additionalRoutes',
+  'allowDuplicatePaths',
   'ariaDescribedBySubmit',
   'backLinkText',
   'chapters',


### PR DESCRIPTION
## Summary

After #42033 was merged, a [unit test failure](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/21685151414/job/62530406650) emerged in the `main` branch due to a missing config key in the form validator spec file. This PR resolves the unit test failure.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#131821

## Testing done

Confirmed that the unit tests pass locally after making the change.

## Screenshots
N/A

## What areas of the site does it impact?

Appoint a Rep: `/get-help-from-accredited-representative/appoint-rep/introduction/`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).