### PR TITLE
Add refill remaining to med card when there are 0 remaining

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -55,7 +55,7 @@ const MedicationsListCard = ({ rx }) => {
       <>
         {rx &&
           rx.isRefillable &&
-          rx.refillRemaining >= 1 && (
+          rx.refillRemaining >= 0 && (
             <p
               data-testid="rx-refill-remaining"
               data-dd-privacy="mask"

--- a/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
+++ b/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
@@ -257,7 +257,7 @@ const ExtraDetails = ({ showRenewalLink = false, page, ...rx }) => {
 
       case dispStatusObj.activeParked:
         return (
-          <div>
+          <div className="vads-u-width--full">
             <p className="vads-u-margin-y--0" data-testid="active-parked">
               You can request this prescription when you need it.
             </p>

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
@@ -155,15 +155,17 @@ describe('Medication card component', () => {
     expect(queryByTestId('rx-refill-remaining')).to.be.null;
   });
 
-  it('Does not show number of refills when it has less than 1 refill remaining', () => {
+  it('Does show number of refills when it has 0 refill remaining', () => {
     const rx = {
       ...prescriptionsListItem,
       isRefillable: true,
       dispStatus: 'Active',
       refillRemaining: 0,
     };
-    const { queryByTestId } = setup(rx);
-    expect(queryByTestId('rx-refill-remaining')).to.be.null;
+    const { getByTestId } = setup(rx);
+    expect(getByTestId('rx-refill-remaining')).to.have.text(
+      'Refills remaining: 0',
+    );
   });
 
   it('displays "Not available" when prescription number is missing', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Originally, we had recommended adding the Refills remaining information to med cards when number of refills was >0. But we would now like to also include 0.

Also add another med card fix for Chris that aligns success alert bar going across the whole card.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/132119

## Testing done

- Manual check to see if refill remaining shows when a prescription has 0 refills.
- Change spec to match behavior

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  <img width="438" height="207" alt="Screenshot 2026-02-05 at 10 43 09 AM" src="https://github.com/user-attachments/assets/b3d81af4-fef8-490d-9c1b-a48d62cbb2a2" /> | <img width="502" height="233" alt="Screenshot 2026-02-05 at 10 41 17 AM" src="https://github.com/user-attachments/assets/67aa289c-457f-4d95-8503-c78f532475cb" /> |

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
