### PR TITLE
Remove "or cancel" content

### DIFF
--- a/src/platform/mhv/components/CernerFacilityAlert/constants.js
+++ b/src/platform/mhv/components/CernerFacilityAlert/constants.js
@@ -29,12 +29,12 @@ export const CernerAlertContent = {
     infoAlertText: 'You can manage most of your appointments here.',
     // Migration alert configuration
     warningPhases: ['p0', 'p1'],
-    warningMessage: `you won’t be able to schedule or cancel appointments online for`,
+    warningMessage: `you won’t be able to schedule appointments online for`,
     warningGetNote: facilityText =>
       `During this time, you can still call ${facilityText} to schedule or cancel appointments.`,
     errorPhases: ['p2', 'p3', 'p4', 'p5', 'p6'],
     errorHeadline: `You can’t manage appointments online for some facilities right now`,
-    errorMessage: `You can’t schedule or cancel appointments online for`,
+    errorMessage: `You can’t schedule appointments online for`,
     errorNote:
       'If you need to schedule or cancel appointments now, call the facility directly.',
     errorStartDate: 'p2',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed "or cancel" from the appointments-specific Oracle Health (OH) facility transition alerts in the `CernerFacilityAlert` constants.
- Updated the `warningMessage` from `"you won't be able to schedule or cancel appointments online for"` to `"you won't be able to schedule appointments online for"`.
- Updated the `errorMessage` from `"You can't schedule or cancel appointments online for"` to `"You can't schedule appointments online for"`.
- The "or cancel" language remains in the `warningGetNote` and `errorNote` strings, which instruct users to call the facility — those are appropriate since cancellation is still possible by phone.
- MHV on VA.gov team owns this component.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#0000

## Testing done

- Verified the old behavior: the warning and error alert messages for appointments included "or cancel" phrasing (e.g., "you won't be able to schedule or cancel appointments online for").
- After the change, confirmed the alert messages no longer include "or cancel" in the `warningMessage` and `errorMessage` fields.
- Ran unit tests for `CernerFacilityAlert` and `MigratingFacilitiesAlerts` — all 77 tests pass.
  - `yarn test:unit src/platform/mhv/tests/components/CernerFacilityAlert.unit.spec.jsx src/platform/mhv/tests/components/MigratingFacilitiesAlerts.unit.spec.jsx`

## Screenshots

N/A — content-only change to alert text strings; no visual/layout changes.

## What areas of the site does it impact?

The OH facility transition alerts shown on the MHV appointments page for users registered at facilities undergoing Oracle Health migration.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a straightforward content change — only two string values were updated in `src/platform/mhv/components/CernerFacilityAlert/constants.js`. The phone-based call-to-action strings (`warningGetNote`, `errorNote`) intentionally still reference "or cancel" since cancellation remains available by phone.