### PR TITLE
0969 - Remove unauthenticated content

### DIFF
--- a/src/applications/income-and-asset-statement/components/NextStepsSection.jsx
+++ b/src/applications/income-and-asset-statement/components/NextStepsSection.jsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { apiRequest } from 'platform/utilities/api';
 import { getFormLink, inProgressApi } from 'platform/forms/helpers';
 
-const NextStepsSection = ({ loggedIn }) => {
+const NextStepsSection = () => {
   const [loading, setLoading] = useState(false);
   const [hasInProgress, setHasInProgress] = useState(false);
 
@@ -38,77 +37,62 @@ const NextStepsSection = ({ loggedIn }) => {
     </>
   );
 
-  useEffect(
-    () => {
-      let isMounted = true;
+  useEffect(() => {
+    let isMounted = true;
 
-      const checkInProgress = async () => {
-        if (!loggedIn) return;
-        setLoading(true);
-        try {
-          await apiRequest(inProgressApi('21P-527EZ'));
-          if (isMounted) {
-            setHasInProgress(true);
-          }
-        } catch (e) {
-          // Any failure → log and gracefully fall back to NextSteps content
-          /* eslint-disable no-console */
-          console.warn('Failed to check in-progress 21P-527EZ:', e);
-          /* eslint-enable no-console */
-          if (isMounted) {
-            setHasInProgress(false);
-          }
-        } finally {
-          if (isMounted) setLoading(false);
+    const checkInProgress = async () => {
+      setLoading(true);
+      try {
+        await apiRequest(inProgressApi('21P-527EZ'));
+        if (isMounted) {
+          setHasInProgress(true);
         }
-      };
+      } catch (e) {
+        // Any failure → log and gracefully fall back to NextSteps content
+        /* eslint-disable no-console */
+        console.warn('Failed to check in-progress 21P-527EZ:', e);
+        /* eslint-enable no-console */
+        if (isMounted) {
+          setHasInProgress(false);
+        }
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
 
-      checkInProgress();
-      return () => {
-        isMounted = false;
-      };
-    },
-    [loggedIn],
-  );
+    checkInProgress();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return (
     <section>
       <h2>What to do next</h2>
+      {loading && (
+        <va-loading-indicator message="Checking your in-progress applications…" />
+      )}
 
-      {!loggedIn && <NextSteps />}
-
-      {loggedIn && (
+      {!loading && (
         <>
-          {loading && (
-            <va-loading-indicator message="Checking your in-progress applications…" />
-          )}
-
-          {!loading && (
+          {hasInProgress ? (
             <>
-              {hasInProgress ? (
-                <>
-                  <p>
-                    You have an in-progress Pension benefits application. You
-                    can return to the online form to complete your application.
-                  </p>
-                  <va-link-action
-                    href={pensionLink}
-                    text="Continue Veterans Pension application"
-                  />
-                </>
-              ) : (
-                <NextSteps />
-              )}
+              <p>
+                You have an in-progress Pension benefits application. You can
+                return to the online form to complete your application.
+              </p>
+              <va-link-action
+                href={pensionLink}
+                text="Continue Veterans Pension application"
+              />
             </>
+          ) : (
+            <NextSteps />
           )}
         </>
       )}
     </section>
   );
-};
-
-NextStepsSection.propTypes = {
-  loggedIn: PropTypes.bool.isRequired,
 };
 
 export default NextStepsSection;

--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/otherVeteranInformation.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/otherVeteranInformation.js
@@ -8,14 +8,13 @@ import {
   vaFileNumberSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { hasSession } from '../../../helpers';
 import { SSNReviewField } from '../../../components/SSNReviewField';
 
 /** @type {PageSchema} */
 export default {
   title: 'Veteran information',
   path: 'veteran/information',
-  depends: formData => !(formData?.claimantType === 'VETERAN' && hasSession()),
+  depends: formData => formData?.claimantType !== 'VETERAN',
   uiSchema: {
     ...titleUI('Veteran information'),
     otherVeteranFullName: fullNameNoSuffixUI(title => `Veteran’s ${title}`),

--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/personalInformation.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/personalInformation.js
@@ -1,12 +1,11 @@
 import CustomPersonalInfo from '../../../components/CustomPersonalInfo';
 import CustomPersonalInfoReview from '../../../components/CustomPersonalInfoReview';
-import { hasSession } from '../../../helpers';
 
 /** @type {PageSchema} */
 export default {
   title: 'Personal information',
   path: 'personal/information',
-  depends: formData => formData?.claimantType === 'VETERAN' && hasSession(),
+  depends: formData => formData?.claimantType === 'VETERAN',
   CustomPage: CustomPersonalInfo,
   CustomPageReview: CustomPersonalInfoReview,
   hideOnReview: false,

--- a/src/applications/income-and-asset-statement/config/form.js
+++ b/src/applications/income-and-asset-statement/config/form.js
@@ -88,14 +88,10 @@ const formConfig = {
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
       messageAriaDescribedby:
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      fullNamePath: formData => {
-        if (formData?.claimantType === 'VETERAN') {
-          return formData?.isLoggedIn
-            ? 'veteranFullName'
-            : 'otherVeteranFullName';
-        }
-        return 'claimantFullName';
-      },
+      fullNamePath: formData =>
+        formData?.claimantType === 'VETERAN'
+          ? 'veteranFullName'
+          : 'claimantFullName',
     },
   },
   title: 'Pension or DIC Income and Asset Statement',

--- a/src/applications/income-and-asset-statement/config/submit.js
+++ b/src/applications/income-and-asset-statement/config/submit.js
@@ -89,8 +89,8 @@ export function prepareFormData(data) {
   // Step 1: clone to avoid mutating original form (Redux immutability)
   const clonedData = cloneDeep(data);
 
-  const { claimantType, isLoggedIn } = clonedData;
-  const userIsVeteran = isLoggedIn === true && claimantType === 'VETERAN';
+  const { claimantType } = clonedData;
+  const userIsVeteran = claimantType === 'VETERAN';
 
   // Step 2: remap “otherVeteran*” → “veteran*” only when necessary
   const dataWithVeteranFieldsAdjusted = userIsVeteran

--- a/src/applications/income-and-asset-statement/containers/ConfirmationPage.jsx
+++ b/src/applications/income-and-asset-statement/containers/ConfirmationPage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { isLoggedIn } from 'platform/user/selectors';
 import environment from 'platform/utilities/environment';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import NextStepsSection from '../components/NextStepsSection';
@@ -15,7 +14,6 @@ if (!environment.isProduction() && !environment.isStaging()) {
 
 export const ConfirmationPage = props => {
   const form = useSelector(state => state.form || {});
-  const loggedIn = useSelector(isLoggedIn);
   const { formConfig } = props.route;
   const { submission } = form;
   const submitDate = submission.timestamp;
@@ -53,30 +51,16 @@ export const ConfirmationPage = props => {
       <h2>Save a copy of your form</h2>
       <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
-      <NextStepsSection loggedIn={loggedIn} />
+      <NextStepsSection />
       <SupplementaryFormsSection formData={form.data} />
       <ConfirmationView.WhatsNextProcessList
         item1Content={
-          loggedIn ? (
-            <>
-              <p>
-                This can take up to 10 days. When we receive your form, we’ll
-                update the status on My VA.
-              </p>
-            </>
-          ) : (
-            <>
-              <p>
-                This can take up to 10 days. When we receive your form, we’ll
-                send you a confirmation email.
-              </p>
-            </>
-          )
-        }
-        item1Actions={
-          loggedIn
-            ? undefined
-            : null /* Special: null turns off the default link for logged-out users */
+          <>
+            <p>
+              This can take up to 10 days. When we receive your form, we’ll
+              update the status on My VA.
+            </p>
+          </>
         }
       />
       <section>
@@ -124,7 +108,6 @@ ConfirmationPage.propTypes = {
       timestamp: PropTypes.string,
     }),
   }),
-  isLoggedIn: PropTypes.bool,
   route: PropTypes.shape({
     formConfig: PropTypes.object.isRequired,
   }),

--- a/src/applications/income-and-asset-statement/helpers.js
+++ b/src/applications/income-and-asset-statement/helpers.js
@@ -224,71 +224,50 @@ export const generateDeleteDescription = (props, getItemName) => {
 /**
  * Resolve the recipient's full name to display on summary cards.
  *
- * - If the recipientRelationship is "VETERAN":
- *   - Use `veteranFullName` when the user is logged in
- *   - Use `otherVeteranFullName` when the user is not logged in
+ * - If the recipient is the Veteran, use `veteranFullName`
  * - If the recipient is not the Veteran, use `recipientName`
  *
  * This helper is useful across multiple arrayBuilder pages where we conditionally display
  * either the Veteran's name or the name of another recipient.
  *
  * @param {object} item - The array item object containing recipient data.
- * @param {object} formData - The overall form data, which may include veteran names and logged in.
+ * @param {object} formData - The overall form data, which includes applicant names
  * @returns {string} The formatted full name string or undefined if no name is resolvable
  */
 export function resolveRecipientFullName(item, formData) {
   const { recipientRelationship, recipientName } = item;
-  const {
-    veteranFullName,
-    otherVeteranFullName,
-    isLoggedIn = false,
-  } = formData;
+  const { veteranFullName } = formData;
 
   const isVeteran = recipientRelationship === 'VETERAN';
 
-  if (isVeteran) {
-    const veteranName = isLoggedIn ? veteranFullName : otherVeteranFullName;
-    return formatFullNameNoSuffix(veteranName);
-  }
-
-  return formatFullNameNoSuffix(recipientName);
+  return isVeteran
+    ? formatFullNameNoSuffix(veteranFullName)
+    : formatFullNameNoSuffix(recipientName);
 }
 
-// updated version of above function
-// needed a separate function and not just a showUpdatedContent check because
-// these functions are reused across the app and i'm unsure that the same
-// functionality is needed everywhere
 /**
  * Resolve the recipient's full name to display on summary cards.
  * Post-MVP updates
  *
- * - If the recipientRelationship is "VETERAN":
- *   - Use `veteranFullName` when the user is logged in
- *   - Use `otherVeteranFullName` when the user is not logged in
- * - If the recipientRelationship is "SPOUSE":
- *   - Use "Spouse"
+ * - If the recipientRelationship is "VETERAN", use `veteranFullName`
+ * - If the recipientRelationship is "SPOUSE", use "Spouse"
  * - If the recipient is not the Veteran, use `recipientName`
  *
  * This helper is useful across multiple arrayBuilder pages where we conditionally display
  * either the Veteran's name or the name of another recipient.
  *
  * @param {object} item - The array item object containing recipient data.
- * @param {object} formData - The overall form data, which may include veteran names and logged in.
+ * @param {object} formData - The overall form data, which includes applicant names
  * @returns {string} The formatted full name string or undefined if no name is resolvable
  */
 export function updatedResolveRecipientFullName(item, formData) {
   const { recipientRelationship, recipientName } = item;
-  const {
-    veteranFullName,
-    otherVeteranFullName,
-    isLoggedIn = false,
-  } = formData;
+  const { veteranFullName } = formData;
 
   const isVeteran = recipientRelationship === 'VETERAN';
 
   if (isVeteran) {
-    const veteranName = isLoggedIn ? veteranFullName : otherVeteranFullName;
-    return formatFullNameNoSuffix(veteranName);
+    return formatFullNameNoSuffix(veteranFullName);
   }
   const isSpouse = recipientRelationship === 'SPOUSE';
   if (showUpdatedContent() && isSpouse) {

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/05-owned-assets/ownedAssetPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/05-owned-assets/ownedAssetPages.unit.spec.jsx
@@ -209,41 +209,6 @@ describe('owned asset list and loop pages', () => {
         );
       });
 
-      it('should return "Alex Smith’s income from a business" if recipient is Veteran and assetType is "business" and not logged in', () => {
-        const item = {
-          recipientRelationship: 'VETERAN',
-          assetType: 'BUSINESS',
-        };
-        expect(
-          options.text.getItemName(item, 0, {
-            ...mockFormData,
-            isLoggedIn: false,
-          }),
-        ).to.equal('Alex Smith’s income from a business');
-      });
-
-      it('should return "Alex Smith’s income from a farm" if recipient is Veteran and assetType is "farm" and not logged in', () => {
-        const item = { recipientRelationship: 'VETERAN', assetType: 'FARM' };
-        expect(
-          options.text.getItemName(item, 0, {
-            ...mockFormData,
-            isLoggedIn: false,
-          }),
-        ).to.equal('Alex Smith’s income from a farm');
-      });
-
-      it('should return "Alex Smith’s income from a rental property" if recipient is Veteran and assetType is "rental property" and not logged in', () => {
-        const item = {
-          recipientRelationship: 'VETERAN',
-          assetType: 'RENTAL_PROPERTY',
-        };
-        expect(
-          options.text.getItemName(item, 0, {
-            ...mockFormData,
-            isLoggedIn: false,
-          }),
-        ).to.equal('Alex Smith’s income from a rental property');
-      });
       it('should return undefined if required keys are not defined', () => {
         expect(options.text.getItemName({}, 0)).to.be.undefined;
       });

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
@@ -75,18 +75,6 @@ describe('royalties list and loop pages', () => {
         'John Doe’s income from intellectual property rights',
       );
     });
-    it('should return "Alex Smith’s income" if recipient is Veteran and not logged in', () => {
-      const item = {
-        recipientRelationship: 'VETERAN',
-        incomeGenerationMethod: 'USE_OF_LAND',
-      };
-      expect(
-        options.text.getItemName(item, 0, {
-          ...mockFormData,
-          isLoggedIn: false,
-        }),
-      ).to.equal('Alex Smith’s income from land usage fees');
-    });
     it('should return "Jane Doe’s income', () => {
       const recipientName = { first: 'Jane', middle: 'A', last: 'Doe' };
       const formattedName = formatFullNameNoSuffix(recipientName);

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
@@ -89,19 +89,6 @@ describe('income receipt waiver list and loop pages', () => {
         'John Doe’s waived income from social security',
       );
     });
-    it('should return "Alex Smith’s waived income from `payer`" if recipient is Veteran and not logged in', () => {
-      const item = {
-        recipientRelationship: 'VETERAN',
-        recipientName: { first: 'Jane', last: 'Smith' },
-        payer: 'social security',
-      };
-      expect(
-        options.text.getItemName(item, 0, {
-          ...mockFormData,
-          isLoggedIn: false,
-        }),
-      ).to.equal('Alex Smith’s waived income from social security');
-    });
     it('should return "Jane Smith’s waived income from `payer`" if recipient is not Veteran', () => {
       const item = {
         recipientRelationship: 'SPOUSE',

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/multiPageTests.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/multiPageTests.spec.jsx
@@ -54,27 +54,9 @@ export const testOptionsTextGetItemNameRecurringIncome = options => {
     const recipientName = { first: 'Jane', middle: 'A', last: 'Doe' };
     const payer = 'Walmart';
 
-    it('should use veteranFullName when recipient is "VETERAN" and user is logged in', () => {
+    it('should use veteranFullName when recipient is "VETERAN"', () => {
       const formData = {
         isLoggedIn: true,
-        veteranFullName,
-        otherVeteranFullName,
-      };
-
-      const item = {
-        recipientRelationship: 'VETERAN',
-        payer,
-      };
-
-      const expectedName = resolveRecipientFullName(item, formData);
-      expect(options.text.getItemName(item, 0, formData)).to.equal(
-        `${expectedName}’s income from ${payer}`,
-      );
-    });
-
-    it('should use otherVeteranFullName when recipient is "VETERAN" and user is not logged in', () => {
-      const formData = {
-        isLoggedIn: false,
         veteranFullName,
         otherVeteranFullName,
       };

--- a/src/applications/income-and-asset-statement/tests/unit/components/NextStepsSection.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/components/NextStepsSection.unit.spec.jsx
@@ -40,40 +40,7 @@ describe('NextStepsSection confirmation page component', () => {
     }
   });
 
-  it('renders heading and next steps when not logged in', () => {
-    const { container, getByText, getAllByRole, getByRole } = render(
-      <NextStepsSection loggedIn={false} />,
-    );
-
-    const h2 = getByRole('heading', { level: 2, name: /what to do next/i });
-    expect(h2).to.exist;
-
-    expect(getByText(/You don’t need to reapply for Veterans Pension or DIC/i))
-      .to.exist;
-
-    const h3s = getAllByRole('heading', { level: 3 });
-    expect(h3s.length).to.be.at.least(2);
-    expect(
-      getByRole('heading', {
-        level: 3,
-        name: /if you’re applying for veterans pension benefits/i,
-      }),
-    ).to.exist;
-    expect(
-      getByRole('heading', {
-        level: 3,
-        name: /if you’re applying for dic benefits/i,
-      }),
-    ).to.exist;
-
-    const pensionLinkEl = container.querySelector('va-link');
-    expect(pensionLinkEl).to.exist;
-    expect(pensionLinkEl.getAttribute('href')).to.equal(MOCK_PENSION_LINK);
-
-    expect(container.querySelector('va-loading-indicator')).to.not.exist;
-  });
-
-  it('shows loading indicator while checking in-progress app when logged in', async () => {
+  it('shows loading indicator while checking in-progress app', async () => {
     let resolveReq;
     const pending = new Promise(res => {
       resolveReq = res;

--- a/src/applications/income-and-asset-statement/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/config/form.unit.spec.jsx
@@ -52,12 +52,6 @@ describe('21P-0969 form config', () => {
     });
     expect(vLoggedIn).to.equal('veteranFullName');
 
-    const vLoggedOut = psi.statementOfTruth.fullNamePath({
-      claimantType: 'VETERAN',
-      isLoggedIn: false,
-    });
-    expect(vLoggedOut).to.equal('otherVeteranFullName');
-
     const nonVet = psi.statementOfTruth.fullNamePath({
       claimantType: 'SPOUSE',
     });

--- a/src/applications/income-and-asset-statement/tests/unit/config/submit-helpers.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/config/submit-helpers.unit.spec.jsx
@@ -176,7 +176,7 @@ describe('submit-helpers.js', () => {
     });
   });
 
-  describe('removeInvalidFields', () => {
+  describe('oveInvalidFields', () => {
     it('should remove undefined, null, and view: prefixed fields', () => {
       const formData = {
         data: {

--- a/src/applications/income-and-asset-statement/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -119,7 +119,7 @@ describe('Confirmation page', () => {
     expect(queryByText(/Your confirmation number is/i)).to.be.null;
   });
 
-  it('should show the "Check the status of your form on My VA" link when user is logged in', () => {
+  it('should show the "Check the status of your form on My VA" link', () => {
     const { mockStore } = getData();
 
     const { container } = render(
@@ -133,21 +133,5 @@ describe('Confirmation page', () => {
     );
 
     expect(link).to.not.be.null;
-  });
-
-  it('should not show the "Check the status of your form on My VA" link when user is not logged in', () => {
-    const { mockStore } = getData({ loggedIn: false });
-
-    const { container } = render(
-      <Provider store={mockStore}>
-        <ConfirmationPage route={{ formConfig }} />
-      </Provider>,
-    );
-
-    const link = container.querySelector(
-      'va-link[text="Check the status of your form on My VA"][href="/my-va#benefit-applications"]',
-    );
-
-    expect(link).to.be.null;
   });
 });

--- a/src/applications/income-and-asset-statement/tests/unit/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/containers/PreSubmitInfo.unit.spec.jsx
@@ -70,20 +70,7 @@ const getData = ({
 };
 
 describe('<PreSubmitInfo />', () => {
-  describe('when not logged in', () => {
-    it('should render the va-statement-of-truth and not va-privacy-agreement', () => {
-      const { props, mockStore } = getData({ loggedIn: false });
-      const { container } = render(
-        <Provider store={mockStore}>
-          <PreSubmitInfo {...props} />
-        </Provider>,
-      );
-      expect($('va-statement-of-truth', container)).to.exist;
-      expect($('va-privacy-agreement', container)).not.to.exist;
-    });
-  });
-
-  describe('when logged in and is not a self-representing veteran', () => {
+  describe('when not a self-representing veteran', () => {
     it('should render the va-statement-of-truth component and not va-privacy-agreement', () => {
       const { props, mockStore } = getData({
         loggedIn: true,
@@ -102,7 +89,7 @@ describe('<PreSubmitInfo />', () => {
     });
   });
 
-  describe('when logged in and is a self-representing veteran', () => {
+  describe('when a self-representing veteran', () => {
     it('should render the va-privacy-agreement component and use profile name', () => {
       const { props, mockStore } = getData({
         loggedIn: true,

--- a/src/applications/income-and-asset-statement/tests/unit/helpers.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/helpers.unit.spec.jsx
@@ -246,7 +246,7 @@ describe('Income and Asset helpers', () => {
     const veteran = { first: 'john', middle: 'm', last: 'doe' };
     const otherVeteran = { first: 'alex', last: 'carter' };
 
-    it('returns veteranFullName when recipient is VETERAN and isLoggedIn is true', () => {
+    it('returns veteranFullName when recipient is VETERAN', () => {
       const item = { recipientRelationship: 'VETERAN' };
       const formData = {
         isLoggedIn: true,
@@ -255,17 +255,6 @@ describe('Income and Asset helpers', () => {
       };
 
       expect(resolveRecipientFullName(item, formData)).to.equal('John M. Doe');
-    });
-
-    it('returns otherVeteranFullName when recipient is VETERAN and isLoggedIn is false', () => {
-      const item = { recipientRelationship: 'VETERAN' };
-      const formData = {
-        isLoggedIn: false,
-        veteranFullName: veteran,
-        otherVeteranFullName: otherVeteran,
-      };
-
-      expect(resolveRecipientFullName(item, formData)).to.equal('Alex Carter');
     });
 
     it('returns recipientName when recipient is not the Veteran', () => {

--- a/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
@@ -50,17 +50,6 @@ describe('Income and asset submit', () => {
       spy.restore();
     });
     describe('remap `otherVeteran` fields', () => {
-      it('calls remapOtherVeteranFields when not logged in', () => {
-        const form = {
-          data: {
-            isLoggedIn: false,
-          },
-        };
-
-        SubmitModule.transform(form);
-        expect(spy.calledOnce).to.be.true;
-      });
-
       it('calls remapOtherVeteranFields when isLoggedIn is undefined', () => {
         const form = {
           data: {},
@@ -70,7 +59,7 @@ describe('Income and asset submit', () => {
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('calls remapOtherVeteranFields when logged in and claimantType is not VETERAN', () => {
+      it('calls remapOtherVeteranFields when claimantType is not VETERAN', () => {
         const form = {
           data: {
             isLoggedIn: true,
@@ -82,7 +71,7 @@ describe('Income and asset submit', () => {
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('does not call remapOtherVeteranFields when logged in and claimantType is VETERAN', () => {
+      it('does not call remapOtherVeteranFields when claimantType is VETERAN', () => {
         const form = {
           data: {
             isLoggedIn: true,


### PR DESCRIPTION
### Summary of Changes
This PR removes **unauthenticated-only content** from the **Income and Asset Statement (VA Form 21P-0969)**.  
The cleanup ensures the form no longer relies on conditional messaging or logic intended for unauthenticated users, preparing the form for stricter authentication requirements and simplifying the overall flow for authenticated applicants.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129184

### How to Set Up in Local Environment
1. Run the local environment
2. Ensure you are logged in with a test user (authenticated).
3. Navigate to the 0969 form:  
   http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/
4. (If applicable) Enable content updates:  
   http://localhost:3000/flipper/features/income_and_assets_content_updates

### How to Test
1. Load the 0969 form while authenticated.
2. Navigate through the form and verify:
   - No unauthenticated-only content or messaging is rendered.
   - Page content remains complete and accurate.
3. Review summary and Review & Submit pages to ensure no gaps remain from removed content.
4. Confirm there are no console errors or accessibility regressions.

### Feature Flag Note
- No new feature flags introduced.
- This change prepares the form for removal of any remaining unauthenticated conditional logic.

### Acceptance Criteria
- [x] All unauthenticated-only content is removed from the 0969 form.
- [x] Form renders correctly for authenticated users.
- [x] No dependencies remain on unauthenticated conditional logic.
- [x] No regressions in navigation, validation, or accessibility.

### Definition of Done
- [x] Code reviewed and approved.
- [x] Verified locally while authenticated.
- [ ] No console errors or accessibility issues.
- [x] Tests updated or verified passing.
