### PR TITLE
[5391] Prefill Pattern: Create end to end tests for the pattern

### DIFF
--- a/src/applications/simple-forms/mock-form-prefill/config/form.js
+++ b/src/applications/simple-forms/mock-form-prefill/config/form.js
@@ -83,7 +83,6 @@ const formConfig = {
       pages: {
         ...profilePersonalInfoPage(),
         ...profileContactInfoPages({
-          contactPath: 'veteran-information',
           contactInfoRequiredKeys: ['mailingAddress'],
         }),
       },

--- a/src/applications/simple-forms/mock-form-prefill/config/prefill-transformer.js
+++ b/src/applications/simple-forms/mock-form-prefill/config/prefill-transformer.js
@@ -1,10 +1,50 @@
 export const prefillTransformer = (pages, formData, metadata) => {
-  const { ssn, vaFileNumber } = formData?.data?.attributes?.veteran || {};
+  const {
+    ssn,
+    vaFileNumber,
+    firstName,
+    middleName,
+    lastName,
+    suffix,
+    dateOfBirth,
+    gender,
+    address = {},
+    homePhone,
+    mobilePhone,
+    emailAddressText,
+    lastServiceBranch,
+  } = formData?.data?.attributes?.veteran || {};
+
   return {
     metadata,
     formData: {
       ssn,
       vaFileNumber,
+      fullName: {
+        first: firstName,
+        middle: middleName,
+        last: lastName,
+        suffix,
+      },
+      dateOfBirth,
+      gender,
+      veteran: {
+        mailingAddress: {
+          street: address.addressLine1,
+          street2: address.addressLine2,
+          street3: address.addressLine3,
+          city: address.city,
+          state: address.stateCode,
+          postalCode: address.zipCode5,
+          country: address.countryName,
+        },
+        homePhone,
+        mobilePhone,
+        email: emailAddressText
+          ? { emailAddress: emailAddressText }
+          : undefined,
+      },
+      lastServiceBranch,
     },
     pages,
   };

--- a/src/applications/simple-forms/mock-form-prefill/config/prefill-transformer.js
+++ b/src/applications/simple-forms/mock-form-prefill/config/prefill-transformer.js
@@ -1,19 +1,6 @@
 export const prefillTransformer = (pages, formData, metadata) => {
-  const {
-    ssn,
-    vaFileNumber,
-    firstName,
-    middleName,
-    lastName,
-    suffix,
-    dateOfBirth,
-    gender,
-    address = {},
-    homePhone,
-    mobilePhone,
-    emailAddressText,
-    lastServiceBranch,
-  } = formData?.data?.attributes?.veteran || {};
+  const { ssn, vaFileNumber, firstName, middleName, lastName, suffix } =
+    formData?.data?.attributes?.veteran || {};
 
   return {
     metadata,
@@ -26,25 +13,6 @@ export const prefillTransformer = (pages, formData, metadata) => {
         last: lastName,
         suffix,
       },
-      dateOfBirth,
-      gender,
-      veteran: {
-        mailingAddress: {
-          street: address.addressLine1,
-          street2: address.addressLine2,
-          street3: address.addressLine3,
-          city: address.city,
-          state: address.stateCode,
-          postalCode: address.zipCode5,
-          country: address.countryName,
-        },
-        homePhone,
-        mobilePhone,
-        email: emailAddressText
-          ? { emailAddress: emailAddressText }
-          : undefined,
-      },
-      lastServiceBranch,
     },
     pages,
   };

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update-profile.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update-profile.cypress.spec.js
@@ -181,7 +181,6 @@ const testConfig = createTestConfig(
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
       cy.login(user);
     },
-    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update-profile.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update-profile.cypress.spec.js
@@ -1,0 +1,190 @@
+/**
+ * E2E test for mock form prefill.
+ */
+import path from 'path';
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+import featureToggles from '../fixtures/mocks/feature-toggles.json';
+import user from '../fixtures/mocks/user.json';
+import mockSubmit from '../fixtures/mocks/application-submit.json';
+import mockSipGet from '../fixtures/mocks/sip-get.json';
+import mockSipPut from '../fixtures/mocks/sip-put.json';
+import mockVamcEhr from '../fixtures/mocks/vamc-ehr.json';
+import mockProfileStatus from '../fixtures/mocks/profile-status.json';
+import mockAddressValidation from '../fixtures/mocks/address-validation.json';
+import mockProfileTelephones from '../fixtures/mocks/profile-telephones.json';
+import mockProfileAddresses from '../fixtures/mocks/profile-addresses.json';
+import mockProfileEmailAddresses from '../fixtures/mocks/profile-email-addresses.json';
+import mockProfileAddressTransaction from '../fixtures/mocks/profile-address-transaction.json';
+import mockProfileTelephoneTransaction from '../fixtures/mocks/profile-telephone-transaction.json';
+import mockProfileEmailTransaction from '../fixtures/mocks/profile-email-transaction.json';
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import { reviewAndSubmitPageFlow } from './helpers';
+
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataSets: ['minimal-test'],
+    dataDir: path.join(__dirname, '..', 'fixtures', 'data'),
+    pageHooks: {
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.findAllByText(/^start/i, { selector: 'a[href="#start"]' })
+            .last()
+            .click({ force: true });
+        });
+      },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            cy.get('@userDataUpdater').then(updater => {
+              // Create a deep clone of user data for updates
+              const newUserData = JSON.parse(JSON.stringify(user.data));
+
+              cy.get('va-button[label="Edit contact information"]').click();
+
+              // Update mailing address in profile
+              cy.get('va-link[label="Edit mailing address"]').click();
+              cy.fillVaTextInput('root_addressLine1', '456 Edited Street');
+              cy.fillVaTextInput('root_city', 'Updated City');
+              cy.selectVaSelect('root_stateCode', 'CA');
+              cy.fillVaTextInput('root_zipCode', '90210');
+              cy.findByLabelText('Yes, also update my profile').click();
+
+              // Update the mock data
+              newUserData.attributes.vet360ContactInformation.mailingAddress.addressLine1 =
+                '456 Edited Street';
+              newUserData.attributes.vet360ContactInformation.mailingAddress.city =
+                'Updated City';
+              newUserData.attributes.vet360ContactInformation.mailingAddress.stateCode =
+                'CA';
+              newUserData.attributes.vet360ContactInformation.mailingAddress.zipCode =
+                '90210';
+              updater.setUserData(newUserData);
+
+              cy.findByTestId('save-edit-button').click();
+              cy.findByTestId('confirm-address-button').click();
+
+              // Update home phone number in profile
+              cy.get('va-link[label="Edit home phone number"]').click();
+              cy.fillVaTextInput('root_inputPhoneNumber', '2105556791');
+
+              // Update the mock data
+              newUserData.attributes.vet360ContactInformation.homePhone.areaCode =
+                '210';
+              newUserData.attributes.vet360ContactInformation.homePhone.phoneNumber =
+                '5556791';
+              updater.setUserData(newUserData);
+
+              cy.findByTestId('save-edit-button').click();
+
+              // Update mobile phone number in profile
+              cy.get('va-link[label="Edit mobile phone number"]').click();
+              cy.fillVaTextInput('root_inputPhoneNumber', '2105556791');
+
+              // Update the mock data
+              newUserData.attributes.vet360ContactInformation.mobilePhone.areaCode =
+                '210';
+              newUserData.attributes.vet360ContactInformation.mobilePhone.phoneNumber =
+                '5556791';
+              updater.setUserData(newUserData);
+
+              cy.findByTestId('save-edit-button').click();
+
+              // Update email address in profile
+              cy.get('va-link[label="Edit email address"]').click();
+              cy.fillVaTextInput(
+                'root_emailAddress',
+                'mitchell.jenkins.test1@gmail.com',
+              );
+
+              // Update the mock data
+              newUserData.attributes.vet360ContactInformation.email.emailAddress =
+                'mitchell.jenkins.test1@gmail.com';
+              updater.setUserData(newUserData);
+
+              cy.findByTestId('save-edit-button').click();
+
+              // cy.get('va-button[text="Update page"]').click();
+
+              const { fullName } = data;
+              reviewAndSubmitPageFlow(fullName, 'Submit application');
+            });
+          });
+        });
+      },
+    },
+    setupPerTest: () => {
+      // Store updated user data in a closure
+      let updatedUserData = null;
+
+      cy.intercept('GET', '/v0/user', user);
+      cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
+      cy.intercept(
+        'GET',
+        '/v0/in_progress_forms/FORM-MOCK-PREFILL',
+        mockSipGet,
+      );
+
+      // Dynamically return either original or updated user data
+      cy.intercept('GET', '/v0/user?now=*', req => {
+        req.reply({
+          data: updatedUserData || user.data,
+          meta: {
+            errors: [],
+          },
+        });
+      }).as('mockUserUpdated');
+
+      // Store the updater function so we can modify userData later
+      cy.wrap({
+        setUserData: newData => {
+          updatedUserData = newData;
+        },
+      }).as('userDataUpdater');
+
+      cy.intercept('GET', '/data/cms/vamc-ehr.json', mockVamcEhr);
+      cy.intercept('GET', '/v0/profile/status/', mockProfileStatus);
+      cy.intercept(
+        'GET',
+        '/v0/profile/status/6a03b50c-c2f2-47f1-b6d1-90fc73f63ed7',
+        mockProfileAddressTransaction,
+      );
+      cy.intercept(
+        'GET',
+        '/v0/profile/status/c2a14e7b-0ac8-4e37-8908-aa7a433cbb61',
+        mockProfileTelephoneTransaction,
+      );
+      cy.intercept(
+        'GET',
+        '/v0/profile/status/e35c40cf-28d2-4618-8e28-ef422f2a7ebf',
+        mockProfileEmailTransaction,
+      );
+      cy.intercept(
+        'PUT',
+        '/v0/in_progress_forms/FORM-MOCK-PREFILL',
+        mockSipPut,
+      );
+      cy.intercept('PUT', '/v0/profile/telephones', mockProfileTelephones);
+      cy.intercept('PUT', '/v0/profile/addresses', mockProfileAddresses);
+      cy.intercept(
+        'PUT',
+        '/v0/profile/email_addresses',
+        mockProfileEmailAddresses,
+      );
+      cy.intercept(
+        'POST',
+        '/v0/profile/address_validation',
+        mockAddressValidation,
+      );
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+      cy.login(user);
+    },
+    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update.cypress.spec.js
@@ -10,6 +10,8 @@ import mockSubmit from '../fixtures/mocks/application-submit.json';
 import mockSipGet from '../fixtures/mocks/sip-get.json';
 import mockSipPut from '../fixtures/mocks/sip-put.json';
 import mockVamcEhr from '../fixtures/mocks/vamc-ehr.json';
+import mockProfileStatus from '../fixtures/mocks/profile-status.json';
+import mockAddressValidation from '../fixtures/mocks/address-validation.json';
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 import { reviewAndSubmitPageFlow } from './helpers';
@@ -30,8 +32,21 @@ const testConfig = createTestConfig(
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            const { fullName } = data;
+            cy.get('va-button[label="Edit contact information"]').click();
 
+            // update mailing address in the form only
+            cy.get('va-link[label="Edit mailing address"]').click();
+            cy.fillVaTextInput('root_addressLine1', '456 Edited Street');
+            cy.fillVaTextInput('root_city', 'Updated City');
+            cy.selectVaSelect('root_stateCode', 'CA');
+            cy.fillVaTextInput('root_zipCode', '90210');
+            cy.findByLabelText('No, only update this form').click();
+            cy.findByTestId('save-edit-button').click();
+            cy.findByTestId('confirm-address-button').click();
+
+            // cy.get('va-button[text="Update page"]').click();
+
+            const { fullName } = data;
             reviewAndSubmitPageFlow(fullName, 'Submit application');
           });
         });
@@ -46,12 +61,18 @@ const testConfig = createTestConfig(
         '/v0/in_progress_forms/FORM-MOCK-PREFILL',
         mockSipGet,
       );
+      cy.intercept('GET', '/v0/profile/status/', mockProfileStatus);
       cy.intercept(
         'PUT',
         '/v0/in_progress_forms/FORM-MOCK-PREFILL',
         mockSipPut,
       );
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+      cy.intercept(
+        'POST',
+        '/v0/profile/address_validation',
+        mockAddressValidation,
+      );
       cy.login(user);
     },
     skip: Cypress.env('CI'), // Skip CI initially until content-build is merged

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-review-update.cypress.spec.js
@@ -75,7 +75,6 @@ const testConfig = createTestConfig(
       );
       cy.login(user);
     },
-    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-update-profile.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-update-profile.cypress.spec.js
@@ -1,0 +1,198 @@
+/**
+ * E2E test for mock form prefill - Edit Contact Info (form-only update).
+ * Tests editing contact info fields that only update the form data,
+ * not the VA profile.
+ */
+import path from 'path';
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+import featureToggles from '../fixtures/mocks/feature-toggles.json';
+import user from '../fixtures/mocks/user.json';
+import mockSubmit from '../fixtures/mocks/application-submit.json';
+import mockSipGet from '../fixtures/mocks/sip-get.json';
+import mockSipPut from '../fixtures/mocks/sip-put.json';
+import mockVamcEhr from '../fixtures/mocks/vamc-ehr.json';
+import mockProfileStatus from '../fixtures/mocks/profile-status.json';
+import mockAddressValidation from '../fixtures/mocks/address-validation.json';
+import mockProfileTelephones from '../fixtures/mocks/profile-telephones.json';
+import mockProfileAddresses from '../fixtures/mocks/profile-addresses.json';
+import mockProfileEmailAddresses from '../fixtures/mocks/profile-email-addresses.json';
+import mockProfileAddressTransaction from '../fixtures/mocks/profile-address-transaction.json';
+import mockProfileTelephoneTransaction from '../fixtures/mocks/profile-telephone-transaction.json';
+import mockProfileEmailTransaction from '../fixtures/mocks/profile-email-transaction.json';
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import { reviewAndSubmitPageFlow } from './helpers';
+
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataSets: ['minimal-test'],
+    dataDir: path.join(__dirname, '..', 'fixtures', 'data'),
+    pageHooks: {
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.findAllByText(/^start/i, { selector: 'a[href="#start"]' })
+            .last()
+            .click({ force: true });
+        });
+      },
+      'personal-information': ({ afterHook }) => {
+        afterHook(() => {
+          cy.findByText(/continue/i, { selector: 'button' }).click();
+        });
+      },
+      'contact-information': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@userDataUpdater').then(updater => {
+            // Create a deep clone of user data for updates
+            const newUserData = JSON.parse(JSON.stringify(user.data));
+
+            // Update mailing address in profile
+            cy.get('va-link[label="Edit mailing address"]').click();
+            cy.fillVaTextInput('root_addressLine1', '456 Edited Street');
+            cy.fillVaTextInput('root_city', 'Updated City');
+            cy.selectVaSelect('root_stateCode', 'CA');
+            cy.fillVaTextInput('root_zipCode', '90210');
+            cy.findByLabelText('Yes, also update my profile').click();
+
+            // Update the mock data
+            newUserData.attributes.vet360ContactInformation.mailingAddress.addressLine1 =
+              '456 Edited Street';
+            newUserData.attributes.vet360ContactInformation.mailingAddress.city =
+              'Updated City';
+            newUserData.attributes.vet360ContactInformation.mailingAddress.stateCode =
+              'CA';
+            newUserData.attributes.vet360ContactInformation.mailingAddress.zipCode =
+              '90210';
+            updater.setUserData(newUserData);
+
+            cy.findByTestId('save-edit-button').click();
+            cy.findByTestId('confirm-address-button').click();
+
+            // Update home phone number in profile
+            cy.get('va-link[label="Edit home phone number"]').click();
+            cy.fillVaTextInput('root_inputPhoneNumber', '2101234567');
+
+            // Update the mock data
+            newUserData.attributes.vet360ContactInformation.homePhone.areaCode =
+              '210';
+            newUserData.attributes.vet360ContactInformation.homePhone.phoneNumber =
+              '1234567';
+            updater.setUserData(newUserData);
+
+            cy.findByTestId('save-edit-button').click();
+
+            // Update mobile phone number in profile
+            cy.get('va-link[label="Edit mobile phone number"]').click();
+            cy.fillVaTextInput('root_inputPhoneNumber', '2109876543');
+
+            // Update the mock data
+            newUserData.attributes.vet360ContactInformation.mobilePhone.areaCode =
+              '210';
+            newUserData.attributes.vet360ContactInformation.mobilePhone.phoneNumber =
+              '9876543';
+            updater.setUserData(newUserData);
+
+            cy.findByTestId('save-edit-button').click();
+
+            // Update email address in profile
+            cy.get('va-link[label="Edit email address"]').click();
+            cy.fillVaTextInput(
+              'root_emailAddress',
+              'mitchell.jenkins.test1@gmail.com',
+            );
+
+            // Update the mock data
+            newUserData.attributes.vet360ContactInformation.email.emailAddress =
+              'mitchell.jenkins.test1@gmail.com';
+            updater.setUserData(newUserData);
+
+            cy.findByTestId('save-edit-button').click();
+            cy.url().should('include', 'contact-information');
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            const { fullName } = data;
+            reviewAndSubmitPageFlow(fullName, 'Submit application');
+          });
+        });
+      },
+    },
+    setupPerTest: () => {
+      // Store updated user data in a closure
+      let updatedUserData = null;
+
+      cy.intercept('GET', '/v0/user', user);
+      cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
+      cy.intercept(
+        'GET',
+        '/v0/in_progress_forms/FORM-MOCK-PREFILL',
+        mockSipGet,
+      );
+
+      // Dynamically return either original or updated user data
+      cy.intercept('GET', '/v0/user?now=*', req => {
+        req.reply({
+          data: updatedUserData || user.data,
+          meta: {
+            errors: [],
+          },
+        });
+      }).as('mockUserUpdated');
+
+      // Store the updater function so we can modify userData later
+      cy.wrap({
+        setUserData: newData => {
+          updatedUserData = newData;
+        },
+      }).as('userDataUpdater');
+
+      cy.intercept('GET', '/data/cms/vamc-ehr.json', mockVamcEhr);
+      cy.intercept('GET', '/v0/profile/status/', mockProfileStatus);
+      cy.intercept(
+        'GET',
+        '/v0/profile/status/6a03b50c-c2f2-47f1-b6d1-90fc73f63ed7',
+        mockProfileAddressTransaction,
+      );
+      cy.intercept(
+        'GET',
+        '/v0/profile/status/c2a14e7b-0ac8-4e37-8908-aa7a433cbb61',
+        mockProfileTelephoneTransaction,
+      );
+      cy.intercept(
+        'GET',
+        '/v0/profile/status/e35c40cf-28d2-4618-8e28-ef422f2a7ebf',
+        mockProfileEmailTransaction,
+      );
+      cy.intercept(
+        'PUT',
+        '/v0/in_progress_forms/FORM-MOCK-PREFILL',
+        mockSipPut,
+      );
+      cy.intercept('PUT', '/v0/profile/telephones', mockProfileTelephones);
+      cy.intercept('PUT', '/v0/profile/addresses', mockProfileAddresses);
+      cy.intercept(
+        'PUT',
+        '/v0/profile/email_addresses',
+        mockProfileEmailAddresses,
+      );
+      cy.intercept(
+        'POST',
+        '/v0/profile/address_validation',
+        mockAddressValidation,
+      );
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+      cy.login(user);
+    },
+    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-update-profile.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-update-profile.cypress.spec.js
@@ -189,7 +189,6 @@ const testConfig = createTestConfig(
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
       cy.login(user);
     },
-    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-update.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill-update.cypress.spec.js
@@ -85,7 +85,6 @@ const testConfig = createTestConfig(
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
       cy.login(user);
     },
-    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill.cypress.spec.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/e2e/mock-form-prefill.cypress.spec.js
@@ -54,7 +54,6 @@ const testConfig = createTestConfig(
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
       cy.login(user);
     },
-    skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/data/maximal-test.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/data/maximal-test.json
@@ -1,10 +1,31 @@
 {
   "data": {
+    "ssn": "6789",
+    "vaFileNumber": "2345",
     "fullName": {
       "first": "Mitchell",
       "middle": "George",
-      "last": "Jenkins"
+      "last": "Jenkins",
+      "suffix": ""
     },
-    "dateOfBirth": "1980-01-01"
+    "dateOfBirth": "1956-07-10",
+    "gender": "M",
+    "veteran": {
+      "mailingAddress": {
+        "street": "125 Main St.",
+        "street2": "",
+        "street3": "",
+        "city": "Fulton",
+        "state": "NY",
+        "postalCode": "97063",
+        "country": "United States"
+      },
+      "homePhone": "5558081234",
+      "mobilePhone": "5554044567",
+      "email": {
+        "emailAddress": "mitchell.jenkins.test@gmail.com"
+      }
+    },
+    "lastServiceBranch": "Air Force"
   }
 }

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/data/minimal-test.json
@@ -1,10 +1,24 @@
 {
   "data": {
+    "ssn": "6789",
+    "vaFileNumber": "2345",
     "fullName": {
       "first": "Mitchell",
       "middle": "George",
       "last": "Jenkins"
     },
-    "dateOfBirth": "1980-01-01"
+    "dateOfBirth": "1956-07-10",
+    "veteran": {
+      "mailingAddress": {
+        "street": "125 Main St.",
+        "city": "Fulton",
+        "state": "NY",
+        "postalCode": "97063",
+        "country": "United States"
+      },
+      "email": {
+        "emailAddress": "mitchell.jenkins.test@gmail.com"
+      }
+    }
   }
 }

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/address-validation.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/address-validation.json
@@ -1,0 +1,23 @@
+{
+  "addresses": [
+    {
+      "address": {
+        "addressLine1": "456 Edited Street",
+        "addressType": "DOMESTIC",
+        "city": "Updated City",
+        "countryName": "United States",
+        "countryCodeIso3": "USA",
+        "stateCode": "CA",
+        "zipCode": "90210"
+      },
+      "addressMetaData": {
+        "confidenceScore": 0.0,
+        "addressType": "Domestic",
+        "deliveryPointValidation": "MISSING_ZIP"
+      }
+    }
+  ],
+  "overrideValidationKey": 1217835228,
+  "validationKey": 1217835228,
+  "validated": true
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/local-mock-responses.js
@@ -6,13 +6,17 @@ const mockFeatureToggles = require('./feature-toggles.json');
 const mockSipPut = require('./sip-put.json');
 const mockSipGet = require('./sip-get.json');
 const mockSubmit = require('./application-submit.json');
+const mockVamcEhr = require('./vamc-ehr.json');
+const mockProfileStatus = require('./profile-status.json');
 
 const responses = {
   'GET /v0/user': mockUser,
   'OPTIONS /v0/maintenance_windows': 'OK',
   'GET /v0/maintenance_windows': { data: [] },
   'GET /v0/feature_toggles': mockFeatureToggles,
+  'GET /data/cms/vamc-ehr.json': mockVamcEhr,
   'GET /v0/in_progress_forms/FORM-MOCK-PREFILL': mockSipGet,
+  'GET /v0/profile/status/*': mockProfileStatus,
   'PUT /v0/in_progress_forms/FORM-MOCK-PREFILL': mockSipPut,
   'POST /v0/api': mockSubmit,
 };

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/local-mock-responses.js
@@ -12,8 +12,8 @@ const responses = {
   'OPTIONS /v0/maintenance_windows': 'OK',
   'GET /v0/maintenance_windows': { data: [] },
   'GET /v0/feature_toggles': mockFeatureToggles,
-  'GET /v0/in_progress_forms/FORM_MOCK_PREFILL': mockSipGet,
-  'PUT /v0/in_progress_forms/FORM_MOCK_PREFILL': mockSipPut,
+  'GET /v0/in_progress_forms/FORM-MOCK-PREFILL': mockSipGet,
+  'PUT /v0/in_progress_forms/FORM-MOCK-PREFILL': mockSipPut,
   'POST /v0/api': mockSubmit,
 };
 

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-address-transaction.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-address-transaction.json
@@ -1,0 +1,15 @@
+{
+  "statusCode": 200,
+  "body": {
+    "data": {
+      "id": "",
+      "type": "async_transaction_va_profile_address_transactions",
+      "attributes": {
+        "transactionId": "6a03b50c-c2f2-47f1-b6d1-90fc73f63ed7",
+        "transactionStatus": "COMPLETED_SUCCESS",
+        "type": "AsyncTransaction::VAProfile::AddressTransaction",
+        "metadata": []
+      }
+    }
+  }
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-addresses.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-addresses.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_address_transactions",
+    "attributes": {
+      "transactionId": "6a03b50c-c2f2-47f1-b6d1-90fc73f63ed7",
+      "transactionStatus": "RECEIVED",
+      "type": "AsyncTransaction::VAProfile::AddressTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-email-addresses.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-email-addresses.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_email_transactions",
+    "attributes": {
+      "transactionId": "e35c40cf-28d2-4618-8e28-ef422f2a7ebf",
+      "transactionStatus": "RECEIVED",
+      "type": "AsyncTransaction::VAProfile::EmailTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-email-transaction.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-email-transaction.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_email_transactions",
+    "attributes": {
+      "transactionId": "e35c40cf-28d2-4618-8e28-ef422f2a7ebf",
+      "transactionStatus": "COMPLETED_SUCCESS",
+      "type": "AsyncTransaction::VAProfile::EmailTransaction",
+      "metadata": [
+        {
+          "code": "EMAIL309",
+          "key": "emailBio.CheckMXRecordExists",
+          "retryable": false,
+          "severity": "INFO",
+          "text": "Domain Mail Exchange (MX) Record must be present"
+        },
+        {
+          "code": "EMAIL308",
+          "key": "emailBio.CheckDomainExists",
+          "retryable": false,
+          "severity": "INFO",
+          "text": "DNS lookup failed for the email domain."
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-status.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-status.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "id": "",
+      "type": "async_transaction_va_profile_email_transactions",
+      "attributes": {
+        "transactionId": "34e84fb8-86ed-4cd0-9c6d-73179c83fcef",
+        "transactionStatus": "COMPLETED_NO_CHANGES_DETECTED",
+        "type": "AsyncTransaction::VAProfile::EmailTransaction",
+        "metadata": []
+      }
+    },
+    {
+      "id": "",
+      "type": "async_transaction_va_profile_telephone_transactions",
+      "attributes": {
+        "transactionId": "4b0918f9-97b2-43d4-9b8e-ae0dc999d9c4",
+        "transactionStatus": "COMPLETED_NO_CHANGES_DETECTED",
+        "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+        "metadata": []
+      }
+    }
+  ]
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-telephone-transaction.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-telephone-transaction.json
@@ -1,0 +1,15 @@
+{
+  "statusCode": 200,
+  "body": {
+    "data": {
+      "id": "",
+      "type": "async_transaction_va_profile_telephone_transactions",
+      "attributes": {
+        "transactionId": "c2a14e7b-0ac8-4e37-8908-aa7a433cbb61",
+        "transactionStatus": "COMPLETED_SUCCESS",
+        "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+        "metadata": []
+      }
+    }
+  }
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-telephones.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/profile-telephones.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_telephone_transactions",
+    "attributes": {
+      "transactionId": "c2a14e7b-0ac8-4e37-8908-aa7a433cbb61",
+      "transactionStatus": "RECEIVED",
+      "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/sip-get.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/sip-get.json
@@ -6,30 +6,28 @@
           "firstName": "Mitchell",
           "middleName": "George",
           "lastName": "Jenkins",
+          "suffix": "",
           "gender": "M",
           "dateOfBirth": "1956-07-10",
           "ssn": "6789",
           "vaFileNumber": "2345",
+          "address": {
+            "addressLine1": "125 Main St.",
+            "addressLine2": "",
+            "addressLine3": "",
+            "city": "Fulton",
+            "stateCode": "NY",
+            "zipCode5": "97063",
+            "countryName": "United States"
+          },
+          "phone": {
+            "areaCode": "555",
+            "phoneNumber": "8081234"
+          },
           "homePhone": "5558081234",
-          "email": "mitchell.jenkins.test@gmail.com",
-          "view:maritalStatus": {
-            "maritalStatus": "MARRIED"
-          },
-          "spouseFullName": {
-            "first": "Michelle",
-            "last": "Smith"
-          },
-          "spouseDateOfBirth": "1984-08-03",
-          "spouseSocialSecurityNumber": "451906574",
-          "maritalStatus": "Married",
-          "dateOfMarriage": "2020-10-15",
-          "cohabitedLastYear": true,
-          "view:reportDependents": true,
-          "view:skipDependentInfo": false,
-          "isMedicaidEligible": false,
-          "isEnrolledMedicarePartA": true,
-          "medicarePartAEffectiveDate": "2009-01-02",
-          "medicareClaimNumber": "7AD5WC9MW60"
+          "emailAddressText": "mitchell.jenkins.test@gmail.com",
+          "mobilePhone": "5554044567",
+          "lastServiceBranch": "Air Force"
         }
       }
     }

--- a/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/vamc-ehr.json
+++ b/src/applications/simple-forms/mock-form-prefill/tests/fixtures/mocks/vamc-ehr.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "nodeQuery": {
+      "count": 0,
+      "entities": []
+    }
+  }
+}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR creates end-to-end cypress tests for the prefill pattern via the [Mock Form Prefill](https://staging.va.gov/mock-form-prefill/introduction)

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5391

## Testing done

End-to-end testing

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user