### PR TITLE
Updated Feature Toggles to use apiRequest

### DIFF
--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -1,5 +1,6 @@
 /* This file is must run in both NodeJS and browser environments */
 
+import { apiRequest } from '../api';
 import { getFlipperId } from './helpers';
 
 const FLIPPER_ID = getFlipperId();
@@ -15,33 +16,12 @@ function FlipperClient({
   let _timeoutId;
   let _pollingActive;
   const _subscriberCallbacks = [];
-  const csrfTokenStored = localStorage.getItem('csrfToken');
 
   const _fetchToggleValues = async () => {
     try {
-      const response = await fetch(`${host}${toggleValuesPath}`, {
-        credentials: 'include',
-        headers: {
-          'X-CSRF-Token': csrfTokenStored,
-        },
-      });
-      if (!response.ok) {
-        const errorMessage = `Failed to fetch toggle values with status ${
-          response.status
-        } ${response.statusText}`;
-        return { error: errorMessage };
-      }
-
-      // Get CSRF Token from API header
-      const csrfToken = response.headers.get('X-CSRF-Token');
-
-      if (csrfToken && csrfToken !== csrfTokenStored) {
-        localStorage.setItem('csrfToken', csrfToken);
-      }
-
-      return response.json();
+      return await apiRequest(`${host}${toggleValuesPath}`);
     } catch (error) {
-      return { error: error.message };
+      return { error };
     }
   };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated `flipper-client.js` so that `_fetchToggleValues` uses `apiRequest` instead of `fetch`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1078)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/platform/utilities/tests/feature-toggles/*.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts `flipper-client.js`.

## Acceptance criteria
- [x] Fix `/feature_toggles` not calling `/refresh`.