### PR TITLE
Fix useExportFile hook test timing

### DIFF
--- a/src/applications/mhv-medications/tests/hooks/useExportFile.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useExportFile.unit.spec.jsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 import useExportFile from '../../hooks/useExportFile';
 import {
@@ -60,9 +60,15 @@ describe('useExportFile', () => {
 
   describe('onDownload', () => {
     it('should set status to InProgress when called', async () => {
-      const { result } = renderHook(() => useExportFile(defaultProps));
+      const props = {
+        ...defaultProps,
+        isReady: false,
+      };
+      const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.status.status).to.equal(
@@ -80,7 +86,9 @@ describe('useExportFile', () => {
       };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).to.be.true;
@@ -94,7 +102,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onGeneratePdf };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(onGeneratePdf.calledOnce).to.be.true;
@@ -106,7 +116,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onGeneratePdf };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
@@ -122,7 +134,9 @@ describe('useExportFile', () => {
       };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).to.be.true;
@@ -140,7 +154,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onGenerateTxt };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      });
 
       await waitFor(() => {
         expect(onGenerateTxt.calledOnce).to.be.true;
@@ -152,7 +168,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onGenerateTxt };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
@@ -166,7 +184,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onBeforePrint };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(result.current.shouldPrint).to.be.true;
@@ -178,7 +198,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onBeforePrint };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(onBeforePrint.calledOnce).to.be.true;
@@ -188,13 +210,17 @@ describe('useExportFile', () => {
     it('should clear print trigger when clearPrintTrigger is called', async () => {
       const { result } = renderHook(() => useExportFile(defaultProps));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(result.current.shouldPrint).to.be.true;
       });
 
-      result.current.clearPrintTrigger();
+      await act(async () => {
+        result.current.clearPrintTrigger();
+      });
 
       await waitFor(() => {
         expect(result.current.shouldPrint).to.be.false;
@@ -210,7 +236,9 @@ describe('useExportFile', () => {
       };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -229,7 +257,9 @@ describe('useExportFile', () => {
       };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -243,7 +273,9 @@ describe('useExportFile', () => {
       };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.errorFormat).to.equal(DOWNLOAD_FORMAT.PDF);
@@ -268,7 +300,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, onGeneratePdf, onGenerationError };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -283,7 +317,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, prepare };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(prepare.calledOnce).to.be.true;
@@ -297,7 +333,9 @@ describe('useExportFile', () => {
       const props = { ...defaultProps, prepare, onGenerationError };
       const { result } = renderHook(() => useExportFile(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -309,13 +347,17 @@ describe('useExportFile', () => {
     it('should reset all state', async () => {
       const { result } = renderHook(() => useExportFile(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
       });
 
-      result.current.resetExportFlow();
+      await act(async () => {
+        result.current.resetExportFlow();
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).to.be.false;

--- a/src/applications/mhv-medications/tests/hooks/useRxDetailExport.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useRxDetailExport.unit.spec.jsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 import useRxDetailExport from '../../hooks/useRxDetailExport';
 import * as pdfConfigs from '../../util/pdfConfigs';
@@ -92,9 +92,12 @@ describe('useRxDetailExport', () => {
 
   describe('onDownload', () => {
     it('should set status to InProgress when called', async () => {
+      generateMedicationsPDFStub.returns(new Promise(() => {}));
       const { result } = renderHook(() => useRxDetailExport(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.status.status).to.equal(
@@ -109,7 +112,9 @@ describe('useRxDetailExport', () => {
     it('should generate PDF when allergies are ready', async () => {
       const { result } = renderHook(() => useRxDetailExport(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(generateMedicationsPDFStub.calledOnce).to.be.true;
@@ -119,7 +124,9 @@ describe('useRxDetailExport', () => {
     it('should set isSuccess after PDF generation', async () => {
       const { result } = renderHook(() => useRxDetailExport(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
@@ -131,7 +138,9 @@ describe('useRxDetailExport', () => {
     it('should generate TXT file when allergies are ready', async () => {
       const { result } = renderHook(() => useRxDetailExport(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      });
 
       await waitFor(() => {
         expect(generateTextFileStub.calledOnce).to.be.true;
@@ -141,7 +150,9 @@ describe('useRxDetailExport', () => {
     it('should set isSuccess after TXT generation', async () => {
       const { result } = renderHook(() => useRxDetailExport(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
@@ -157,7 +168,9 @@ describe('useRxDetailExport', () => {
       };
       const { result } = renderHook(() => useRxDetailExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -172,7 +185,9 @@ describe('useRxDetailExport', () => {
       };
       const { result } = renderHook(() => useRxDetailExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;

--- a/src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { expect } from 'chai';
-import { waitFor, render } from '@testing-library/react';
+import { act, waitFor, render } from '@testing-library/react';
 import sinon from 'sinon';
 import useRxListExport from '../../hooks/useRxListExport';
 import * as pdfConfigs from '../../util/pdfConfigs';
@@ -137,7 +137,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(fetchExportListStub.calledOnce).to.be.true;
@@ -153,7 +155,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.true;
@@ -164,7 +168,9 @@ describe('useRxListExport', () => {
     it('should set error state when fetchExportList is not provided', async () => {
       const { result } = renderHook(() => useRxListExport(defaultProps));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.true;
@@ -178,7 +184,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).to.be.true;
@@ -196,7 +204,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(result.current.shouldPrint).to.be.true;
@@ -213,13 +223,17 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(result.current.shouldPrint).to.be.true;
       });
 
-      result.current.clearPrintTrigger();
+      await act(async () => {
+        result.current.clearPrintTrigger();
+      });
 
       await waitFor(() => {
         expect(result.current.shouldPrint).to.be.false;
@@ -237,7 +251,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(buildPrescriptionsPDFListStub.calledOnce).to.be.true;
@@ -256,7 +272,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
@@ -276,7 +294,9 @@ describe('useRxListExport', () => {
       };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(
@@ -304,7 +324,9 @@ describe('useRxListExport', () => {
       };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      });
 
       await waitFor(() => {
         expect(fetchExportListStub.calledOnce).to.be.true;
@@ -336,7 +358,9 @@ describe('useRxListExport', () => {
       };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -356,7 +380,9 @@ describe('useRxListExport', () => {
       };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.ok;
@@ -379,14 +405,18 @@ describe('useRxListExport', () => {
       const { result } = renderHook(() => useRxListExport(props));
 
       // Trigger export
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.isSuccess).to.be.true;
       });
 
       // Reset state
-      result.current.resetExportState();
+      await act(async () => {
+        result.current.resetExportState();
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).to.be.false;
@@ -408,14 +438,18 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.true;
         expect(result.current.errorFormat).to.equal(DOWNLOAD_FORMAT.PDF);
       });
 
-      result.current.resetExportState();
+      await act(async () => {
+        result.current.resetExportState();
+      });
 
       await waitFor(() => {
         expect(result.current.hasError).to.be.false;
@@ -434,7 +468,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.errorFormat).to.equal(DOWNLOAD_FORMAT.PDF);
@@ -450,7 +486,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.TXT);
+      });
 
       await waitFor(() => {
         expect(result.current.errorFormat).to.equal(DOWNLOAD_FORMAT.TXT);
@@ -466,7 +504,9 @@ describe('useRxListExport', () => {
       const props = { ...defaultProps, fetchExportList: fetchExportListStub };
       const { result } = renderHook(() => useRxListExport(props));
 
-      result.current.onDownload(PRINT_FORMAT.PRINT);
+      await act(async () => {
+        result.current.onDownload(PRINT_FORMAT.PRINT);
+      });
 
       await waitFor(() => {
         expect(result.current.errorFormat).to.equal(PRINT_FORMAT.PRINT);
@@ -476,6 +516,12 @@ describe('useRxListExport', () => {
 
   describe('status tracking', () => {
     it('should track status progression through export lifecycle', async () => {
+      let resolvePdf;
+      generateMedicationsPdfFileStub.returns(
+        new Promise(resolve => {
+          resolvePdf = resolve;
+        }),
+      );
       const fetchExportListStub = sandbox.stub().resolves({
         data: { prescriptions: mockPrescriptions },
         isError: false,
@@ -491,13 +537,19 @@ describe('useRxListExport', () => {
       expect(result.current.status.format).to.be.undefined;
 
       // Start download
-      result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      await act(async () => {
+        result.current.onDownload(DOWNLOAD_FORMAT.PDF);
+      });
 
       await waitFor(() => {
         expect(result.current.status.status).to.equal(
           PDF_TXT_GENERATE_STATUS.InProgress,
         );
         expect(result.current.status.format).to.equal(DOWNLOAD_FORMAT.PDF);
+      });
+
+      await act(async () => {
+        resolvePdf();
       });
 
       // Wait for success

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -176,6 +176,12 @@ function setupJSDom() {
   if (!URL.revokeObjectURL) {
     URL.revokeObjectURL = () => {};
   }
+  if (window.URL && !window.URL.createObjectURL) {
+    window.URL.createObjectURL = () => '';
+  }
+  if (window.URL && !window.URL.revokeObjectURL) {
+    window.URL.revokeObjectURL = () => {};
+  }
 
   // Override global Event constructors to use jsdom's implementations
   // In Node 22, native Event constructors create objects incompatible with jsdom


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Stabilize MHV medications export hook unit tests by wrapping state changes in `act` and controlling async resolution.
- Add a jsdom `window.URL.createObjectURL`/`revokeObjectURL` polyfill for FileSaver-based PDF generation in unit tests (Node 22).
- Team: MHV (medications). Flipper: N/A.

## Related issue(s)

- N/A (no ticket provided)
- N/A (no previous change link provided)
- N/A (no epic provided)

## Testing done

- Old behavior: CI-only timeouts/flakes in MHV medications export hook tests.
- Steps: Run the unit tests below.
- Tests:
  - `yarn test:unit src/applications/mhv-medications/tests/hooks/useExportFile.unit.spec.jsx`
  - `yarn test:unit src/applications/mhv-medications/tests/hooks/useRxDetailExport.unit.spec.jsx`
  - `yarn test:unit src/applications/mhv-medications/tests/hooks/useRxListExport.unit.spec.jsx`
  - `yarn test:unit --app-folder mhv-medications`

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._ 

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A    | N/A   |
| Desktop | N/A    | N/A   |

## What areas of the site does it impact?

- MHV medications unit tests (export hooks)
- Platform unit test setup (jsdom URL polyfill)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed (not run)
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added (N/A - no UI changes)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - no UI changes)

### Error Handling

- [ ] Browser console contains no warnings or errors (not checked)
- [ ] Events are being sent to the appropriate logging solution (not applicable)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (not applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (not applicable)

## Requested Feedback

Please focus review on CI stability under Node 22 for the updated medications export tests.
