### PR TITLE
Disable alert focus test temporarily

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-button.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-button.cypress.spec.js
@@ -45,18 +45,18 @@ const testConfig = createTestConfig(
               ).should('exist');
             };
 
-            const tryContinueAndShouldBeStoppedByError = () => {
-              // Remove wait after the following issue is fixed.
-              // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
-              // Wait required to avoid race condition with SIP causing page rerender.
-              // eslint-disable-next-line cypress/no-unnecessary-waiting
-              cy.wait(100);
-              cy.findByText(/continue/i, { selector: 'button' }).click();
-              // Missing info alert should be focused
-              cy.get(
-                'va-card[name="employer_1"] .array-builder-missing-info-alert',
-              ).should('have.attr', 'tabindex', '-1');
-            };
+            // const tryContinueAndShouldBeStoppedByError = () => {
+            //   // Remove wait after the following issue is fixed.
+            //   // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            //   // Wait required to avoid race condition with SIP causing page rerender.
+            //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+            //   cy.wait(100);
+            //   cy.findByText(/continue/i, { selector: 'button' }).click();
+            //   // Missing info alert should be focused
+            //   cy.get(
+            //     'va-card[name="employer_1"] .array-builder-missing-info-alert',
+            //   ).should('have.attr', 'tabindex', '-1');
+            // };
 
             const deleteCard = () => {
               // Remove card with error and should be able to continue
@@ -78,7 +78,9 @@ const testConfig = createTestConfig(
             };
 
             expectInitialLayout();
-            tryContinueAndShouldBeStoppedByError();
+            // TODO: re-enable once the following ticket is resolved:
+            // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            // tryContinueAndShouldBeStoppedByError();
             deleteCard();
             continueNoError();
           });

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-button.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-button.cypress.spec.js
@@ -81,6 +81,11 @@ const testConfig = createTestConfig(
             // TODO: re-enable once the following ticket is resolved:
             // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
             // tryContinueAndShouldBeStoppedByError();
+
+            // Wait required to avoid race condition with SIP causing page rerender.
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(200);
+
             deleteCard();
             continueNoError();
           });

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-link.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-link.cypress.spec.js
@@ -83,6 +83,11 @@ const testConfig = createTestConfig(
             // TODO: re-enable once the following ticket is resolved:
             // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
             // tryContinueAndShouldBeStoppedByError();
+
+            // Wait required to avoid race condition with SIP causing page rerender.
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(200);
+
             deleteCard();
             continueNoError();
           });

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-link.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-link.cypress.spec.js
@@ -45,18 +45,20 @@ const testConfig = createTestConfig(
               ).should('exist');
             };
 
-            const tryContinueAndShouldBeStoppedByError = () => {
-              // Remove wait after the following issue is fixed.
-              // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
-              // Wait required to avoid race condition with SIP causing page rerender.
-              // eslint-disable-next-line cypress/no-unnecessary-waiting
-              cy.wait(100);
-              cy.findByText(/continue/i, { selector: 'button' }).click();
-              // Missing info alert should be focused
-              cy.get(
-                'va-card[name="employer_1"] .array-builder-missing-info-alert',
-              ).should('have.attr', 'tabindex', '-1');
-            };
+            // const tryContinueAndShouldBeStoppedByError = () => {
+            //   // Remove wait after the following issue is fixed.
+            //   // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            //   // Wait required to avoid race condition with SIP causing page rerender.
+            //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+            //   cy.wait(100);
+            //   cy.findByText(/continue/i, { selector: 'button' }).click();
+            //   // focusElement uses async querySelectorWithShadowRoot for web components,
+            //   // so we need to wait for the tabindex attribute to be set asynchronously
+            //   cy.get(
+            //     'va-card[name="employer_1"] .array-builder-missing-info-alert',
+            //     { timeout: 15000 },
+            //   ).should('have.attr', 'tabindex', '-1');
+            // };
 
             const deleteCard = () => {
               // Remove card with error and should be able to continue
@@ -78,7 +80,9 @@ const testConfig = createTestConfig(
             };
 
             expectInitialLayout();
-            tryContinueAndShouldBeStoppedByError();
+            // TODO: re-enable once the following ticket is resolved:
+            // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            // tryContinueAndShouldBeStoppedByError();
             deleteCard();
             continueNoError();
           });

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-yes-no.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-yes-no.cypress.spec.js
@@ -41,21 +41,21 @@ const testConfig = createTestConfig(
               ).should('exist');
             };
 
-            const tryContinueAndShouldBeStoppedByError = () => {
-              // Remove wait after the following issue is fixed.
-              // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
-              // Wait required to avoid race condition with SIP causing page rerender.
-              // eslint-disable-next-line cypress/no-unnecessary-waiting
-              cy.wait(100);
-              cy.findByText(/continue/i, { selector: 'button' }).click();
+            // const tryContinueAndShouldBeStoppedByError = () => {
+            //   // Remove wait after the following issue is fixed.
+            //   // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            //   // Wait required to avoid race condition with SIP causing page rerender.
+            //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+            //   cy.wait(100);
+            //   cy.findByText(/continue/i, { selector: 'button' }).click();
 
-              // skipping this test pending resolution of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
-              // in CI this assertion will fail because the click handler attached to the continue button (ProgressButton) doesn't run after preceding interaciton
-              // Missing info alert should be focused
-              // cy.get(
-              //   'va-card[name="employer_1"] .array-builder-missing-info-alert',
-              // ).should('have.attr', 'tabindex', '-1');
-            };
+            //   // skipping this test pending resolution of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            //   // in CI this assertion will fail because the click handler attached to the continue button (ProgressButton) doesn't run after preceding interaciton
+            //   // Missing info alert should be focused
+            //   // cy.get(
+            //   //   'va-card[name="employer_1"] .array-builder-missing-info-alert',
+            //   // ).should('have.attr', 'tabindex', '-1');
+            // };
 
             const deleteCard = () => {
               // Remove card with error and should be able to continue
@@ -78,7 +78,9 @@ const testConfig = createTestConfig(
             };
 
             expectInitialLayout();
-            tryContinueAndShouldBeStoppedByError();
+            // TODO: re-enable once the following ticket is resolved:
+            // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
+            // tryContinueAndShouldBeStoppedByError();
             deleteCard();
             continueNoError();
           });

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-yes-no.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-missing-info-yes-no.cypress.spec.js
@@ -81,6 +81,11 @@ const testConfig = createTestConfig(
             // TODO: re-enable once the following ticket is resolved:
             // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469
             // tryContinueAndShouldBeStoppedByError();
+
+            // Wait required to avoid race condition with SIP causing page rerender.
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(200);
+
             deleteCard();
             continueNoError();
           });


### PR DESCRIPTION
## Summary

- Disable array builder missing info alert focus test temporarily due to e2e flakiness

## Related issue(s)

Add note to renable when this ticket is fixed

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4469

## Testing done

- Browser testing still works appropriately - the error focus ring does not happen sometimes due to react page rerenders, and is a known existing issue.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
