### PR TITLE
Form Review | Trim whitespace from statement of truth name validation

### DIFF
--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -41,23 +41,17 @@ export function statementOfTruthFullName(
   if (useProfileFullName && profileFullName) {
     fullName = profileFullName;
   } else {
-    fullName = get(
-      formData,
+    const path =
       typeof fullNamePath === 'function'
         ? fullNamePath(formData)
-        : fullNamePath || 'veteran.fullName',
-    );
+        : fullNamePath || 'veteran.fullName';
+    fullName = get(formData, path);
   }
 
-  let fullNameString = fullName?.first || '';
-
-  if (fullName?.middle) {
-    fullNameString += ` ${fullName?.middle}`;
-  }
-
-  fullNameString += ` ${fullName?.last || ''}`;
-
-  return fullNameString;
+  return [fullName?.first, fullName?.middle, fullName?.last]
+    .filter(Boolean)
+    .map(part => part.trim())
+    .join(' ');
 }
 
 export function fullNameReducer(fullNameString) {

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -49,8 +49,8 @@ export function statementOfTruthFullName(
   }
 
   return [fullName?.first, fullName?.middle, fullName?.last]
+    .map(part => part?.trim())
     .filter(Boolean)
-    .map(part => part.trim())
     .join(' ');
 }
 

--- a/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
+++ b/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
@@ -361,4 +361,21 @@ describe('statementOfTruthFullName', () => {
     const result = statementOfTruthFullName(formData, statementOfTruth);
     expect(result).to.equal('John Doe');
   });
+
+  it('should filter out middle name with only whitespace', () => {
+    const formData = {
+      veteran: {
+        fullName: {
+          first: 'John',
+          middle: '   ',
+          last: 'Doe',
+        },
+      },
+    };
+    const statementOfTruth = {
+      fullNamePath: 'veteran.fullName',
+    };
+    const result = statementOfTruthFullName(formData, statementOfTruth);
+    expect(result).to.equal('John Doe');
+  });
 });

--- a/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
+++ b/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
@@ -8,7 +8,9 @@ import createCommonStore from 'platform/startup/store';
 import createSchemaFormReducer from 'platform/forms-system/src/js/state';
 import reducers from 'platform/forms-system/src/js/state/reducers';
 
-import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import PreSubmitSection, {
+  statementOfTruthFullName,
+} from 'platform/forms/components/review/PreSubmitSection';
 
 const createForm = options => ({
   formId: 'test',
@@ -272,5 +274,91 @@ describe('Review PreSubmitSection component', () => {
 
     expect(tree.container.querySelector('va-statement-of-truth')).to.exist;
     tree.unmount();
+  });
+});
+
+describe('statementOfTruthFullName', () => {
+  it('should return full name with trimmed spaces', () => {
+    const formData = {
+      veteran: {
+        fullName: {
+          first: 'John ',
+          middle: ' Michael ',
+          last: ' Doe',
+        },
+      },
+    };
+    const statementOfTruth = {
+      fullNamePath: 'veteran.fullName',
+    };
+    const result = statementOfTruthFullName(formData, statementOfTruth);
+    expect(result).to.equal('John Michael Doe');
+  });
+
+  it('should handle name without middle name', () => {
+    const formData = {
+      veteran: {
+        fullName: {
+          first: 'John',
+          last: 'Doe',
+        },
+      },
+    };
+    const statementOfTruth = {
+      fullNamePath: 'veteran.fullName',
+    };
+    const result = statementOfTruthFullName(formData, statementOfTruth);
+    expect(result).to.equal('John Doe');
+  });
+
+  it('should handle name with trailing spaces', () => {
+    const formData = {
+      veteran: {
+        fullName: {
+          first: 'John',
+          last: 'Doe   ',
+        },
+      },
+    };
+    const statementOfTruth = {
+      fullNamePath: 'veteran.fullName',
+    };
+    const result = statementOfTruthFullName(formData, statementOfTruth);
+    expect(result).to.equal('John Doe');
+  });
+
+  it('should use profile full name when useProfileFullName is true', () => {
+    const formData = {};
+    const statementOfTruth = {
+      useProfileFullName: true,
+    };
+    const profileFullName = {
+      first: 'Jane ',
+      middle: ' Marie ',
+      last: ' Smith',
+    };
+    const result = statementOfTruthFullName(
+      formData,
+      statementOfTruth,
+      profileFullName,
+    );
+    expect(result).to.equal('Jane Marie Smith');
+  });
+
+  it('should handle empty middle name properly', () => {
+    const formData = {
+      veteran: {
+        fullName: {
+          first: 'John',
+          middle: '',
+          last: 'Doe',
+        },
+      },
+    };
+    const statementOfTruth = {
+      fullNamePath: 'veteran.fullName',
+    };
+    const result = statementOfTruthFullName(formData, statementOfTruth);
+    expect(result).to.equal('John Doe');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the `statementOfTruthFullName` function in `PreSubmitSection.jsx` to improve how full names are constructed and trimmed, and adds comprehensive unit tests to verify its behavior. The main focus is on ensuring that names are properly concatenated and whitespace is handled correctly.

Improvements to full name construction:

* Refactored the `statementOfTruthFullName` function to build the full name using an array of name parts, filter out empty values, trim whitespace from each part, and join them with spaces. This ensures consistent formatting and eliminates extra spaces.

Testing enhancements:

* Added a suite of unit tests in `PreSubmitSection.unit.spec.jsx` to verify `statementOfTruthFullName` handles various cases, including names with/without middle names, trailing spaces, use of profile full name, and empty middle names.
* Updated imports in the test file to include `statementOfTruthFullName` for direct testing.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#132330

## Testing done

- Prior to the change, trailing or leading whitespace in name fields caused statement of truth validation to fail even when the user entered their name correctly.
- After the change, whitespace is automatically trimmed from name parts, allowing validation to pass regardless of extra spaces in the form data.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Users with trailing or leading spaces in their name fields can successfully validate the statement of truth by entering their name without extra spaces
- Name validation works consistently regardless of whether the form data contains whitespace characters

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user