### PR TITLE
125076 - Use new table-title-summary prop to create focused element on statementTable

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/StatementTable.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementTable.jsx
@@ -174,6 +174,7 @@ const StatementTable = ({ charges, formatCurrency, selectedCopay }) => {
       <div key={`table-wrapper-${currentPage}`}>
         <va-table
           table-title={getStatementDateRange()}
+          table-title-summary={getStatementDateRange()}
           scrollable={false}
           table-type="bordered"
           full-width

--- a/src/applications/combined-debt-portal/medical-copays/components/StatementTable.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementTable.jsx
@@ -18,17 +18,16 @@ const StatementTable = ({ charges, formatCurrency, selectedCopay }) => {
 
   const MAX_ROWS = 10;
 
-  function paginate(array, pageSize, pageNumber) {
+  const paginate = (array, pageSize, pageNumber) => {
     return array?.slice((pageNumber - 1) * pageSize, pageNumber * pageSize);
-  }
+  };
 
-  function getPaginationText(
+  const getPaginationText = (
     currentPage,
     pageSize,
     totalItems,
     label = 'charges',
-  ) {
-    // Ensure numbers are valid
+  ) => {
     if (totalItems === 0) {
       return `Showing 0 ${label}`;
     }
@@ -37,7 +36,7 @@ const StatementTable = ({ charges, formatCurrency, selectedCopay }) => {
     const end = Math.min(currentPage * pageSize, totalItems);
 
     return `Showing ${start}-${end} of ${totalItems} ${label}`;
-  }
+  };
 
   const normalizedCharges = shouldShowVHAPaymentHistory
     ? charges.map(item => ({
@@ -70,20 +69,20 @@ const StatementTable = ({ charges, formatCurrency, selectedCopay }) => {
 
   const numPages = Math.ceil(normalizedCharges?.length / MAX_ROWS);
 
-  const getStatementDateRange = () => {
-    const pageText = getPaginationText(
-      currentPage,
-      MAX_ROWS,
-      normalizedCharges?.length,
-      'charges',
-    );
+  const paginationText = getPaginationText(
+    currentPage,
+    MAX_ROWS,
+    normalizedCharges?.length,
+    'charges',
+  );
 
+  const getStatementDateRange = () => {
     if (
       !selectedCopay?.statementStartDate ||
       !selectedCopay?.statementEndDate
     ) {
       if (normalizedCharges?.length > MAX_ROWS) {
-        return `This statement shows your current charges. ${pageText}.`;
+        return `This statement shows your current charges. ${paginationText}.`;
       }
       return 'This statement shows your current charges.';
     }
@@ -92,7 +91,7 @@ const StatementTable = ({ charges, formatCurrency, selectedCopay }) => {
     const endDate = formatDate(selectedCopay.statementEndDate);
 
     if (normalizedCharges?.length > MAX_ROWS) {
-      return `This statement shows charges you received between ${startDate} and ${endDate}. ${pageText}.`;
+      return `This statement shows charges you received between ${startDate} and ${endDate}. ${paginationText}.`;
     }
     return `This statement shows charges you received between ${startDate} and ${endDate}.`;
   };
@@ -174,7 +173,7 @@ const StatementTable = ({ charges, formatCurrency, selectedCopay }) => {
       <div key={`table-wrapper-${currentPage}`}>
         <va-table
           table-title={getStatementDateRange()}
-          table-title-summary={getStatementDateRange()}
+          table-title-summary={paginationText}
           scrollable={false}
           table-type="bordered"
           full-width

--- a/src/applications/combined-debt-portal/medical-copays/tests/unit/paymentHistory.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/tests/unit/paymentHistory.unit.spec.jsx
@@ -146,12 +146,12 @@ describe('Feature Toggle Data Confirmation', () => {
       const table = container.querySelector('va-table');
       expect(table).to.exist;
 
-      const tableTitleSummary = table.getAttribute('table-title-summary');
-      expect(tableTitleSummary).to.exist;
-      expect(tableTitleSummary).to.include(
+      expect(table.getAttribute('table-title')).to.include(
         'This statement shows charges you received between May 3, 2024 and June 3, 2024',
       );
-      expect(table.getAttribute('table-title')).to.equal(tableTitleSummary);
+      expect(table.getAttribute('table-title-summary')).to.equal(
+        'Showing 1-3 of 3 charges',
+      );
     });
 
     it('renders va-table with table-title-summary when statement dates are missing', () => {
@@ -173,8 +173,11 @@ describe('Feature Toggle Data Confirmation', () => {
 
       const table = container.querySelector('va-table');
       expect(table).to.exist;
-      expect(table.getAttribute('table-title-summary')).to.equal(
+      expect(table.getAttribute('table-title')).to.equal(
         'This statement shows your current charges.',
+      );
+      expect(table.getAttribute('table-title-summary')).to.equal(
+        'Showing 1-2 of 2 charges',
       );
     });
 
@@ -205,7 +208,8 @@ describe('Feature Toggle Data Confirmation', () => {
       );
 
       await waitFor(() => {
-        expect(table.getAttribute('table-title-summary')).to.equal(
+        const updatedTable = container.querySelector('va-table');
+        expect(updatedTable.getAttribute('table-title-summary')).to.equal(
           'Showing 11-15 of 15 charges',
         );
       });
@@ -213,8 +217,9 @@ describe('Feature Toggle Data Confirmation', () => {
       // Focus logic targets va-table and sets tabindex="-1" on it; in jsdom
       // custom elements may not receive document.activeElement, so we assert
       // the correct component was targeted for focus.
-      expect(table).to.exist;
-      expect(table.getAttribute('tabindex')).to.equal('-1');
+      const tableAfterUpdate = container.querySelector('va-table');
+      expect(tableAfterUpdate).to.exist;
+      expect(tableAfterUpdate.getAttribute('tabindex')).to.equal('-1');
     });
   });
 

--- a/src/applications/combined-debt-portal/medical-copays/tests/unit/paymentHistory.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/tests/unit/paymentHistory.unit.spec.jsx
@@ -119,6 +119,95 @@ describe('Feature Toggle Data Confirmation', () => {
     });
   });
 
+  describe('StatementTable focus', () => {
+    const mockSelectedCopay = {
+      pHNewBalance: 25,
+      pHTotCredits: 15,
+      pHPrevBal: 30,
+      pSStatementDateOutput: '05/03/2024',
+      pSStatementVal: 'STMT-123',
+      statementStartDate: '2024-05-03',
+      statementEndDate: '2024-06-03',
+    };
+
+    it('renders va-table with table-title-summary set to the statement date range', () => {
+      const charges = createCharges(3);
+      const store = createMockStore(false);
+      const { container } = render(
+        <Provider store={store}>
+          <StatementTable
+            charges={charges}
+            formatCurrency={mockFormatCurrency}
+            selectedCopay={{ ...mockSelectedCopay }}
+          />
+        </Provider>,
+      );
+
+      const table = container.querySelector('va-table');
+      expect(table).to.exist;
+
+      const tableTitleSummary = table.getAttribute('table-title-summary');
+      expect(tableTitleSummary).to.exist;
+      expect(tableTitleSummary).to.include(
+        'This statement shows charges you received between May 3, 2024 and June 3, 2024',
+      );
+      expect(table.getAttribute('table-title')).to.equal(tableTitleSummary);
+    });
+
+    it('renders va-table with table-title-summary when statement dates are missing', () => {
+      const charges = createCharges(2);
+      const store = createMockStore(false);
+      const { container } = render(
+        <Provider store={store}>
+          <StatementTable
+            charges={charges}
+            formatCurrency={mockFormatCurrency}
+            selectedCopay={{
+              ...mockSelectedCopay,
+              statementStartDate: null,
+              statementEndDate: null,
+            }}
+          />
+        </Provider>,
+      );
+
+      const table = container.querySelector('va-table');
+      expect(table).to.exist;
+      expect(table.getAttribute('table-title-summary')).to.equal(
+        'This statement shows your current charges.',
+      );
+    });
+
+    it('after pagination click, the va-table component is the focus target', () => {
+      const charges = createCharges(15);
+      const store = createMockStore(false);
+      const { container } = render(
+        <Provider store={store}>
+          <StatementTable
+            charges={charges}
+            formatCurrency={mockFormatCurrency}
+            selectedCopay={{ ...mockSelectedCopay }}
+          />
+        </Provider>,
+      );
+
+      const pagination = container.querySelector('va-pagination');
+      pagination.dispatchEvent(
+        new CustomEvent('pageSelect', {
+          detail: { page: 2 },
+          bubbles: true,
+        }),
+      );
+
+      // Focus logic targets va-table and sets tabindex="-1" on it; in jsdom
+      // custom elements may not receive document.activeElement, so we assert
+      // the correct component was targeted for focus.
+      const table = container.querySelector('va-table');
+      expect(table).to.exist;
+      expect(table.getAttribute('tabindex')).to.equal('-1');
+    });
+  });
+
   // TODO: to be removed once toggle is fully enabled
   it('showVHAPaymentHistory is false', () => {
     const mockState = {

--- a/src/applications/combined-debt-portal/medical-copays/tests/unit/paymentHistory.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/tests/unit/paymentHistory.unit.spec.jsx
@@ -178,7 +178,7 @@ describe('Feature Toggle Data Confirmation', () => {
       );
     });
 
-    it('after pagination click, the va-table component is the focus target', () => {
+    it('after pagination click, the va-table component is the focus target', async () => {
       const charges = createCharges(15);
       const store = createMockStore(false);
       const { container } = render(
@@ -191,6 +191,11 @@ describe('Feature Toggle Data Confirmation', () => {
         </Provider>,
       );
 
+      const table = container.querySelector('va-table');
+      expect(table.getAttribute('table-title-summary')).to.equal(
+        'Showing 1-10 of 15 charges',
+      );
+
       const pagination = container.querySelector('va-pagination');
       pagination.dispatchEvent(
         new CustomEvent('pageSelect', {
@@ -199,10 +204,15 @@ describe('Feature Toggle Data Confirmation', () => {
         }),
       );
 
+      await waitFor(() => {
+        expect(table.getAttribute('table-title-summary')).to.equal(
+          'Showing 11-15 of 15 charges',
+        );
+      });
+
       // Focus logic targets va-table and sets tabindex="-1" on it; in jsdom
       // custom elements may not receive document.activeElement, so we assert
       // the correct component was targeted for focus.
-      const table = container.querySelector('va-table');
       expect(table).to.exist;
       expect(table.getAttribute('tabindex')).to.equal('-1');
     });


### PR DESCRIPTION
# Summary:
Added focus tag to va-table that fires upon pagination click & specs. This is done with the table-title-summary prop. Now allows us to show pagination count text.
<img width="702" height="315" alt="Screenshot 2026-02-05 at 1 28 46 PM" src="https://github.com/user-attachments/assets/d1797686-64c7-461f-8238-edb4ece5d899" />
