### PR TITLE
Fix infinite loop for file upload

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -272,6 +272,7 @@ export function uploadFile(
   onError,
   trackingPrefix,
   password,
+  hasAttemptedTokenRefresh = false,
 ) {
   // This item should have been set in any previous API calls
   const csrfTokenStored = localStorage.getItem('csrfToken');
@@ -385,7 +386,7 @@ export function uploadFile(
           ...fileData,
           isEncrypted: !!password,
         });
-      } else if (req.status === 403) {
+      } else if (req.status === 403 && !hasAttemptedTokenRefresh) {
         let errorResponse;
         try {
           errorResponse = JSON.parse(req.response);
@@ -403,6 +404,7 @@ export function uploadFile(
                   onError,
                   trackingPrefix,
                   password,
+                  true,
                 )(dispatch, getState);
               },
             );


### PR DESCRIPTION
## Summary

- Fix infinite loop for file upload
- If we already got a 403 and are attempting a refresh of the token, don't try more than once. This matches the pattern above also in the file.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131850

## Testing done

- Test on http://localhost:3001/forms/upload/21-0779/upload

## What areas of the site does it impact?

file upload

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
