### PR TITLE
Updated Identity GA to Ignore Cypress Tests

### DIFF
--- a/src/applications/auth/containers/AuthMetrics.jsx
+++ b/src/applications/auth/containers/AuthMetrics.jsx
@@ -20,7 +20,8 @@ export default class AuthMetrics {
     this.authnContext = get('authnContext', this.userProfile, undefined);
     this.serviceName = get('signIn.serviceName', this.userProfile, null);
     this.isProduction =
-      environment.getRawBuildtype() === environments.VAGOVPROD;
+      environment.getRawBuildtype() === environments.VAGOVPROD &&
+      !window.Cypress;
   }
 
   compareLoginPolicy = () => {

--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -111,7 +111,7 @@ export const CallToActionWidget = ({
   setFocus = true,
   toggleLoginModal: propsToggleLoginModal,
 }) => {
-  const isProduction = environment.isProduction();
+  const isProduction = environment.isProduction() && !environment.isTest();
   const ctaWidget = ctaWidgetsLookup?.[appId];
   const featureToggle = ctaWidget?.featureToggle;
   const gaPrefix = 'register-mhv';

--- a/src/platform/user/authentication/components/LoginButton.jsx
+++ b/src/platform/user/authentication/components/LoginButton.jsx
@@ -9,7 +9,7 @@ import { createOktaOAuthRequest } from '../../../utilities/oauth/utilities';
 export function loginHandler(loginType, isOAuth, oktaParams = {}) {
   const isOAuthAttempt = isOAuth && '-oauth';
   const { codeChallenge = '', clientId = '', state = '' } = oktaParams;
-  const isProduction = environment.isProduction();
+  const isProduction = environment.isProduction() && !environment.isTest();
 
   if (OKTA_APPS?.includes(clientId)) {
     const url = createOktaOAuthRequest({

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -311,7 +311,7 @@ export function redirect(redirectUrl, clickedEvent, type = '') {
   const { application } = getQueryParams();
   const externalRedirect = isExternalRedirect();
   const existingReturnUrl = sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL);
-  const isProduction = environment.isProduction();
+  const isProduction = environment.isProduction() && !environment.isTest();
 
   // Keep track of the URL to return to after auth operation.
   // If the user is coming via the standalone sign-in, redirect to the home page.

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -160,7 +160,7 @@ export async function createOAuthRequest({
   );
 
   sessionStorage.setItem('ci', usedClientId);
-  if (environment.isProduction()) {
+  if (environment.isProduction() && !environment.isTest()) {
     recordEvent({ event: `login-attempted-${type}-oauth-${clientId}` });
   }
   return url.toString();
@@ -215,7 +215,7 @@ export const requestToken = async ({ code, redirectUri, csp }) => {
     credentials: 'include',
   });
 
-  if (environment.isProduction()) {
+  if (environment.isProduction() && !environment.isTest()) {
     recordEvent({
       event: response.ok
         ? `login-success-${csp}-oauth-tokenexchange`
@@ -351,7 +351,7 @@ export const logoutEvent = async (signInServiceName, wait = {}) => {
   const sleep = time => {
     return new Promise(resolve => setTimeout(resolve, time));
   };
-  if (environment.isProduction()) {
+  if (environment.isProduction() && !environment.isTest()) {
     recordEvent({ event: `${AUTH_EVENTS.OAUTH_LOGOUT}-${signInServiceName}` });
   }
 
@@ -388,7 +388,7 @@ export function createOktaOAuthRequest({
   );
 
   sessionStorage.setItem('ci', clientId);
-  if (environment.isProduction()) {
+  if (environment.isProduction() && !environment.isTest()) {
     recordEvent({ event: `login-attempted-${loginType}-oauth-${clientId}` });
   }
   return url.toString();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated Identity Google Analytics to not run during Cypress tests.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1085)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running: 
  - `yarn test:unit src/applications/auth/tests/AuthMetrics.unit.spec.jsx`
  - `yarn test:unit src/applications/static-pages/cta-widget/tests/index.unit.spec.jsx`

## What areas of the site does it impact?
This impacts `AuthMetrics.jsx`, the CTA Widget, and Auth utilities.

## Acceptance criteria
- [x] Fix erroneous GA logs being sent during Cypress tests.