### PR TITLE
[Node 22 upgrade] Fix PreSubmitInfo flaky test by removing useEffect hooks

### DIFF
--- a/src/applications/representative-appoint/containers/PreSubmitInfo.jsx
+++ b/src/applications/representative-appoint/containers/PreSubmitInfo.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   VaCheckboxGroup,
   VaCheckbox,
@@ -20,46 +20,48 @@ export const PreSubmitInfo = ({
     false,
   );
   const [formReplacementChecked, setFormReplacementChecked] = useState(false);
-  const [termsAndConditionsError, setTermsAndConditionsError] = useState(false);
-  const [formReplacementError, setFormReplacementError] = useState(false);
   const [privacyPolicyChecked, setPrivacyPolicyChecked] = useState(false);
-  const [privacyPolicyError, setPrivacyPolicyError] = useState(false);
+
+  // Derive error states directly from props and checked state.
+  // Avoids an extra render cycle from useEffect + setState, which caused
+  // flaky test failures under Node 22's faster scheduler timing.
+  const termsAndConditionsError =
+    showError && !hasSubmit && !termsAndConditionsChecked;
+  const formReplacementError =
+    showError && !hasSubmit && !formReplacementChecked;
+  const privacyPolicyError = showError && !hasSubmit && !privacyPolicyChecked;
 
   const applicantFullName = getApplicantName(formData);
 
   // Returns org for orgs and VSO reps, otherwise full name of attorney/claims agent
   const representativeName = getRepresentativeName(formData);
 
-  useEffect(
-    () => {
-      onSectionComplete(
-        termsAndConditionsChecked &&
-          formReplacementChecked &&
-          privacyPolicyChecked,
-      );
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [termsAndConditionsChecked, formReplacementChecked, privacyPolicyChecked],
-  );
+  // Notify the parent of section completion synchronously from the change
+  // handlers. Avoids a useEffect which would schedule the callback
+  // asynchronously, causing flaky tests under Node 22's scheduler timing.
+  const handleTermsAndConditionsChange = value => {
+    const { checked } = value.detail;
+    setTermsAndConditionsChecked(checked);
+    onSectionComplete(
+      checked && formReplacementChecked && privacyPolicyChecked,
+    );
+  };
 
-  useEffect(
-    () => {
-      setTermsAndConditionsError(
-        showError && !hasSubmit && !termsAndConditionsChecked,
-      );
-      setFormReplacementError(
-        showError && !hasSubmit && !formReplacementChecked,
-      );
-      setPrivacyPolicyError(showError && !hasSubmit && !privacyPolicyChecked);
-    },
-    [
-      showError,
-      hasSubmit,
-      termsAndConditionsChecked,
-      formReplacementChecked,
-      privacyPolicyChecked,
-    ],
-  );
+  const handleFormReplacementChange = value => {
+    const { checked } = value.detail;
+    setFormReplacementChecked(checked);
+    onSectionComplete(
+      termsAndConditionsChecked && checked && privacyPolicyChecked,
+    );
+  };
+
+  const handlePrivacyPolicyChange = value => {
+    const { checked } = value.detail;
+    setPrivacyPolicyChecked(checked);
+    onSectionComplete(
+      termsAndConditionsChecked && formReplacementChecked && checked,
+    );
+  };
 
   if (isSubmitPending) {
     return (
@@ -124,9 +126,7 @@ export const PreSubmitInfo = ({
             name="I agree to the terms and conditions"
             checked={termsAndConditionsChecked}
             aria-describedby="accept-terms-conditions"
-            onVaChange={value =>
-              setTermsAndConditionsChecked(value.detail.checked)
-            }
+            onVaChange={handleTermsAndConditionsChange}
             error={termsAndConditionsError ? 'This field is mandatory' : null}
             data-testid="terms-and-conditions"
           />
@@ -136,18 +136,14 @@ export const PreSubmitInfo = ({
             required
             aria-describedby="accept-form-replacement"
             checked={formReplacementChecked}
-            onVaChange={value =>
-              setFormReplacementChecked(value.detail.checked)
-            }
+            onVaChange={handleFormReplacementChange}
             error={formReplacementError ? 'This field is mandatory' : null}
             data-testid="form-replacement"
           />
           <div className="vads-u-margin-top--3">
             <VaPrivacyAgreement
               enable-analytics
-              onVaChange={value =>
-                setPrivacyPolicyChecked(value.detail.checked)
-              }
+              onVaChange={handlePrivacyPolicyChange}
               showError={privacyPolicyError}
             />
           </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

- [x] No

## Summary

> **Note:** This fix has already been merged to the `update-node-22` branch via [#42136](https://github.com/department-of-veterans-affairs/vets-website/pull/42136). This PR targets `main` so the representative-appoint team can review the changes ahead of the Node 22 merge.

- The `PreSubmitInfo` unit test "clears error states when checkboxes are checked" fails intermittently on Node 22 in CI.
- **Root cause:** The component used `useEffect` + `setState` for values that are fully derivable from existing state/props. This caused unnecessary extra render cycles on every checkbox change. Under Node 22, React's scheduler uses native `MessageChannel` (instead of `setTimeout` on Node 14), which shifts effect timing. Under CI load with thousands of concurrent tests, `waitFor` times out during intermediate renders.
- **Fix (two parts):**
  1. **Error states** (`termsAndConditionsError`, `formReplacementError`, `privacyPolicyError`): Replaced `useState`/`useEffect` with direct derivation during render, since these are fully computable from `showError`, `hasSubmit`, and checked state.
  2. **`onSectionComplete`**: Moved from a `useEffect` into the checkbox change handlers, calling it synchronously when a checkbox changes. This eliminates the last async scheduling dependency.
- The component now has **zero `useEffect` hooks** — no async scheduling, no intermediate states, no timing sensitivity.
- Platform SRE, supporting the Node 22 upgrade effort.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#131838
- department-of-veterans-affairs/vets-website#42089
- department-of-veterans-affairs/vets-website#42136
- department-of-veterans-affairs/vets-website#41426

## Testing done

- Verified all 344 representative-appoint tests pass on Node 22.22.0 locally (5 pending).
- `yarn test:unit --app-folder representative-appoint` — 344 passing.
- No behavioral or UI changes — error states are computed identically and `onSectionComplete` is called with the same values, just without the extra render cycles.

## Screenshots

N/A — no UI changes.

## What areas of the site does it impact?

representative-appoint form only. The `PreSubmitInfo` component on the review-and-submit page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A)
- [ ] Screenshot of the developed feature is added (N/A — no UI change)
- [ ] Accessibility testing has been performed (N/A — no UI change)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution (N/A)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — no UI change)

## Requested Feedback

Both `useEffect` hooks have been removed. The key changes:

**Error states** — derived instead of stored:
```jsx
// Before: useState + useEffect (extra render cycle)
const [privacyPolicyError, setPrivacyPolicyError] = useState(false);
useEffect(() => {
  setPrivacyPolicyError(showError && !hasSubmit && !privacyPolicyChecked);
}, [showError, hasSubmit, privacyPolicyChecked]);

// After: direct derivation (no extra render)
const privacyPolicyError = showError && !hasSubmit && !privacyPolicyChecked;
```

**onSectionComplete** — called synchronously from handlers:
```jsx
// Before: useEffect (async scheduling)
useEffect(() => {
  onSectionComplete(tc && fr && pp);
}, [tc, fr, pp]);

// After: called in each handler with the new value
const handleTermsAndConditionsChange = value => {
  const checked = value.detail.checked;
  setTermsAndConditionsChecked(checked);
  onSectionComplete(checked && formReplacementChecked && privacyPolicyChecked);
};
```