### PR TITLE
Refactor DefaultPage component to streamline description content handling and update unit tests for accurate rendering checks.

### DIFF
--- a/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
@@ -40,6 +40,9 @@ export default function DefaultPage({
   // Priority 3: Simple API description (plain text with formatting markers)
   const apiDescription = formatDescription(item.description);
 
+  const hasDescriptionContent =
+    apiLongDescription || frontendDescription || apiDescription;
+
   // Use API boolean properties with fallback to evidenceDictionary
   const isSensitive =
     item.isSensitive ?? frontendContentOverride?.isSensitive ?? false;
@@ -147,8 +150,6 @@ export default function DefaultPage({
     );
   } else if (isFirstParty) {
     // Fallback: Empty state
-    const hasDescriptionContent =
-      apiLongDescription || frontendDescription || apiDescription;
     nextStepsContent = (
       <>
         <p>To respond to this request:</p>
@@ -306,7 +307,7 @@ export default function DefaultPage({
       )}
 
       {isFirstParty &&
-        frontendContentOverride && (
+        hasDescriptionContent && (
           <div
             className="vads-u-margin-y--4"
             data-testid="learn-about-request-section"

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/DefaultPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/DefaultPage.unit.spec.jsx
@@ -721,7 +721,7 @@ describe('<DefaultPage>', () => {
         } else if (testCase.item.description) {
           expect(getByTestId('api-description')).to.exist;
           getByText(new RegExp(testCase.expectedDescriptionText, 'i'));
-          expect(queryByTestId('learn-about-request-section')).to.not.exist;
+          expect(queryByTestId('learn-about-request-section')).to.exist;
         } else {
           expect(getByTestId('empty-state-description')).to.exist;
           getByText(new RegExp(testCase.expectedDescriptionText, 'i'));


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The "Learn about this request in your claim letter" section on the evidence request `DefaultPage` was only rendering when a `frontendContentOverride` (evidence dictionary entry) existed for the tracked item. This meant first-party requests that had an API-provided long description (`apiLongDescription`) or simple API description (`apiDescription`) — but no frontend dictionary entry — were missing the claim letter section entirely.
- Updated the condition from `isFirstParty && frontendContentOverride` to `isFirstParty && (apiLongDescription || frontendDescription || apiDescription)` so the section renders whenever any description content is available.
- As the migration from frontend dictionary content to API-provided content progresses, more tracked items will rely on API descriptions without frontend dictionary entries, making this fix necessary.
- Team: Benefits Management Tools Team 2 (Bee's Knees)

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132354
- department-of-veterans-affairs/va.gov-team#120481

## Testing done

- **Old behavior:** The "Learn about this request in your claim letter" section only appeared for first-party requests that had a matching entry in the frontend evidence dictionary (`evidenceDictionary`). Requests with only an `apiLongDescription` or `apiDescription` did not show the section.
- **New behavior:** The section now appears for all first-party requests that have any description content available (`apiLongDescription`, `frontendDescription`, or `apiDescription`). It remains hidden only for the empty state (when no description content exists at all).
- **Steps to verify:**
  1. Navigate to a first-party evidence request that has an API description but no frontend dictionary entry
  2. Verify the "Learn about this request in your claim letter" section is now visible
  3. Verify the section still appears for requests with a frontend dictionary entry
  4. Verify the section does NOT appear for requests with no description content (empty state)
- Updated unit test assertions in `DefaultPage.unit.spec.jsx` to expect the section to be present when `apiDescription` is available

## Screenshots

N/A — No visual design changes; the section content is unchanged, only the visibility condition was corrected.

## What areas of the site does it impact?

Claims Status Tool — Evidence request detail pages (`DefaultPage`) for first-party tracked items.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a minimal conditional change. Please verify the updated condition correctly captures all three description sources and that no edge cases were missed.