### PR TITLE
fix(mhv-medications): Fix custom renderHook implementation for Node 22 compatibility

### DIFF
--- a/src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx
@@ -1,7 +1,6 @@
-/* eslint-disable react/prop-types */
-import React from 'react';
 import { expect } from 'chai';
-import { waitFor, render } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 import useRxListExport from '../../hooks/useRxListExport';
 import * as pdfConfigs from '../../util/pdfConfigs';
@@ -14,32 +13,6 @@ import {
   DOWNLOAD_FORMAT,
   PRINT_FORMAT,
 } from '../../util/constants';
-
-// Custom renderHook function
-function renderHook(renderCallback, options = {}) {
-  const { initialProps, ...renderOptions } = options;
-  const result = { current: null };
-
-  function TestComponent({ renderCallbackProps }) {
-    const hookResult = renderCallback(renderCallbackProps);
-    // Update result.current on every render to capture state changes
-    result.current = hookResult;
-    return null;
-  }
-
-  const { rerender: baseRerender, unmount } = render(
-    <TestComponent renderCallbackProps={initialProps} />,
-    renderOptions,
-  );
-
-  function rerender(rerenderCallbackProps) {
-    return baseRerender(
-      <TestComponent renderCallbackProps={rerenderCallbackProps} />,
-    );
-  }
-
-  return { result, rerender, unmount };
-}
 
 describe('useRxListExport', () => {
   let sandbox;

--- a/src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx
@@ -18,17 +18,12 @@ import {
 // Custom renderHook function
 function renderHook(renderCallback, options = {}) {
   const { initialProps, ...renderOptions } = options;
-  const result = React.createRef();
-  result.current = null;
+  const result = { current: null };
 
   function TestComponent({ renderCallbackProps }) {
     const hookResult = renderCallback(renderCallbackProps);
+    // Update result.current on every render to capture state changes
     result.current = hookResult;
-
-    React.useEffect(() => {
-      result.current = hookResult;
-    });
-
     return null;
   }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fix failing unit tests in `useRxListExport.unit.spec.jsx` that were breaking in CI for Node 22
- The custom `renderHook` implementation was not properly handling React's state updates and re-renders, causing race conditions with Node 22's stricter timing
- **Solution**: Replace the custom `renderHook` implementation with `@testing-library/react-hooks`'s `renderHook`, which is already a dependency in the project and properly handles hook state updates and re-renders
- This removes ~27 lines of custom code in favor of the well-tested library implementation
- Team: MHV Medications

## Related issue(s)

- CI test failures in Node 22 environment

## Testing done

- **Old behavior**: Tests were failing in CI with Node 22 with `AssertionError: expected false to be true` because the custom `renderHook` wasn't properly capturing async state updates
- **Steps to verify**: Run `yarn test:unit src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx`
- **Results**: All 19 tests now pass locally

```
yarn test:unit src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx

  19 passing (973ms)
```

## Screenshots

N/A - No UI changes, test-only fix

## What areas of the site does it impact?

This is a test-only change with no impact on production code.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - test fix only)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A - test fix only)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - test fix only)

## Requested Feedback

The fix replaces a custom `renderHook` implementation with the standard `@testing-library/react-hooks` library that's already a project dependency. The custom implementation had issues with React's state update timing in Node 22. This is a straightforward improvement that reduces custom test code in favor of well-maintained library code.