### PR TITLE
10-7959f-1 | Fix linting errors

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/tests/e2e/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/ivc-champva/10-7959f-1/tests/e2e/fixtures/mocks/local-mock-responses.js
@@ -1,7 +1,7 @@
 // use this file to mock api responses for local development
 // yarn mock-api --responses ./src/applications/ivc-champva/10-7959f-1/tests/e2e/fixtures/mocks/local-mock-responses.js
 const mockUser = require('./user.json');
-const mockFeatureToggles = require('./featureToggles.json');
+const mockFeatureToggles = require('./feature-toggles.json');
 const mockSipPut = require('./sip-put.json');
 const mockSipGet = require('./sip-get.json');
 const mockUpload = require('./upload.json');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR makes a minor change to the mock API responses for local development by correcting the filename for the feature toggles mock data.

* Updated the import statement to reference `feature-toggles.json` instead of `featureToggles.json` in `local-mock-responses.js` to match the correct file name.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#130866

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- App is free from lint errors

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user