### PR TITLE
Adds optional addRole attribute to InfoAlert. Uses for alert on VAFacilityPageV2

### DIFF
--- a/src/applications/vaos/components/InfoAlert.jsx
+++ b/src/applications/vaos/components/InfoAlert.jsx
@@ -25,6 +25,7 @@ export default function InfoAlert({
   headline,
   level = 2,
   status,
+  addRole = undefined,
 }) {
   const H = `h${level}`;
   if (backgroundOnly) {
@@ -45,7 +46,12 @@ export default function InfoAlert({
     );
   }
   return (
-    <va-alert class={className} status={status} uswds>
+    <va-alert
+      role={addRole || undefined}
+      class={className}
+      status={status}
+      uswds
+    >
       {headline && (
         <H className="vads-u-font-size--h3" slot="headline">
           {headline}
@@ -59,6 +65,7 @@ export default function InfoAlert({
 InfoAlert.propTypes = {
   status: PropTypes.oneOf(['info', 'error', 'success', 'warning', 'continue'])
     .isRequired,
+  addRole: PropTypes.string,
   backgroundOnly: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -174,6 +174,7 @@ export default function VAFacilityPageV2() {
       <div>
         {pageHeader}
         <InfoAlert
+          addRole="alert"
           status="error"
           level={2}
           headline="We can’t schedule your appointment right now"

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -26,5 +26,5 @@ module.exports = [
   { name: 'vaOnlineSchedulingImmediateCareAlert', value: false },
   { name: 'vaOnlineSchedulingRemoveFacilityConfigCheck', value: true },
   { name: 'vaOnlineSchedulingUseBrowserTimezone', value: true },
-  { name: 'vaOnlineSchedulingUseVpg', value: false },
+  { name: 'vaOnlineSchedulingUseVpg', value: true },
 ];


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary


This pull request introduces an accessibility improvement to the `InfoAlert` component and updates a feature flag in the VAOS application. The most significant change allows consumers of `InfoAlert` to specify a custom `role` attribute, which is utilized in the VAFacilityPageV2 to enhance screen reader support for error alerts. Additionally, a feature flag is enabled for the use of VPG.

**Accessibility Enhancements:**

* Added an optional `addRole` prop to the `InfoAlert` component, allowing consumers to set a custom `role` attribute for the underlying `va-alert` element, improving accessibility for screen readers. (`src/applications/vaos/components/InfoAlert.jsx`) [[1]](diffhunk://#diff-95d1b479eeadc264180754d7bf2b5c3602e341180b356898d1230c807360e17dR28) [[2]](diffhunk://#diff-95d1b479eeadc264180754d7bf2b5c3602e341180b356898d1230c807360e17dL48-R54) [[3]](diffhunk://#diff-95d1b479eeadc264180754d7bf2b5c3602e341180b356898d1230c807360e17dR68)
* Updated `VAFacilityPageV2` to pass `addRole="alert"` to `InfoAlert`, ensuring that error alerts are properly announced by assistive technologies. (`src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx`)

**Feature Flag Update:**

* Enabled the `vaOnlineSchedulingUseVpg` feature flag by setting its value to `true` in the mock feature flags configuration. (`src/applications/vaos/services/mocks/featureFlags.js`)

- Adds a property that can be optionally set for the InfoAlert component.
- UAE / Appointments/ Orion

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128361

## Testing done

- Tested locally on JAWS and NVDA and VO mac
- Block the eligibility calls or facilities call before the facility select page.

## Screenshots

<details><summary>Adds role when specified</summary>
<img width="1719" height="488" alt="Screenshot 2026-02-04 at 5 35 45 PM" src="https://github.com/user-attachments/assets/5710139c-527b-4c9d-90f2-7cb980be5030" />
</details>

<details><summary>No (same as staging) role attribute when not specified</summary>
<img width="1695" height="219" alt="Screenshot 2026-02-04 at 5 39 17 PM" src="https://github.com/user-attachments/assets/4e4bd5be-e87b-4344-8c8c-26deb208679a" />
</details>



## What areas of the site does it impact?

Only change is role=alert specified on the single alert the addRole is set for (on the Facility V2 screen of the new appointment/request flow)

## Acceptance criteria

- announces to user of a Screen Reader or other assistive technology when dynamic alert for "We can't schedule your appointment right now" is shown on screen.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check on your device that this adds only the role to the one alert.