### PR TITLE
131002 VASS Cypress E2E Tests

### DIFF
--- a/src/applications/vass/components/AppointmentCard.jsx
+++ b/src/applications/vass/components/AppointmentCard.jsx
@@ -70,7 +70,7 @@ const AppointmentCard = ({
         appointmentData?.topics.length > 0 && (
           <CardSection
             data-testid="topics-section"
-            heading="Topics you'd like to learn more about"
+            heading="Topics you’d like to learn more about"
             textContent={appointmentData?.topics
               .map(topic => topic?.topicName || '')
               .join(', ')}

--- a/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { waitFor } from '@testing-library/react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 as renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
@@ -10,6 +9,7 @@ import {
   setFetchJSONResponse,
   setFetchJSONFailure,
 } from 'platform/testing/unit/helpers';
+import sinon from 'sinon';
 import CancelAppointment from './CancelAppointment';
 import { getDefaultRenderOptions, LocationDisplay } from '../utils/test-utils';
 import * as authUtils from '../utils/auth';
@@ -73,13 +73,15 @@ describe('VASS Page: CancelAppointment', () => {
   });
 
   describe('navigation', () => {
-    beforeEach(() => {
+    it('should navigate to cancel confirmation page when "Yes, cancel appointment" is clicked', async () => {
+      setFetchJSONResponse(
+        global.fetch.onCall(0),
+        createAppointmentDetailsResponse({ appointmentId }),
+      );
       setFetchJSONResponse(
         global.fetch.onCall(1),
         createCancelAppointmentResponse({ appointmentId }),
       );
-    });
-    it('should navigate to cancel confirmation page when "Yes, cancel appointment" is clicked', async () => {
       const { getByTestId } = renderWithStoreAndRouter(
         <>
           <Routes>

--- a/src/applications/vass/pages/DateTimeSelection.jsx
+++ b/src/applications/vass/pages/DateTimeSelection.jsx
@@ -141,6 +141,7 @@ const DateTimeSelection = () => {
         availableSlots={slots}
         value={selectedSlot?.dtStartUtc ? [selectedSlot.dtStartUtc] : []}
         id="dateTime"
+        data-testid="dateTime"
         timezone={timezone}
         additionalOptions={{
           required: true,

--- a/src/applications/vass/pages/EnterOTP.jsx
+++ b/src/applications/vass/pages/EnterOTP.jsx
@@ -11,7 +11,7 @@ import {
   selectFlowType,
   selectObfuscatedEmail,
 } from '../redux/slices/formSlice';
-import { FLOW_TYPES, URLS, OTC_ERROR_CODES } from '../utils/constants';
+import { FLOW_TYPES, URLS, OTP_ERROR_CODES } from '../utils/constants';
 import {
   isAccountLockedError,
   isServerError,
@@ -20,9 +20,9 @@ import {
 
 const getErrorMessage = (errorCode, attemptsRemaining = 0) => {
   switch (errorCode) {
-    case OTC_ERROR_CODES.ACCOUNT_LOCKED:
+    case OTP_ERROR_CODES.ACCOUNT_LOCKED:
       return 'The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes. Check your email and select the link to schedule a call.';
-    case OTC_ERROR_CODES.INVALID_OTP:
+    case OTP_ERROR_CODES.INVALID_OTP:
       if (attemptsRemaining === 1) {
         return 'The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again.';
       }

--- a/src/applications/vass/pages/EnterOTP.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTP.unit.spec.jsx
@@ -294,6 +294,7 @@ describe('VASS Component: EnterOTP', () => {
 
   describe('appointment already booked redirect', () => {
     it('should navigate to already-scheduled page when user has existing appointment', async () => {
+      const appointmentId = 'appt-123';
       setFetchJSONResponse(global.fetch.onCall(0), {
         data: {
           token: 'jwt-token',
@@ -303,7 +304,7 @@ describe('VASS Component: EnterOTP', () => {
       });
       setFetchJSONFailure(
         global.fetch.onCall(1),
-        createAppointmentAlreadyBookedError('appt-123'),
+        createAppointmentAlreadyBookedError({ appointmentId }),
       );
 
       const { container, getByTestId } = renderWithStoreAndRouterV6(
@@ -329,7 +330,7 @@ describe('VASS Component: EnterOTP', () => {
 
       await waitFor(() => {
         expect(getByTestId('location-display').textContent).to.equal(
-          `${URLS.ALREADY_SCHEDULED}/appt-123`,
+          `${URLS.ALREADY_SCHEDULED}/${appointmentId}`,
         );
       });
     });

--- a/src/applications/vass/redux/api/vassApi.js
+++ b/src/applications/vass/redux/api/vassApi.js
@@ -182,11 +182,7 @@ export const vassApi = createApi({
           });
         } catch ({ errors }) {
           return {
-            error: {
-              code: errors?.[0]?.code,
-              detail: errors?.[0]?.detail,
-              appointment: errors?.[0]?.appointment,
-            },
+            error: errors?.[0],
           };
         }
       },

--- a/src/applications/vass/services/mocks/utils/errors.js
+++ b/src/applications/vass/services/mocks/utils/errors.js
@@ -1,5 +1,5 @@
 const {
-  OTC_ERROR_CODES,
+  OTP_ERROR_CODES,
   AUTH_ERROR_CODES,
   TOKEN_ERROR_CODES,
   APPOINTMENT_ERROR_CODES,
@@ -39,7 +39,7 @@ const createOTPInvalidError = (attemptsRemaining = 0) => {
   return {
     errors: [
       {
-        code: OTC_ERROR_CODES.INVALID_OTP,
+        code: OTP_ERROR_CODES.INVALID_OTP,
         detail: 'Invalid or expired OTP.  Please try again.',
         attemptsRemaining,
       },
@@ -51,7 +51,7 @@ const createOTPAccountLockedError = (retryAfter = 900) => {
   return {
     errors: [
       {
-        code: OTC_ERROR_CODES.ACCOUNT_LOCKED,
+        code: OTP_ERROR_CODES.ACCOUNT_LOCKED,
         detail: 'Too many failed attempts.  Please request a new OTP.',
         retryAfter,
       },
@@ -109,23 +109,104 @@ const createNotWithinCohortError = () => {
     errors: [
       {
         code: AVAILABILITY_ERROR_CODES.NOT_WITHIN_COHORT,
-        detail: 'Not within cohort',
+        detail: 'Current date outside of appointment cohort date ranges',
       },
     ],
   };
 };
 
-const createAppointmentAlreadyBookedError = appointmentId => {
+const createAppointmentAlreadyBookedError = ({
+  appointmentId = 'e61e1a40-1e63-f011-bec2-001dd80351ea',
+  dtStartUTC = '2025-12-20T14:00:00Z',
+  dtEndUTC = '2025-12-20T14:30:00Z',
+} = {}) => {
   return {
     errors: [
       {
         code: AVAILABILITY_ERROR_CODES.APPOINTMENT_ALREADY_BOOKED,
-        detail: 'Veteran already has a scheduled appointment',
+        detail: 'already scheduled',
         appointment: {
           appointmentId,
-          dtStartUTC: '2026-02-10T14:00:00Z',
-          dtEndUTC: '2026-02-10T14:30:00Z',
+          dtStartUTC,
+          dtEndUTC,
         },
+      },
+    ],
+  };
+};
+
+const createNoSlotsAvailableError = () => {
+  return {
+    errors: [
+      {
+        code: AVAILABILITY_ERROR_CODES.NO_SLOTS_AVAILABLE,
+        detail: 'No available appointment slots',
+      },
+    ],
+  };
+};
+
+const createMissingAuthParameterError = paramName => {
+  return {
+    errors: [
+      {
+        code: AUTH_ERROR_CODES.MISSING_PARAMETER,
+        detail: `param is missing or the value is empty: ${paramName}`,
+      },
+    ],
+  };
+};
+
+const createMissingOtpParameterError = paramName => {
+  return {
+    errors: [
+      {
+        code: OTP_ERROR_CODES.MISSING_PARAMETER,
+        detail: `param is missing or the value is empty: ${paramName}`,
+      },
+    ],
+  };
+};
+
+const createMissingAppointmentParameterError = paramName => {
+  return {
+    errors: [
+      {
+        code: APPOINTMENT_ERROR_CODES.MISSING_PARAMETER,
+        detail: `param is missing or the value is empty: ${paramName}`,
+      },
+    ],
+  };
+};
+
+const createOTPExpiredError = () => {
+  return {
+    errors: [
+      {
+        code: OTP_ERROR_CODES.OTP_EXPIRED,
+        detail: 'OTP has expired. Please request a new one.',
+      },
+    ],
+  };
+};
+
+const createAppointmentNotFoundError = () => {
+  return {
+    errors: [
+      {
+        code: APPOINTMENT_ERROR_CODES.APPOINTMENT_NOT_FOUND,
+        detail: 'Appointment not found',
+      },
+    ],
+  };
+};
+
+const createCancellationFailedError = () => {
+  return {
+    errors: [
+      {
+        code: APPOINTMENT_ERROR_CODES.CANCELLATION_FAILED,
+        detail: 'Failed to cancel appointment',
       },
     ],
   };
@@ -143,4 +224,11 @@ module.exports = {
   createNotWithinCohortError,
   createAppointmentAlreadyBookedError,
   createInvalidTokenError,
+  createNoSlotsAvailableError,
+  createMissingAuthParameterError,
+  createMissingOtpParameterError,
+  createMissingAppointmentParameterError,
+  createOTPExpiredError,
+  createAppointmentNotFoundError,
+  createCancellationFailedError,
 };

--- a/src/applications/vass/services/mocks/utils/responses.js
+++ b/src/applications/vass/services/mocks/utils/responses.js
@@ -1,10 +1,68 @@
 /** @typedef {import('../../../utils/appointments').Appointment} Appointment */
+/** @typedef {import('../../../utils/appointments').Topic} Topic */
+
+const { createDefaultTopics } = require('./topic');
 
 /**
  * Mock success responses for VASS API endpoints
  * Based on the API specification:
  * https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md
  */
+
+/**
+ * Creates a success response for POST /vass/v0/request-otp
+ * @param {Object} options - Response options
+ * @param {string} options.message - Success message
+ * @param {number} options.expiresIn - Time in seconds until OTP expires (default 10 minutes)
+ * @param {string} options.email - Masked email address
+ * @returns {Object} Request OTP success response
+ */
+const createRequestOtpResponse = ({
+  message = 'OTP sent to registered email address',
+  expiresIn = 600,
+  email = 's****@email.com',
+} = {}) => {
+  return {
+    data: {
+      message,
+      expiresIn,
+      email,
+    },
+  };
+};
+
+/**
+ * Creates a success response for POST /vass/v0/authenticate-otp
+ * @param {Object} options - Response options
+ * @param {string} options.token - JWT token string
+ * @param {number} options.expiresIn - Token expiration in seconds (default 1 hour)
+ * @returns {Object} Authenticate OTP success response
+ */
+const createAuthenticateOtpResponse = ({ token, expiresIn = 3600 } = {}) => {
+  return {
+    data: {
+      token,
+      expiresIn,
+      tokenType: 'Bearer',
+    },
+  };
+};
+
+/**
+ * Creates a success response for POST /vass/v0/revoke-token
+ * @param {Object} options - Response options
+ * @param {string} options.message - Success message
+ * @returns {Object} Revoke token success response
+ */
+const createRevokeTokenResponse = ({
+  message = 'Token successfully revoked',
+} = {}) => {
+  return {
+    data: {
+      message,
+    },
+  };
+};
 
 /**
  * Creates a success response for GET /vass/v0/appointment-availability
@@ -23,6 +81,31 @@ const createAppointmentAvailabilityResponse = ({
       availableSlots,
     },
   };
+};
+
+/**
+ * Creates a success response for GET /vass/v0/topics
+ * @param {Object} options - Response options
+ * @param {Topic[]} options.topics - Array of topic objects with topicId and topicName
+ * @returns {Object} Topics success response
+ */
+const createTopicsResponse = ({ topics = [] } = {}) => {
+  return {
+    data: {
+      topics,
+    },
+  };
+};
+
+/**
+ * Creates a success response with default topics
+ * @param {Object} options - Response options
+ * @param {number} options.numberOfTopics - Number of topics to include in the response (default 17)
+ * @returns {Object} Topics success response with default topics
+ */
+const createTopicsResponseWithDefaultTopics = (numberOfTopics = 17) => {
+  const topics = createDefaultTopics(numberOfTopics);
+  return createTopicsResponse({ topics });
 };
 
 /**
@@ -87,7 +170,12 @@ const createCancelAppointmentResponse = ({
 };
 
 module.exports = {
+  createRequestOtpResponse,
+  createAuthenticateOtpResponse,
+  createRevokeTokenResponse,
   createAppointmentAvailabilityResponse,
+  createTopicsResponse,
+  createTopicsResponseWithDefaultTopics,
   createAppointmentResponse,
   createAppointmentDetailsResponse,
   createCancelAppointmentResponse,

--- a/src/applications/vass/services/mocks/utils/topic.js
+++ b/src/applications/vass/services/mocks/utils/topic.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../../../utils/appointments').Topic} Topic */
+
 const mockTopics = [
   { topicId: 'burial', topicName: 'Burial' },
   {
@@ -30,4 +32,15 @@ const mockTopics = [
   { topicId: 'general-va-benefits', topicName: 'General VA benefits' },
 ];
 
-module.exports = mockTopics;
+/**
+ * Creates the default set of mock topics.
+ * @param {number} [numberOfTopics=17] - Number of topics to include in the response.
+ * @returns {Topic[]} Array of topic objects.
+ */
+const createDefaultTopics = (numberOfTopics = 17) => {
+  return mockTopics.slice(0, numberOfTopics);
+};
+
+module.exports = {
+  createDefaultTopics,
+};

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -11,6 +11,7 @@ import {
   mockCreateAppointmentApi,
   mockAppointmentDetailsApi,
   mockCancelAppointmentApi,
+  patchCookiesForCI,
 } from './vass-e2e-helpers';
 import MockAppointmentAvailabilityResponse from '../fixtures/MockAppointmentAvailabilityResponse';
 import MockAppointmentDetailsResponse from '../fixtures/MockAppointmentDetailsResponse';
@@ -32,6 +33,10 @@ const mockToday = new Date('2025-06-02T12:00:00Z');
 
 describe('VASS Schedule Appointment', () => {
   beforeEach(() => {
+    // Patch document.cookie so the VASS JWT cookie can be stored
+    // in CI where the test server runs on http://127.0.0.1 (not HTTPS/va.gov)
+    patchCookiesForCI();
+
     // Setup API mocks before visiting the page
     mockRequestOtpApi();
 

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -47,8 +47,6 @@ describe('VASS Schedule Appointment', () => {
 
   describe('Schedule Appointment', () => {
     beforeEach(() => {
-      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
-
       mockAppointmentAvailabilityApi();
 
       mockTopicsApi();
@@ -56,6 +54,12 @@ describe('VASS Schedule Appointment', () => {
       mockCreateAppointmentApi();
 
       mockAppointmentDetailsApi();
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+    });
+
+    it('should load the verify page', () => {
+      VerifyPageObject.assertVerifyPage();
+      cy.injectAxeThenAxeCheck();
     });
 
     it('should schedule an appointment', () => {

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -1,0 +1,444 @@
+import { formatInTimeZone } from 'date-fns-tz';
+import VerifyPageObject from './page-objects/VerifyPageObject';
+import EnterOTPPageObject from './page-objects/EnterOTPPageObject';
+import DateTimeSelectionPageObject from './page-objects/DateTimeSelectionPageObject';
+import TopicSelectionPageObject from './page-objects/TopicSelectionPageObject';
+import {
+  mockRequestOtpApi,
+  mockAuthenticateOtpApi,
+  mockAppointmentAvailabilityApi,
+  mockTopicsApi,
+  mockCreateAppointmentApi,
+  mockAppointmentDetailsApi,
+  mockCancelAppointmentApi,
+} from './vass-e2e-helpers';
+import MockAppointmentAvailabilityResponse from '../fixtures/MockAppointmentAvailabilityResponse';
+import MockAppointmentDetailsResponse from '../fixtures/MockAppointmentDetailsResponse';
+import { createMockJwt } from '../../utils/mock-helpers';
+import MockAuthenticateOtpResponse from '../fixtures/MockAuthenticateOtpResponse';
+import ReviewPageObject from './page-objects/ReviewPageObject';
+import ConfirmationPageObject from './page-objects/ConfirmationPageObject';
+import CancelAppointmentPageObject from './page-objects/CancelAppointmentPageObject';
+import CancelConfirmationPageObject from './page-objects/CancelConfirmationPageObject';
+import AlreadyScheduledPageObject from './page-objects/AlreadyScheduledPageObject';
+import { createAppointmentAlreadyBookedError } from '../../services/mocks/utils/errors';
+import MockCancelAppointmentResponse from '../fixtures/MockCancelAppointmentResponse';
+
+const uuid = 'c0ffee-1234-beef-5678';
+const expiresIn = 3600;
+
+// Fixed "today" for consistent calendar and slot selection (same pattern as VAOS referral-appointments)
+const mockToday = new Date('2025-06-02T12:00:00Z');
+
+describe('VASS Schedule Appointment', () => {
+  beforeEach(() => {
+    // Setup API mocks before visiting the page
+    mockRequestOtpApi();
+
+    const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+      token: createMockJwt(uuid, expiresIn),
+      expiresIn,
+    }).toJSON();
+    mockAuthenticateOtpApi({
+      response: authenticateOtpResponse,
+      responseCode: 200,
+    });
+  });
+
+  describe('Schedule Appointment', () => {
+    beforeEach(() => {
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+
+      mockAppointmentAvailabilityApi();
+
+      mockTopicsApi();
+
+      mockCreateAppointmentApi();
+
+      mockAppointmentDetailsApi();
+    });
+
+    it('should schedule an appointment', () => {
+      VerifyPageObject.assertVerifyPage();
+
+      cy.injectAxeThenAxeCheck();
+
+      VerifyPageObject.fillAndSubmitValidForm();
+
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.assertEnterOTPPage();
+
+      cy.injectAxeThenAxeCheck();
+      EnterOTPPageObject.fillAndSubmitValidOTP();
+
+      cy.wait('@vass:get:appointment-availability');
+      DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+      cy.injectAxeThenAxeCheck();
+      DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+
+      cy.wait('@vass:get:topics');
+      cy.injectAxeThenAxeCheck();
+      TopicSelectionPageObject.assertTopicSelectionPage();
+      TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
+
+      ReviewPageObject.assertReviewPage();
+      cy.injectAxeThenAxeCheck();
+      ReviewPageObject.assertTopicDescription('General VA benefits');
+      ReviewPageObject.clickConfirmAppointment();
+
+      cy.wait('@vass:post:appointment');
+      cy.injectAxeThenAxeCheck();
+      cy.wait('@vass:get:appointment-details');
+
+      ConfirmationPageObject.assertConfirmationPage({
+        agentName: 'Agent Smith',
+        topics: ['General VA benefits'],
+      });
+      cy.injectAxeThenAxeCheck();
+      ConfirmationPageObject.assertAddToCalendarButton();
+      ConfirmationPageObject.assertPrintFunctionality();
+    });
+
+    it('should allow the user to change the date and time', () => {
+      const topic = 'General VA benefits';
+
+      // Fixed slots for deterministic assertions (same day, two times)
+      const firstSlotStart = '2025-06-03T13:00:00.000Z';
+      const secondSlotStart = '2025-06-03T13:30:00.000Z';
+      const firstSlot = MockAppointmentAvailabilityResponse.createSlot({
+        dtStartUtc: firstSlotStart,
+        dtEndUtc: '2025-06-03T13:30:00.000Z',
+      });
+      const secondSlot = MockAppointmentAvailabilityResponse.createSlot({
+        dtStartUtc: secondSlotStart,
+        dtEndUtc: '2025-06-03T14:00:00.000Z',
+      });
+      mockAppointmentAvailabilityApi({
+        response: new MockAppointmentAvailabilityResponse({
+          availableSlots: [firstSlot, secondSlot],
+        }).toJSON(),
+      });
+
+      mockAppointmentDetailsApi({
+        response: new MockAppointmentDetailsResponse({
+          appointmentId: 'abcdef123456',
+          startUTC: secondSlotStart,
+          endUTC: '2025-06-03T14:00:00.000Z',
+        }).toJSON(),
+      });
+
+      // Format expected date/time in the same timezone as the app (works in UTC or any server TZ)
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const expectedDate = formatInTimeZone(
+        firstSlotStart,
+        tz,
+        'EEEE, MMMM dd, yyyy',
+      );
+      const expectedTime1 = formatInTimeZone(firstSlotStart, tz, 'hh:mm a');
+      const expectedTime2 = formatInTimeZone(secondSlotStart, tz, 'hh:mm a');
+
+      // Control time so calendar and slots are consistent
+      cy.clock(mockToday, ['Date']);
+
+      VerifyPageObject.assertVerifyPage();
+      cy.injectAxeThenAxeCheck();
+      VerifyPageObject.fillAndSubmitValidForm();
+
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.assertEnterOTPPage();
+      cy.injectAxeThenAxeCheck();
+      EnterOTPPageObject.fillAndSubmitValidOTP();
+
+      cy.wait('@vass:get:appointment-availability');
+      DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+      cy.injectAxeThenAxeCheck();
+      // Select first slot (index 0) in a consistent manner
+      DateTimeSelectionPageObject.selectFirstAvailableDate();
+      DateTimeSelectionPageObject.selectTimeSlotByIndex(0);
+      DateTimeSelectionPageObject.clickContinue();
+
+      cy.wait('@vass:get:topics');
+      cy.injectAxeThenAxeCheck();
+      TopicSelectionPageObject.assertTopicSelectionPage();
+      TopicSelectionPageObject.selectTopicAndContinue(topic);
+
+      ReviewPageObject.assertReviewPage();
+      cy.injectAxeThenAxeCheck();
+      ReviewPageObject.assertTopicDescription(topic);
+      ReviewPageObject.assertDateTimeDescriptionContains(expectedDate);
+      ReviewPageObject.assertDateTimeDescriptionContains(expectedTime1);
+
+      // Change date/time: go back and select the second slot
+      ReviewPageObject.clickEditDateTime();
+      DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+      DateTimeSelectionPageObject.selectFirstAvailableDate();
+      DateTimeSelectionPageObject.selectTimeSlotByIndex(1);
+      DateTimeSelectionPageObject.clickContinue();
+
+      TopicSelectionPageObject.assertTopicSelectionPage();
+      TopicSelectionPageObject.clickContinue();
+
+      ReviewPageObject.assertReviewPage();
+      ReviewPageObject.assertDateTimeDescriptionContains(expectedDate);
+      ReviewPageObject.assertDateTimeDescriptionContains(expectedTime2);
+      ReviewPageObject.clickConfirmAppointment();
+
+      cy.wait('@vass:post:appointment');
+      cy.injectAxeThenAxeCheck();
+      cy.wait('@vass:get:appointment-details');
+
+      ConfirmationPageObject.assertConfirmationPage({
+        agentName: 'Agent Smith',
+        topics: [topic],
+      });
+      ConfirmationPageObject.assertWhenSectionContainsDateTime(expectedDate);
+      ConfirmationPageObject.assertWhenSectionContainsDateTime(expectedTime2);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('should allow the user to change the topic', () => {
+      const firstTopic = 'General VA benefits';
+      const secondTopic = 'Education';
+
+      VerifyPageObject.assertVerifyPage();
+      cy.injectAxeThenAxeCheck();
+      VerifyPageObject.fillAndSubmitValidForm();
+
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.assertEnterOTPPage();
+      cy.injectAxeThenAxeCheck();
+      EnterOTPPageObject.fillAndSubmitValidOTP();
+
+      cy.wait('@vass:get:appointment-availability');
+      DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+      cy.injectAxeThenAxeCheck();
+      DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+
+      cy.wait('@vass:get:topics');
+      cy.injectAxeThenAxeCheck();
+      TopicSelectionPageObject.assertTopicSelectionPage();
+      TopicSelectionPageObject.selectTopicAndContinue(firstTopic);
+
+      ReviewPageObject.assertReviewPage();
+      cy.injectAxeThenAxeCheck();
+      ReviewPageObject.assertTopicDescription(firstTopic);
+
+      // Change topic: go back, unselect first and select second
+      ReviewPageObject.clickEditTopic();
+      TopicSelectionPageObject.assertTopicSelectionPage();
+      TopicSelectionPageObject.unselectTopicByTestId(
+        'topic-checkbox-general-va-benefits',
+      );
+      TopicSelectionPageObject.selectTopicAndContinue(secondTopic);
+
+      ReviewPageObject.assertReviewPage();
+      ReviewPageObject.assertTopicDescription(secondTopic);
+      ReviewPageObject.clickConfirmAppointment();
+
+      cy.wait('@vass:post:appointment');
+      cy.injectAxeThenAxeCheck();
+      cy.wait('@vass:get:appointment-details');
+
+      ConfirmationPageObject.assertConfirmationPage({
+        agentName: 'Agent Smith',
+        topics: [secondTopic],
+      });
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  describe('Cancel Appointment', () => {
+    beforeEach(() => {
+      const appointmentId = 'abcdef123456';
+      const availabilityResponse = new MockAppointmentAvailabilityResponse({
+        appointmentId,
+        availableSlots: MockAppointmentAvailabilityResponse.createSlots(),
+      }).toJSON();
+      mockAppointmentAvailabilityApi({
+        response: availabilityResponse,
+        responseCode: 200,
+      });
+
+      mockTopicsApi();
+
+      mockCreateAppointmentApi();
+
+      mockAppointmentDetailsApi({
+        response: new MockAppointmentDetailsResponse({
+          appointmentId,
+        }).toJSON(),
+        responseCode: 200,
+      });
+      mockCancelAppointmentApi();
+    });
+
+    it('should cancel an appointment from the schdelued appointment confirmation page', () => {
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+
+      VerifyPageObject.assertVerifyPage();
+      cy.injectAxeThenAxeCheck();
+
+      VerifyPageObject.fillAndSubmitForm({
+        lastName: 'Smith',
+        dateOfBirth: '1935-04-07',
+      });
+
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.assertEnterOTPPage();
+
+      cy.injectAxeThenAxeCheck();
+      EnterOTPPageObject.fillAndSubmitValidOTP();
+
+      cy.wait('@vass:get:appointment-availability');
+      DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+      cy.injectAxeThenAxeCheck();
+      DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+
+      cy.wait('@vass:get:topics');
+      cy.injectAxeThenAxeCheck();
+      TopicSelectionPageObject.assertTopicSelectionPage();
+      TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
+
+      ReviewPageObject.assertReviewPage();
+      cy.injectAxeThenAxeCheck();
+      ReviewPageObject.clickConfirmAppointment();
+
+      cy.wait('@vass:post:appointment');
+      cy.injectAxeThenAxeCheck();
+      cy.wait('@vass:get:appointment-details');
+
+      cy.injectAxeThenAxeCheck();
+      ConfirmationPageObject.clickCancelAppointment();
+
+      CancelAppointmentPageObject.assertCancelAppointmentPage({
+        agentName: 'Agent Smith',
+      });
+      cy.injectAxeThenAxeCheck();
+
+      CancelAppointmentPageObject.clickYesCancelAppointment();
+      cy.wait('@vass:post:cancel-appointment');
+
+      CancelConfirmationPageObject.assertCancelConfirmationPage({
+        agentName: 'Agent Smith',
+      });
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('should cancel an appointment from a cancelation link', () => {
+      cy.visit(
+        `/service-member/benefits/solid-start/schedule?uuid=${uuid}&cancel=true`,
+      );
+
+      VerifyPageObject.assertVerifyPage({ cancellationFlow: true });
+      cy.injectAxeThenAxeCheck();
+      VerifyPageObject.fillAndSubmitValidForm();
+
+      cy.wait('@vass:post:request-otp');
+      cy.injectAxeThenAxeCheck();
+      EnterOTPPageObject.assertEnterOTPPage({ cancellationFlow: true });
+      EnterOTPPageObject.assertSuccessAlertContainsEmail('s****@email.com');
+      EnterOTPPageObject.fillAndSubmitValidOTP();
+
+      cy.wait('@vass:get:appointment-details');
+
+      cy.injectAxeThenAxeCheck();
+      CancelAppointmentPageObject.assertCancelAppointmentPage({
+        agentName: 'Agent Smith',
+      });
+
+      CancelAppointmentPageObject.clickYesCancelAppointment();
+      cy.wait('@vass:post:cancel-appointment');
+
+      CancelConfirmationPageObject.assertCancelConfirmationPage({
+        agentName: 'Agent Smith',
+      });
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  describe('Already Scheduled Appointment', () => {
+    beforeEach(() => {
+      const appointmentId = 'already-scheduled-appointment-id';
+      const startUTC = '2025-12-20T14:00:00Z';
+      const endUTC = '2025-12-20T14:30:00Z';
+      mockAppointmentAvailabilityApi({
+        response: createAppointmentAlreadyBookedError({
+          appointmentId,
+          dtStartUTC: startUTC,
+          dtEndUTC: endUTC,
+        }),
+        responseCode: 409,
+      });
+
+      mockTopicsApi();
+
+      mockAppointmentDetailsApi({
+        response: new MockAppointmentDetailsResponse({
+          appointmentId,
+          startUTC,
+          endUTC,
+        }).toJSON(),
+        responseCode: 200,
+      });
+      mockCancelAppointmentApi({
+        response: new MockCancelAppointmentResponse({
+          appointmentId,
+        }).toJSON(),
+        responseCode: 200,
+      });
+    });
+
+    describe('when the user attempts to schedule an appointment that is already scheduled', () => {
+      it('should redirect to the already scheduled appointment page', () => {
+        cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+
+        VerifyPageObject.assertVerifyPage();
+        cy.injectAxeThenAxeCheck();
+        VerifyPageObject.fillAndSubmitValidForm();
+
+        cy.wait('@vass:post:request-otp');
+        cy.injectAxeThenAxeCheck();
+        EnterOTPPageObject.fillAndSubmitValidOTP();
+
+        cy.wait('@vass:get:appointment-availability');
+        cy.wait('@vass:get:appointment-details');
+
+        AlreadyScheduledPageObject.assertAlreadyScheduledPage();
+        cy.injectAxeThenAxeCheck();
+      });
+
+      it('should allow the user to cancel', () => {
+        cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+
+        VerifyPageObject.assertVerifyPage();
+        cy.injectAxeThenAxeCheck();
+        VerifyPageObject.fillAndSubmitValidForm();
+
+        cy.wait('@vass:post:request-otp');
+        EnterOTPPageObject.assertEnterOTPPage();
+        cy.injectAxeThenAxeCheck();
+        EnterOTPPageObject.fillAndSubmitValidOTP();
+
+        cy.wait('@vass:get:appointment-availability');
+        cy.wait('@vass:get:appointment-details');
+
+        AlreadyScheduledPageObject.assertAlreadyScheduledPage();
+        cy.injectAxeThenAxeCheck();
+        AlreadyScheduledPageObject.clickCancelAppointment();
+
+        CancelAppointmentPageObject.assertCancelAppointmentPage({
+          agentName: 'Agent Smith',
+        });
+        cy.injectAxeThenAxeCheck();
+
+        CancelAppointmentPageObject.clickYesCancelAppointment();
+        cy.wait('@vass:post:cancel-appointment');
+
+        CancelConfirmationPageObject.assertCancelConfirmationPage({
+          agentName: 'Agent Smith',
+        });
+        cy.injectAxeThenAxeCheck();
+      });
+    });
+  });
+});

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -62,11 +62,6 @@ describe('VASS Schedule Appointment', () => {
       cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
     });
 
-    it('should load the verify page', () => {
-      VerifyPageObject.assertVerifyPage();
-      cy.injectAxeThenAxeCheck();
-    });
-
     it('should schedule an appointment', () => {
       VerifyPageObject.assertVerifyPage();
 

--- a/src/applications/vass/tests/e2e/page-objects/AlreadyScheduledPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/AlreadyScheduledPageObject.js
@@ -1,0 +1,68 @@
+import PageObject from './Page-Object';
+import { VASS_PHONE_NUMBER } from '../../../utils/constants';
+
+export class AlreadyScheduledPageObject extends PageObject {
+  /**
+   * Assert the Already Scheduled page is displayed with all expected elements
+   * @returns {AlreadyScheduledPageObject}
+   */
+  assertAlreadyScheduledPage() {
+    // Page heading
+    this.assertHeading({
+      name: 'You already scheduled your appointment with VA Solid Start',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    // Page structure
+    this.assertElement('already-scheduled-page');
+
+    // Date/time message
+    this.assertElement('already-scheduled-date-time', {
+      containsText: 'Your VA Solid Start appointment is scheduled for',
+    });
+
+    // Phone number message with contact info
+    this.assertElement('already-scheduled-phone-number', {
+      containsText:
+        'Your VA Solid Start representative will call you at the time you requested',
+    });
+    cy.findByTestId('already-scheduled-phone-number')
+      .find('va-telephone')
+      .should('exist')
+      .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+
+    // Cancel button
+    cy.findByTestId('already-scheduled-cancel-button')
+      .should('exist')
+      .and('have.attr', 'text', 'Cancel this appointment');
+
+    // Reschedule message with phone number
+    this.assertElement('already-scheduled-reschedule-message', {
+      containsText: 'If you want to reschedule this appointment, call us at',
+    });
+    cy.findByTestId('already-scheduled-reschedule-message')
+      .find('va-telephone')
+      .should('exist')
+      .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Click the cancel appointment link
+   * @returns {AlreadyScheduledPageObject}
+   */
+  clickCancelAppointment() {
+    cy.findByTestId('already-scheduled-cancel-button').click();
+    return this;
+  }
+}
+
+export default new AlreadyScheduledPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/AlreadyScheduledPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/AlreadyScheduledPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 import { VASS_PHONE_NUMBER } from '../../../utils/constants';
 
 export class AlreadyScheduledPageObject extends PageObject {
@@ -15,7 +15,7 @@ export class AlreadyScheduledPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     // Page structure
     this.assertElement('already-scheduled-page');

--- a/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 import { VASS_PHONE_NUMBER } from '../../../utils/constants';
 
 export class CancelAppointmentPageObject extends PageObject {
@@ -17,7 +17,7 @@ export class CancelAppointmentPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     // Page structure
     this.assertElement('cancel-appointment-page');

--- a/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
@@ -1,0 +1,90 @@
+import PageObject from './Page-Object';
+import { VASS_PHONE_NUMBER } from '../../../utils/constants';
+
+export class CancelAppointmentPageObject extends PageObject {
+  /**
+   * Assert the Cancel Appointment page is displayed with all appointment card details
+   * @param {Object} options - Options
+   * @param {string} options.agentName - Expected agent name (defaults to 'Agent Smith')
+   * @returns {CancelAppointmentPageObject}
+   */
+  assertCancelAppointmentPage({ agentName = 'Agent Smith' } = {}) {
+    // Page heading
+    this.assertHeading({
+      name: 'Would you like to cancel this appointment?',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    // Page structure
+    this.assertElement('cancel-appointment-page');
+
+    // Appointment card
+    this.assertElement('appointment-card');
+    this.assertElement('appointment-type', {
+      containsText: 'Phone appointment',
+    });
+
+    // How to join section with phone number
+    this.assertElement('how-to-join-section', {
+      containsText: 'Your representative will call you from',
+    });
+    cy.findByTestId('how-to-join-section').within(() => {
+      cy.findByTestId('solid-start-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+    });
+
+    // When section
+    this.assertElement('when-section');
+
+    // What section
+    this.assertElement('what-section', { containsText: 'VA Solid Start' });
+
+    // Who section with agent name
+    this.assertElement('who-section', { containsText: agentName });
+
+    // Cancel/print buttons should NOT be present on this page (different from Confirmation)
+    this.assertElement('print-button', { exist: false });
+    this.assertElement('cancel-button', { exist: false });
+
+    // Button pair for cancel confirmation
+    this.assertElement('cancel-confirm-button-pair');
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Click "Yes, cancel appointment" button
+   * @returns {CancelAppointmentPageObject}
+   */
+  clickYesCancelAppointment() {
+    cy.findByTestId('cancel-confirm-button-pair')
+      .shadow()
+      .find('va-button')
+      .first()
+      .click();
+    return this;
+  }
+
+  /**
+   * Click "No, don't cancel" button
+   * @returns {CancelAppointmentPageObject}
+   */
+  clickNoDontCancel() {
+    cy.findByTestId('cancel-confirm-button-pair')
+      .shadow()
+      .find('va-button')
+      .last()
+      .click();
+    return this;
+  }
+}
+
+export default new CancelAppointmentPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/CancelConfirmationPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/CancelConfirmationPageObject.js
@@ -1,0 +1,69 @@
+import PageObject from './Page-Object';
+import { VASS_PHONE_NUMBER } from '../../../utils/constants';
+
+export class CancelConfirmationPageObject extends PageObject {
+  /**
+   * Assert the Cancel Confirmation page is displayed with all appointment card details
+   * @param {Object} options - Options
+   * @param {string} options.agentName - Expected agent name (defaults to 'Agent Smith')
+   * @returns {CancelConfirmationPageObject}
+   */
+  assertCancelConfirmationPage({ agentName = 'Agent Smith' } = {}) {
+    // Page heading
+    this.assertHeading({
+      name: 'You have canceled your appointment',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    // Page structure
+    this.assertElement('cancel-confirmation-page');
+
+    // Cancellation message with phone number
+    this.assertElement('cancel-confirmation-message', {
+      containsText: 'If you need to reschedule, call us at',
+    });
+    cy.findByTestId('cancel-confirmation-phone')
+      .should('exist')
+      .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+
+    // Appointment card
+    this.assertElement('appointment-card');
+    this.assertElement('appointment-type', {
+      containsText: 'Phone appointment',
+    });
+
+    // How to join section with phone number
+    this.assertElement('how-to-join-section', {
+      containsText: 'Your representative will call you from',
+    });
+    cy.findByTestId('how-to-join-section').within(() => {
+      cy.findByTestId('solid-start-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+    });
+
+    // When section
+    this.assertElement('when-section');
+
+    // What section
+    this.assertElement('what-section', { containsText: 'VA Solid Start' });
+
+    // Who section with agent name
+    this.assertElement('who-section', { containsText: agentName });
+
+    // Cancel/print buttons should NOT be present on this page
+    this.assertElement('print-button', { exist: false });
+    this.assertElement('cancel-button', { exist: false });
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+}
+
+export default new CancelConfirmationPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/CancelConfirmationPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/CancelConfirmationPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 import { VASS_PHONE_NUMBER } from '../../../utils/constants';
 
 export class CancelConfirmationPageObject extends PageObject {
@@ -17,7 +17,7 @@ export class CancelConfirmationPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     // Page structure
     this.assertElement('cancel-confirmation-page');

--- a/src/applications/vass/tests/e2e/page-objects/ConfirmationPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/ConfirmationPageObject.js
@@ -1,0 +1,182 @@
+import PageObject from './Page-Object';
+import { VASS_PHONE_NUMBER } from '../../../utils/constants';
+
+export class ConfirmationPageObject extends PageObject {
+  /**
+   * Assert the Confirmation page is displayed with all appointment card details
+   * @param {Object} options - Options
+   * @param {string} options.agentName - Expected agent name (defaults to 'Agent Smith')
+   * @param {string[]} options.topics - Expected topic names to verify
+   * @returns {ConfirmationPageObject}
+   */
+  assertConfirmationPage({ agentName = 'Agent Smith', topics = [] } = {}) {
+    // Page heading
+    this.assertHeading({
+      name: 'Your VA Solid Start appointment is scheduled',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    // Confirmation page structure
+    this.assertElement('confirmation-page');
+    this.assertElement('confirmation-message', {
+      containsText: 'We’ve confirmed your appointment',
+    });
+
+    // Appointment card
+    this.assertElement('appointment-card');
+    this.assertElement('appointment-type', {
+      containsText: 'Phone appointment',
+    });
+
+    // How to join section with phone number
+    this.assertElement('how-to-join-section', {
+      containsText: `Your representative will call you from`,
+    });
+    cy.findByTestId('how-to-join-section').within(() => {
+      cy.findByTestId('solid-start-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+    });
+
+    // When section
+    this.assertElement('when-section');
+
+    // What section
+    this.assertElement('what-section', { containsText: 'VA Solid Start' });
+
+    // Who section with agent name
+    this.assertElement('who-section', { containsText: agentName });
+
+    // Topics section (if topics provided)
+    if (topics.length > 0) {
+      this.assertElement('topics-section');
+      topics.forEach(topic => {
+        cy.findByTestId('topics-section').and('contain.text', topic);
+      });
+    }
+
+    // Action buttons
+    this.assertElement('print-button');
+    this.assertElement('cancel-button');
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Assert the Confirmation page is displayed in details-only mode (no heading/message)
+   * @param {Object} options - Options
+   * @param {string} options.agentName - Expected agent name
+   * @param {string[]} options.topics - Expected topic names to verify
+   * @returns {ConfirmationPageObject}
+   */
+  assertDetailsOnlyPage({ agentName = 'Agent Smith', topics = [] } = {}) {
+    // Page structure without confirmation message
+    this.assertElement('confirmation-page');
+    this.assertElement('confirmation-message', { exist: false });
+
+    // Appointment card details
+    this.assertElement('appointment-card');
+    this.assertElement('appointment-type', {
+      containsText: 'Phone appointment',
+    });
+
+    // How to join section with phone number
+    this.assertElement('how-to-join-section');
+    cy.findByTestId('solid-start-telephone')
+      .should('exist')
+      .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+
+    // When section
+    this.assertElement('when-section');
+
+    // What section
+    this.assertElement('what-section', { containsText: 'VA Solid Start' });
+
+    // Who section with agent name
+    this.assertElement('who-section', { containsText: agentName });
+
+    // Topics section (if topics provided)
+    if (topics.length > 0) {
+      this.assertElement('topics-section');
+      topics.forEach(topic => {
+        cy.findByTestId('topics-section').and('contain.text', topic);
+      });
+    }
+
+    // Action buttons
+    this.assertElement('print-button');
+    this.assertElement('cancel-button');
+
+    return this;
+  }
+
+  /**
+   * Click the print button
+   * @returns {ConfirmationPageObject}
+   */
+  clickPrint() {
+    cy.findByTestId('print-button')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Click the cancel appointment button
+   * @returns {ConfirmationPageObject}
+   */
+  clickCancelAppointment() {
+    cy.findByTestId('cancel-button')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Assert the confirmation page "When" section displays the given date/time text.
+   * Use this to verify the confirmed appointment shows the updated time (e.g. after changing date/time).
+   * @param {string} text - Text that should appear in the When section (e.g. formatted date or time)
+   * @returns {ConfirmationPageObject}
+   */
+  assertWhenSectionContainsDateTime(text) {
+    cy.findByTestId('when-section').should('contain.text', text);
+    return this;
+  }
+
+  /**
+   * Assert the add to calendar button
+   * @returns {ConfirmationPageObject}
+   */
+  assertAddToCalendarButton() {
+    cy.findByTestId('add-to-calendar-button').should('exist');
+    cy.findByTestId('add-to-calendar-link')
+      .should('exist')
+      .and('have.attr', 'href')
+      .and('match', /^data:text\/calendar;charset=utf-8,/);
+    return this;
+  }
+
+  /**
+   * Assert the print functionality
+   * @returns {ConfirmationPageObject}
+   */
+  assertPrintFunctionality() {
+    cy.window().then(win => {
+      cy.stub(win, 'print').as('printStub');
+    });
+    cy.findByTestId('print-button')
+      .should('exist')
+      .click();
+    cy.get('@printStub').should('have.been.calledOnce');
+    return this;
+  }
+}
+
+export default new ConfirmationPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/ConfirmationPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/ConfirmationPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 import { VASS_PHONE_NUMBER } from '../../../utils/constants';
 
 export class ConfirmationPageObject extends PageObject {
@@ -18,7 +18,7 @@ export class ConfirmationPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     // Confirmation page structure
     this.assertElement('confirmation-page');

--- a/src/applications/vass/tests/e2e/page-objects/DateTimeSelectionPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/DateTimeSelectionPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 
 export class DateTimeSelectionPageObject extends PageObject {
   /**
@@ -13,7 +13,7 @@ export class DateTimeSelectionPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     this.assertElement('date-time-selection', { exist: true });
     this.assertElement('content', { exist: true });

--- a/src/applications/vass/tests/e2e/page-objects/DateTimeSelectionPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/DateTimeSelectionPageObject.js
@@ -1,0 +1,267 @@
+import PageObject from './Page-Object';
+
+export class DateTimeSelectionPageObject extends PageObject {
+  /**
+   * Assert the Date Time Selection page is displayed
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertDateTimeSelectionPage() {
+    this.assertHeading({
+      name: 'When do you want to schedule your appointment?(*Required)',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    this.assertElement('date-time-selection', { exist: true });
+    this.assertElement('content', { exist: true });
+    this.assertCalendarWidget();
+    this.assertContinueButton();
+
+    this.assertContentText();
+    this.assertCalendarWidget();
+    cy.findByText(/Appointment times are displayed in/i).should('exist');
+    cy.findByText(
+      /You can schedule a appointment on a week day within the next 2 weeks\./i,
+    ).should('exist');
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Assert the page content text is displayed
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertContentText() {
+    this.assertElement('content', {
+      containsText: 'Select an available date and time from the calendar below',
+    });
+    return this;
+  }
+
+  /**
+   * Assert the calendar widget is displayed
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertCalendarWidget() {
+    this.assertElement('vaos-calendar', { exist: true });
+    return this;
+  }
+
+  /**
+   * Assert the validation error message is displayed
+   * @param {string} errorMessage - The expected error message
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertValidationError(errorMessage) {
+    cy.get('.vaos-calendar__validation-msg')
+      .should('exist')
+      .and('contain.text', errorMessage);
+    return this;
+  }
+
+  /**
+   * Assert no validation error is displayed
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertNoValidationError() {
+    cy.get('.vaos-calendar__validation-msg').should('not.exist');
+    return this;
+  }
+
+  /**
+   * Select the first available date on the calendar
+   * @returns {DateTimeSelectionPageObject}
+   */
+  selectFirstAvailableDate() {
+    cy.findByTestId('vaos-calendar').within(() => {
+      cy.findAllByRole('button')
+        .not('[disabled]')
+        .not('.usa-button-disabled')
+        .first()
+        .click();
+    });
+    return this;
+  }
+
+  /**
+   * Select the first available time slot
+   * @returns {DateTimeSelectionPageObject}
+   */
+  selectFirstAvailableTimeSlot() {
+    cy.get('.vaos-calendar__option-cell input[type="radio"]:not([disabled])')
+      .first()
+      .click({ force: true });
+    return this;
+  }
+
+  /**
+   * Select a time slot by index (0-based). Use after a date is already selected.
+   * Consistent with VAOS referral flow: select by index for deterministic tests.
+   * @param {number} index - Index of the time slot to select (0-based)
+   * @returns {DateTimeSelectionPageObject}
+   */
+  selectTimeSlotByIndex(index = 0) {
+    cy.get('.vaos-calendar__option-cell input[type="radio"]:not([disabled])')
+      .eq(index)
+      .click({ force: true });
+    return this;
+  }
+
+  /**
+   * Click the continue button
+   * @returns {DateTimeSelectionPageObject}
+   */
+  clickContinue() {
+    cy.findByTestId('continue-button')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Assert the continue button exists
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertContinueButton() {
+    this.assertElement('continue-button', { exist: true });
+    return this;
+  }
+
+  /**
+   * Navigate to the next month on the calendar
+   * @returns {DateTimeSelectionPageObject}
+   */
+  goToNextMonth() {
+    cy.get('.vaos-calendar__nav-links button')
+      .last()
+      .click();
+    return this;
+  }
+
+  /**
+   * Navigate to the previous month on the calendar
+   * @returns {DateTimeSelectionPageObject}
+   */
+  goToPreviousMonth() {
+    cy.get('.vaos-calendar__nav-links button')
+      .first()
+      .click();
+    return this;
+  }
+
+  /**
+   * Assert a specific date is available (not disabled)
+   * @param {string} date - The date to check
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertDateAvailable(date) {
+    cy.get(`[data-date="${date}"]`).should('not.be.disabled');
+    return this;
+  }
+
+  /**
+   * Assert a specific date is unavailable (disabled)
+   * @param {string} date - The date to check
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertDateUnavailable(date) {
+    cy.get(`[data-date="${date}"]`).should('be.disabled');
+    return this;
+  }
+
+  /**
+   * Assert that a time slot is selected
+   * @param {string} slotId - The slot identifier
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertTimeSlotSelected(slotId) {
+    cy.get(`[data-value="${slotId}"]`).should('be.checked');
+    return this;
+  }
+
+  /**
+   * Select an available date and time slot, then continue
+   * @returns {DateTimeSelectionPageObject}
+   */
+  selectFirstAvailableDateTimeAndContinue() {
+    this.selectFirstAvailableDate();
+    this.selectFirstAvailableTimeSlot();
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Submit form without selecting any date/time to trigger validation errors
+   * @returns {DateTimeSelectionPageObject}
+   */
+  submitWithoutSelection() {
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Assert the timezone text is displayed
+   * @param {string} timezone - The expected timezone description
+   * @returns {DateTimeSelectionPageObject}
+   */
+  assertTimezoneText(timezone) {
+    cy.findByTestId('content')
+      .should('exist')
+      .and('contain.text', timezone);
+    return this;
+  }
+
+  /**
+   * Selects an appointment slot by index
+   * @param {number} index - Index of the slot to select (0-based)
+   */
+  selectAppointmentSlot(index = 0) {
+    const buttonIndex = index + 1; // Add one for the Prev button
+    cy.findByTestId('cal-widget').within(() => {
+      // Check that we are on the next month
+      cy.findByLabelText(/Prev/i).should('not.be.disabled');
+
+      // Find active buttons and click the specified one
+      cy.findAllByRole('button')
+        .not('[disabled]')
+        .not('.usa-button-disabled')
+        .eq(buttonIndex)
+        .click();
+      // Verify that at least one radio button with time information is present
+      cy.findAllByRole('radio')
+        .eq(0)
+        .click();
+    });
+    return this;
+  }
+
+  /**
+   * Validates that appointment slots are displayed
+   * @param {Object} options - Options for assertion
+   * @param {number} options.count - Expected number of active appointment slots
+   */
+  assertAppointmentSlots(count = 3) {
+    const buttonCount = count + 1; // Add one for the Prev button
+    cy.findByTestId('cal-widget')
+      .should('exist')
+      .within(() => {
+        // Check that we are on the next month
+        cy.findByLabelText(/Prev/i).should('not.be.disabled');
+
+        // Find buttons that are not disabled (active slots)
+        cy.findAllByRole('button')
+          .not('[disabled]')
+          .not('.usa-button-disabled')
+          .should('have.length', buttonCount);
+      });
+    return this;
+  }
+}
+
+export default new DateTimeSelectionPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 
 export class EnterOTPPageObject extends PageObject {
   /**
@@ -17,7 +17,7 @@ export class EnterOTPPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     this.assertElement('otp-input', { exist: true });
     this.assertElement('continue-button', { exist: true });

--- a/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
@@ -1,0 +1,180 @@
+import PageObject from './Page-Object';
+
+export class EnterOTPPageObject extends PageObject {
+  /**
+   * Assert the Enter OTP page is displayed with scheduling flow heading
+   * @returns {EnterOTPPageObject}
+   */
+  assertEnterOTPPage({ cancellationFlow = false } = {}) {
+    const headingText = cancellationFlow
+      ? 'Cancel VA Solid Start appointment'
+      : 'Schedule an appointment with VA Solid Start';
+
+    this.assertHeading({
+      name: headingText,
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    this.assertElement('otp-input', { exist: true });
+    this.assertElement('continue-button', { exist: true });
+    this.assertElement('enter-otp-success-alert', { exist: true });
+    this.assertSuccessAlert({ exist: true });
+
+    // Assert no error states on initial load
+    this.assertOTPErrorAlert({ exist: false });
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Assert the verification error page is displayed (account locked)
+   * @returns {EnterOTPPageObject}
+   */
+  assertVerificationErrorPage() {
+    this.assertHeading({
+      name: /We couldn.t verify your information/i,
+      level: 1,
+      exist: true,
+    });
+    return this;
+  }
+
+  /**
+   * Enter an OTP code value
+   * @param {string} code - The OTP code to enter
+   * @returns {EnterOTPPageObject}
+   */
+  enterOTP(code) {
+    cy.fillVaTextInput('otp', code);
+    return this;
+  }
+
+  /**
+   * Enter a valid OTP code for testing
+   * @returns {EnterOTPPageObject}
+   */
+  enterValidOTP() {
+    return this.enterOTP('123456');
+  }
+
+  /**
+   * Click the continue button
+   * @returns {EnterOTPPageObject}
+   */
+  clickContinue() {
+    cy.findByTestId('continue-button')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Assert the success alert is displayed or not
+   * @param {Object} props - Options
+   * @param {boolean} props.exist - Whether the alert should exist
+   * @returns {EnterOTPPageObject}
+   */
+  assertSuccessAlert({ exist = true } = {}) {
+    this.assertElement('enter-otp-success-alert', { exist });
+    return this;
+  }
+
+  /**
+   * Assert the error alert is displayed or not
+   * @param {Object} props - Options
+   * @param {boolean} props.exist - Whether the alert should exist
+   * @returns {EnterOTPPageObject}
+   */
+  assertOTPErrorAlert({ exist = true } = {}) {
+    this.assertElement('enter-otp-error-alert', { exist });
+    return this;
+  }
+
+  /**
+   * Assert the continue button is in loading state
+   * @returns {EnterOTPPageObject}
+   */
+  assertContinueLoading() {
+    cy.findByTestId('continue-button').should('have.attr', 'loading', 'true');
+    return this;
+  }
+
+  /**
+   * Assert the continue button is not in loading state
+   * @returns {EnterOTPPageObject}
+   */
+  assertContinueNotLoading() {
+    cy.findByTestId('continue-button').should('not.have.attr', 'loading');
+    return this;
+  }
+
+  /**
+   * Assert the OTP input has an error
+   * @param {string} errorMessage - The expected error message
+   * @returns {EnterOTPPageObject}
+   */
+  assertOTPError(errorMessage) {
+    cy.findByTestId('otp-input').should('have.attr', 'error', errorMessage);
+    return this;
+  }
+
+  /**
+   * Assert the OTP input has no error
+   * @returns {EnterOTPPageObject}
+   */
+  assertNoOTPError() {
+    cy.findByTestId('otp-input').should('not.have.attr', 'error');
+    return this;
+  }
+
+  /**
+   * Assert the success alert contains the obfuscated email
+   * @param {string} email - The obfuscated email to check for
+   * @returns {EnterOTPPageObject}
+   */
+  assertSuccessAlertContainsEmail(email) {
+    this.assertElement('enter-otp-success-alert', {
+      containsText: email,
+    });
+    return this;
+  }
+
+  /**
+   * Fill the form with valid OTP and submit
+   * @returns {EnterOTPPageObject}
+   */
+  fillAndSubmitValidOTP() {
+    this.enterValidOTP();
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Fill the form with custom OTP and submit
+   * @param {string} code - The OTP code to enter
+   * @returns {EnterOTPPageObject}
+   */
+  fillAndSubmitOTP(code) {
+    this.enterOTP(code);
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Submit form without entering any data to trigger validation errors
+   * @returns {EnterOTPPageObject}
+   */
+  submitEmptyForm() {
+    this.clickContinue();
+    return this;
+  }
+}
+
+export default new EnterOTPPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/Page-Object.js
+++ b/src/applications/vass/tests/e2e/page-objects/Page-Object.js
@@ -1,0 +1,123 @@
+import { VASS_PHONE_NUMBER } from '../../../utils/constants';
+
+export default class PageObject {
+  rootUrl = '/service-member/benefits/solid-start/schedule';
+
+  /**
+   * Assert an element exists and optionally contains text
+   * @param {string} testId - The data-testid to find
+   * @param {Object} options - Options
+   * @param {boolean} options.exist - Whether the element should exist
+   * @param {string} options.containsText - Text the element should contain
+   * @returns {PageObject}
+   */
+  assertElement(testId, { exist = true, containsText } = {}) {
+    if (exist && containsText) {
+      cy.findByTestId(testId)
+        .should('exist')
+        .and('contain.text', containsText);
+    } else {
+      cy.findByTestId(testId).should(exist ? 'exist' : 'not.exist');
+    }
+    return this;
+  }
+
+  /**
+   * Assert a heading exists and optionally contains text
+   * @param {Object} props - Properties used to determine what type of heading to assert.
+   * @param {string|RegExp=} props.name - The name of the heading to assert.
+   * @param {number=} props.level - The level of the heading to assert.
+   * @returns {PageObject}
+   */
+  assertHeading({ name, level = 1, exist = true } = {}) {
+    cy.findByRole('heading', { level, name }).should(
+      exist ? 'exist' : 'not.exist',
+    );
+
+    return this;
+  }
+
+  /**
+   * Assert the error alert is displayed or not
+   * @param {Object} props - Options
+   * @param {boolean} props.exist - Whether the alert should exist
+   * @returns {PageObject}
+   */
+  assertErrorAlert({ exist = true } = {}) {
+    this.assertElement('error-alert', { exist });
+    return this;
+  }
+
+  /**
+   * Assert the loading state is displayed
+   * @returns {PageObject}
+   */
+  assertLoading() {
+    this.assertElement('loading-indicator', { exist: true });
+    return this;
+  }
+
+  /**
+   * Assert the loading state is not displayed
+   * @returns {PageObject}
+   */
+  assertNotLoading() {
+    this.assertElement('loading-indicator', { exist: false });
+    return this;
+  }
+
+  /**
+   * Assert the need help footer is displayed with all expected content
+   * @returns {PageObject}
+   */
+  assertNeedHelpFooter() {
+    // Assert the footer container exists
+    this.assertElement('help-footer', { exist: true });
+
+    cy.findByTestId('help-footer').within(() => {
+      // Assert the "Need help?" heading
+      this.assertHeading({
+        name: 'Need help?',
+        level: 2,
+        exist: true,
+      });
+
+      // Assert VA Solid Start section content
+      cy.root().should(
+        'contain.text',
+        'If you need to get in touch with VA Solid Start,',
+      );
+      cy.findByTestId('solid-start-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+      cy.get(
+        'a[href="https://benefits.va.gov/benefits/solid-start.asp?trk=public_post_comment-text"]',
+      )
+        .should('exist')
+        .and('contain.text', 'VA Solid Start');
+
+      // Assert Veterans Crisis Line section content
+      cy.root().should(
+        'contain.text',
+        'If you’re in crisis or having thoughts of suicide,',
+      );
+      cy.findByTestId('veterans-crisis-line-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', '988');
+      cy.findByTestId('veterans-crisis-line-text-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', '838255');
+
+      // Assert emergency section content
+      cy.root().should(
+        'contain.text',
+        'If you think your life or health is in danger,',
+      );
+      cy.findByTestId('emergency-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', '911');
+    });
+
+    return this;
+  }
+}

--- a/src/applications/vass/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/PageObject.js
@@ -38,12 +38,12 @@ export default class PageObject {
   }
 
   /**
-   * Assert the error alert is displayed or not
+   * Assert the wrapper error alert is displayed or not
    * @param {Object} props - Options
    * @param {boolean} props.exist - Whether the alert should exist
    * @returns {PageObject}
    */
-  assertErrorAlert({ exist = true } = {}) {
+  assertWrapperErrorAlert({ exist = true } = {}) {
     this.assertElement('error-alert', { exist });
     return this;
   }

--- a/src/applications/vass/tests/e2e/page-objects/ReviewPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/ReviewPageObject.js
@@ -1,0 +1,186 @@
+import PageObject from './Page-Object';
+
+export class ReviewPageObject extends PageObject {
+  /**
+   * Assert the Review page is displayed
+   * @returns {ReviewPageObject}
+   */
+  assertReviewPage() {
+    this.assertHeading({
+      name: 'Review your VA Solid Start appointment details',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    this.assertElement('review-page', { exist: true });
+    this.assertConfirmButton();
+
+    this.assertDateTimeSection();
+    this.assertTopicSection();
+    this.assertConfirmButton();
+    this.assertTopicDescriptionExists();
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Assert the date and time section is displayed
+   * @returns {ReviewPageObject}
+   */
+  assertDateTimeSection() {
+    this.assertElement('date-time-title', {
+      containsText: 'Date and time',
+    });
+    this.assertElement('date-time-edit-link', { exist: true });
+    return this;
+  }
+
+  /**
+   * Assert the date and time description contains the given text (e.g. date or time portion).
+   * Use this to verify the displayed appointment date/time after changing the selection.
+   * @param {string} text - Text that should appear in the date-time-description (e.g. "June 3, 2025" or "1:30")
+   * @returns {ReviewPageObject}
+   */
+  assertDateTimeDescriptionContains(text) {
+    this.assertElement('date-time-description', {
+      containsText: text,
+    });
+    return this;
+  }
+
+  /**
+   * Assert the topic section is displayed
+   * @returns {ReviewPageObject}
+   */
+  assertTopicSection() {
+    this.assertElement('topic-title', {
+      containsText: 'Topic',
+    });
+    this.assertElement('topic-edit-link', { exist: true });
+    return this;
+  }
+
+  /**
+   * Assert the topic description contains specific text
+   * @param {string} topicText - The expected topic text
+   * @returns {ReviewPageObject}
+   */
+  assertTopicDescription(topicText) {
+    this.assertElement('topic-description', {
+      containsText: topicText,
+    });
+    return this;
+  }
+
+  /**
+   * Assert the topic description exists
+   * @returns {ReviewPageObject}
+   */
+  assertTopicDescriptionExists() {
+    this.assertElement('topic-description', { exist: true });
+    return this;
+  }
+
+  /**
+   * Click the edit link for date and time
+   * @returns {ReviewPageObject}
+   */
+  clickEditDateTime() {
+    cy.findByTestId('date-time-edit-link')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Click the edit link for topic
+   * @returns {ReviewPageObject}
+   */
+  clickEditTopic() {
+    cy.findByTestId('topic-edit-link')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Click the confirm appointment button
+   * @returns {ReviewPageObject}
+   */
+  clickConfirmAppointment() {
+    cy.findByTestId('confirm-call-button')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Assert the confirm button exists
+   * @returns {ReviewPageObject}
+   */
+  assertConfirmButton() {
+    cy.findByTestId('confirm-call-button').should(
+      'have.attr',
+      'text',
+      'Confirm appointment',
+    );
+    return this;
+  }
+
+  /**
+   * Assert the confirm button is in loading state
+   * @returns {ReviewPageObject}
+   */
+  assertConfirmLoading() {
+    cy.findByTestId('confirm-call-button').should(
+      'have.attr',
+      'loading',
+      'true',
+    );
+    return this;
+  }
+
+  /**
+   * Assert the confirm button is not in loading state
+   * @returns {ReviewPageObject}
+   */
+  assertConfirmNotLoading() {
+    cy.findByTestId('confirm-call-button').should('not.have.attr', 'loading');
+    return this;
+  }
+
+  /**
+   * Confirm the appointment by clicking the confirm button
+   * @returns {ReviewPageObject}
+   */
+  confirmAppointment() {
+    this.clickConfirmAppointment();
+    return this;
+  }
+
+  /**
+   * Edit the date and time selection
+   * @returns {ReviewPageObject}
+   */
+  editDateTime() {
+    this.clickEditDateTime();
+    return this;
+  }
+
+  /**
+   * Edit the topic selection
+   * @returns {ReviewPageObject}
+   */
+  editTopic() {
+    this.clickEditTopic();
+    return this;
+  }
+}
+
+export default new ReviewPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/ReviewPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/ReviewPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 
 export class ReviewPageObject extends PageObject {
   /**
@@ -13,7 +13,7 @@ export class ReviewPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     this.assertElement('review-page', { exist: true });
     this.assertConfirmButton();

--- a/src/applications/vass/tests/e2e/page-objects/TopicSelectionPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/TopicSelectionPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 
 export class TopicSelectionPageObject extends PageObject {
   /**
@@ -14,14 +14,14 @@ export class TopicSelectionPageObject extends PageObject {
     });
 
     // Assert no error states on initial load
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     this.assertElement('button-pair', { exist: true });
 
     this.assertCheckboxGroupLabel();
     this.assertButtonPair();
     this.assertTopicCount(numberOfTopics);
-    this.assertErrorAlert({ exist: false });
+    this.assertWrapperErrorAlert({ exist: false });
 
     // Assert need help footer
     this.assertNeedHelpFooter();

--- a/src/applications/vass/tests/e2e/page-objects/TopicSelectionPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/TopicSelectionPageObject.js
@@ -1,0 +1,242 @@
+import PageObject from './Page-Object';
+
+export class TopicSelectionPageObject extends PageObject {
+  /**
+   * Assert the Topic Selection page is displayed
+   * @param {number} numberOfTopics - The number of topics to display
+   * @returns {TopicSelectionPageObject}
+   */
+  assertTopicSelectionPage(numberOfTopics = 17) {
+    this.assertHeading({
+      name: 'What do you want to learn more about?(*Required)',
+      level: 1,
+      exist: true,
+    });
+
+    // Assert no error states on initial load
+    this.assertErrorAlert({ exist: false });
+
+    this.assertElement('button-pair', { exist: true });
+
+    this.assertCheckboxGroupLabel();
+    this.assertButtonPair();
+    this.assertTopicCount(numberOfTopics);
+    this.assertErrorAlert({ exist: false });
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Assert the checkbox group label is displayed
+   * @returns {TopicSelectionPageObject}
+   */
+  assertCheckboxGroupLabel() {
+    cy.findByTestId('topic-checkbox-group')
+      .should('exist')
+      .and('have.attr', 'label', 'Check all that apply');
+    return this;
+  }
+
+  /**
+   * Assert the validation error message is displayed on the checkbox group
+   * @param {string} errorMessage - The expected error message
+   * @returns {TopicSelectionPageObject}
+   */
+  assertValidationError(errorMessage) {
+    cy.findByTestId('topic-checkbox-group').should(
+      'have.attr',
+      'error',
+      errorMessage,
+    );
+    return this;
+  }
+
+  /**
+   * Assert no validation error is displayed
+   * @returns {TopicSelectionPageObject}
+   */
+  assertNoValidationError() {
+    cy.findByTestId('topic-checkbox-group').should('not.have.attr', 'error');
+    return this;
+  }
+
+  /**
+   * Select a topic by its checkbox testId
+   * @param {string} topicTestId - The testId of the topic checkbox (e.g., 'topic-checkbox-education')
+   * @returns {TopicSelectionPageObject}
+   */
+  selectTopicByTestId(topicTestId) {
+    cy.findByTestId(topicTestId)
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Select a topic by its name/label
+   * @param {string} topicName - The label text of the topic
+   * @returns {TopicSelectionPageObject}
+   */
+  selectTopicByName(topicName) {
+    cy.get(`va-checkbox[label="${topicName}"]`)
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Unselect a topic by its checkbox testId
+   * @param {string} topicTestId - The testId of the topic checkbox
+   * @returns {TopicSelectionPageObject}
+   */
+  unselectTopicByTestId(topicTestId) {
+    cy.findByTestId(topicTestId)
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Select the first available topic checkbox
+   * @returns {TopicSelectionPageObject}
+   */
+  selectFirstTopic() {
+    cy.findByTestId('topic-checkbox-group')
+      .find('va-checkbox')
+      .first()
+      .click();
+    return this;
+  }
+
+  /**
+   * Select multiple topics by their testIds
+   * @param {string[]} topicTestIds - Array of topic checkbox testIds
+   * @returns {TopicSelectionPageObject}
+   */
+  selectTopics(topicTestIds) {
+    topicTestIds.forEach(testId => {
+      this.selectTopicByTestId(testId);
+    });
+    return this;
+  }
+
+  /**
+   * Assert a topic checkbox is checked
+   * @param {string} topicTestId - The testId of the topic checkbox
+   * @returns {TopicSelectionPageObject}
+   */
+  assertTopicChecked(topicTestId) {
+    cy.findByTestId(topicTestId).should('have.attr', 'checked', 'true');
+    return this;
+  }
+
+  /**
+   * Assert a topic checkbox is not checked
+   * @param {string} topicTestId - The testId of the topic checkbox
+   * @returns {TopicSelectionPageObject}
+   */
+  assertTopicNotChecked(topicTestId) {
+    cy.findByTestId(topicTestId).should('not.have.attr', 'checked');
+    return this;
+  }
+
+  /**
+   * Assert a specific number of topics are displayed
+   * @param {number} count - The expected number of topics
+   * @returns {TopicSelectionPageObject}
+   */
+  assertTopicCount(count) {
+    cy.findByTestId('topic-checkbox-group')
+      .find('va-checkbox')
+      .should('have.length', count);
+    return this;
+  }
+
+  /**
+   * Click the continue button
+   * @returns {TopicSelectionPageObject}
+   */
+  clickContinue() {
+    cy.findByTestId('button-pair')
+      .shadow()
+      .find('va-button[continue]')
+      .click();
+    return this;
+  }
+
+  /**
+   * Click the back button
+   * @returns {TopicSelectionPageObject}
+   */
+  clickBack() {
+    cy.findByTestId('button-pair')
+      .shadow()
+      .find('va-button[back]')
+      .click();
+    return this;
+  }
+
+  /**
+   * Assert the button pair exists
+   * @returns {TopicSelectionPageObject}
+   */
+  assertButtonPair() {
+    cy.findByTestId('button-pair').should('exist');
+    return this;
+  }
+
+  /**
+   * Select the first topic and continue
+   * @returns {TopicSelectionPageObject}
+   */
+  selectFirstTopicAndContinue() {
+    this.selectFirstTopic();
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Select a topic by its name/label and continue
+   * @param {string} topicName - The label text of the topic
+   * @returns {TopicSelectionPageObject}
+   */
+  selectTopicAndContinue(topicName) {
+    this.selectTopicByName(topicName);
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Submit form without selecting any topic to trigger validation errors
+   * @returns {TopicSelectionPageObject}
+   */
+  submitWithoutSelection() {
+    this.clickContinue();
+    return this;
+  }
+
+  /**
+   * Assert a topic with a specific label exists
+   * @param {string} topicName - The label text of the topic
+   * @returns {TopicSelectionPageObject}
+   */
+  assertTopicExists(topicName) {
+    cy.get(`va-checkbox[label="${topicName}"]`).should('exist');
+    return this;
+  }
+
+  /**
+   * Assert a topic with a specific label does not exist
+   * @param {string} topicName - The label text of the topic
+   * @returns {TopicSelectionPageObject}
+   */
+  assertTopicNotExists(topicName) {
+    cy.get(`va-checkbox[label="${topicName}"]`).should('not.exist');
+    return this;
+  }
+}
+
+export default new TopicSelectionPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -1,4 +1,4 @@
-import PageObject from './Page-Object';
+import PageObject from './PageObject';
 
 export class VerifyPageObject extends PageObject {
   /**

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -1,0 +1,169 @@
+import PageObject from './Page-Object';
+
+export class VerifyPageObject extends PageObject {
+  /**
+   * Assert the Verify page is displayed with all elements in correct initial state
+   * @param {Object} options - Options
+   * @param {boolean} options.cancellationFlow - Whether this is the cancellation flow
+   * @returns {VerifyPageObject}
+   */
+  assertVerifyPage({ cancellationFlow = false } = {}) {
+    // Assert correct heading based on flow
+    const headingText = cancellationFlow
+      ? 'Cancel VA Solid Start appointment'
+      : 'Schedule an appointment with VA Solid Start';
+
+    this.assertHeading({
+      name: headingText,
+      level: 1,
+      exist: true,
+    });
+
+    // Assert intro text is displayed with correct content
+    cy.findByTestId('verify-intro-text')
+      .should('exist')
+      .and(
+        'contain.text',
+        'we’ll need your information so we can send you a one-time verification code',
+      );
+
+    // Assert form inputs exist
+    this.assertElement('last-name-input', { exist: true });
+    this.assertElement('dob-input', { exist: true });
+
+    // Assert submit button exists and is in correct initial state
+    cy.findByTestId('submit-button')
+      .should('exist')
+      .and('have.attr', 'loading', 'false')
+      .and('not.have.attr', 'disabled');
+
+    // Assert no error states on initial load
+    this.assertVerifyErrorAlert({ exist: false });
+
+    // Assert need help footer
+    this.assertNeedHelpFooter();
+
+    return this;
+  }
+
+  /**
+   * Assert the verification error page is displayed
+   * @returns {VerifyPageObject}
+   */
+  assertVerificationErrorPage() {
+    this.assertHeading({
+      name: /We couldn.t verify your information/i,
+      level: 1,
+      exist: true,
+    });
+    return this;
+  }
+
+  /**
+   * Assert the error alert is displayed
+   * @returns {VerifyPageObject}
+   */
+  assertVerifyErrorAlert({ exist = true } = {}) {
+    this.assertElement('verify-error-alert', { exist });
+    return this;
+  }
+
+  /**
+   * Assert the last name input has an error
+   * @param {string} errorMessage - The expected error message
+   * @returns {VerifyPageObject}
+   */
+  assertLastNameError(errorMessage) {
+    cy.findByTestId('last-name-input').should(
+      'have.attr',
+      'error',
+      errorMessage,
+    );
+    return this;
+  }
+
+  /**
+   * Assert the date of birth input has an error
+   * @param {string} errorMessage - The expected error message
+   * @returns {VerifyPageObject}
+   */
+  assertDateOfBirthError(errorMessage) {
+    cy.findByTestId('dob-input').should('have.attr', 'error', errorMessage);
+    return this;
+  }
+
+  /**
+   * Enter a last name value
+   * @param {string} lastName - The last name to enter
+   * @returns {VerifyPageObject}
+   */
+  enterLastName(lastName) {
+    cy.fillVaTextInput('last-name', lastName);
+    return this;
+  }
+
+  /**
+   * Enter a valid last name for testing
+   * @returns {VerifyPageObject}
+   */
+  enterValidLastName() {
+    return this.enterLastName('Smith');
+  }
+
+  /**
+   * Enter a date of birth using the VaMemorableDate component
+   * @param {string} dateString - Date in YYYY-MM-DD format (e.g., '1990-01-15')
+   * @returns {VerifyPageObject}
+   */
+  enterDateOfBirth(dateString) {
+    // monthSelect is false in Verify.jsx, so pass false for useMonthSelect
+    cy.fillVaMemorableDate('date-of-birth', dateString, false);
+    return this;
+  }
+
+  /**
+   * Enter a valid date of birth for testing
+   * @returns {VerifyPageObject}
+   */
+  enterValidDateOfBirth() {
+    return this.enterDateOfBirth('1990-01-15');
+  }
+
+  /**
+   * Click the submit button
+   * @returns {VerifyPageObject}
+   */
+  clickSubmit() {
+    cy.findByTestId('submit-button')
+      .should('exist')
+      .click();
+    return this;
+  }
+
+  /**
+   * Fill the form with valid data and submit
+   * @returns {VerifyPageObject}
+   */
+  fillAndSubmitValidForm() {
+    this.enterValidLastName();
+    this.enterValidDateOfBirth();
+    this.clickSubmit();
+    return this;
+  }
+
+  /**
+   * Fill the form with custom data and submit
+   * @param {Object} props - Form data
+   * @param {string} props.lastName - Last name to enter
+   * @param {string} props.dateOfBirth - Date of birth in YYYY-MM-DD format
+   * @returns {VerifyPageObject}
+   */
+  fillAndSubmitForm({ lastName, dateOfBirth }) {
+    this.enterLastName(lastName);
+    this.enterDateOfBirth(dateOfBirth);
+    this.clickSubmit();
+    return this;
+  }
+}
+
+export default new VerifyPageObject();

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -119,13 +119,14 @@ export class VerifyPageObject extends PageObject {
    * @returns {VerifyPageObject}
    */
   enterDateOfBirth(dateString) {
-    const [year, month, day] = dateString.split('-').map(
-      dateComponent =>
-        // eslint-disable-next-line no-restricted-globals
-        isFinite(dateComponent)
-          ? parseInt(dateComponent, 10).toString()
-          : dateComponent,
-    );
+    const [year, month, day] = dateString
+      .split('-')
+      .map(
+        dateComponent =>
+          Number.isFinite(dateComponent)
+            ? parseInt(dateComponent, 10).toString()
+            : dateComponent,
+      );
 
     const getSelectors = type =>
       `va-text-input.input-${type}, va-text-input.usa-form-group--${type}-input`;

--- a/src/applications/vass/tests/e2e/vass-e2e-helpers.js
+++ b/src/applications/vass/tests/e2e/vass-e2e-helpers.js
@@ -43,34 +43,6 @@ export function patchCookiesForCI() {
 }
 
 /**
- * Function to add custom Cypress commands.
- *
- * @export
- */
-export function vassSetup() {
-  Cypress.Commands.add('axeCheckBestPractice', (context = 'main') => {
-    cy.axeCheck(context, {
-      runOnly: {
-        type: 'tag',
-        values: [
-          'section508',
-          'wcag2a',
-          'wcag2aa',
-          'wcag21a',
-          'wcag21aa',
-          'best-practice',
-        ],
-      },
-      rules: {
-        'aria-allowed-role': {
-          enabled: false,
-        },
-      },
-    });
-  });
-}
-
-/**
  * Function to mock the 'POST' request-otp endpoint.
  *
  * @example POST '/vass/v0/request-otp'

--- a/src/applications/vass/tests/e2e/vass-e2e-helpers.js
+++ b/src/applications/vass/tests/e2e/vass-e2e-helpers.js
@@ -1,0 +1,285 @@
+import MockRequestOtpResponse from '../fixtures/MockRequestOtpResponse';
+import MockAuthenticateOtpResponse from '../fixtures/MockAuthenticateOtpResponse';
+import MockAppointmentAvailabilityResponse from '../fixtures/MockAppointmentAvailabilityResponse';
+import MockTopicsResponse from '../fixtures/MockTopicsResponse';
+import MockCreateAppointmentResponse from '../fixtures/MockCreateAppointmentResponse';
+import MockAppointmentDetailsResponse from '../fixtures/MockAppointmentDetailsResponse';
+import MockCancelAppointmentResponse from '../fixtures/MockCancelAppointmentResponse';
+
+/**
+ * Function to add custom Cypress commands.
+ *
+ * @export
+ */
+export function vassSetup() {
+  Cypress.Commands.add('axeCheckBestPractice', (context = 'main') => {
+    cy.axeCheck(context, {
+      runOnly: {
+        type: 'tag',
+        values: [
+          'section508',
+          'wcag2a',
+          'wcag2aa',
+          'wcag21a',
+          'wcag21aa',
+          'best-practice',
+        ],
+      },
+      rules: {
+        'aria-allowed-role': {
+          enabled: false,
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Function to mock the 'POST' request-otp endpoint.
+ *
+ * @example POST '/vass/v0/request-otp'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockRequestOtpApi({
+  response = new MockRequestOtpResponse().toJSON(),
+  responseCode = 200,
+} = {}) {
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: '/vass/v0/request-otp',
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:post:request-otp');
+}
+
+/**
+ * Function to mock the 'POST' authenticate-otp endpoint.
+ *
+ * @example POST '/vass/v0/authenticate-otp'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {string} [arguments.uuid='mock-uuid'] - UUID of the user.
+ * @param {number} [arguments.expiresIn=3600] - Token expiration in seconds (1 hour).
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockAuthenticateOtpApi({
+  response = new MockAuthenticateOtpResponse({
+    uuid: 'mock-uuid',
+    expiresIn: 3600,
+  }).toJSON(),
+  responseCode = 200,
+} = {}) {
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: '/vass/v0/authenticate-otp',
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:post:authenticate-otp');
+}
+
+/**
+ * Function to mock the 'GET' appointment-availability endpoint.
+ *
+ * @example GET '/vass/v0/appointment-availability'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockAppointmentAvailabilityApi({
+  response = new MockAppointmentAvailabilityResponse({
+    availableSlots: MockAppointmentAvailabilityResponse.createSlots(),
+  }).toJSON(),
+  responseCode = 200,
+} = {}) {
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname: '/vass/v0/appointment-availability',
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:get:appointment-availability');
+}
+
+/**
+ * Function to mock the 'GET' topics endpoint.
+ *
+ * @example GET '/vass/v0/topics'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockTopicsApi({
+  response = new MockTopicsResponse({
+    topics: MockTopicsResponse.createDefaultTopics(),
+  }).toJSON(),
+  responseCode = 200,
+} = {}) {
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname: '/vass/v0/topics',
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:get:topics');
+}
+
+/**
+ * Function to mock the 'POST' appointment endpoint (create appointment).
+ *
+ * @example POST '/vass/v0/appointment'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockCreateAppointmentApi({
+  response = new MockCreateAppointmentResponse().toJSON(),
+  responseCode = 200,
+} = {}) {
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: '/vass/v0/appointment',
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:post:appointment');
+}
+
+/**
+ * Function to mock the 'GET' appointment details endpoint.
+ *
+ * @example GET '/vass/v0/appointment/:appointmentId'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockAppointmentDetailsApi({
+  response = new MockAppointmentDetailsResponse().toJSON(),
+  responseCode = 200,
+} = {}) {
+  const { appointmentId } = response.data;
+  const pathPattern = appointmentId
+    ? `/vass/v0/appointment/${appointmentId}`
+    : /\/vass\/v0\/appointment\/[^/]+$/;
+
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname: pathPattern,
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:get:appointment-details');
+}
+
+/**
+ * Function to mock the 'POST' cancel appointment endpoint.
+ *
+ * @example POST '/vass/v0/appointment/:appointmentId/cancel'
+ *
+ * @export
+ * @param {Object} arguments - Function arguments.
+ * @param {Object} [arguments.response] - The response to return from the mock api call.
+ * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ */
+export function mockCancelAppointmentApi({
+  response = new MockCancelAppointmentResponse().toJSON(),
+  responseCode = 200,
+} = {}) {
+  const { appointmentId } = response.data;
+  const pathPattern = appointmentId
+    ? `/vass/v0/appointment/${appointmentId}/cancel`
+    : /\/vass\/v0\/appointment\/[^/]+\/cancel$/;
+
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: pathPattern,
+    },
+    req => {
+      if (responseCode !== 200) {
+        req.reply({
+          body: response,
+          statusCode: responseCode,
+        });
+        return;
+      }
+
+      req.reply(response);
+    },
+  ).as('vass:post:cancel-appointment');
+}

--- a/src/applications/vass/tests/fixtures/MockAppointmentAvailabilityResponse.js
+++ b/src/applications/vass/tests/fixtures/MockAppointmentAvailabilityResponse.js
@@ -1,0 +1,176 @@
+import {
+  createNotWithinCohortError,
+  createAppointmentAlreadyBookedError,
+  createNoSlotsAvailableError,
+  createUnauthorizedError,
+  createVassApiError,
+  createServiceError,
+} from '../../services/mocks/utils/errors';
+import { createAppointmentAvailabilityResponse } from '../../services/mocks/utils/responses';
+
+/** @typedef {import('../../redux/slices/formSlice').Slot} Slot */
+
+/**
+ * Mock appointment availability response.
+ *
+ * Based on API spec: GET /vass/v0/appointment-availability
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#get-vassv0appointment-availablity
+ *
+ * @export
+ * @class MockAppointmentAvailabilityResponse
+ */
+export default class MockAppointmentAvailabilityResponse {
+  /**
+   * Creates an instance of MockAppointmentAvailabilityResponse.
+   *
+   * @param {Object} props - Properties used to create the mock response.
+   * @param {string} [props.appointmentId='e61e1a40-1e63-f011-bec2-001dd80351ea'] - Unique identifier for the appointment.
+   * @param {Slot[]} [props.availableSlots=[]] - Array of available time slots.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  constructor({
+    appointmentId = 'e61e1a40-1e63-f011-bec2-001dd80351ea',
+    availableSlots = [],
+  } = {}) {
+    this.data = createAppointmentAvailabilityResponse({
+      appointmentId,
+      availableSlots,
+    });
+  }
+
+  /**
+   * Returns the response as a plain object.
+   *
+   * @returns {{ data: { appointmentId: string, availableSlots: Slot[] } }} The mock response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates a time slot object.
+   *
+   * @static
+   * @param {Object} props - Slot properties.
+   * @param {string} props.dtStartUtc - ISO8601 UTC datetime string for slot start.
+   * @param {string} props.dtEndUtc - ISO8601 UTC datetime string for slot end.
+   * @returns {Slot} Time slot object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createSlot({ dtStartUtc, dtEndUtc }) {
+    return { dtStartUtc, dtEndUtc };
+  }
+
+  /**
+   * Creates an array of time slots for the next few days.
+   *
+   * @static
+   * @param {Object} props - Options for slot generation.
+   * @param {number} [props.numberOfSlots=5] - Number of slots to generate.
+   * @param {number} [props.slotDurationMinutes=30] - Duration of each slot in minutes.
+   * @param {Date} [props.startDate] - Start date for slots (defaults to tomorrow).
+   * @returns {Slot[]} Array of time slot objects.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createSlots({
+    numberOfSlots = 5,
+    slotDurationMinutes = 30,
+    startDate = new Date(Date.now() + 24 * 60 * 60 * 1000), // Tomorrow
+  } = {}) {
+    const slots = [];
+    const currentDate = new Date(startDate);
+    currentDate.setHours(9, 0, 0, 0); // Start at 9 AM
+
+    for (let i = 0; i < numberOfSlots; i += 1) {
+      const dtStartUtc = currentDate.toISOString();
+      currentDate.setMinutes(currentDate.getMinutes() + slotDurationMinutes);
+      const dtEndUtc = currentDate.toISOString();
+
+      slots.push({ dtStartUtc, dtEndUtc });
+
+      // Add a gap between slots
+      currentDate.setMinutes(currentDate.getMinutes() + 30);
+    }
+
+    return slots;
+  }
+
+  /**
+   * Creates an appointment already booked error response.
+   *
+   * @static
+   * @param {Object} props - Error properties.
+   * @param {string} [props.appointmentId] - The booked appointment ID.
+   * @param {string} [props.dtStartUTC] - Appointment start time.
+   * @param {string} [props.dtEndUTC] - Appointment end time.
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createAppointmentAlreadyBookedError({
+    appointmentId,
+    dtStartUTC,
+    dtEndUTC,
+  } = {}) {
+    return createAppointmentAlreadyBookedError({
+      appointmentId,
+      dtStartUTC,
+      dtEndUTC,
+    });
+  }
+
+  /**
+   * Creates a not within cohort error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createNotWithinCohortError() {
+    return createNotWithinCohortError();
+  }
+
+  /**
+   * Creates a no slots available error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createNoSlotsAvailableError() {
+    return createNoSlotsAvailableError();
+  }
+
+  /**
+   * Creates an unauthorized error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createUnauthorizedError() {
+    return createUnauthorizedError();
+  }
+
+  /**
+   * Creates a VASS API error response (Bad Gateway).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a service error response (Service Unavailable).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentAvailabilityResponse
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/fixtures/MockAppointmentDetailsResponse.js
+++ b/src/applications/vass/tests/fixtures/MockAppointmentDetailsResponse.js
@@ -1,0 +1,116 @@
+import {
+  createAppointmentNotFoundError,
+  createMissingAppointmentParameterError,
+  createUnauthorizedError,
+  createVassApiError,
+  createServiceError,
+} from '../../services/mocks/utils/errors';
+import { createAppointmentDetailsResponse } from '../../services/mocks/utils/responses';
+
+/** @typedef {import('../../utils/appointments').Appointment} Appointment */
+
+/**
+ * Mock appointment details response.
+ *
+ * Based on API spec: GET /vass/v0/appointment/{appointmentId}
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#get-vassv0appointmentappointmentid
+ *
+ * @export
+ * @class MockAppointmentDetailsResponse
+ */
+export default class MockAppointmentDetailsResponse {
+  /**
+   * Creates an instance of MockAppointmentDetailsResponse.
+   *
+   * @param {Partial<Appointment>} [props={}] - Properties used to create the mock response.
+   * @memberof MockAppointmentDetailsResponse
+   */
+  constructor({
+    appointmentId = 'abcdef123456',
+    startUTC = '2025-12-24T10:00:00Z',
+    endUTC = '2025-12-24T10:30:00Z',
+    agentId = '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
+    agentNickname = 'Agent Smith',
+    appointmentStatusCode = 1,
+    appointmentStatus = 'Confirmed',
+    cohortStartUtc = '2025-12-01T00:00:00Z',
+    cohortEndUtc = '2026-02-28T23:59:59Z',
+  } = {}) {
+    this.data = createAppointmentDetailsResponse({
+      appointmentId,
+      startUTC,
+      endUTC,
+      agentId,
+      agentNickname,
+      appointmentStatusCode,
+      appointmentStatus,
+      cohortStartUtc,
+      cohortEndUtc,
+    });
+  }
+
+  /**
+   * Returns the response as a plain object.
+   *
+   * @returns {Appointment} The mock response object (appointment details).
+   * @memberof MockAppointmentDetailsResponse
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates an appointment not found error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentDetailsResponse
+   */
+  static createAppointmentNotFoundError() {
+    return createAppointmentNotFoundError();
+  }
+
+  /**
+   * Creates a missing appointment ID parameter error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentDetailsResponse
+   */
+  static createMissingAppointmentIdError() {
+    return createMissingAppointmentParameterError('appointment_id');
+  }
+
+  /**
+   * Creates an unauthorized error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentDetailsResponse
+   */
+  static createUnauthorizedError() {
+    return createUnauthorizedError();
+  }
+
+  /**
+   * Creates a VASS API error response (Bad Gateway).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentDetailsResponse
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a service error response (Service Unavailable).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAppointmentDetailsResponse
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/fixtures/MockAuthenticateOtpResponse.js
+++ b/src/applications/vass/tests/fixtures/MockAuthenticateOtpResponse.js
@@ -1,0 +1,112 @@
+import {
+  createOTPInvalidError,
+  createOTPAccountLockedError,
+  createVassApiError,
+  createServiceError,
+  createMissingAuthParameterError,
+  createOTPExpiredError,
+} from '../../services/mocks/utils/errors';
+import { createAuthenticateOtpResponse } from '../../services/mocks/utils/responses';
+
+/**
+ * Mock authenticate OTP response.
+ *
+ * Based on API spec: POST /vass/v0/authenticate-otp
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#post-vassv0authenticate-otp
+ *
+ * @export
+ * @class MockAuthenticateOtpResponse
+ */
+export default class MockAuthenticateOtpResponse {
+  /**
+   * Creates an instance of MockAuthenticateOtpResponse.
+   *
+   * @param {Object} props - Properties used to create the mock response.
+   * @param {string} [props.token='mock-jwt-token'] - JWT token string.
+   * @param {number} [props.expiresIn=3600] - Token expiration in seconds (1 hour).
+   * @param {string} [props.tokenType='Bearer'] - Token type for Authorization header.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  constructor({ token = 'mock-jwt-token', expiresIn = 3600 } = {}) {
+    this.data = createAuthenticateOtpResponse({ token, expiresIn });
+  }
+
+  /**
+   * Returns the response as a plain object.
+   *
+   * @returns {Object} The mock response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates an invalid OTP error response.
+   *
+   * @static
+   * @param {number} [attemptsRemaining=3] - Number of validation attempts left before lockout.
+   * @returns {Object} The error response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  static createInvalidOtpError(attemptsRemaining = 3) {
+    return createOTPInvalidError(attemptsRemaining);
+  }
+
+  /**
+   * Creates an account locked error response.
+   *
+   * @static
+   * @param {number} [retryAfter=900] - Time in seconds before a new OTP can be requested (15 minutes).
+   * @returns {Object} The error response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  static createAccountLockedError(retryAfter = 900) {
+    return createOTPAccountLockedError(retryAfter);
+  }
+
+  /**
+   * Creates an OTP expired error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  static createOtpExpiredError() {
+    return createOTPExpiredError();
+  }
+
+  /**
+   * Creates a missing parameter error response.
+   *
+   * @static
+   * @param {string} paramName - The name of the missing parameter (uuid, last_name, dob, or otp).
+   * @returns {Object} The error response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  static createMissingParameterError(paramName) {
+    return createMissingAuthParameterError(paramName);
+  }
+
+  /**
+   * Creates a VASS API error response (Bad Gateway).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a service error response (Service Unavailable).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockAuthenticateOtpResponse
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/fixtures/MockCancelAppointmentResponse.js
+++ b/src/applications/vass/tests/fixtures/MockCancelAppointmentResponse.js
@@ -1,0 +1,90 @@
+import {
+  createCancellationFailedError,
+  createAppointmentNotFoundError,
+  createMissingAppointmentParameterError,
+  createUnauthorizedError,
+  createVassApiError,
+  createServiceError,
+} from '../../services/mocks/utils/errors';
+import { createCancelAppointmentResponse } from '../../services/mocks/utils/responses';
+
+/**
+ * Mock response class for POST /vass/v0/appointment/{appointmentId}/cancel
+ *
+ * Based on the VASS API specification:
+ * https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#post-vassv0appointmentappointmentidcancel
+ */
+export default class MockCancelAppointmentResponse {
+  /**
+   * Creates a successful cancel appointment response.
+   *
+   * @param {Object} options - Configuration options.
+   * @param {string} [options.appointmentId='abcdef123456'] - The unique identifier of the cancelled appointment.
+   */
+  constructor({ appointmentId = 'abcdef123456' } = {}) {
+    this.data = createCancelAppointmentResponse({ appointmentId });
+  }
+
+  /**
+   * Returns the response as a JSON object.
+   *
+   * @returns {Object} The response object with data property.
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates a cancellation failed error response.
+   *
+   * @returns {Object} Error response for when cancellation fails.
+   */
+  static createCancellationFailedError() {
+    return createCancellationFailedError();
+  }
+
+  /**
+   * Creates an appointment not found error response.
+   *
+   * @returns {Object} Error response for when appointment is not found.
+   */
+  static createAppointmentNotFoundError() {
+    return createAppointmentNotFoundError();
+  }
+
+  /**
+   * Creates a missing appointment ID error response.
+   *
+   * @returns {Object} Error response for missing appointment_id parameter.
+   */
+  static createMissingAppointmentIdError() {
+    return createMissingAppointmentParameterError('appointment_id');
+  }
+
+  /**
+   * Creates an unauthorized error response.
+   *
+   * @returns {Object} Error response for unauthorized access.
+   */
+  static createUnauthorizedError() {
+    return createUnauthorizedError();
+  }
+
+  /**
+   * Creates a VASS API error response.
+   *
+   * @returns {Object} Error response for upstream API issues.
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a generic service error response.
+   *
+   * @returns {Object} Error response for service unavailability.
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/fixtures/MockCreateAppointmentResponse.js
+++ b/src/applications/vass/tests/fixtures/MockCreateAppointmentResponse.js
@@ -1,0 +1,129 @@
+import {
+  createAppointmentSaveFailedError,
+  createMissingAppointmentParameterError,
+  createUnauthorizedError,
+  createVassApiError,
+  createServiceError,
+} from '../../services/mocks/utils/errors';
+import { createAppointmentResponse } from '../../services/mocks/utils/responses';
+
+/**
+ * Mock create appointment response.
+ *
+ * Based on API spec: POST /vass/v0/appointment
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#post-vassv0appointment
+ *
+ * @export
+ * @class MockCreateAppointmentResponse
+ */
+export default class MockCreateAppointmentResponse {
+  /**
+   * Creates an instance of MockCreateAppointmentResponse.
+   *
+   * @param {Object} props - Properties used to create the mock response.
+   * @param {string} [props.appointmentId='abcdef123456'] - Unique identifier for the newly created appointment.
+   * @memberof MockCreateAppointmentResponse
+   */
+  constructor({ appointmentId = 'abcdef123456' } = {}) {
+    this.data = createAppointmentResponse({ appointmentId });
+  }
+
+  /**
+   * Returns the response as a plain object.
+   *
+   * @returns {Object} The mock response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates a missing parameter error response.
+   *
+   * @static
+   * @param {string} paramName - The name of the missing parameter (topics, dtStartUtc, or dtEndUtc).
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createMissingParameterError(paramName) {
+    return createMissingAppointmentParameterError(paramName);
+  }
+
+  /**
+   * Creates a missing topics error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createMissingTopicsError() {
+    return createMissingAppointmentParameterError('topics');
+  }
+
+  /**
+   * Creates a missing start time error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createMissingStartTimeError() {
+    return createMissingAppointmentParameterError('dtStartUtc');
+  }
+
+  /**
+   * Creates a missing end time error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createMissingEndTimeError() {
+    return createMissingAppointmentParameterError('dtEndUtc');
+  }
+
+  /**
+   * Creates an appointment save failed error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createAppointmentSaveFailedError() {
+    return createAppointmentSaveFailedError();
+  }
+
+  /**
+   * Creates an unauthorized error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createUnauthorizedError() {
+    return createUnauthorizedError();
+  }
+
+  /**
+   * Creates a VASS API error response (Bad Gateway).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a service error response (Service Unavailable).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockCreateAppointmentResponse
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/fixtures/MockRequestOtpResponse.js
+++ b/src/applications/vass/tests/fixtures/MockRequestOtpResponse.js
@@ -1,0 +1,103 @@
+import {
+  createRateLimitExceededError,
+  createInvalidCredentialsError,
+  createVassApiError,
+  createServiceError,
+  createMissingOtpParameterError,
+} from '../../services/mocks/utils/errors';
+import { createRequestOtpResponse } from '../../services/mocks/utils/responses';
+
+/**
+ * Mock request OTP response.
+ *
+ * Based on API spec: POST /vass/v0/request-otp
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#post-vassv0request-otp
+ *
+ * @export
+ * @class MockRequestOtpResponse
+ */
+export default class MockRequestOtpResponse {
+  /**
+   * Creates an instance of MockRequestOtpResponse.
+   *
+   * @param {Object} props - Properties used to create the mock response.
+   * @param {string} [props.email='s****@email.com'] - Obfuscated email address.
+   * @param {number} [props.expiresIn=600] - Time in seconds until OTP expires (10 minutes).
+   * @param {string} [props.message='OTP sent to registered email address'] - Success message.
+   * @memberof MockRequestOtpResponse
+   */
+  constructor({
+    email = 's****@email.com',
+    expiresIn = 600,
+    message = 'OTP sent to registered email address',
+  } = {}) {
+    this.data = createRequestOtpResponse({ email, expiresIn, message });
+  }
+
+  /**
+   * Returns the response as a plain object.
+   *
+   * @returns {Object} The mock response object.
+   * @memberof MockRequestOtpResponse
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates a rate limit exceeded error response.
+   *
+   * @static
+   * @param {number} [retryAfter=900] - Time in seconds before another request can be made.
+   * @returns {Object} The error response object.
+   * @memberof MockRequestOtpResponse
+   */
+  static createRateLimitExceededError(retryAfter = 900) {
+    return createRateLimitExceededError(retryAfter);
+  }
+
+  /**
+   * Creates an invalid credentials error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockRequestOtpResponse
+   */
+  static createInvalidCredentialsError() {
+    return createInvalidCredentialsError();
+  }
+
+  /**
+   * Creates a missing parameter error response.
+   *
+   * @static
+   * @param {string} paramName - The name of the missing parameter (uuid, last_name, or dob).
+   * @returns {Object} The error response object.
+   * @memberof MockRequestOtpResponse
+   */
+  static createMissingParameterError(paramName) {
+    return createMissingOtpParameterError(paramName);
+  }
+
+  /**
+   * Creates a VASS API error response (Bad Gateway).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockRequestOtpResponse
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a service error response (Service Unavailable).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockRequestOtpResponse
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/fixtures/MockTopicsResponse.js
+++ b/src/applications/vass/tests/fixtures/MockTopicsResponse.js
@@ -1,0 +1,88 @@
+import {
+  createUnauthorizedError,
+  createVassApiError,
+  createServiceError,
+} from '../../services/mocks/utils/errors';
+import { createTopicsResponse } from '../../services/mocks/utils/responses';
+import { createDefaultTopics } from '../../services/mocks/utils/topic';
+
+/** @typedef {import('../../utils/appointments').Topic} Topic */
+
+/**
+ * Mock topics response.
+ *
+ * Based on API spec: GET /vass/v0/topics
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#get-vassv0topics
+ *
+ * @export
+ * @class MockTopicsResponse
+ */
+export default class MockTopicsResponse {
+  /**
+   * Creates an instance of MockTopicsResponse.
+   *
+   * @param {Object} props - Properties used to create the mock response.
+   * @param {Topic[]} [props.topics=[]] - Array of topic objects with topicId and topicName.
+   * @memberof MockTopicsResponse
+   */
+  constructor({ topics = [] } = {}) {
+    this.data = createTopicsResponse({
+      topics,
+    });
+  }
+
+  /**
+   * Returns the response as a plain object.
+   *
+   * @returns {{ data: { topics: Topic[] } }} The mock response object.
+   * @memberof MockTopicsResponse
+   */
+  toJSON() {
+    return this.data;
+  }
+
+  /**
+   * Creates the default set of mock topics.
+   *
+   * @static
+   * @param {number} [numberOfTopics=17] - Number of topics to include in the response.
+   * @returns {Topic[]} Array of topic objects.
+   * @memberof MockTopicsResponse
+   */
+  static createDefaultTopics(numberOfTopics = 17) {
+    return createDefaultTopics(numberOfTopics);
+  }
+
+  /**
+   * Creates an unauthorized error response.
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockTopicsResponse
+   */
+  static createUnauthorizedError() {
+    return createUnauthorizedError();
+  }
+
+  /**
+   * Creates a VASS API error response (Bad Gateway).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockTopicsResponse
+   */
+  static createVassApiError() {
+    return createVassApiError();
+  }
+
+  /**
+   * Creates a service error response (Service Unavailable).
+   *
+   * @static
+   * @returns {Object} The error response object.
+   * @memberof MockTopicsResponse
+   */
+  static createServiceError() {
+    return createServiceError();
+  }
+}

--- a/src/applications/vass/tests/vass.cypress.spec.js
+++ b/src/applications/vass/tests/vass.cypress.spec.js
@@ -1,7 +1,0 @@
-import manifest from '../manifest.json';
-
-describe(manifest.appName, () => {
-  it.skip('is accessible', () => {
-    // Skip tests in CI until the app is released.
-  });
-});

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -52,8 +52,8 @@ const AUTH_ERROR_CODES = Object.freeze({
   MISSING_PARAMETER: 'missing_parameter',
 });
 
-// OTP/OTC Verification errors (POST /vass/v0/authenticate-otp)
-const OTC_ERROR_CODES = Object.freeze({
+// OTP Verification errors (POST /vass/v0/authenticate-otp)
+const OTP_ERROR_CODES = Object.freeze({
   INVALID_OTP: 'invalid_otp',
   ACCOUNT_LOCKED: 'account_locked',
   OTP_EXPIRED: 'otp_expired',
@@ -95,7 +95,7 @@ module.exports = {
   VASS_TOKEN_COOKIE_NAME,
   VASS_COOKIE_OPTIONS,
   AUTH_ERROR_CODES,
-  OTC_ERROR_CODES,
+  OTP_ERROR_CODES,
   TOKEN_ERROR_CODES,
   AVAILABILITY_ERROR_CODES,
   APPOINTMENT_ERROR_CODES,

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -38,7 +38,6 @@ const VASS_COOKIE_OPTIONS = {
   secure: isProduction,
   sameSite: isProduction ? 'strict' : undefined,
   path: '/',
-  ...(isProduction ? { domain: 'va.gov' } : {}),
 };
 
 /**

--- a/src/applications/vass/utils/errors.js
+++ b/src/applications/vass/utils/errors.js
@@ -1,6 +1,6 @@
 import {
   AUTH_ERROR_CODES,
-  OTC_ERROR_CODES,
+  OTP_ERROR_CODES,
   SERVER_ERROR_CODES,
   AVAILABILITY_ERROR_CODES,
   APPOINTMENT_ERROR_CODES,
@@ -27,13 +27,13 @@ const isRateLimitExceededError = error => {
 const isMissingParameterError = error => {
   return (
     error?.code === AUTH_ERROR_CODES.MISSING_PARAMETER ||
-    error?.code === OTC_ERROR_CODES.MISSING_PARAMETER ||
+    error?.code === OTP_ERROR_CODES.MISSING_PARAMETER ||
     error?.code === APPOINTMENT_ERROR_CODES.MISSING_PARAMETER
   );
 };
 
 const isAccountLockedError = error => {
-  return error?.code === OTC_ERROR_CODES.ACCOUNT_LOCKED;
+  return error?.code === OTP_ERROR_CODES.ACCOUNT_LOCKED;
 };
 
 const isServerError = error => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Added Cypress E2E happy-path tests for the VASS (VA Solid Start) scheduling application,
  covering scheduling, canceling, editing date/time, editing topic, and already-scheduled
  appointment flows.
  - Added Page Object classes for all VASS pages (Verify, EnterOTP, DateTimeSelection,
  TopicSelection, Review, Confirmation, CancelAppointment, CancelConfirmation, AlreadyScheduled) to
   support maintainable E2E testing.
  - Added mock fixture response builders (`MockAppointmentAvailabilityResponse`,
  `MockAppointmentDetailsResponse`, `MockAuthenticateOtpResponse`, `MockCancelAppointmentResponse`,
   `MockCreateAppointmentResponse`, `MockRequestOtpResponse`, `MockTopicsResponse`) and E2E helper
  utilities for API mocking.
  - Renamed `OTC_ERROR_CODES` to `OTP_ERROR_CODES` across the codebase for naming consistency.
  - Updated `jwt-utils.js` to work in both Node.js and browser environments (replacing
  `Buffer`-only calls with `TextEncoder`/`TextDecoder` fallbacks for Cypress browser context).
  - Fixed a curly-quote encoding issue in `AppointmentCard.jsx`.
  - Improved `CancelAppointment.jsx` to handle loading/error states during cancellation and
  conditionally navigate only on success.
  - Simplified the error object shape returned from `vassApi.js` `getAppointmentAvailability` error
   handler.
  - VASS team owns this component.

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#131002

  ## Testing done

  - Prior to this change, the VASS application had no Cypress E2E tests covering the happy-path
  flows.
  - **7 Cypress E2E test cases** were added and verified:
    1. **Schedule an appointment** — navigates through Verify > OTP > Date/Time > Topic > Review >
  Confirmation, asserting page content and accessibility at each step.
    2. **Change date and time** — selects one time slot, proceeds to Review, edits date/time,
  selects a different slot, and confirms the updated time appears on Review and Confirmation pages.
    3. **Change topic** — selects a topic, proceeds to Review, edits the topic, selects a different
   one, and confirms the updated topic on Confirmation.
    4. **Cancel from confirmation page** — completes scheduling then cancels from the Confirmation
  page, asserting the cancel and cancel-confirmation pages.
    5. **Cancel from cancellation link** — visits with `cancel=true` query param, verifies the
  cancellation-specific UI copy, and cancels the appointment.
    6. **Already scheduled — redirect** — mocks a 409 conflict response and asserts the user is
  redirected to the Already Scheduled page.
    7. **Already scheduled — cancel** — from the Already Scheduled page, cancels the appointment
  and asserts the cancel confirmation.
  - Each test includes `cy.injectAxeThenAxeCheck()` accessibility checks at every page transition.
  - All API calls are intercepted with Cypress `cy.intercept` using mock fixture data — no live API
   calls are made.
  - **Known gap**: Only happy-path flows are covered. Error-path E2E tests (invalid OTP, expired
  OTP, account locked, server errors, network failures) are not yet implemented and may be added in
   a follow-up PR.

  ## Screenshots

  N/A — This PR adds E2E test infrastructure only (Cypress specs, page objects, fixtures, and
  helpers). No UI changes were made that affect visual rendering. The minor code changes
  (curly-quote fix, `OTC` to `OTP` rename, `jwt-utils` browser compat) are non-visual.

  ## What areas of the site does it impact?

  This PR is scoped entirely to `src/applications/vass/`. It does not touch shared platform code,
  site-wide styles, or other applications. The source-code changes (`jwt-utils.js`, `constants.js`,
   `errors.js`, `CancelAppointment.jsx`, `AppointmentCard.jsx`, `vassApi.js`) are internal to the
  VASS application.

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
  hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [ ] Documentation has been updated ([link to documentation](#) *if necessary) — No
  documentation changes needed; this is test infrastructure.
  - [ ] Screenshot of the developed feature is added — N/A, no UI changes.
  - [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-c
  ycle/prepare-for-an-accessibility-staging-review) has been performed —
  `cy.injectAxeThenAxeCheck()` is called at every page transition in all 7 E2E tests.

  ### Error Handling

  - [x] Browser console contains no warnings or errors.
  - [ ] Events are being sent to the appropriate logging solution — No new logging was introduced
  in this PR; existing logging remains unchanged.
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, this is
  test-only; no new production features requiring monitoring.

  ### Authentication

  - [ ] Did you login to a local build and verify all authenticated routes work as expected with a
  test user — VASS uses its own OTP-based authentication (not VA.gov session auth). The E2E tests
  mock the OTP authentication flow and verify it works end-to-end. A local build with mock server
  was used during development.

  ## Requested Feedback

  - Please review the Page Object pattern used for the Cypress tests — feedback on naming
  conventions and organization is welcome.
  - The `jwt-utils.js` changes add browser environment support (`TextEncoder`/`btoa` fallback)
  alongside the existing Node.js `Buffer` path. Please verify this dual-environment approach is
  acceptable.
  - **Known risk**: Error/edge-case E2E paths are not covered yet. These are planned for a
  follow-up ticket.