### PR TITLE
Form Review | Prevent crash when error property is undefined

### DIFF
--- a/src/platform/forms-system/src/js/utilities/data/reduceErrors.js
+++ b/src/platform/forms-system/src/js/utilities/data/reduceErrors.js
@@ -13,7 +13,7 @@ import numberToWords from './numberToWords';
 export const replaceNumberWithWord = (_, word, number) => {
   const num = parseInt(number, 10);
   return `${
-    isNaN(num) || !isFinite(num) ? number : numberToWords(num + 1)
+    Number.isNaN(num) || !Number.isFinite(num) ? number : numberToWords(num + 1)
   } ${word}`;
 };
 
@@ -283,7 +283,7 @@ export const reduceErrors = (errors, pageList, reviewErrors = {}) =>
               navigationType,
             });
           }
-        } else if (err.property) {
+        } else if (err.property && typeof err.property === 'string') {
           // property includes a path to the error; we'll remove "instance",
           // then use `getPropertyInfo` to search the pageList to find the
           // matching chapterKey & pageKey
@@ -294,7 +294,9 @@ export const reduceErrors = (errors, pageList, reviewErrors = {}) =>
           //
           // http://sentry.vfs.va.gov/vets-gov/website-production/issues/12188/events/cf24a5bc9ef9452e9611f3e14846f6f0/
           const argument =
-            Array.isArray(err.argument) || !err.argument || !isNaN(err.argument)
+            Array.isArray(err.argument) ||
+            !err.argument ||
+            typeof err.argument === 'number'
               ? property.split('.').slice(-1)[0]
               : err.argument;
           // name is the property that had the validation error
@@ -333,7 +335,9 @@ export const reduceErrors = (errors, pageList, reviewErrors = {}) =>
               // display this message to the user in some future work
               message:
                 getErrorMessage(reviewErrors[propertyName], index) ||
-                formatErrors(err.stack || err.message),
+                (err.stack || err.message
+                  ? formatErrors(err.stack || err.message)
+                  : 'Validation error'),
               // Accordion (chapter) key that needs to be highlighted
               chapterKey,
               // page within the chapter that contains the error; will be used
@@ -346,7 +350,7 @@ export const reduceErrors = (errors, pageList, reviewErrors = {}) =>
         }
         // process nested error messages (follows uiSchema nesting)
         Object.keys(err).forEach(key => {
-          if (!isNaN(key) && typeof err[key] !== 'string') {
+          if (!Number.isNaN(Number(key)) && typeof err[key] !== 'string') {
             // save array/object index if key is a number; but ignore it if the
             // value is a string, e.g. an __error message string
             errorIndex = key;

--- a/src/platform/forms-system/test/js/utilities/reduceErrors.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/utilities/reduceErrors.unit.spec.jsx
@@ -679,6 +679,54 @@ describe('Process form validation errors', () => {
     };
     expect(reduceErrors(raw, pages, reviewErrors)).to.eql(result);
   });
+
+  it('should handle error with undefined property', () => {
+    const pages = [
+      {
+        title: 'Test',
+        path: '/test',
+        uiSchema: {
+          testField: {},
+        },
+        schema: {},
+        chapterKey: 'testChapter',
+        pageKey: 'testPage',
+      },
+    ];
+    const raw = [
+      {
+        property: undefined,
+        message: 'test error',
+        stack: 'test error stack',
+      },
+    ];
+    // Should not throw and should return empty array since property is undefined
+    expect(() => reduceErrors(raw, pages)).to.not.throw();
+    expect(reduceErrors(raw, pages)).to.eql([]);
+  });
+
+  it('should use fallback message when stack and message are undefined', () => {
+    const pages = [
+      {
+        title: 'Test',
+        path: '/test',
+        uiSchema: {
+          testField: {},
+        },
+        schema: {},
+        chapterKey: 'testChapter',
+        pageKey: 'testPage',
+      },
+    ];
+    const raw = [
+      {
+        property: 'instance.testField',
+        name: 'error',
+      },
+    ];
+    const result = reduceErrors(raw, pages);
+    expect(result[0].message).to.equal('Validation error');
+  });
 });
 
 describe('getPropertyInfo', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR makes improvements to error handling in the `reduceErrors` utility, focusing on more robust type checking and fallback messaging. These changes help prevent runtime errors and ensure that users receive meaningful error messages even when certain error properties are missing or undefined. Additionally, new unit tests have been added to verify these behaviors.

**Error handling improvements:**

* Improved type checking for `property` in error objects to ensure it is a string before processing, preventing issues when it is undefined or not a string.
* Updated logic for handling `argument` in errors to check for its type more accurately, using `typeof err.argument === 'number'` instead of relying on `isNaN`, which increases reliability.
* Added a fallback error message ("Validation error") when both `stack` and `message` are undefined, ensuring users always see a message.

**Type checking improvements:**

* Replaced `isNaN` and `isFinite` with `Number.isNaN` and `Number.isFinite` for stricter and more predictable number validation in `replaceNumberWithWord` and error key processing.

**Testing enhancements:**

* Added unit tests to verify handling of errors with undefined `property` and to check fallback messaging when `stack` and `message` are missing, ensuring the new behaviors are covered.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#131221

## Testing done

- Prior to the change, the review page would crash with "Cannot read properties of undefined (reading 'replace')" when validation errors had undefined property values after saving and continuing a form.
- After the change, errors with undefined or non-string properties are safely handled and skipped, allowing the review page to function normally with a fallback error message when needed.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Users can save and continue forms, then edit pages on the review page without encountering JavaScript errors
- Validation errors with missing or malformed property data display a fallback "Validation error" message instead of crashing the page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user