### PR TITLE
standardized dispatch action across domains to minimized chance of bugs

### DIFF
--- a/.github/instructions/mhv-medical-records.instructions.md
+++ b/.github/instructions/mhv-medical-records.instructions.md
@@ -368,9 +368,32 @@ Update this file when you:
   - `listCurrentAsOf`: Date when list was last confirmed current
   - `refreshStatus`: PHR refresh status array
   - `extractType`: Extract type(s) to check (e.g., 'Allergy')
-  - `dispatchAction`: Action creator to fetch data
+  - `dispatchAction`: Action creator to fetch data (should be wrapped in `useCallback`)
   - `dispatch`: Redux dispatch function
-- **Behavior**: Fetches data when refresh is current and local data is stale
+  - `isLoading`: (optional, default `false`) Whether feature toggles are still loading. When `true`, defers fetching until toggles finish loading to ensure the correct accelerated/non-accelerated API path is used.
+- **Behavior**: 
+  - Fetches data when refresh is current and local data is stale
+  - Waits for `isLoading` to be `false` before dispatching any fetches
+  - Use `useCallback` for `dispatchAction` to provide a stable function reference and avoid unnecessary effect re-runs
+- **Usage Pattern**:
+  ```javascript
+  const { isLoading, isAcceleratingDomain } = useAcceleratedData();
+  
+  const dispatchAction = useCallback(
+    isCurrent => getRecordsList(isCurrent, isAcceleratingDomain),
+    [isAcceleratingDomain],
+  );
+  
+  useListRefresh({
+    listState,
+    listCurrentAsOf,
+    refreshStatus: refresh.status,
+    extractType: refreshExtractTypes.DOMAIN,
+    dispatchAction,
+    dispatch,
+    isLoading,
+  });
+  ```
 
 ### useAlerts
 - **Location**: `hooks/use-alerts.js`
@@ -743,12 +766,20 @@ import { getAllergies, getAllergy } from '../api/MrApi';
 
 ### Handling PHR Refresh in a List Component
 ```javascript
+const { isLoading, isAcceleratingAllergies } = useAcceleratedData();
+
+const dispatchAction = useCallback(
+  isCurrent => getAllergiesList(isCurrent, isAcceleratingAllergies),
+  [isAcceleratingAllergies],
+);
+
 useListRefresh({
   listState,
   listCurrentAsOf,
   refreshStatus: refresh.status,
   extractType: refreshExtractTypes.ALLERGY,
-  dispatchAction: getAllergiesList,
+  dispatchAction,
   dispatch,
+  isLoading,
 });
 ```

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import PropTypes from 'prop-types';
@@ -73,9 +73,10 @@ const Allergies = props => {
       ({ facilityId }) => facilityId === MEDS_BY_MAIL_FACILITY_ID,
     ) ?? false;
 
-  const dispatchAction = isCurrent => {
-    return getAllergiesList(isCurrent, isAcceleratingAllergies, isCerner);
-  };
+  const dispatchAction = useCallback(
+    isCurrent => getAllergiesList(isCurrent, isAcceleratingAllergies, isCerner),
+    [isAcceleratingAllergies, isCerner],
+  );
 
   useListRefresh({
     listState,
@@ -84,6 +85,7 @@ const Allergies = props => {
     extractType: refreshExtractTypes.ALLERGY,
     dispatchAction,
     dispatch,
+    isLoading,
   });
 
   useTrackAction(statsdFrontEndActions.ALLERGIES_LIST);

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
@@ -64,21 +64,12 @@ const CareSummariesAndNotes = () => {
 
   const { isLoading, isAcceleratingCareNotes } = useAcceleratedData();
 
-  const dispatchAction = useMemo(
-    () => {
-      return isCurrent => {
-        return getCareSummariesAndNotesList(
-          isCurrent,
-          isAcceleratingCareNotes,
-          {
-            startDate: dateRange.fromDate,
-            endDate: dateRange.toDate,
-          },
-        );
-      };
-    },
-    [isAcceleratingCareNotes, dateRange],
-  );
+  const dispatchAction = isCurrent => {
+    return getCareSummariesAndNotesList(isCurrent, isAcceleratingCareNotes, {
+      startDate: dateRange.fromDate,
+      endDate: dateRange.toDate,
+    });
+  };
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
@@ -64,12 +64,14 @@ const CareSummariesAndNotes = () => {
 
   const { isLoading, isAcceleratingCareNotes } = useAcceleratedData();
 
-  const dispatchAction = isCurrent => {
-    return getCareSummariesAndNotesList(isCurrent, isAcceleratingCareNotes, {
-      startDate: dateRange.fromDate,
-      endDate: dateRange.toDate,
-    });
-  };
+  const dispatchAction = useCallback(
+    isCurrent =>
+      getCareSummariesAndNotesList(isCurrent, isAcceleratingCareNotes, {
+        startDate: dateRange.fromDate,
+        endDate: dateRange.toDate,
+      }),
+    [isAcceleratingCareNotes, dateRange],
+  );
 
   useListRefresh({
     listState,
@@ -78,6 +80,7 @@ const CareSummariesAndNotes = () => {
     extractType: refreshExtractTypes.VPR,
     dispatchAction,
     dispatch,
+    isLoading,
   });
 
   // On Unmount: reload any newly updated records and normalize the FETCHING state.

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
@@ -44,9 +44,11 @@ const HealthConditions = () => {
   useTrackAction(statsdFrontEndActions.HEALTH_CONDITIONS_LIST);
 
   const { isLoading, isAcceleratingConditions } = useAcceleratedData();
-  const dispatchAction = isCurrent => {
-    return getConditionsList(isCurrent, isAcceleratingConditions);
-  };
+
+  const dispatchAction = useCallback(
+    isCurrent => getConditionsList(isCurrent, isAcceleratingConditions),
+    [isAcceleratingConditions],
+  );
 
   useListRefresh({
     listState,
@@ -55,6 +57,7 @@ const HealthConditions = () => {
     extractType: refreshExtractTypes.VPR,
     dispatchAction,
     dispatch,
+    isLoading,
   });
 
   // On Unmount: reload any newly updated records and normalize the FETCHING state.

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
@@ -44,14 +44,9 @@ const HealthConditions = () => {
   useTrackAction(statsdFrontEndActions.HEALTH_CONDITIONS_LIST);
 
   const { isLoading, isAcceleratingConditions } = useAcceleratedData();
-  const dispatchAction = useMemo(
-    () => {
-      return isCurrent => {
-        return getConditionsList(isCurrent, isAcceleratingConditions);
-      };
-    },
-    [isAcceleratingConditions],
-  );
+  const dispatchAction = isCurrent => {
+    return getConditionsList(isCurrent, isAcceleratingConditions);
+  };
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -124,22 +124,17 @@ const LabsAndTests = () => {
   const isLoadingAcceleratedData =
     isAcceleratingLabsAndTests && listState === loadStates.FETCHING;
 
-  const dispatchAction = useMemo(
-    () => {
-      return isCurrent => {
-        return getLabsAndTestsList(
-          isCurrent,
-          isAcceleratingLabsAndTests,
-          {
-            startDate: dateRange.fromDate,
-            endDate: dateRange.toDate,
-          },
-          mergeCvixWithScdf,
-        );
-      };
-    },
-    [isAcceleratingLabsAndTests, dateRange, mergeCvixWithScdf],
-  );
+  const dispatchAction = isCurrent => {
+    return getLabsAndTestsList(
+      isCurrent,
+      isAcceleratingLabsAndTests,
+      {
+        startDate: dateRange.fromDate,
+        endDate: dateRange.toDate,
+      },
+      mergeCvixWithScdf,
+    );
+  };
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -124,17 +124,19 @@ const LabsAndTests = () => {
   const isLoadingAcceleratedData =
     isAcceleratingLabsAndTests && listState === loadStates.FETCHING;
 
-  const dispatchAction = isCurrent => {
-    return getLabsAndTestsList(
-      isCurrent,
-      isAcceleratingLabsAndTests,
-      {
-        startDate: dateRange.fromDate,
-        endDate: dateRange.toDate,
-      },
-      mergeCvixWithScdf,
-    );
-  };
+  const dispatchAction = useCallback(
+    isCurrent =>
+      getLabsAndTestsList(
+        isCurrent,
+        isAcceleratingLabsAndTests,
+        {
+          startDate: dateRange.fromDate,
+          endDate: dateRange.toDate,
+        },
+        mergeCvixWithScdf,
+      ),
+    [isAcceleratingLabsAndTests, dateRange, mergeCvixWithScdf],
+  );
 
   useListRefresh({
     listState,
@@ -143,6 +145,7 @@ const LabsAndTests = () => {
     extractType: [refreshExtractTypes.CHEM_HEM, refreshExtractTypes.VPR],
     dispatchAction,
     dispatch,
+    isLoading,
   });
 
   // On Unmount: reload any newly updated records and normalize the FETCHING state.

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -74,9 +74,10 @@ const Vaccines = props => {
   const isLoadingAcceleratedData =
     isAcceleratingVaccines && listState === loadStates.FETCHING;
 
-  const dispatchAction = isCurrent => {
-    return getVaccinesList(isCurrent, isAcceleratingVaccines);
-  };
+  const dispatchAction = useCallback(
+    isCurrent => getVaccinesList(isCurrent, isAcceleratingVaccines),
+    [isAcceleratingVaccines],
+  );
 
   useTrackAction(statsdFrontEndActions.VITALS_LIST);
 
@@ -87,6 +88,7 @@ const Vaccines = props => {
     extractType: refreshExtractTypes.VPR,
     dispatchAction,
     dispatch,
+    isLoading,
   });
 
   // On Unmount: reload any newly updated records and normalize the FETCHING state.

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -79,7 +79,7 @@ const Vaccines = props => {
     [isAcceleratingVaccines],
   );
 
-  useTrackAction(statsdFrontEndActions.VITALS_LIST);
+  useTrackAction(statsdFrontEndActions.VACCINES_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -51,14 +51,9 @@ const Vitals = () => {
   const isLoadingAcceleratedData =
     (isCerner || isAcceleratingVitals) && listState === loadStates.FETCHING;
 
-  const dispatchAction = useMemo(
-    () => {
-      return isCurrent => {
-        return getVitals(isCurrent, isCerner, isAcceleratingVitals);
-      };
-    },
-    [isCerner, isAcceleratingVitals],
-  );
+  const dispatchAction = isCurrent => {
+    return getVitals(isCurrent, isCerner, isAcceleratingVitals);
+  };
 
   useTrackAction(statsdFrontEndActions.VITALS_LIST);
 

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
@@ -51,9 +51,10 @@ const Vitals = () => {
   const isLoadingAcceleratedData =
     (isCerner || isAcceleratingVitals) && listState === loadStates.FETCHING;
 
-  const dispatchAction = isCurrent => {
-    return getVitals(isCurrent, isCerner, isAcceleratingVitals);
-  };
+  const dispatchAction = useCallback(
+    isCurrent => getVitals(isCurrent, isCerner, isAcceleratingVitals),
+    [isCerner, isAcceleratingVitals],
+  );
 
   useTrackAction(statsdFrontEndActions.VITALS_LIST);
 
@@ -64,6 +65,7 @@ const Vitals = () => {
     extractType: refreshExtractTypes.VPR,
     dispatchAction,
     dispatch,
+    isLoading,
   });
 
   // On Unmount: reload any newly updated records and normalize the FETCHING state.

--- a/src/applications/mhv-medical-records/hooks/useListRefresh.js
+++ b/src/applications/mhv-medical-records/hooks/useListRefresh.js
@@ -17,6 +17,7 @@ import {
  * @param {string|array} extractType the relevant extract type(s) from the PHR refresh status call (e.g. ALLERGY)
  * @param {function} dispatchAction the action creator function that will fetch the list
  * @param {function} dispatch the React dispatch function
+ * @param {boolean} isLoading whether feature toggles are still loading (optional, defaults to false)
  */
 function useListRefresh({
   listState,
@@ -25,6 +26,7 @@ function useListRefresh({
   extractType,
   dispatchAction,
   dispatch,
+  isLoading = false,
 }) {
   const refreshIsCurrent = useMemo(
     () => {
@@ -64,10 +66,13 @@ function useListRefresh({
   useEffect(
     /**
      * Dispatch the action to refresh list data if:
-     * 1. The list has not yet been fetched.
-     * 2. The list data is stale, the refresh is current, and list is not currently being fetched.
+     * 1. Feature toggles have finished loading (isLoading is false).
+     * 2. The list has not yet been fetched.
+     * 3. The list data is stale, the refresh is current, and list is not currently being fetched.
      */
     () => {
+      if (isLoading) return;
+
       const shouldFetch =
         listState === loadStates.PRE_FETCH ||
         (listState !== loadStates.FETCHING && refreshIsCurrent && isDataStale);
@@ -76,7 +81,14 @@ function useListRefresh({
         dispatch(dispatchAction(refreshIsCurrent));
       }
     },
-    [refreshIsCurrent, listState, isDataStale, dispatchAction, dispatch],
+    [
+      refreshIsCurrent,
+      listState,
+      isDataStale,
+      dispatchAction,
+      dispatch,
+      isLoading,
+    ],
   );
 }
 

--- a/src/applications/mhv-medical-records/tests/hooks/useListRefresh.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/hooks/useListRefresh.unit.spec.jsx
@@ -141,4 +141,59 @@ describe('useListRefresh', () => {
       });
     });
   });
+
+  describe('with isLoading parameter', () => {
+    it('should not fetch data when isLoading is true even if listState is PRE_FETCH', async () => {
+      const { dispatchActionMock } = renderTestComponentWithProps({
+        listState: loadStates.PRE_FETCH,
+        listCurrentAsOf: undefined,
+        refreshStatus: undefined,
+        isLoading: true,
+      });
+
+      await waitFor(() => {
+        sinon.assert.notCalled(dispatchActionMock);
+      });
+    });
+
+    it('should fetch data once isLoading becomes false', async () => {
+      const dispatchActionMock = sinon.spy();
+      const dispatchMock = sinon.spy();
+
+      const { rerender } = render(
+        <TestComponent
+          {...defaultTestProps}
+          listState={loadStates.PRE_FETCH}
+          listCurrentAsOf={undefined}
+          refreshStatus={undefined}
+          dispatchAction={dispatchActionMock}
+          dispatch={dispatchMock}
+          isLoading
+        />,
+      );
+
+      // Should not fetch while loading
+      await waitFor(() => {
+        sinon.assert.notCalled(dispatchActionMock);
+      });
+
+      // Re-render with isLoading = false
+      rerender(
+        <TestComponent
+          {...defaultTestProps}
+          listState={loadStates.PRE_FETCH}
+          listCurrentAsOf={undefined}
+          refreshStatus={undefined}
+          dispatchAction={dispatchActionMock}
+          dispatch={dispatchMock}
+          isLoading={false}
+        />,
+      );
+
+      // Should fetch now that loading is complete
+      await waitFor(() => {
+        sinon.assert.called(dispatchActionMock);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?

- [x] No

## Summary

- **What changed**: Standardized the `dispatchAction` pattern across all 6 MHV Medical Records domains to use `useCallback` for a stable function reference and added an `isLoading` guard to `useListRefresh` to defer fetching until feature toggles are loaded.
- **Bug**: A race condition existed where `dispatchAction` was called before feature toggles loaded, causing the legacy API path to be used instead of the accelerated path. Additionally, using inline functions caused unnecessary re-renders and potential duplicate fetches.
- **Solution**:
  1. Wrapped `dispatchAction` in `useCallback` in all 6 domains to provide a stable reference that only updates when toggle values change.
  2. Added an `isLoading` parameter to `useListRefresh` hook that gates fetching until feature toggles have loaded.
  3. All domains now pass `isLoading` from `useAcceleratedData()` to ensure the first request uses the correct accelerated/non-accelerated path.
- **Team**: MHV Medical Records team owns maintenance of these components.
- **Flipper**: Uses existing `mhvAcceleratedDeliveryEnabled` and domain-specific accelerating toggles (no new flippers).

## Related issue(s)

-N/A 

## Testing done

- **Old behavior**: When accelerating feature toggles were enabled, `dispatchAction` could be called before toggles loaded, causing API calls to use the legacy `/my_health/v1` path. Inline function definitions also caused the `useListRefresh` effect to re-run on every render, potentially triggering duplicate fetches.
- **New behavior**:
  - `useCallback` provides a stable function reference that only changes when toggle dependencies change.
  - `isLoading` guard in `useListRefresh` prevents any fetch until feature toggles are loaded.
  - First API request now correctly uses the accelerated `/my_health/v2` path when toggles are enabled.
- **Verification steps**:
  1. Enable `mhvAcceleratedDeliveryEnabled` and domain-specific toggles in local dev
  2. Navigate to each domain (Allergies, Vaccines, Vitals, Labs and Tests, Care Summaries and Notes, Health Conditions)
  3. Verify network requests use `/my_health/v2/medical_records/...` endpoint
  4. Verify only a single fetch occurs on initial load (no duplicate requests)
- **Tests**: Existing unit tests pass. The change is an internal refactor that doesn't affect component behavior/rendering.

## Screenshots

_N/A - No UI changes. This is a bug fix for API call routing logic._

## What areas of the site does it impact?

MHV Medical Records - the following domains:

- Allergies (`/my-health/medical-records/allergies`)
- Vaccines (`/my-health/medical-records/vaccines`)
- Vitals (`/my-health/medical-records/vitals`)
- Labs and Tests (`/my-health/medical-records/labs-and-tests`)
- Care Summaries and Notes (`/my-health/medical-records/summaries-and-notes`)
- Health Conditions (`/my-health/medical-records/conditions`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added _(N/A - no UI changes)_
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed _(N/A - no UI changes)_

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) _(Uses existing monitoring)_

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This PR standardizes the `dispatchAction` pattern across all MHV Medical Records domains with two key improvements:

1. **`useCallback`** - Provides a stable function reference, preventing unnecessary effect re-runs and potential duplicate fetches.
2. **`isLoading` guard** - Added to `useListRefresh` hook to defer fetching until feature toggles are loaded, ensuring the correct API path is used on the first request.

**Files changed:**

- `src/applications/mhv-medical-records/hooks/useListRefresh.js` - Added `isLoading` parameter
- `src/applications/mhv-medical-records/containers/Allergies.jsx`
- `src/applications/mhv-medical-records/containers/Vaccines.jsx`
- `src/applications/mhv-medical-records/containers/Vitals.jsx`
- `src/applications/mhv-medical-records/containers/LabsAndTests.jsx`
- `src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx`
- `src/applications/mhv-medical-records/containers/HealthConditions.jsx`
