### PR TITLE
Refactor scheduleCerner Page & eligibility alerts

### DIFF
--- a/src/applications/vaos/new-appointment/components/ScheduleCernerPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/ScheduleCernerPageV2.jsx
@@ -1,14 +1,13 @@
-import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
-import { getCernerURL } from 'platform/utilities/cerner';
 import React, { useEffect } from 'react';
+import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import FacilityPhone from '../../components/FacilityPhone';
-import NewTabAnchor from '../../components/NewTabAnchor';
-import { TYPE_OF_CARE_IDS } from '../../utils/constants';
+import { selectFeatureUseVpg } from '../../redux/selectors';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 import { routeToPreviousAppointmentPage } from '../redux/actions';
 import { getChosenFacilityInfo, selectTypeOfCare } from '../redux/selectors';
+import ScheduleCernerPage from './ScheduleCernerPage';
 
 const pageKey = 'scheduleCerner';
 
@@ -16,47 +15,28 @@ export default function ScheduleCernerPageV2() {
   const dispatch = useDispatch();
   const facility = useSelector(getChosenFacilityInfo);
   const typeOfCare = useSelector(selectTypeOfCare);
+  const featureUseVpg = useSelector(selectFeatureUseVpg);
 
   const history = useHistory();
   const pageTitle = 'You can’t schedule this appointment online';
   const phone = facility?.telecom?.find(tele => tele.system === 'phone')?.value;
-
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
   }, []);
 
-  return (
+  return !featureUseVpg ? (
+    <ScheduleCernerPage />
+  ) : (
     <>
       <h1>{pageTitle}</h1>
       <p>
-        To schedule an appointment, you’ll need to contact {facility?.name}:
+        To schedule an appointment for {typeOfCare?.name.toLowerCase()}, you’ll
+        need to contact {facility?.name}:
       </p>
       <p>
         <FacilityPhone contact={phone} />
       </p>
-      {(TYPE_OF_CARE_IDS.PHARMACY_ID === typeOfCare?.id ||
-        TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID === typeOfCare?.id) && (
-        <>
-          <p>
-            You can also access tools to schedule appointments online in the My
-            VA Health portal.
-            <br />
-            <NewTabAnchor href={getCernerURL('/pages/scheduling/upcoming')}>
-              Go to My VA Health (opens in a new tab)
-            </NewTabAnchor>
-          </p>
-        </>
-      )}
-      <va-additional-info
-        trigger="Why can't I schedule online?"
-        uswds
-        data-testid="additional-info"
-      >
-        <p className="vads-u-margin-top--0">
-          {`This facility doesn't support online scheduling for ${typeOfCare?.name.toLowerCase()}.`}
-        </p>
-      </va-additional-info>
       <p>
         <ProgressButton
           onButtonClick={() =>

--- a/src/applications/vaos/new-appointment/components/ScheduleCernerPageV2.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ScheduleCernerPageV2.unit.spec.jsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import { expect } from 'chai';
+import userEvent from '@testing-library/user-event';
+import Sinon from 'sinon';
+import {
+  createTestStore,
+  renderWithStoreAndRouter,
+} from '../../tests/mocks/setup';
+import { TYPE_OF_CARE_IDS } from '../../utils/constants';
+import ScheduleCernerPageV2 from './ScheduleCernerPageV2';
+import { Facility } from '../../tests/mocks/unit-test-helpers';
+
+describe('VAOS Page: ScheduleCernerPageV2', () => {
+  const sandbox = Sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('when featureUseVpg is false', () => {
+    it('should render ScheduleCernerPage (legacy)', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: false,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
+            vaFacility: '983',
+          },
+          facilities: {
+            '323': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      // Assert - Should show legacy "How to schedule" page
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: 'How to schedule',
+        }),
+      ).to.be.ok;
+      expect(
+        screen.getByText(
+          /To schedule an appointment online at this facility, go to/i,
+        ),
+      ).to.be.ok;
+      expect(screen.getByRole('link', { name: /My VA Health/i })).to.be.ok;
+    });
+  });
+
+  describe('when featureUseVpg is true', () => {
+    it('should display "You can\'t schedule this appointment online" heading', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: true,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
+            vaFacility: '983',
+          },
+          facilities: {
+            '323': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /You can’t schedule this appointment online/i,
+        }),
+      ).to.be.ok;
+    });
+
+    it('should display type of care and facility name in the message', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: true,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
+            vaFacility: '983',
+          },
+          facilities: {
+            '323': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      // Assert
+      expect(screen.getByText(/To schedule an appointment for primary care/i))
+        .to.be.ok;
+      expect(screen.getByText(/Cheyenne VA Medical Center/i)).to.be.ok;
+    });
+
+    it('should display facility phone number', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: true,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
+            vaFacility: '983',
+          },
+          facilities: {
+            '323': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      // Assert - Check for phone component
+      expect(screen.getByTestId('facility-telephone')).to.be.ok;
+    });
+
+    it('should navigate back when Back button is clicked', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: true,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
+            vaFacility: '983',
+          },
+          facilities: {
+            '323': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+      const dispatchStub = sandbox.stub(store, 'dispatch');
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      const button = screen.getByRole('button', { name: /Back/i });
+      userEvent.click(button);
+
+      // Assert
+      Sinon.assert.calledOnce(dispatchStub);
+    });
+
+    it('should display correct message for Pharmacy type of care', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: true,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.PHARMACY_ID,
+            vaFacility: '983',
+          },
+          facilities: {
+            '160': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      // Assert
+      expect(screen.getByText(/To schedule an appointment for pharmacy/i)).to.be
+        .ok;
+    });
+
+    it('should display correct message for Food and Nutrition type of care', async () => {
+      // Arrange
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingUseVpg: true,
+        },
+        newAppointment: {
+          data: {
+            typeOfCareId: TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID,
+            vaFacility: '983',
+          },
+          facilities: {
+            '123': [new Facility('983')],
+          },
+        },
+      };
+      const store = createTestStore(initialState);
+
+      // Act
+      const screen = renderWithStoreAndRouter(<ScheduleCernerPageV2 />, {
+        store,
+      });
+
+      // Assert
+      expect(
+        screen.getByText(/To schedule an appointment for nutrition and food/i),
+      ).to.be.ok;
+    });
+  });
+});

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
@@ -13,6 +13,7 @@ export default function getEligibilityMessage({
 
   const requestReason = eligibility.requestReasons[0];
   const directReason = eligibility.directReasons[0];
+  const requestDisabled = !eligibility.request;
 
   if (
     (requestReason === ELIGIBILITY_REASONS.notSupported &&
@@ -32,7 +33,7 @@ export default function getEligibilityMessage({
       </>
     );
   } else if (
-    requestReason === ELIGIBILITY_REASONS.notSupported &&
+    (requestReason === ELIGIBILITY_REASONS.notSupported || requestDisabled) &&
     (directReason === ELIGIBILITY_REASONS.noClinics ||
       directReason === ELIGIBILITY_REASONS.noMatchingClinics)
   ) {

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.unit.spec.jsx
@@ -1,0 +1,285 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { ELIGIBILITY_REASONS } from '../../../utils/constants';
+import getEligibilityMessage from './getEligibilityMessage';
+
+describe('VAOS Component: getEligibilityMessage', () => {
+  const facilityDetails = {
+    id: '983',
+    name: 'Cheyenne VA Medical Center',
+    telecom: [{ system: 'phone', value: '307-778-7550' }],
+  };
+
+  describe('noRecentVisit scenarios', () => {
+    it('should return correct message when requestReason is noRecentVisit', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.noRecentVisit],
+        directReasons: [],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(/You can.t schedule an appointment online/);
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(/You haven.t had a recent appointment at this facility/i),
+      ).to.exist;
+      expect(getByText(/Or you can choose a different facility/i)).to.exist;
+    });
+
+    it('should return correct message when requestReason is notSupported and directReason is noRecentVisit', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.notSupported],
+        directReasons: [ELIGIBILITY_REASONS.noRecentVisit],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(/You can.t schedule an appointment online/);
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(/You haven.t had a recent appointment at this facility/i),
+      ).to.exist;
+    });
+  });
+
+  describe('noClinics and noMatchingClinics scenarios', () => {
+    it('should return correct message when requestReason is notSupported and directReason is noClinics', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.notSupported],
+        directReasons: [ELIGIBILITY_REASONS.noClinics],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule this appointment online/,
+      );
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(
+          /We couldn.t find any open appointment times for online scheduling/i,
+        ),
+      ).to.exist;
+      expect(getByText(/You.ll need to call the facility to schedule/i)).to
+        .exist;
+      expect(getByText(/Or you can go back and choose a different facility/i))
+        .to.exist;
+    });
+
+    it('should return correct message when requestReason is notSupported and directReason is noMatchingClinics', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.notSupported],
+        directReasons: [ELIGIBILITY_REASONS.noMatchingClinics],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule this appointment online/,
+      );
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(
+          /We couldn.t find any open appointment times for online scheduling/i,
+        ),
+      ).to.exist;
+    });
+
+    it('should return correct message when request is disabled and directReason is noClinics', () => {
+      const eligibility = {
+        request: false,
+        requestReasons: [],
+        directReasons: [ELIGIBILITY_REASONS.noClinics],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule this appointment online/,
+      );
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(
+          /We couldn.t find any open appointment times for online scheduling/i,
+        ),
+      ).to.exist;
+    });
+
+    it('should return correct message when request is disabled and directReason is noMatchingClinics', () => {
+      const eligibility = {
+        request: false,
+        requestReasons: [],
+        directReasons: [ELIGIBILITY_REASONS.noMatchingClinics],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule this appointment online/,
+      );
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(
+          /We couldn.t find any open appointment times for online scheduling/i,
+        ),
+      ).to.exist;
+    });
+  });
+
+  describe('error scenarios', () => {
+    it('should return error message when directReason is error', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [],
+        directReasons: [ELIGIBILITY_REASONS.error],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule an appointment online right now/,
+      );
+      expect(result.content).to.match(
+        /We.re sorry\. There.s a problem with our system\. Try again later\./,
+      );
+      expect(result.status).to.equal('error');
+    });
+
+    it('should return error message when requestReason is error', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.error],
+        directReasons: [],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule an appointment online right now/,
+      );
+      expect(result.content).to.match(
+        /We.re sorry\. There.s a problem with our system\. Try again later\./,
+      );
+      expect(result.status).to.equal('error');
+    });
+  });
+
+  describe('notSupported scenarios', () => {
+    it('should return correct message when requestReason is notSupported (without noRecentVisit or noClinics)', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.notSupported],
+        directReasons: [ELIGIBILITY_REASONS.notEnabled],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /This facility doesn.t accept online scheduling for this care/,
+      );
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(
+        getByText(
+          /You.ll need to call your VA health facility to schedule this appointment/i,
+        ),
+      ).to.exist;
+    });
+  });
+
+  describe('overRequestLimit scenarios', () => {
+    it('should return correct message when requestReason is overRequestLimit', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.overRequestLimit],
+        directReasons: [],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+
+      expect(result.title).to.match(
+        /You can.t schedule this appointment online/,
+      );
+      expect(result.status).to.not.equal('error');
+
+      const { getByText } = render(<>{result.content}</>);
+      expect(getByText(/You.ll need to call to schedule at this facility/i)).to
+        .exist;
+      expect(getByText(/Or you can choose a different facility/i)).to.exist;
+    });
+  });
+
+  describe('FacilityDetails rendering', () => {
+    it('should render facility details in noRecentVisit message', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.noRecentVisit],
+        directReasons: [],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+      const { getByText } = render(<>{result.content}</>);
+
+      expect(getByText('Cheyenne VA Medical Center')).to.exist;
+    });
+
+    it('should render facility details in noClinics message', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.notSupported],
+        directReasons: [ELIGIBILITY_REASONS.noClinics],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+      const { getByText } = render(<>{result.content}</>);
+
+      expect(getByText('Cheyenne VA Medical Center')).to.exist;
+    });
+
+    it('should render facility details in overRequestLimit message', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.overRequestLimit],
+        directReasons: [],
+      };
+
+      const result = getEligibilityMessage({ eligibility, facilityDetails });
+      const { getByText } = render(<>{result.content}</>);
+
+      expect(getByText('Cheyenne VA Medical Center')).to.exist;
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error when no matching eligibility reason is found', () => {
+      const eligibility = {
+        request: true,
+        requestReasons: [ELIGIBILITY_REASONS.notEnabled],
+        directReasons: [ELIGIBILITY_REASONS.notEnabled],
+      };
+
+      expect(() =>
+        getEligibilityMessage({ eligibility, facilityDetails }),
+      ).to.throw('Missing eligibility display reason');
+    });
+  });
+});

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.unit.spec.jsx
@@ -529,6 +529,166 @@ describe('VAOS newAppointmentFlow', () => {
         expect(nextState).to.equal('selectProvider');
       });
 
+      it('should show eligibility modal when Cerner facility is selected, VPG is enabled and type of care is foodAndNutrition but patient is not eligible', async () => {
+        mockFetch();
+
+        const state = {
+          featureToggles: {
+            ...defaultState.featureToggles,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingUseVpg: true,
+          },
+          user: {
+            profile: {
+              facilities: [
+                {
+                  facilityId: '983',
+                  isCerner: false,
+                },
+                {
+                  facilityId: '692',
+                  isCerner: false,
+                },
+              ],
+            },
+          },
+          drupalStaticData: {
+            vamcEhrData: {
+              loading: false,
+              data: {
+                ehrDataByVhaId: {
+                  692: {
+                    vhaId: '692',
+                    vamcFacilityName: 'White City VA Medical Center',
+                    vamcSystemName: 'VA Southern Oregon health care',
+                    ehr: 'cerner',
+                  },
+                },
+                cernerFacilities: [
+                  {
+                    vhaId: '692',
+                    vamcFacilityName: 'White City VA Medical Center',
+                    vamcSystemName: 'VA Southern Oregon health care',
+                    ehr: 'cerner',
+                  },
+                ],
+                vistaFacilities: [],
+              },
+            },
+          },
+
+          newAppointment: {
+            data: {
+              vaFacility: '692',
+              typeOfCareId: TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID,
+            },
+            facilities: {
+              123: [
+                {
+                  id: '692',
+                },
+              ],
+            },
+            eligibility: {
+              '692_123': {
+                direct: false,
+                request: false,
+              },
+            },
+          },
+        };
+        const dispatch = sinon.spy();
+
+        const nextState = await getNewAppointmentFlow(state).vaFacilityV2.next(
+          state,
+          dispatch,
+        );
+
+        // Should show eligibility modal and stay on vaFacilityV2
+        expect(dispatch.called).to.be.true;
+        expect(nextState).to.equal('vaFacilityV2');
+      });
+
+      it('should show eligibility modal when Cerner facility is selected, VPG is enabled and Type of care is Pharmacy but patient is not eligible', async () => {
+        mockFetch();
+
+        const state = {
+          featureToggles: {
+            ...defaultState.featureToggles,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingUseVpg: true,
+          },
+          user: {
+            profile: {
+              facilities: [
+                {
+                  facilityId: '983',
+                  isCerner: false,
+                },
+                {
+                  facilityId: '692',
+                  isCerner: false,
+                },
+              ],
+            },
+          },
+          drupalStaticData: {
+            vamcEhrData: {
+              loading: false,
+              data: {
+                ehrDataByVhaId: {
+                  692: {
+                    vhaId: '692',
+                    vamcFacilityName: 'White City VA Medical Center',
+                    vamcSystemName: 'VA Southern Oregon health care',
+                    ehr: 'cerner',
+                  },
+                },
+                cernerFacilities: [
+                  {
+                    vhaId: '692',
+                    vamcFacilityName: 'White City VA Medical Center',
+                    vamcSystemName: 'VA Southern Oregon health care',
+                    ehr: 'cerner',
+                  },
+                ],
+                vistaFacilities: [],
+              },
+            },
+          },
+
+          newAppointment: {
+            data: {
+              vaFacility: '692',
+              typeOfCareId: TYPE_OF_CARE_IDS.PHARMACY_ID,
+            },
+            facilities: {
+              160: [
+                {
+                  id: '692',
+                },
+              ],
+            },
+            eligibility: {
+              '692_160': {
+                direct: false,
+                request: false,
+              },
+            },
+          },
+        };
+        const dispatch = sinon.spy();
+
+        const nextState = await getNewAppointmentFlow(state).vaFacilityV2.next(
+          state,
+          dispatch,
+        );
+
+        // Should show eligibility modal and stay on vaFacilityV2
+        expect(dispatch.called).to.be.true;
+        expect(nextState).to.equal('vaFacilityV2');
+      });
+
       it('should be clinicChoice page if eligible', async () => {
         mockFetch();
         const state = {


### PR DESCRIPTION
## Summary
- This PR updates the eligibility checks when the VPG flag is enabled for Oracle Health-enabled types of care (Clinical Pharmacy Primary Care and Food & Nutrition).

## Related issue(s)
- When a veteran selects a Cerner facility with VPG enabled for an OH-enabled type of care, but is NOT eligible for direct scheduling or appointment requests, the flow now shows an eligibility modal instead of routing to the ScheduleCernerPage.
- This ensures veterans see appropriate messaging about why they can't schedule online.


## Testing done
- Added 2 new e2e tests for Pharmacy and Food & Nutrition ineligibility scenarios.
- Added 2 new tests in `newAppointmentFlow.unit.spec.jsx` covering Cerner + VPG + not eligible scenarios.
- Added `ScheduleCernerPageV2.unit.spec.jsx` with tests covering component rendering with/without VPG.
- Added `getEligibilityMessage.unit.spec.jsx` with tests covering all eligibility message scenarios.


### Quality Assurance & Testing

- I went over the different scenario(s) in my local env with Peter.

- Updated the cerner alert to add the **type of care**, take out the VA Health link and dropdown.

<img width="1474" height="1430" alt="Screenshot 2026-02-09 at 9 50 00 PM" src="https://github.com/user-attachments/assets/ab5bbc3d-b683-4949-8087-fc7630b28391" />

