### PR TITLE
132367 BIO - Conditional submit URL based on feature flag - form 21P-0537

### DIFF
--- a/src/applications/simple-forms/21p-0537/config/form.js
+++ b/src/applications/simple-forms/21p-0537/config/form.js
@@ -42,6 +42,7 @@ const statementOfTruthBody = (
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
+  // This submitUrl changes based on a feature toggle - see App.jsx
   submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   transformForSubmit,
   trackingPrefix: '21p-0537-dic-marital-status-',

--- a/src/applications/simple-forms/21p-0537/containers/App.jsx
+++ b/src/applications/simple-forms/21p-0537/containers/App.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import environment from 'platform/utilities/environment';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { DowntimeNotification } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
-import { Toggler } from 'platform/utilities/feature-toggles';
+import { Toggler, useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { WIP } from '../../shared/components/WIP';
 import formConfig from '../config/form';
 
@@ -14,6 +15,19 @@ const wipContent = {
 };
 
 export default function App({ location, children }) {
+  const {
+    useFormFeatureToggleSync,
+    useToggleValue,
+    TOGGLE_NAMES,
+  } = useFeatureToggle();
+
+  useFormFeatureToggleSync(['bioHeartMMSSubmit']);
+  const bioEndpointEnabled = useToggleValue(TOGGLE_NAMES.bioHeartMMSSubmit);
+
+  formConfig.submitUrl = bioEndpointEnabled
+    ? `${environment.API_URL}/bio_heart_api/v1/bio_heart`
+    : `${environment.API_URL}/simple_forms_api/v1/simple_forms`;
+
   return (
     <Toggler toggleName={Toggler.TOGGLE_NAMES.form21P0537}>
       <Toggler.Enabled>

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -16,6 +16,7 @@
   "bannerUseAlternativeBanners": "banner_use_alternative_banners",
   "benefitsDocumentsUseLighthouse": "benefits_documents_use_lighthouse",
   "benefitsNonDisabilityCh31V2": "benefits_non_disability_ch31_v2",
+  "bioHeartMMSSubmit": "bio_heart_mms_submit",
   "burialConfirmationPage": "burial_confirmation_page",
   "burialFormEnabled": "burial_form_enabled",
   "burialBrowserMonitoringEnabled": "burial_browser_monitoring_enabled",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds a mechanism for swapping out the `submitUrl` based on a feature toggle. This supports the work here to enable BIO forms to submit structured data to MMS following a successful submission to Benefits Intake.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130768
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132367
- https://github.com/department-of-veterans-affairs/vets-api/pull/26350

## Testing done

- Manual

## Screenshots

NA

## What areas of the site does it impact?

This form only - additionally, all functionality changes are behind a feature toggle.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA