### PR TITLE
PBB - Add LOA3 route guards

### DIFF
--- a/src/applications/burials-ez/BurialsApp.jsx
+++ b/src/applications/burials-ez/BurialsApp.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import RoutedSavableApp from '@department-of-veterans-affairs/platform-forms/RoutedSavableApp';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
 
+import manifest from './manifest.json';
 import formConfig from './config/form';
 import { NoFormPage } from './components/NoFormPage';
 
@@ -66,11 +67,26 @@ export default function BurialsApp({ location, children }) {
     return <NoFormPage />;
   }
 
-  return (
+  const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
+
+  // If on intro page, return content
+  if (location.pathname === '/introduction') {
+    return content;
+  }
+
+  // If a user is not logged in redirect them to the introduction page
+  if (!isLoggedIn) {
+    document.location.replace(manifest.rootUrl);
+    return (
+      <va-loading-indicator message="Redirecting to introduction page..." />
+    );
+  }
+
+  return content;
 }
 
 BurialsApp.propTypes = {

--- a/src/applications/burials-ez/tests/BurialsApp.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/BurialsApp.unit.spec.jsx
@@ -20,13 +20,14 @@ const burialsLocation = {
 const store = ({
   burialFormEnabled = true,
   featuresLoading = true,
+  isLoggedIn = true,
   profileLoading = false,
   savedForms = [],
 } = {}) => ({
   getState: () => ({
     user: {
       login: {
-        currentlyLoggedIn: true,
+        currentlyLoggedIn: isLoggedIn,
       },
       profile: {
         loading: profileLoading,
@@ -68,5 +69,22 @@ describe('BurialsApp', () => {
     );
     const location = window.location.pathname || window.location.href;
     expect(location).to.eq('/burials-memorials/veterans-burial-allowance/');
+  });
+
+  it('should render redirect loading indicator when user is not logged in on form page', () => {
+    const mockStore = store({ featuresLoading: false, isLoggedIn: false });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <BurialsApp
+          location={{ ...burialsLocation, pathname: '/inside-form' }}
+        />
+      </Provider>,
+    );
+
+    const loadingIndicator = container.querySelector('va-loading-indicator');
+    expect(loadingIndicator).to.exist;
+    expect(loadingIndicator.getAttribute('message')).to.equal(
+      'Redirecting to introduction page...',
+    );
   });
 });

--- a/src/applications/income-and-asset-statement/containers/App.jsx
+++ b/src/applications/income-and-asset-statement/containers/App.jsx
@@ -7,6 +7,7 @@ import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { openReviewChapter as openReviewChapterAction } from 'platform/forms-system/src/js/actions';
 
+import manifest from '../manifest.json';
 import formConfig from '../config/form';
 import { NoFormPage } from '../components/NoFormPage';
 import { getAssetTypes } from '../components/FormAlerts/SupplementaryFormsAlert';
@@ -101,6 +102,19 @@ function App({ location, children, isLoggedIn, openReviewChapter }) {
 
   if (!incomeAndAssetsFormEnabled) {
     return <NoFormPage />;
+  }
+
+  // If on intro page, return content
+  if (location.pathname === '/introduction') {
+    return content;
+  }
+
+  // If a user is not logged in redirect them to the introduction page
+  if (!isLoggedIn) {
+    document.location.replace(manifest.rootUrl);
+    return (
+      <va-loading-indicator message="Redirecting to introduction page..." />
+    );
   }
 
   return content;

--- a/src/applications/income-and-asset-statement/tests/unit/App.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/App.unit.spec.jsx
@@ -123,4 +123,26 @@ describe('Income and Asset Statement App', () => {
       );
     });
   });
+
+  it('should render redirect loading indicator when user is not logged in on form page', () => {
+    const { props, data } = getData({
+      loggedIn: false,
+      toggle: true,
+      isLoading: false,
+    });
+    const { container } = render(
+      <Provider store={mockStore(data)}>
+        <App
+          {...props}
+          location={{ ...appLocation, pathname: '/inside-form' }}
+        />
+      </Provider>,
+    );
+
+    const loadingIndicator = container.querySelector('va-loading-indicator');
+    expect(loadingIndicator).to.exist;
+    expect(loadingIndicator.getAttribute('message')).to.equal(
+      'Redirecting to introduction page...',
+    );
+  });
 });

--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -7,6 +7,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import IntentToFile from 'platform/shared/itf/IntentToFile';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
 
+import manifest from './manifest.json';
 import formConfig from './config/form';
 import { NoFormPage } from './components/NoFormPage';
 
@@ -81,12 +82,27 @@ export default function PensionEntry({ location, children }) {
     return <NoFormPage />;
   }
 
-  return (
+  const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       <IntentToFile itfType="pension" location={location} disableAutoFocus />
       {children}
     </RoutedSavableApp>
   );
+
+  // If on intro page, return content
+  if (location.pathname === '/introduction') {
+    return content;
+  }
+
+  // If a user is not logged in redirect them to the introduction page
+  if (!isLoggedIn) {
+    document.location.replace(manifest.rootUrl);
+    return (
+      <va-loading-indicator message="Redirecting to introduction page..." />
+    );
+  }
+
+  return content;
 }
 PensionEntry.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/applications/pensions/tests/unit/PensionsApp.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/PensionsApp.unit.spec.jsx
@@ -16,11 +16,15 @@ const pensionLocation = {
   query: '{}',
 };
 
-const store = ({ pensionFormEnabled = true, loading = true } = {}) => ({
+const store = ({
+  pensionFormEnabled = true,
+  loading = true,
+  isLoggedIn = true,
+} = {}) => ({
   getState: () => ({
     user: {
       login: {
-        currentlyLoggedIn: true,
+        currentlyLoggedIn: isLoggedIn,
       },
     },
     featureToggles: {
@@ -77,5 +81,22 @@ describe('PensionsApp', () => {
     });
 
     global.window.location = oldLocation;
+  });
+
+  it('should render redirect loading indicator when user is not logged in on form page', () => {
+    const mockStore = store({ loading: false, isLoggedIn: false });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <PensionsApp
+          location={{ ...pensionLocation, pathname: '/inside-form' }}
+        />
+      </Provider>,
+    );
+
+    const loadingIndicator = container.querySelector('va-loading-indicator');
+    expect(loadingIndicator).to.exist;
+    expect(loadingIndicator.getAttribute('message')).to.equal(
+      'Redirecting to introduction page...',
+    );
   });
 });


### PR DESCRIPTION
### Summary of Changes
This PR adds **route guards** across all **PBB forms** (Pension Benefits, Burial Benefits, and Income and Asset Statement) now that these forms are **LOA3 by default and require login**.

The update ensures applicants cannot inadvertently access form routes by manually entering a URL (for example, a deep link to a chapter page). When an unauthenticated user attempts to access a protected route, they are redirected to the form’s **introduction page** to prevent completing the form without being logged in.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132353

### How to Set Up in Local Environment
1. Run the local environment
2. Ensure you can test both authenticated and unauthenticated states:
3. Test each form base route:
   - Pension Benefits (21P-527EZ):  
     http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/
   - Burial Benefits (21P-530EZ):  
     http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/
   - Income and Asset Statement (21P-0969):  
     http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/

### How to Test
1. Unauthenticated (signed out)
   1. Attempt to deep-link to a non-introduction form route for each app (example paths):
      - Pension: `/applicant/information` (or another in-progress chapter route)
      - Burial: a mid-form route under the application
      - 0969: a mid-form route under the application
   2. Verify the user is redirected to the **introduction page** for that form.
   3. Confirm the form pages are not accessible unless logged in.

2. Authenticated (signed in with LOA3)
   1. Repeat the same deep-link navigation for each form.
   2. Verify the user can access routes normally and continue the form.
   3. Confirm there are no regressions for save-in-progress or resume flows.

3. Validate general behavior
   - No redirect loops
   - No console errors
   - Accessibility and focus behavior remains unchanged on redirect

### Feature Flag Note
- No new feature flags introduced. This change enforces existing LOA3-required behavior across PBB forms.

### Acceptance Criteria
- [x] Unauthenticated users cannot access non-introduction form routes for any PBB form.
- [x] Unauthenticated deep links redirect to the form’s introduction page.
- [x] Authenticated users can access and complete forms without regression.
- [x] No redirect loops or console errors introduced.
- [x] E2E and unit tests pass (or are updated as needed).

### Definition of Done
- [ ] Code reviewed and approved.
- [x] Verified locally in both authenticated and unauthenticated states across all three forms.
- [x] No console errors or accessibility issues.
- [x] Tests updated or verified passing.