### PR TITLE
Burials - Remove unauthenticated content

### DIFF
--- a/src/applications/burials-ez/components/IntroductionPage.jsx
+++ b/src/applications/burials-ez/components/IntroductionPage.jsx
@@ -7,7 +7,7 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
-import { isLoggedIn, selectProfile } from 'platform/user/selectors';
+import { selectProfile } from 'platform/user/selectors';
 import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
 import { formatDateLong } from 'platform/utilities/date';
 import { showPdfFormAlignment } from '../utils/helpers';
@@ -17,7 +17,6 @@ const IntroductionPage = ({ route }) => {
     focusElement('.va-nav-breadcrumbs-list');
   }, []);
 
-  const loggedIn = useSelector(isLoggedIn);
   // LOA3 Verified?
   const isVerified = useSelector(
     state => selectProfile(state)?.verified || false,
@@ -136,7 +135,7 @@ const IntroductionPage = ({ route }) => {
         - the user does not have an in-progress form (we want LOA1 users to be
           able to continue their form)
       */}
-      {loggedIn && pbbFormsRequireLoa3 && !isVerified && !hasInProgressForm ? (
+      {pbbFormsRequireLoa3 && !isVerified && !hasInProgressForm ? (
         <>
           <VerifyAlert />
           <p>

--- a/src/applications/burials-ez/components/NoFormPage.jsx
+++ b/src/applications/burials-ez/components/NoFormPage.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { apiRequest } from 'platform/utilities/api';
 import { formatSSN } from 'platform/utilities/ui';
-import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 
 const convertDateFormat = date => {
   return date.replace(/^(\d{4})-(\d{2})-(\d{2})$/, '$2/$3/$1');
@@ -290,7 +288,6 @@ const CreateSummarySections = ({
 export const NoFormPage = () => {
   const [data, setData] = useState({});
   const [loading, setLoading] = useState(true);
-  const loggedIn = useSelector(isLoggedIn);
 
   useEffect(() => {
     const resource = '/in_progress_forms/21P-530EZ';
@@ -314,7 +311,7 @@ export const NoFormPage = () => {
   }
 
   const { formData } = data;
-  return loggedIn ? (
+  return (
     <div className="row vads-u-margin-bottom--4">
       <h1>Review burial benefits application</h1>
       <p>VA Form 21P-530EZ</p>
@@ -421,36 +418,6 @@ export const NoFormPage = () => {
           </p>
         </>
       )}
-    </div>
-  ) : (
-    <div className="row vads-u-margin-bottom--4">
-      <h1>Review burial benefits application</h1>
-      <p>VA Form 21P-530EZ</p>
-      <va-alert close-btn-aria-label="Close notification" status="info" visible>
-        <h2 id="track-your-status-on-mobile" slot="headline">
-          You don’t have any saved online burial forms.
-        </h2>
-        <div>
-          <p className="vads-u-margin-y--0">
-            You can apply for VA burial benefits by mail, in person at a VA
-            regional office, or with the help of a VSO or other accredited
-            representative.
-          </p>
-        </div>
-        <br />
-        <va-link
-          href="https://www.va.gov/burials-memorials/veterans-burial-allowance/"
-          text="Learn more about how to apply for VA burial benefits"
-        />
-      </va-alert>
-      <h2 className="vads-u-margin-bottom--0 vads-u-padding-bottom--0p5 vads-u-font-size--h3 vads-u-border-bottom--2px vads-u-border-color--primary">
-        Need help?
-      </h2>
-      <p>
-        Call us at <va-telephone contact="8008271000" />. We’re here Monday
-        through Friday, 8:00 a.m to 9:00 p.m ET. If you have hearing loss, call{' '}
-        <va-telephone contact="711" tty />.
-      </p>
     </div>
   );
 };

--- a/src/applications/burials-ez/components/PrefillMessage.jsx
+++ b/src/applications/burials-ez/components/PrefillMessage.jsx
@@ -1,19 +1,12 @@
-import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 import React from 'react';
-import { useSelector } from 'react-redux';
 
-export default function PrefillMessage() {
-  const loggedIn = useSelector(isLoggedIn);
-  return loggedIn ? (
-    <>
-      <va-alert close-btn-aria-label="Close notification" status="info" visible>
-        <p className="vads-u-margin-y--0">
-          We’ve prefilled some of your information from your account. If you
-          need to correct anything, you can edit the form fields below.
-        </p>
-      </va-alert>
-    </>
-  ) : (
-    <></>
-  );
-}
+const PrefillMessage = () => (
+  <va-alert close-btn-aria-label="Close notification" status="info" visible>
+    <p className="vads-u-margin-y--0">
+      We’ve prefilled some of your information from your account. If you need to
+      correct anything, you can edit the form fields below.
+    </p>
+  </va-alert>
+);
+
+export default PrefillMessage;

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -7,7 +7,7 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { benefitsLabels } from '../utils/labels';
 
-const ConfirmationPage = ({ form, isLoggedIn, route }) => {
+const ConfirmationPage = ({ form, route }) => {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const burialsConfirmationPage = useToggleValue(
     TOGGLE_NAMES.burialConfirmationPage,
@@ -356,33 +356,23 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         information, we’ll contact you by phone, email, or mail. Then we’ll send
         you a letter with our decision.
       </p>
-      {isLoggedIn && (
-        <>
-          <h2>How can I check the status of my claim?</h2>
-          <p>
-            You can check the status of your claim online. <br />
-            <strong>Note:</strong> It may take 7 to 10 days after you apply for
-            the status of your claim to show online.
-          </p>
-          <va-link-action
-            href="/claim-or-appeal-status/"
-            text="Check the status of your claim"
-            class="vads-u-margin-bottom--4"
-          />
-          <br />
-          <va-link-action
-            href="https://www.va.gov/"
-            text="Go back to VA.gov"
-            type="secondary"
-          />
-        </>
-      )}
-      {!isLoggedIn && (
-        <>
-          <va-link-action href="https://www.va.gov/" text="Go back to VA.gov" />
-        </>
-      )}
-
+      <h2>How can I check the status of my claim?</h2>
+      <p>
+        You can check the status of your claim online. <br />
+        <strong>Note:</strong> It may take 7 to 10 days after you apply for the
+        status of your claim to show online.
+      </p>
+      <va-link-action
+        href="/claim-or-appeal-status/"
+        text="Check the status of your claim"
+        class="vads-u-margin-bottom--4"
+      />
+      <br />
+      <va-link-action
+        href="https://www.va.gov/"
+        text="Go back to VA.gov"
+        type="secondary"
+      />
       <div className="vads-u-margin-top--9">
         <va-need-help>
           <div slot="content">
@@ -405,7 +395,6 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
 function mapStateToProps(state) {
   return {
     form: state.form,
-    isLoggedIn: state.user?.login?.currentlyLoggedIn,
   };
 }
 
@@ -420,7 +409,6 @@ ConfirmationPage.propTypes = {
       transportationReceipts: PropTypes.arrayOf(PropTypes.shape({})),
     }),
   }),
-  isLoggedIn: PropTypes.bool,
   route: PropTypes.shape({
     formConfig: PropTypes.shape({}),
   }),

--- a/src/applications/burials-ez/tests/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/components/IntroductionPage.unit.spec.jsx
@@ -76,16 +76,6 @@ describe('IntroductionPage', () => {
       .exist;
   });
 
-  it('renders sign in required alert when not logged in & toggle on', () => {
-    // logged in false, toggle true, verified false, saved form false
-    const { container } = render(
-      <Provider store={getStore({ loggedIn: false, toggle: true })}>
-        <IntroductionPage {...props} />
-      </Provider>,
-    );
-    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
-  });
-
   it('renders start action link when logged in, no saved form & toggle off', () => {
     // logged in true, toggle false, verified false, saved form false
     const { container } = render(

--- a/src/applications/burials-ez/tests/components/NoFormPage.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/components/NoFormPage.unit.spec.jsx
@@ -7,7 +7,7 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import { mockApiRequest } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { NoFormPage } from '../../components/NoFormPage';
 
-const store = ({ isLoggedIn = false } = {}) => ({
+const store = ({ isLoggedIn = true } = {}) => ({
   getState: () => ({
     user: {
       login: {
@@ -62,33 +62,14 @@ const mockFormData = {
 };
 
 describe('NoFormPage', () => {
-  it('should render if NOT logged in', async () => {
-    mockApiRequest(mockFormData);
+  it('should render if DOES NOT have form data in progress', async () => {
+    mockApiRequest({ formData: {}, metadata: {} });
     const mockStore = store();
     const { container } = render(
       <Provider store={mockStore}>
         <NoFormPage />
       </Provider>,
     );
-    expect($('va-loading-indicator', container)).to.exist;
-    await waitFor(() => {
-      expect($('h1', container).textContent).to.eql(
-        'Review burial benefits application',
-      );
-      expect($$('h2', container)[0].textContent).to.eql(
-        'You don’t have any saved online burial forms.',
-      );
-    });
-  });
-
-  it('should render if IS logged in && DOES NOT have form data in progress', async () => {
-    mockApiRequest({ formData: {}, metadata: {} });
-    const mockStore = store({ isLoggedIn: true });
-    const { container } = render(
-      <Provider store={mockStore}>
-        <NoFormPage />
-      </Provider>,
-    );
     await waitFor(() => {
       expect($('h1', container).textContent).to.eql(
         'Review burial benefits application',
@@ -96,9 +77,9 @@ describe('NoFormPage', () => {
     });
   });
 
-  it('should render if IS logged in && DOES have form data in progress', async () => {
+  it('should render if DOES have form data in progress', async () => {
     mockApiRequest(mockFormData);
-    const mockStore = store({ isLoggedIn: true });
+    const mockStore = store();
     const { container } = render(
       <Provider store={mockStore}>
         <NoFormPage />
@@ -112,11 +93,11 @@ describe('NoFormPage', () => {
     });
   });
 
-  it('should render if IS logged in && DOES have form data in progress && supports no form data', async () => {
+  it('should render if DOES have form data in progress && supports no form data', async () => {
     const defaultMockData = { ...mockFormData };
     defaultMockData.formData = {};
     mockApiRequest(defaultMockData);
-    const mockStore = store({ isLoggedIn: true });
+    const mockStore = store();
     const { container } = render(
       <Provider store={mockStore}>
         <NoFormPage />


### PR DESCRIPTION
### Summary of Changes
This PR removes **unauthenticated-only content** from the **Burial Benefits form (VA Form 21P-530EZ)**.  
This cleanup is required before the `pbb_forms_require_loa3` feature toggle can be safely removed, ensuring the form no longer relies on conditional logic for unauthenticated users.

No functional changes are introduced for authenticated users; the update strictly removes legacy unauthenticated messaging and related conditional content.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129183

### How to Set Up in Local Environment
1. Run the local environment
2. Ensure you are logged in with a test user (LOA3).
3. Navigate to the Burial Benefits form:  
   http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/

### How to Test
1. Load the Burial Benefits form while authenticated.
2. Navigate through the form and verify:
   - No unauthenticated-only content is rendered.
   - Page content and instructions remain accurate and complete.
3. Review the Introduction, Applicant Information, and Confirmation pages, and any previously conditional sections to ensure removed content does not leave gaps.
4. Confirm no console errors or accessibility regressions.

### Feature Flag Note
- This change prepares the form for safe removal of the `pbb_forms_require_loa3` feature toggle.
- No new feature flags were introduced.

### Acceptance Criteria
- [x] All unauthenticated-only content is removed.
- [x] Form renders correctly for authenticated users.
- [x] No dependencies remain on unauthenticated conditional logic.
- [x] No regressions in navigation, validation, or accessibility.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally while authenticated.
- [ ] No console errors or accessibility issues.
- [ ] Tests updated or verified passing.