### PR TITLE
[Find a Rep] 79287/105462: Encode Query Params to Resolve Special Character Search Bug

### DIFF
--- a/src/applications/representative-search/config.js
+++ b/src/applications/representative-search/config.js
@@ -131,15 +131,15 @@ export const resolveParamsWithUrl = ({
   distance,
 }) => {
   const params = [
-    address ? `address=${address}` : null,
-    lat ? `lat=${lat}` : null,
-    long ? `long=${long}` : null,
-    name ? `name=${name}` : null,
-    `page=${page || 1}`,
-    `per_page=${perPage}`,
-    `sort=${sort}`,
-    `type=${type}`,
-    distance ? `distance=${distance}` : null,
+    address ? `address=${encodeURIComponent(address)}` : null,
+    lat ? `lat=${encodeURIComponent(lat)}` : null,
+    long ? `long=${encodeURIComponent(long)}` : null,
+    name ? `name=${encodeURIComponent(name)}` : null,
+    `page=${encodeURIComponent(page) || 1}`,
+    `per_page=${encodeURIComponent(perPage)}`,
+    `sort=${encodeURIComponent(sort)}`,
+    `type=${encodeURIComponent(type)}`,
+    distance ? `distance=${encodeURIComponent(distance)}` : null,
   ];
 
   return `?${compact([...params]).join('&')}`;

--- a/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.jsx
+++ b/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.jsx
@@ -157,6 +157,32 @@ describe('Locator url and parameters builder', () => {
     );
   });
 
+  it('should encode special characters in request query string', () => {
+    const { fetchOtherReps } = getEndpointOptions();
+    const { requestUrl } = getApi(fetchOtherReps);
+
+    const params = resolveParamsWithUrl({
+      address: '1 Test Parkway Apt #20, Chicago, Illinois, 60605',
+      lat,
+      long,
+      name: 'Test ?&=# Test',
+      page: 1,
+      perPage: 10,
+      sort,
+      distance,
+    });
+
+    const test = `${requestUrl}${params}`;
+    expect(test).to.eql(
+      `${
+        environment.API_URL
+      }/services/veteran/v0/other_accredited_representatives` +
+        `?address=1%20Test%20Parkway%20Apt%20%2320%2C%20Chicago%2C%20Illinois%2C%2060605` +
+        `&lat=40.17887&long=-99.27246&name=Test%20%3F%26%3D%23%20Test&page=1&per_page=10` +
+        `&sort=distance_asc&type=veteran_service_officer&distance=100`,
+    );
+  });
+
   it('uses new accredited_individuals endpoints when flag is ON', () => {
     setRepSearchEndpointsFromFlag(true); // new endpoints
     const { fetchVSOReps, fetchOtherReps } = getEndpointOptions();


### PR DESCRIPTION
## Summary

In Find a Rep, searches with URL reserved (special) characters were failing to be built into proper query strings due to a lack of encoding. This resulted in missing parameters and `400 Bad Request` responses from the representative endpoints. 

An example is searching with an address of `1 Test Parkway Apt #20, Chicago, Illinois, 60605`. Before the fix, this search would result in a query string of `?address=1%20Test%20Parkway%20Apt%20` (breaking at the `#` reserved character), rather than the full, properly encoded string of `?address=1%20Test%20Parkway%20Apt%20%2320%2C%20Chicago%2C%20Illinois%2C%2060605&lat=40.305109&long=-87.702341&page=1&per_page=10&sort=distance_asc&type=veteran_service_officer&distance=50` that includes all required parameters.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#79287
- department-of-veterans-affairs/va.gov-team#105462

## Testing done

Prior to fixing, reproduced the bug locally against staging representative data. After the fix, tested several combinations of URL reserved (special) characters and confirmed that the representative results list now returned as expected, with only `200` responses from the representative endpoints.

Ensured that all unit tests pass after the change (`yarn test:unit --app-folder representative-search`). Also added a new unit test to confirm that the query params have been encoded.

## Screenshots
Before the Fix:
<img width="617" height="567" alt="Before Screenshot" src="https://github.com/user-attachments/assets/a635abf6-b26b-454c-a9e6-8555298eeef3" />

After the Fix:
<img width="522" height="744" alt="After Screenshot" src="https://github.com/user-attachments/assets/a37c5993-9676-4b03-98c2-a7edb23c8934" />

## What areas of the site does it impact?

Find a Rep: `/get-help-from-accredited-representative/find-rep/`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).