### PR TITLE
VEBT-4524: Step 6 YRP Contribution - College or prof school should not be required

### DIFF
--- a/src/applications/edu-benefits/0839/pages/contributionLimitsAndDegreeLevel.js
+++ b/src/applications/edu-benefits/0839/pages/contributionLimitsAndDegreeLevel.js
@@ -88,9 +88,6 @@ const uiSchema = {
       title: 'College or professional school',
       description:
         'Do not list specific degree programs (such as Master of Business Administration, Juris Doctorate, Bachelor of Science in Nursing).',
-      errorMessages: {
-        required: 'Enter the college or professional school name',
-      },
       validations: [validateWhiteSpace],
     }),
     'ui:options': {
@@ -170,7 +167,6 @@ const schema = {
   required: [
     'degreeLevel',
     'maximumContributionAmount',
-    'collegeOrProfessionalSchool',
     'maximumStudentsOption',
   ],
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- In form 22-0839 make the college/professional school input field not required on step 6.

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-4524

## Testing done
<img width="1436" height="493" alt="Screenshot 2026-02-06 at 10 13 04 AM" src="https://github.com/user-attachments/assets/5d8e9231-4851-4831-a26d-c6dbeb85ac83" />

## Screenshots

Before
<img width="447" height="209" alt="Screenshot 2026-02-06 at 10 11 41 AM" src="https://github.com/user-attachments/assets/f2484945-7f1b-475a-b33c-c33bdc4dd93a" />

After
<img width="444" height="202" alt="Screenshot 2026-02-06 at 10 13 35 AM" src="https://github.com/user-attachments/assets/24f240ed-4c11-42c3-bb91-5f22f3686e98" />

## What areas of the site does it impact?

edu-benefits/0839

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA