### PR TITLE
[Ask VA] Remove the word "please" from the UI

### DIFF
--- a/src/applications/ask-va/components/YourPersonalInformationAuthenticated.jsx
+++ b/src/applications/ask-va/components/YourPersonalInformationAuthenticated.jsx
@@ -84,7 +84,7 @@ const PersonalAuthenticatedInformation = ({
           </div>
           <p>
             <span className="vads-u-font-weight--bold">Note:</span> If you need
-            to update your personal information, please call us at{' '}
+            to update your personal information, call us at{' '}
             <va-telephone contact="8008271000" />. We’re here Monday through
             Friday, 8:00 a.m. to 9:00 p.m. ET.
           </p>

--- a/src/applications/ask-va/components/search/SearchControls.jsx
+++ b/src/applications/ask-va/components/search/SearchControls.jsx
@@ -102,7 +102,7 @@ const SearchControls = props => {
         {(geoCodeError || hasSearchInput || inputError) && (
           <span className="usa-input-error-message" role="alert">
             <span className="sr-only">Error</span>
-            Please fill in a city or facility name.
+            Fill in a city or facility name.
           </span>
         )}
         {searchHint && <p className="search-hint-text">{searchHint}</p>}

--- a/src/applications/ask-va/config/chapters/personalInformation/aboutTheFamilyMember.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/aboutTheFamilyMember.js
@@ -19,7 +19,7 @@ const aboutTheFamilyMemberPage = {
         'ui:webComponentField': VaTextInputField,
         'ui:autocomplete': 'given-name',
         'ui:required': () => true,
-        'ui:errorMessages': { required: 'Please enter a first name' },
+        'ui:errorMessages': { required: 'Enter a first name' },
       },
       middle: {
         'ui:title': 'Middle name',
@@ -31,7 +31,7 @@ const aboutTheFamilyMemberPage = {
         'ui:webComponentField': VaTextInputField,
         'ui:autocomplete': 'family-name',
         'ui:required': () => true,
-        'ui:errorMessages': { required: 'Please enter a last name' },
+        'ui:errorMessages': { required: 'Enter a last name' },
       },
       suffix: {
         'ui:title': 'Suffix',

--- a/src/applications/ask-va/config/chapters/personalInformation/aboutTheVeteran.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/aboutTheVeteran.js
@@ -47,7 +47,7 @@ const aboutTheVeteranPage = {
         'ui:autocomplete': 'given-name',
         'ui:required': () => true,
         'ui:errorMessages': {
-          required: "Please provide the Veteran's first name",
+          required: "Provide the Veteran's first name",
         },
       },
       middle: {
@@ -61,7 +61,7 @@ const aboutTheVeteranPage = {
         'ui:autocomplete': 'family-name',
         'ui:required': () => true,
         'ui:errorMessages': {
-          required: "Please provide the Veteran's last name",
+          required: "Provide the Veteran's last name",
         },
       },
       suffix: {
@@ -77,7 +77,7 @@ const aboutTheVeteranPage = {
         title: CHAPTER_3.VET_DECEASED.TITLE,
         labels: yesNoOptions,
         errorMessages: {
-          required: 'Please let us know if the Veteran is deceased',
+          required: 'Let us know if the Veteran is deceased',
         },
       }),
       socialOrServiceNum: {
@@ -89,7 +89,7 @@ const aboutTheVeteranPage = {
           (errors, field) => {
             if (!Object.keys(field).some(key => field[key])) {
               errors.addError(
-                "Please enter either the Veteran's Social Security number or Service number",
+                "Enter either the Veteran's Social Security number or Service number",
               );
             }
           },
@@ -110,7 +110,7 @@ const aboutTheVeteranPage = {
       }),
       dateOfBirth: dateOfBirthUI({
         errorMessages: {
-          required: "Please provide the Veteran's date of birth",
+          required: "Provide the Veteran's date of birth",
         },
       }),
     },

--- a/src/applications/ask-va/config/chapters/personalInformation/aboutTheVeteran.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/aboutTheVeteran.js
@@ -32,7 +32,7 @@ const ssnServiceInfo = (
       <span className="form-required-span">(*Required)</span>
     </p>
     <p className="vads-u-font-size--sm vads-u-margin-bottom-1">
-      Please provide one of the following:
+      Provide one of the following:
     </p>
   </div>
 );

--- a/src/applications/ask-va/config/chapters/personalInformation/aboutYourselfRelationshipFamilyMember.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/aboutYourselfRelationshipFamilyMember.js
@@ -19,7 +19,7 @@ const aboutYourselfRelationshipFamilyMemberPage = {
         'ui:webComponentField': VaTextInputField,
         'ui:autocomplete': 'given-name',
         'ui:required': () => true,
-        'ui:errorMessages': { required: 'Please provide your first name' },
+        'ui:errorMessages': { required: 'Provide your first name' },
       },
       middle: {
         'ui:title': 'Middle name',
@@ -31,7 +31,7 @@ const aboutYourselfRelationshipFamilyMemberPage = {
         'ui:webComponentField': VaTextInputField,
         'ui:autocomplete': 'family-name',
         'ui:required': () => true,
-        'ui:errorMessages': { required: 'Please provide your last name' },
+        'ui:errorMessages': { required: 'Provide your last name' },
       },
       suffix: {
         'ui:title': 'Suffix',
@@ -46,14 +46,14 @@ const aboutYourselfRelationshipFamilyMemberPage = {
         ssn: {
           ...ssnUI(),
           'ui:errorMessages': {
-            required: 'Please enter your Social Security Number',
+            required: 'Enter your Social Security Number',
           },
         },
       },
       dateOfBirth: {
         ...dateOfBirthUI(),
         'ui:errorMessages': {
-          required: 'Please provide your date of birth',
+          required: 'Provide your date of birth',
         },
       },
     },

--- a/src/applications/ask-va/config/chapters/personalInformation/deathDate.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/deathDate.js
@@ -16,7 +16,7 @@ const deathDatePage = {
       ...dateOfDeathUI(CHAPTER_3.DEATH_DATE.TITLE),
       'ui:validations': [validateCurrentOrPastMemorableDate],
       'ui:errorMessages': {
-        required: 'Please enter the date of death',
+        required: 'Enter the date of death',
       },
       /* eslint-disable react/prop-types */
       'ui:reviewField': ({ children }) => (

--- a/src/applications/ask-va/config/chapters/personalInformation/familyMembersLocationOfResidence.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/familyMembersLocationOfResidence.js
@@ -11,7 +11,7 @@ const familyMembersLocationOfResidencePage = {
     familyMembersLocationOfResidence: selectUI({
       title: CHAPTER_3.FAMILY_MEMBERS_LOCATION_OF_RESIDENCE.QUESTION_1,
       errorMessages: {
-        required: 'Please select your location',
+        required: 'Select your location',
       },
     }),
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/familyMembersPostalCode.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/familyMembersPostalCode.js
@@ -12,9 +12,8 @@ const familyMembersPostalCodePage = {
       'ui:required': () => true,
       'ui:description': PostalCodeHint,
       'ui:errorMessages': {
-        required: 'Please enter a postal code',
-        pattern:
-          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+        required: 'Enter a postal code',
+        pattern: 'Enter a valid 5- or 9-digit postal code (dashes allowed)',
       },
     },
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/isQuestionAboutVeteranOrSomeoneElse.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/isQuestionAboutVeteranOrSomeoneElse.js
@@ -14,7 +14,7 @@ const isQuestionAboutVeteranOrSomeoneElsePage = {
       labelHeaderLevel: '3',
       labels: isQuestionAboutVeteranOrSomeoneElseLabels,
       errorMessages: {
-        required: 'Please let us know who your question is about.',
+        required: 'Let us know who your question is about.',
       },
     }),
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/moreAboutYourRelationshipToVeteran.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/moreAboutYourRelationshipToVeteran.js
@@ -12,12 +12,12 @@ const moreAboutYourRelationshipToVeteranPage = {
       labelHeaderLevel: '3',
       labels: aboutRelationship,
       errorMessages: {
-        required: 'Please select your relationship to the Veteran',
+        required: 'Select your relationship to the Veteran',
       },
       required: () => true,
     }),
     relationshipNotListed: {
-      'ui:title': `Please describe your relationship to the Veteran`,
+      'ui:title': `Describe your relationship to the Veteran`,
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'moreAboutYourRelationshipToVeteran',
@@ -25,7 +25,7 @@ const moreAboutYourRelationshipToVeteranPage = {
         expandedContentFocus: true,
       },
       'ui:errorMessages': {
-        required: `Please enter your relationship to the Veteran`,
+        required: `Enter your relationship to the Veteran`,
       },
     },
     'ui:options': {

--- a/src/applications/ask-va/config/chapters/personalInformation/relationshipToFamilyMember.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/relationshipToFamilyMember.js
@@ -12,12 +12,12 @@ const aboutYourRelationshipToFamilyMemberPage = {
       labelHeaderLevel: '3',
       labels: aboutFamilyMemberRelationship,
       errorMessages: {
-        required: 'Please select your relationship to the family member',
+        required: 'Select your relationship to the family member',
       },
       required: () => true,
     }),
     relationshipNotListed: {
-      'ui:title': `Please describe your relationship to the family member`,
+      'ui:title': `Describe your relationship to the family member`,
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'aboutYourRelationshipToFamilyMember',
@@ -25,7 +25,7 @@ const aboutYourRelationshipToFamilyMemberPage = {
         expandedContentFocus: true,
       },
       'ui:errorMessages': {
-        required: `Please enter your relationship to the family member`,
+        required: `Enter your relationship to the family member`,
       },
     },
     'ui:options': {

--- a/src/applications/ask-va/config/chapters/personalInformation/relationshipToVeteran.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/relationshipToVeteran.js
@@ -18,7 +18,7 @@ const relationshipToVeteranPage = {
       labels: relationshipOptionsSomeoneElse,
       required: () => true,
       errorMessages: {
-        required: 'Please select your relationship to the Veteran.',
+        required: 'Select your relationship to the Veteran.',
       },
     }),
     'ui:options': {

--- a/src/applications/ask-va/config/chapters/personalInformation/schoolInYourProfile.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/schoolInYourProfile.js
@@ -13,7 +13,7 @@ const schoolInYourProfilePage = {
     'ui:description': YourSchool,
     'ui:objectViewField': PageFieldSummary,
     useSchoolInProfile: radioUI({
-      title: 'Please select if you want to use the school in your profile',
+      title: 'Select if you want to use the school in your profile',
       labelHeaderLevel: '4',
       labels: schoolInYourProfileOptions,
     }),

--- a/src/applications/ask-va/config/chapters/personalInformation/searchSchools.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/searchSchools.js
@@ -11,7 +11,7 @@ const searchSchoolsPage = {
       }),
       'ui:widget': EducationFacilitySearch,
       'ui:errorMessages': {
-        required: 'Please select your school facility',
+        required: 'Select your school facility',
       },
     },
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/stateOfProperty.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/stateOfProperty.js
@@ -13,7 +13,7 @@ const stateOfPropertyPage = {
     stateOfProperty: selectUI({
       title: CHAPTER_3.STATE_OF_PROPERTY.QUESTION_1,
       errorMessages: {
-        required: 'Please select state of property',
+        required: 'Select state of property',
       },
     }),
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/stateOfSchool.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/stateOfSchool.js
@@ -9,7 +9,7 @@ const stateOfSchoolPage = {
       'ui:title': CHAPTER_3.STATE_OF_SCHOOL.QUESTION_1,
       'ui:widget': StateSelect,
       'ui:errorMessages': {
-        required: 'Please select school state',
+        required: 'Select school state',
       },
     },
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/theirRelationshipToVeteran.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/theirRelationshipToVeteran.js
@@ -12,7 +12,7 @@ const theirRelationshipToVeteranPage = {
       labelHeaderLevel: '3',
       labels: aboutTheirRelationshipToVet,
       errorMessages: {
-        required: 'Please select their relationship to the Veteran',
+        required: 'Select their relationship to the Veteran',
       },
     }),
     theyHaveRelationshipNotListed: {
@@ -24,7 +24,7 @@ const theirRelationshipToVeteranPage = {
         expandedContentFocus: true,
       },
       'ui:errorMessages': {
-        required: `Please enter their relationship to the Veteran`,
+        required: `Enter their relationship to the Veteran`,
       },
     },
     'ui:options': {

--- a/src/applications/ask-va/config/chapters/personalInformation/veteransLocationOfResidence.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/veteransLocationOfResidence.js
@@ -11,7 +11,7 @@ const veteransLocationOfResidencePage = {
     veteransLocationOfResidence: selectUI({
       title: CHAPTER_3.VETERAN_LOCATION_OF_RESIDENCE.QUESTION_1,
       errorMessages: {
-        required: 'Please select your location',
+        required: 'Select your location',
       },
     }),
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/veteransPostalCode.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/veteransPostalCode.js
@@ -12,9 +12,8 @@ const veteransPostalCodePage = {
       'ui:required': () => true,
       'ui:description': PostalCodeHint,
       'ui:errorMessages': {
-        required: 'Please enter a postal code',
-        pattern:
-          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+        required: 'Enter a postal code',
+        pattern: 'Enter a valid 5- or 9-digit postal code (dashes allowed)',
       },
     },
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/yourLocationOfResidence.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/yourLocationOfResidence.js
@@ -13,7 +13,7 @@ const yourLocationOfResidencePage = {
     yourLocationOfResidence: selectUI({
       title: CHAPTER_3.YOUR_LOCATION_OF_RESIDENCE.QUESTION_1,
       errorMessages: {
-        required: 'Please select your location of residence',
+        required: 'Select your location of residence',
       },
     }),
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/yourPostalCode.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/yourPostalCode.js
@@ -17,9 +17,8 @@ const yourPostalCodePage = {
       'ui:required': () => true,
       'ui:description': PostalCodeHint,
       'ui:errorMessages': {
-        required: 'Please enter a postal code',
-        pattern:
-          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+        required: 'Enter a postal code',
+        pattern: 'Enter a valid 5- or 9-digit postal code (dashes allowed)',
       },
     },
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/yourRole.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/yourRole.js
@@ -13,7 +13,7 @@ const yourRolePage = {
       labelHeaderLevel: '3',
       labels: yourRoleOptions,
       errorMessages: {
-        required: 'Please select your role',
+        required: 'Select your role',
       },
     }),
   },

--- a/src/applications/ask-va/config/chapters/personalInformation/yourRoleEducation.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/yourRoleEducation.js
@@ -13,7 +13,7 @@ const yourRoleEducationPage = {
       labelHeaderLevel: '3',
       labels: yourRoleOptionsEducation,
       errorMessages: {
-        required: 'Please select your role',
+        required: 'Select your role',
       },
     }),
   },

--- a/src/applications/ask-va/config/helpers.jsx
+++ b/src/applications/ask-va/config/helpers.jsx
@@ -36,8 +36,8 @@ export const ServerErrorAlert = () => (
       We’re sorry. Something went wrong on our end
     </h2>
     <p className="vads-u-font-size--base">
-      Please refresh this page or check back later. You can also sign out of
-      VA.gov and try signing back into this page.
+      Refresh this page or check back later. You can also sign out of VA.gov and
+      try signing back into this page.
     </p>
   </>
 );
@@ -710,7 +710,7 @@ export const getDescriptiveTextFromCRM = status => {
     case 'closed':
       return 'Closed.';
     case 'reference number not found':
-      return "No Results found. We could not locate an inquiry that matches your ID. Please check the number and re-enter. If you receive this message again, you can submit a new inquiry with your original question. Include your old inquiry number for reference and we'll work to get your question fully answered.";
+      return "No Results found. We could not locate an inquiry that matches your ID. Check the number and re-enter. If you receive this message again, you can submit a new inquiry with your original question. Include your old inquiry number for reference and we'll work to get your question fully answered.";
     default:
       return 'error';
   }

--- a/src/applications/ask-va/config/helpers.jsx
+++ b/src/applications/ask-va/config/helpers.jsx
@@ -704,7 +704,7 @@ export const getDescriptiveTextFromCRM = status => {
     case 'in progress':
       return 'Your inquiry is currently being reviewed by an agent.';
     case 'solved':
-      return 'Your inquiry has been closed. If you have additional questions open a new inquiry.';
+      return 'Your inquiry has been closed. If you have additional questions, open a new inquiry.';
     case 'reopened':
       return 'Your reply to this inquiry has been received, and the inquiry is currently being reviewed by an agent.';
     case 'closed':

--- a/src/applications/ask-va/config/helpers.jsx
+++ b/src/applications/ask-va/config/helpers.jsx
@@ -704,7 +704,7 @@ export const getDescriptiveTextFromCRM = status => {
     case 'in progress':
       return 'Your inquiry is currently being reviewed by an agent.';
     case 'solved':
-      return 'Your inquiry has been closed. If you have additional questions please open a new inquiry.';
+      return 'Your inquiry has been closed. If you have additional questions open a new inquiry.';
     case 'reopened':
       return 'Your reply to this inquiry has been received, and the inquiry is currently being reviewed by an agent.';
     case 'closed':

--- a/src/applications/ask-va/config/schema-helpers/personalInformationHelper.js
+++ b/src/applications/ask-va/config/schema-helpers/personalInformationHelper.js
@@ -41,9 +41,7 @@ export const validateSSandSNGroup = (errors, values, formData) => {
     ) &&
     !Object.keys(values).some(key => values[key])
   ) {
-    errors.addError(
-      `Please enter your Social Security number or Service number`,
-    );
+    errors.addError(`Enter your Social Security number or Service number`);
   }
 };
 
@@ -109,7 +107,7 @@ export const personalInformationAboutYourselfUiSchemas = {
     'ui:autocomplete': 'given-name',
     'ui:required': () => true,
     'ui:errorMessages': {
-      required: 'Please enter a first name',
+      required: 'Enter a first name',
       pattern: 'This field accepts alphabetic characters only',
     },
     'ui:options': {
@@ -133,7 +131,7 @@ export const personalInformationAboutYourselfUiSchemas = {
     'ui:autocomplete': 'family-name',
     'ui:required': () => true,
     'ui:errorMessages': {
-      required: 'Please enter a last name',
+      required: 'Enter a last name',
       pattern: 'This field accepts alphabetic characters only',
     },
     'ui:options': {
@@ -209,7 +207,7 @@ export const aboutYourselfGeneralUISchema = {
     'ui:autocomplete': 'given-name',
     'ui:required': () => true,
     'ui:errorMessages': {
-      required: 'Please enter a first name',
+      required: 'Enter a first name',
       pattern: 'This field accepts alphabetic characters only',
     },
     'ui:options': {
@@ -233,7 +231,7 @@ export const aboutYourselfGeneralUISchema = {
     'ui:autocomplete': 'family-name',
     'ui:required': () => true,
     'ui:errorMessages': {
-      required: 'Please enter a last name',
+      required: 'Enter a last name',
       pattern: 'This field accepts alphabetic characters only',
     },
     'ui:options': {

--- a/src/applications/ask-va/config/schema-helpers/personalInformationHelper.js
+++ b/src/applications/ask-va/config/schema-helpers/personalInformationHelper.js
@@ -23,7 +23,7 @@ const ssnServiceInfo = (
       <span className="form-required-span">(*Required)</span>
     </p>
     <span className="vads-u-margin-y--0 vads-u-font-size--sm medium-screen:vads-u-font-size--root">
-      Please provide one of the following:
+      Provide one of the following:
     </span>
   </div>
 );

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -413,7 +413,7 @@ export const CHAPTER_3 = {
   THEIR_RELATIONSHIP_TO_VET: {
     TITLE: 'What is their relationship to the Veteran?',
     PAGE_DESCRIPTION: '',
-    QUESTION_1: 'Please describe their relationship to the Veteran',
+    QUESTION_1: 'Describe their relationship to the Veteran',
   },
   ABOUT_THE_VET: {
     TITLE: 'Tell us about the Veteran',
@@ -496,7 +496,7 @@ export const CHAPTER_3 = {
     },
     QUESTION_2: {
       QUESTION: 'How should we contact you?',
-      ERROR: 'Please select your contact preference',
+      ERROR: 'Select your contact preference',
     },
   },
   YOUR_COUNTRY: {
@@ -559,7 +559,7 @@ export const CHAPTER_3 = {
     TITLE: 'School state or residency state',
     PAGE_DESCRIPTION: 'School or state of residency',
     QUESTION_1:
-      "Please provide your school state. If you don't have a school state, you can provide your residency state instead.",
+      "Provide your school state. If you don't have a school state, you can provide your residency state instead.",
   },
   VETERAN_LOCATION_OF_RESIDENCE: {
     TITLE: `Veteran's location of residence`,
@@ -595,31 +595,31 @@ export const CHAPTER_3 = {
   YOUR_VRE_INFORMATION: {
     TITLE:
       'Have you ever applied for Veteran Readiness and Employment benefits and services?',
-    ERROR: "Please select if you've applied for services.",
+    ERROR: "Select if you've applied for services.",
   },
   YOUR_VRE_COUNSELOR: {
     TITLE: 'Veteran Readiness and Employment counselor',
     DESCRIPTION: 'Name of your counselor:',
-    ERROR: 'Please enter the name of your counselor',
+    ERROR: 'Enter the name of your counselor',
   },
   THEIR_VRE_INFORMATION: {
     TITLE:
       'Have they ever applied for Veteran Readiness and Employment benefits and services?',
-    ERROR: "Please select if they've applied for services.",
+    ERROR: "Select if they've applied for services.",
   },
   THEIR_VRE_COUNSELOR: {
     TITLE: 'Veteran Readiness and Employment counselor',
     DESCRIPTION: 'Name of their counselor:',
-    ERROR: 'Please enter the name of their counselor',
+    ERROR: 'Enter the name of their counselor',
   },
   BRANCH_OF_SERVICE: {
     TITLE: 'Your branch of service',
     DESCRIPTION: 'Select your branch of service',
-    ERROR: 'Please select your branch of service',
+    ERROR: 'Select your branch of service',
   },
   VETERANS_BRANCH_OF_SERVICE: {
     TITLE: 'Branch of service',
-    ERROR: "Please select the Veteran's branch of service",
+    ERROR: "Select the Veteran's branch of service",
   },
 };
 

--- a/src/applications/ask-va/containers/CategorySelectPage.jsx
+++ b/src/applications/ask-va/containers/CategorySelectPage.jsx
@@ -34,7 +34,7 @@ const CategorySelectPage = props => {
       goForward(formData);
     }
     focusElement('va-select');
-    return setValidationError('Please select a category');
+    return setValidationError('Select a category');
   };
 
   const handleChange = event => {

--- a/src/applications/ask-va/containers/ResponseInboxPage.jsx
+++ b/src/applications/ask-va/containers/ResponseInboxPage.jsx
@@ -498,7 +498,7 @@ const ResponseInboxPage = ({ router }) => {
                   className="usa-link"
                   href={`${manifest.rootUrl}/introduction`}
                 >
-                  please ask a new question
+                  ask a new question
                 </a>
                 .
               </p>

--- a/src/applications/ask-va/containers/ResponseInboxPage.jsx
+++ b/src/applications/ask-va/containers/ResponseInboxPage.jsx
@@ -219,8 +219,8 @@ const ResponseInboxPage = ({ router }) => {
             We’ve run into a problem
           </h2>
           <p className="vads-u-font-size--base">
-            We’re sorry. Something went wrong on our end. Please try again later
-            or call us at <VaTelephone contact="800-698-2411" /> (
+            We’re sorry. Something went wrong on our end. Try again later or
+            call us at <VaTelephone contact="800-698-2411" /> (
             <VaTelephone contact="711" tty />
             ). We’re here 24/7.
           </p>

--- a/src/applications/ask-va/containers/SchoolStateOrResidencyStatePage.jsx
+++ b/src/applications/ask-va/containers/SchoolStateOrResidencyStatePage.jsx
@@ -75,8 +75,8 @@ const SchoolStateOrResidencyStateCustomPage = props => {
                 className="usa-input-error-message vads-u-margin-bottom--3"
                 id="root_subject-error-message"
               >
-                <span className="sr-only">Error</span> Please select school
-                state or residency state
+                <span className="sr-only">Error</span> Select school state or
+                residency state
               </span>
             )}
             <VaSelect

--- a/src/applications/ask-va/containers/SubTopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/SubTopicSelectPage.jsx
@@ -26,7 +26,7 @@ const SubTopicSelectPage = props => {
   const showError = data => {
     if (data.selectSubtopic) goForward(data);
     focusElement('va-radio');
-    return setValidationError('Please select a subtopic');
+    return setValidationError('Select a subtopic');
   };
 
   const handleChange = event => {

--- a/src/applications/ask-va/containers/TopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/TopicSelectPage.jsx
@@ -35,7 +35,7 @@ const TopicSelectPage = props => {
       goForward(formData);
     }
     focusElement('va-radio');
-    return setValidationError('Please select a topic');
+    return setValidationError('Select a topic');
   };
 
   const handleChange = event => {

--- a/src/applications/ask-va/containers/WhoIsYourQuestionAboutCustomPage.jsx
+++ b/src/applications/ask-va/containers/WhoIsYourQuestionAboutCustomPage.jsx
@@ -26,7 +26,7 @@ const WhoIsYourQuestionAboutCustomPage = props => {
       goForward(data);
     }
     focusElement('va-radio');
-    return setValidationError('Please select who your question is about');
+    return setValidationError('Select who your question is about');
   };
 
   const handleChange = event => {

--- a/src/applications/ask-va/containers/YourVAHealthFacility.jsx
+++ b/src/applications/ask-va/containers/YourVAHealthFacility.jsx
@@ -105,7 +105,7 @@ const YourVAHealthFacilityPage = props => {
     focusElement('va-radio');
     return setValidationError({
       ...validationError,
-      radioError: 'Please select a facility',
+      radioError: 'Select a facility',
     });
   };
 

--- a/src/applications/ask-va/tests/components/search/SearchControls.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/search/SearchControls.unit.spec.jsx
@@ -135,7 +135,7 @@ describe('SearchControls Component', () => {
 
     expect(wrapper.find('span.usa-input-error-message')).to.have.lengthOf(1);
     expect(wrapper.find('span.usa-input-error-message').text()).to.contain(
-      'Please fill in a city or facility name',
+      'Fill in a city or facility name',
     );
     wrapper.unmount();
   });

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/aboutTheFamilyMember.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/aboutTheFamilyMember.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('aboutTheFamilyMemberPage', () => {
       'They/them/theirs',
       'Ze/zir/zirs',
       'Use my preferred name',
-      'If not listed, please provide your preferred pronouns',
+      'If not listed, provide your preferred pronouns',
     ];
 
     expect($('h3', container).textContent).to.eq(

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/aboutTheVeteran.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/aboutTheVeteran.unit.spec.jsx
@@ -52,7 +52,7 @@ describe('aboutTheVeteranPage', () => {
       'They/them/theirs',
       'Ze/zir/zirs',
       'Use my preferred name',
-      'If not listed, please provide your preferred pronouns',
+      'If not listed, provide your preferred pronouns',
       'Man',
       'Non-binary',
       'Transgender man',

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/aboutTheVeteran.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/aboutTheVeteran.unit.spec.jsx
@@ -90,7 +90,7 @@ describe('aboutTheVeteranPage', () => {
           '.usa-input-error-message',
         );
         expect(errorMessage.textContent).to.contain(
-          "Please enter either the Veteran's Social Security number or Service number",
+          "Enter either the Veteran's Social Security number or Service number",
         );
       });
     });

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/moreAboutYourRelationshipToVeteran.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/moreAboutYourRelationshipToVeteran.unit.spec.jsx
@@ -99,7 +99,7 @@ describe('moreAboutYourRelationshipToVeteran', () => {
           'va-text-input[name="root_relationshipNotListed"]',
         );
         expect(textInput.getAttribute('error')).to.equal(
-          'Please enter your relationship to the Veteran',
+          'Enter your relationship to the Veteran',
         );
       });
     });

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/relationshipToFamilyMember.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/relationshipToFamilyMember.unit.spec.jsx
@@ -99,7 +99,7 @@ describe('relationshipToFamilyMemberPage', () => {
           'va-text-input[name="root_relationshipNotListed"]',
         );
         expect(textInput.getAttribute('error')).to.equal(
-          'Please enter your relationship to the family member',
+          'Enter your relationship to the family member',
         );
       });
     });

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/relationshipToVeteran.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/relationshipToVeteran.unit.spec.jsx
@@ -94,7 +94,7 @@ describe('relationshipToVeteranPage', () => {
       await waitFor(() => {
         const vaRadio = container.querySelector('va-radio');
         expect(vaRadio.getAttribute('error')).to.equal(
-          'Please select your relationship to the Veteran.',
+          'Select your relationship to the Veteran.',
         );
       });
     });

--- a/src/applications/ask-va/tests/config/chapters/personalInformation/theirRelationshipToVeteran.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/chapters/personalInformation/theirRelationshipToVeteran.unit.spec.jsx
@@ -92,7 +92,7 @@ describe('theirRelationshipToVeteranPage', () => {
       const textInput = container.querySelector('va-text-input');
       expect(textInput).to.exist;
       expect(textInput.getAttribute('label')).to.equal(
-        'Please describe their relationship to the Veteran',
+        'Describe their relationship to the Veteran',
       );
     });
 

--- a/src/applications/ask-va/tests/config/helpers.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/helpers.unit.spec.jsx
@@ -634,7 +634,7 @@ describe('Components and Utility Functions', () => {
       new: 'Your inquiry is current in queue to be reviewed.',
       'in progress': 'Your inquiry is currently being reviewed by an agent.',
       solved:
-        'Your inquiry has been closed. If you have additional questions please open a new inquiry.',
+        'Your inquiry has been closed. If you have additional questions open a new inquiry.',
       reopened:
         'Your reply to this inquiry has been received, and the inquiry is currently being reviewed by an agent.',
       closed: 'Closed.',

--- a/src/applications/ask-va/tests/config/helpers.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/helpers.unit.spec.jsx
@@ -634,7 +634,7 @@ describe('Components and Utility Functions', () => {
       new: 'Your inquiry is current in queue to be reviewed.',
       'in progress': 'Your inquiry is currently being reviewed by an agent.',
       solved:
-        'Your inquiry has been closed. If you have additional questions open a new inquiry.',
+        'Your inquiry has been closed. If you have additional questions, open a new inquiry.',
       reopened:
         'Your reply to this inquiry has been received, and the inquiry is currently being reviewed by an agent.',
       closed: 'Closed.',

--- a/src/applications/ask-va/tests/config/helpers.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/helpers.unit.spec.jsx
@@ -639,7 +639,7 @@ describe('Components and Utility Functions', () => {
         'Your reply to this inquiry has been received, and the inquiry is currently being reviewed by an agent.',
       closed: 'Closed.',
       'reference number not found':
-        "No Results found. We could not locate an inquiry that matches your ID. Please check the number and re-enter. If you receive this message again, you can submit a new inquiry with your original question. Include your old inquiry number for reference and we'll work to get your question fully answered.",
+        "No Results found. We could not locate an inquiry that matches your ID. Check the number and re-enter. If you receive this message again, you can submit a new inquiry with your original question. Include your old inquiry number for reference and we'll work to get your question fully answered.",
       'ANY OTHER VALUE': 'error',
     };
     it('returns proper descriptive text', () => {

--- a/src/applications/ask-va/tests/config/schema-helpers/personalInformationHelper.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/schema-helpers/personalInformationHelper.unit.spec.jsx
@@ -160,7 +160,7 @@ describe('Personal Information UI Schemas', () => {
         '(*Required)',
       );
       expect(wrapper.find('.vads-u-margin-y--0').text()).to.equal(
-        'Please provide one of the following:',
+        'Provide one of the following:',
       );
       wrapper.unmount();
     });

--- a/src/applications/ask-va/tests/containers/CategorySelectPage.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/CategorySelectPage.unit.spec.jsx
@@ -139,9 +139,8 @@ describe('<CategorySelect /> component', () => {
     userEvent.click(getByText('Continue'));
 
     await waitFor(() => {
-      expect(
-        container.querySelector('va-select[error="Please select a category"]'),
-      ).to.exist;
+      expect(container.querySelector('va-select[error="Select a category"]')).to
+        .exist;
     });
   });
 

--- a/src/applications/ask-va/tests/containers/SubtopicSelectPage.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/SubtopicSelectPage.unit.spec.jsx
@@ -187,9 +187,7 @@ describe('<SubtopicSelect /> component', () => {
 
       await waitFor(() => {
         const radio = container.querySelector('va-radio');
-        expect(radio.getAttribute('error')).to.equal(
-          'Please select a subtopic',
-        );
+        expect(radio.getAttribute('error')).to.equal('Select a subtopic');
       });
     });
 

--- a/src/applications/ask-va/tests/containers/TopicSelectPage.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/TopicSelectPage.unit.spec.jsx
@@ -195,7 +195,7 @@ describe('<TopicSelect /> component', () => {
 
       await waitFor(() => {
         const radio = container.querySelector('va-radio');
-        expect(radio.getAttribute('error')).to.equal('Please select a topic');
+        expect(radio.getAttribute('error')).to.equal('Select a topic');
       });
     });
 

--- a/src/applications/ask-va/tests/containers/WhoIsYourQuestionAboutCustomPage.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/WhoIsYourQuestionAboutCustomPage.unit.spec.jsx
@@ -190,7 +190,7 @@ describe('WhoIsYourQuestionAboutCustomPage', () => {
       await waitFor(() => {
         const radio = container.querySelector('va-radio');
         expect(radio.getAttribute('error')).to.equal(
-          'Please select who your question is about',
+          'Select who your question is about',
         );
       });
     });

--- a/src/applications/ask-va/tests/containers/YourVAHealthFacility.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/YourVAHealthFacility.unit.spec.jsx
@@ -258,7 +258,7 @@ describe('YourVAHealthFacilityPage', () => {
 
     userEvent.click(getByRole('button', { name: /continue/i }));
     await waitFor(() => {
-      expect(getByText(/please fill in a city or facility name/i)).to.exist;
+      expect(getByText(/fill in a city or facility name/i)).to.exist;
     });
   });
 

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-select-category.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-select-category.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select a category
+    value: Select a category

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-select-subtopic.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-select-subtopic.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select a subtopic
+    value: Select a subtopic

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-select-topic.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-select-topic.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select a topic
+    value: Select a topic

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-tell-us-about-yourself.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-tell-us-about-yourself.yml
@@ -11,7 +11,7 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please enter a first name
+    value: Enter a first name
   - action: exists
     target: error
-    value: Please enter a last name
+    value: Enter a last name

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-what-is-your-relationship-to-the-veteran.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-what-is-your-relationship-to-the-veteran.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select your relationship to the Veteran.
+    value: Select your relationship to the Veteran.

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-who-is-your-question-about.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-who-is-your-question-about.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select who your question is about
+    value: Select who your question is about

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-branch-of-service.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-branch-of-service.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select your branch of service
+    value: Select your branch of service

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-contact-information-radio-buttons.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-contact-information-radio-buttons.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please select your contact preference
+    value: Select your contact preference

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-contact-information.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-contact-information.yml
@@ -11,7 +11,7 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Please enter a 10-digit phone number (with or without dashes)
+    value: Enter a 10-digit phone number (with or without dashes)
   - action: exists
     target: error
     value: 'Enter a valid email address without spaces using this format: email@domain.com'

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-contact-information.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-contact-information.yml
@@ -11,7 +11,7 @@ steps:
     target: call-to-action
   - action: exists
     target: error
-    value: Enter a 10-digit phone number (with or without dashes)
+    value: Please enter a 10-digit phone number (with or without dashes)
   - action: exists
     target: error
     value: 'Enter a valid email address without spaces using this format: email@domain.com'

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-school-state-and-residency-state.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/forms/include-pages/sad-your-school-state-and-residency-state.yml
@@ -11,4 +11,4 @@ steps:
     target: call-to-action
   - action: exists
     target: errorInput
-    value: Please select school state or residency state
+    value: Select school state or residency state

--- a/src/applications/ask-va/tests/fixtures/data/form-data-review.js
+++ b/src/applications/ask-va/tests/fixtures/data/form-data-review.js
@@ -240,7 +240,7 @@ export const mockData = {
             question: {
               'ui:title': "What's your question?",
               'ui:errorMessages': {
-                required: 'Please let us know what your question is about.',
+                required: 'Let us know what your question is about.',
               },
               'ui:options': {
                 required: true,
@@ -317,7 +317,7 @@ export const mockData = {
               question: {
                 'ui:title': "What's your question?",
                 'ui:errorMessages': {
-                  required: 'Please let us know what your question is about.',
+                  required: 'Let us know what your question is about.',
                 },
                 'ui:options': {
                   required: true,
@@ -393,7 +393,7 @@ export const mockData = {
               question: {
                 'ui:title': "What's your question?",
                 'ui:errorMessages': {
-                  required: 'Please let us know what your question is about.',
+                  required: 'Let us know what your question is about.',
                 },
                 'ui:options': {
                   required: true,

--- a/src/applications/ask-va/tests/fixtures/data/reviewPageQuestionCollapsible.js
+++ b/src/applications/ask-va/tests/fixtures/data/reviewPageQuestionCollapsible.js
@@ -25,7 +25,7 @@ export const chapterFormConfig = {
         question: {
           'ui:title': "What's your question?",
           'ui:errorMessages': {
-            required: 'Please let us know what your question is about.',
+            required: 'Let us know what your question is about.',
           },
           'ui:options': {
             required: true,
@@ -101,7 +101,7 @@ export const chapterFormConfig = {
         question: {
           'ui:title': "What's your question?",
           'ui:errorMessages': {
-            required: 'Please let us know what your question is about.',
+            required: 'Let us know what your question is about.',
           },
           'ui:options': {
             required: true,
@@ -317,7 +317,7 @@ export const expandedPages = [
       question: {
         'ui:title': "What's your question?",
         'ui:errorMessages': {
-          required: 'Please let us know what your question is about.',
+          required: 'Let us know what your question is about.',
         },
         'ui:options': {
           required: true,
@@ -550,7 +550,7 @@ const pages = {
       question: {
         'ui:title': "What's your question?",
         'ui:errorMessages': {
-          required: 'Please let us know what your question is about.',
+          required: 'Let us know what your question is about.',
         },
         'ui:options': {
           required: true,


### PR DESCRIPTION
# Overview

Removes the word "please" from Ask VA and adjusts sentences accordingly.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed the word "please" from Ask VA to comply with content guidance
- Ask VA owns all this code

## Related issue(s)

- Closes department-of-veterans-affairs/ask-va/issues/2127
- Closes department-of-veterans-affairs/ask-va/issues/2145
- Closes department-of-veterans-affairs/ask-va/issues/2146

## Testing done

- Tests have not been changed, except for removing "please" from a few strings
- Tests are still passing; confirm with:
  - `yarn cy:run --spec "src/applications/ask-va/tests/e2e/run-yaml-tests.cypress.spec.js"`
  - `yarn test:unit src/applications/ask-va/tests/{containers,components,utils}/**/*.unit.spec.jsx`

## What areas of the site does it impact?

Only Ask VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user