### PR TITLE
fix(profile): Pass useOAuth prop to VerifyAccountLink in VerifyIdentity

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/alerts/VerifyIdentity.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/VerifyIdentity.jsx
@@ -55,7 +55,7 @@ export default function VerifyIdentity({ useOAuth }) {
           {useOAuth ? (
             <CreateAccountLink policy={policy} useOAuth={useOAuth} />
           ) : (
-            <VerifyAccountLink policy={policy} />
+            <VerifyAccountLink policy={policy} useOAuth={useOAuth} />
           )}
         </p>
       ))}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fix a regression introduced by #42052 ("Identity 1080 | Default OAuth to true")
- The `VerifyAccountLink` component's default `useOAuth` value was changed from `false` to `true`
- However, the `VerifyIdentity` component wasn't updated to explicitly pass `useOAuth={useOAuth}` to `VerifyAccountLink`
- This caused SAML URLs to be generated as OAuth URLs when `useOAuth={false}` was passed to `VerifyIdentity`
- Team: Authenticated Experience / Profile

## Related issue(s)

- Regression from #42052

## Testing done

- **Old behavior**: When `<VerifyIdentity useOAuth={false} />` was rendered, OAuth URLs were generated instead of SAML URLs because `VerifyAccountLink` defaulted to `useOAuth={true}`
- **Steps to verify**: Run `yarn test:unit src/applications/personalization/profile/tests/components/direct-deposit/VerifyIdentity.unit.spec.jsx`
- **Results**: 
  - Before fix: 1 passing, 1 failing
  - After fix: 2 passing

## Screenshots

N/A - No UI changes, bug fix

## What areas of the site does it impact?

Direct deposit verification identity flow in the profile section.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A - bug fix)
- [x] Accessibility testing has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - unit test verification)

## Requested Feedback

This is a one-line fix to pass the `useOAuth` prop to `VerifyAccountLink`. The regression was introduced when the default value of `useOAuth` was changed from `false` to `true` in the authentication components, but the `VerifyIdentity` component wasn't updated to explicitly pass the prop.