### PR TITLE
fix: split cypress e2e job to avoid empty docker credentials on image pull

### DIFF
--- a/.github/workflows/full-suite-tests.yml
+++ b/.github/workflows/full-suite-tests.yml
@@ -462,15 +462,16 @@ jobs:
       contents: read
     if: |
       inputs.run_full_e2e_suite &&
+      !inputs.use_node_22 &&
       needs.build.result == 'success' &&
       needs.tests-prep.result == 'success' &&
       needs.tests-prep.outputs.e2e_count != '0'
 
     container:
-      image: ${{ inputs.use_node_22 && 'cypress/browsers:node-22.12.0-chrome-131.0.6778.108-1-ff-133.0-edge-131.0.2903.70-1' || '008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge' }}
+      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
-        username: ${{ inputs.use_node_22 && '' || needs.fetch-ecr-credentials.outputs.ecr_user }}
-        password: ${{ inputs.use_node_22 && '' || needs.fetch-ecr-credentials.outputs.ecr_password }}
+        username: ${{ needs.fetch-ecr-credentials.outputs.ecr_user }}
+        password: ${{ needs.fetch-ecr-credentials.outputs.ecr_password }}
 
     strategy:
       fail-fast: false
@@ -587,6 +588,146 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         with:
           name: cypress-mochawesome-test-results-${{ matrix.ci_node_index }}
+          path: cypress/results
+          retention-days: 1
+
+  cypress-tests-node-22:
+    name: Cypress E2E Tests (Node 22)
+    runs-on: ubuntu-16-cores-latest
+    timeout-minutes: 120
+    needs: [build, tests-prep]
+    permissions:
+      id-token: write
+      contents: read
+    if: |
+      inputs.run_full_e2e_suite &&
+      inputs.use_node_22 &&
+      needs.build.result == 'success' &&
+      needs.tests-prep.result == 'success' &&
+      needs.tests-prep.outputs.e2e_count != '0'
+
+    container:
+      image: cypress/browsers:node-22.12.0-chrome-131.0.6778.108-1-ff-133.0-edge-131.0.2903.70-1
+
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      matrix:
+        ci_node_index: ${{ fromJson(needs.tests-prep.outputs.ci_node_index) }}
+
+    env:
+      CI_NODE_INDEX: ${{ needs.tests-prep.outputs.ci_node_index }}
+      TESTS: ${{ needs.tests-prep.outputs.cypress-tests }}
+
+    steps:
+      - name: Checkout vets-website
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+
+      - name: Configure AWS credentials
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_region: us-gov-west-1
+          role: ${{ vars.AWS_ASSUME_ROLE }}
+
+      - name: Get va-vsp-bot token
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/init-data-repo
+
+      - name: Set Up BigQuery Creds
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Fetch E2E Test Stability Allow List
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: yarn get-allow-list
+        working-directory: qa-standards-dashboard-data
+        env:
+          TEST_TYPE: e2e
+
+      - name: Download production build artifact
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/download-artifact
+        with:
+          name: vagovprod.tar.bz2
+
+      - name: Install missing dependencies
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: apt-get update && apt-get install -y bzip2 curl
+
+      - name: Unpack build
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: |
+          mkdir -p build/vagovprod
+          tar -C build/vagovprod -xjf vagovprod.tar.bz2
+
+      - name: Install dependencies
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/install
+        timeout-minutes: 20
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            /github/home/.cache/Cypress
+            node_modules
+
+      - name: Download Tests to run
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/download-artifact
+        with:
+          name: e2e-tests-to-test
+          path: .
+
+      - name: Check for newly added disallowed tests
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: node script/github-actions/double-check-allow-list.js
+        env:
+          TEST_TYPE: e2e
+          TEST_PROPERTY: 'TESTS'
+
+      - name: Start server
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+
+      - name: Run Cypress tests
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: node script/github-actions/run-cypress-tests.js
+        timeout-minutes: 120
+        env:
+          CYPRESS_CI: true
+          STEP: ${{ matrix.ci_node_index }}
+          NUM_CONTAINERS: ${{ needs.tests-prep.outputs.num_containers }}
+          APP_URLS: 'http://localhost:3001'
+
+      - name: Archive test videos
+        if: ${{ needs.tests-prep.outputs.cypress-tests != '[]' && failure() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: cypress-video-artifacts-node-22-${{ matrix.ci_node_index }}
+          path: cypress/videos
+
+      - name: Archive test screenshots
+        if: ${{ needs.tests-prep.outputs.cypress-tests != '[]' && failure() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: cypress-screenshot-artifacts-node-22-${{ matrix.ci_node_index }}
+          path: cypress/screenshots
+
+      - name: Archive Mochawesome test results
+        if: ${{ needs.tests-prep.outputs.cypress-tests != '[]' && always() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: cypress-mochawesome-test-results-node-22-${{ matrix.ci_node_index }}
           path: cypress/results
           retention-days: 1
 
@@ -732,12 +873,21 @@ jobs:
   testing-reports-cypress:
     name: Testing Reports - Cypress E2E Tests
     runs-on: ubuntu-22.04
-    needs: [testing-reports-prep, tests-prep, cypress-tests]
+    needs: [testing-reports-prep, tests-prep, cypress-tests, cypress-tests-node-22]
     permissions:
       checks: write
       id-token: write
       contents: read
-    if: ${{ always() && inputs.run_full_e2e_suite && needs.tests-prep.outputs.cypress-tests != '' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    if: |
+      always() &&
+      inputs.run_full_e2e_suite &&
+      needs.tests-prep.outputs.cypress-tests != '' &&
+      (
+        needs.cypress-tests.result == 'success' ||
+        needs.cypress-tests.result == 'failure' ||
+        needs.cypress-tests-node-22.result == 'success' ||
+        needs.cypress-tests-node-22.result == 'failure'
+      )
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     continue-on-error: true
@@ -774,7 +924,7 @@ jobs:
           merge-multiple: true
 
       - name: Download Cypress E2E video artifacts
-        if: ${{ needs.cypress-tests.result == 'failure' }}
+        if: ${{ needs.cypress-tests.result == 'failure' || needs.cypress-tests-node-22.result == 'failure' }}
         uses: ./.github/workflows/download-artifact
         with:
           pattern: cypress-video-artifacts-*
@@ -799,7 +949,7 @@ jobs:
           TEST_RESULTS_TABLE_NAME: cypress_test_results
 
       - name: Upload Cypress E2E test videos to s3
-        if: ${{ needs.cypress-tests.result == 'failure' }}
+        if: ${{ needs.cypress-tests.result == 'failure' || needs.cypress-tests-node-22.result == 'failure' }}
         run: aws s3 cp qa-standards-dashboard-data/videos/${{ env.UUID }} s3://testing-tools-testing-reports/vets-website-cypress-reports/videos/${{ env.UUID }} --acl public-read --region us-gov-west-1 --recursive
 
       - name: Upload Cypress E2E test report to s3
@@ -811,6 +961,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Cypress Tests Summary (Full Suite)
-          conclusion: ${{ needs.cypress-tests.result }}
+          conclusion: ${{ inputs.use_node_22 && needs.cypress-tests-node-22.result || needs.cypress-tests.result }}
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}

--- a/.github/workflows/full-suite-tests.yml
+++ b/.github/workflows/full-suite-tests.yml
@@ -595,7 +595,7 @@ jobs:
     name: Cypress E2E Tests (Node 22)
     runs-on: ubuntu-16-cores-latest
     timeout-minutes: 120
-    needs: [build, tests-prep]
+    needs: [build, tests-prep, fetch-ecr-credentials]
     permissions:
       id-token: write
       contents: read
@@ -607,7 +607,10 @@ jobs:
       needs.tests-prep.outputs.e2e_count != '0'
 
     container:
-      image: cypress/browsers:node-22.12.0-chrome-131.0.6778.108-1-ff-133.0-edge-131.0.2903.70-1
+      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/cypress/browsers:node-22.12.0-chrome-131.0.6778.108-1-ff-133.0-edge-131.0.2903.70-1
+      credentials:
+        username: ${{ needs.fetch-ecr-credentials.outputs.ecr_user }}
+        password: ${{ needs.fetch-ecr-credentials.outputs.ecr_password }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The `full-suite-tests` workflow's `cypress-tests` job used a conditional ternary for the container image and credentials, passing empty strings for Docker Hub credentials when `use_node_22` was selected. This caused Docker image pulls to fail because the empty string login/password is treated as an invalid authentication attempt.
- Split the single `cypress-tests` job into two: `cypress-tests` (ECR image with ECR credentials, runs when `!use_node_22`) and `cypress-tests-node-22` (ECR Node 22 image with ECR credentials, runs when `use_node_22`).
- Both jobs now use ECR-hosted images with proper ECR credentials from the `fetch-ecr-credentials` job.
- Updated the `testing-reports-cypress` job to depend on and report results from whichever cypress job ran.
- Platform Tools & CI

## Related issue(s)

- No associated issue

## Testing done

- Verified the workflow YAML is syntactically valid
- The default path (`use_node_22=false`) uses the ECR Node 16 image with proper ECR credentials, unchanged from current behavior
- The Node 22 path (`use_node_22=true`) uses the ECR Node 22 image with proper ECR credentials, eliminating the empty string authentication failure
- The `testing-reports-cypress` job correctly handles results from either job path

## Screenshots

Not applicable - GitHub Actions workflow change, no UI impact.

## What areas of the site does it impact?

CI only - the `full-suite-tests` GitHub Actions workflow. No impact to application code or site functionality.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - Not applicable: GitHub Actions workflow file, no unit/integration tests available
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#))
  - Not applicable
- [ ] Screenshot of the developed feature is added
  - Not applicable: no UI changes
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
  - Not applicable: no UI changes

### Error Handling

- [ ] Browser console contains no warnings or errors.
  - Not applicable: CI workflow change
- [ ] Events are being sent to the appropriate logging solution
  - Not applicable
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
  - Not applicable

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
  - Not applicable: CI workflow change