### PR TITLE
10-10EZ | Apply fix for Intro page loop

### DIFF
--- a/src/applications/hca/config/prefill-transformer.js
+++ b/src/applications/hca/config/prefill-transformer.js
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { isInMPI, selectProfile } from 'platform/user/selectors';
+import { isInMPI, isLoggedIn, selectProfile } from 'platform/user/selectors';
 import set from 'platform/utilities/data/set';
 import { FULL_SCHEMA } from '../utils/imports';
 import { validateDateOfBirth } from '../utils/validation';
@@ -93,6 +93,9 @@ export const prefillTransformer = (pages, formData, metadata, state) => {
   const parsedAddressMatch =
     veteranAddress && veteranHomeAddress ? hasAddressMatch : undefined;
   let dataToReturn = formData;
+
+  const isUserLoggedIn = isLoggedIn(state) || false;
+  dataToReturn = set('view:isLoggedIn', isUserLoggedIn, dataToReturn);
 
   if (isInMPI(state)) {
     dataToReturn = set('view:isUserInMvi', true, dataToReturn);

--- a/src/applications/hca/containers/IdentityPage.jsx
+++ b/src/applications/hca/containers/IdentityPage.jsx
@@ -71,8 +71,16 @@ const IdentityPage = ({ location, route, router }) => {
    */
   useEffect(
     () => {
-      if (loggedIn) router.push('/');
-      else dispatch(resetEnrollmentStatus());
+      if (loggedIn) {
+        const nextPage = getNextPagePath(
+          route.pageList,
+          formData,
+          location.pathname,
+        );
+        router.push(nextPage || '/');
+      } else {
+        dispatch(resetEnrollmentStatus());
+      }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [loggedIn],

--- a/src/applications/hca/containers/IdentityPage.jsx
+++ b/src/applications/hca/containers/IdentityPage.jsx
@@ -66,8 +66,8 @@ const IdentityPage = ({ location, route, router }) => {
   );
 
   /**
-   * reset enrollment status data on when first loading the page if user is
-   * not logged in, else redirect to introduction page
+   * reset enrollment status data when first loading the page if user is
+   * not logged in, else redirect to the next valid page for logged-in users
    */
   useEffect(
     () => {

--- a/src/applications/hca/tests/unit/config/prefill-transformer.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/config/prefill-transformer.unit.spec.jsx
@@ -95,8 +95,8 @@ describe('hca `prefillTransformer` utility', () => {
   it('should return correct form data when profile data omits all addresses', () => {
     const prefillData = getData();
     expect(Object.keys(prefillData)).to.have.lengthOf(16);
-    expect(Object.keys(prefillData).veteranAddress).to.not.exist;
-    expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
+    expect(prefillData.veteranAddress).to.not.exist;
+    expect(prefillData.veteranHomeAddress).to.not.exist;
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(undefined);
   });
 
@@ -109,7 +109,7 @@ describe('hca `prefillTransformer` utility', () => {
   it('should return correct form data when profile data omits mailing address', () => {
     const prefillData = getData({ residentialAddress });
     expect(Object.keys(prefillData)).to.have.lengthOf(17);
-    expect(prefillData.veteranAddress).to.equal(undefined);
+    expect(prefillData.veteranHomeAddress).to.exist;
     expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(7);
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(undefined);
   });
@@ -117,7 +117,9 @@ describe('hca `prefillTransformer` utility', () => {
   it('should return correct form data when profile data includes mailing address that does not match residential address', () => {
     const prefillData = getData({ residentialAddress, mailingAddress });
     expect(Object.keys(prefillData)).to.have.lengthOf(18);
+    expect(prefillData.veteranAddress).to.exist;
     expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(7);
+    expect(prefillData.veteranHomeAddress).to.exist;
     expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(7);
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.false;
   });
@@ -128,7 +130,8 @@ describe('hca `prefillTransformer` utility', () => {
       mailingAddress: residentialAddress,
     });
     expect(Object.keys(prefillData)).to.have.lengthOf(17);
-    expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
+    expect(prefillData.veteranHomeAddress).to.not.exist;
+    expect(prefillData.veteranAddress).to.exist;
     expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(7);
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.true;
   });

--- a/src/applications/hca/tests/unit/config/prefill-transformer.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/config/prefill-transformer.unit.spec.jsx
@@ -23,6 +23,7 @@ describe('hca `prefillTransformer` utility', () => {
     residentialAddress = null,
     mailingAddress = null,
     status = null,
+    loggedIn = false,
     prefillData = defaultPrefillData,
   } = {}) => {
     const state = {
@@ -33,6 +34,9 @@ describe('hca `prefillTransformer` utility', () => {
             mailingAddress,
           },
           status,
+        },
+        login: {
+          currentlyLoggedIn: loggedIn,
         },
       },
     };
@@ -90,7 +94,7 @@ describe('hca `prefillTransformer` utility', () => {
 
   it('should return correct form data when profile data omits all addresses', () => {
     const prefillData = getData();
-    expect(Object.keys(prefillData)).to.have.lengthOf(15);
+    expect(Object.keys(prefillData)).to.have.lengthOf(16);
     expect(Object.keys(prefillData).veteranAddress).to.not.exist;
     expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(undefined);
@@ -98,13 +102,13 @@ describe('hca `prefillTransformer` utility', () => {
 
   it('should return correct form data when user record is located in MPI', () => {
     const prefillData = getData({ status: 'OK' });
-    expect(Object.keys(prefillData)).to.have.lengthOf(16);
+    expect(Object.keys(prefillData)).to.have.lengthOf(17);
     expect(prefillData['view:isUserInMvi']).to.be.true;
   });
 
   it('should return correct form data when profile data omits mailing address', () => {
     const prefillData = getData({ residentialAddress });
-    expect(Object.keys(prefillData)).to.have.lengthOf(16);
+    expect(Object.keys(prefillData)).to.have.lengthOf(17);
     expect(prefillData.veteranAddress).to.equal(undefined);
     expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(7);
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(undefined);
@@ -112,7 +116,7 @@ describe('hca `prefillTransformer` utility', () => {
 
   it('should return correct form data when profile data includes mailing address that does not match residential address', () => {
     const prefillData = getData({ residentialAddress, mailingAddress });
-    expect(Object.keys(prefillData)).to.have.lengthOf(17);
+    expect(Object.keys(prefillData)).to.have.lengthOf(18);
     expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(7);
     expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(7);
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.false;
@@ -123,7 +127,7 @@ describe('hca `prefillTransformer` utility', () => {
       residentialAddress,
       mailingAddress: residentialAddress,
     });
-    expect(Object.keys(prefillData)).to.have.lengthOf(16);
+    expect(Object.keys(prefillData)).to.have.lengthOf(17);
     expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
     expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(7);
     expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.true;
@@ -132,7 +136,7 @@ describe('hca `prefillTransformer` utility', () => {
   context('prefills valid veteranDateOfBirth', () => {
     it('should return correct form data when profile data includes valid veteranDateOfBirth', () => {
       const prefillData = getData({});
-      expect(Object.keys(prefillData)).to.have.lengthOf(15);
+      expect(Object.keys(prefillData)).to.have.lengthOf(16);
       expect(prefillData.veteranDateOfBirth).to.equal(
         defaultPrefillData.veteranDateOfBirth,
       );
@@ -149,7 +153,7 @@ describe('hca `prefillTransformer` utility', () => {
       const prefillData = getData({
         prefillData: prefillDataWithoutDateOfBirth,
       });
-      expect(Object.keys(prefillData)).to.have.lengthOf(14);
+      expect(Object.keys(prefillData)).to.have.lengthOf(15);
       expect(prefillData.veteranDateOfBirth).to.not.exist;
     });
 
@@ -160,7 +164,7 @@ describe('hca `prefillTransformer` utility', () => {
           veteranDateOfBirth: '1880-05-04',
         },
       });
-      expect(Object.keys(prefillData)).to.have.lengthOf(15);
+      expect(Object.keys(prefillData)).to.have.lengthOf(16);
       expect(prefillData.veteranDateOfBirth).to.not.exist;
     });
   });
@@ -168,7 +172,7 @@ describe('hca `prefillTransformer` utility', () => {
   context('prefills valid phone numbers', () => {
     it('should return correct form data when profile data includes valid USA phone numbers', () => {
       const prefillData = getData({});
-      expect(Object.keys(prefillData)).to.have.lengthOf(15);
+      expect(Object.keys(prefillData)).to.have.lengthOf(16);
       expect(prefillData.homePhone).to.equal(defaultPrefillData.homePhone);
       expect(prefillData.mobilePhone).to.equal(defaultPrefillData.mobilePhone);
     });
@@ -181,7 +185,7 @@ describe('hca `prefillTransformer` utility', () => {
           mobilePhone: '416123-4567',
         },
       });
-      expect(Object.keys(prefillData)).to.have.lengthOf(15);
+      expect(Object.keys(prefillData)).to.have.lengthOf(16);
       expect(prefillData.homePhone).to.not.exist;
       expect(prefillData.mobilePhone).to.not.exist;
     });
@@ -194,8 +198,29 @@ describe('hca `prefillTransformer` utility', () => {
       const prefillData = getData({
         prefillData: prefillDataWithoutHomePhone,
       });
-      expect(Object.keys(prefillData)).to.have.lengthOf(14);
+      expect(Object.keys(prefillData)).to.have.lengthOf(15);
       expect(prefillData.homePhone).to.not.exist;
+    });
+  });
+
+  context('sets login state', () => {
+    it('should set view:isLoggedIn to true when user is logged in', () => {
+      const prefillData = getData({ loggedIn: true });
+      expect(prefillData['view:isLoggedIn']).to.be.true;
+    });
+
+    it('should set view:isLoggedIn to false when user is not logged in', () => {
+      const prefillData = getData({ loggedIn: false });
+      expect(prefillData['view:isLoggedIn']).to.be.false;
+    });
+
+    it('should set view:isLoggedIn even when no other prefill data exists', () => {
+      const prefillData = getData({
+        loggedIn: true,
+        prefillData: {},
+      });
+      expect(prefillData['view:isLoggedIn']).to.be.true;
+      expect(Object.keys(prefillData)).to.include('view:isLoggedIn');
     });
   });
 });

--- a/src/applications/hca/tests/unit/containers/IdentityPage.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/containers/IdentityPage.unit.spec.jsx
@@ -79,8 +79,16 @@ describe('hca IdentityPage', () => {
     expect(buttons.submit).to.exist;
   });
 
-  it('should fire the routers `push` method with the correct path when the user is logged in', () => {
+  it('should fire the routers `push` method with the next valid page path when the user is logged in', () => {
     const { props, mockStore } = getData({ loggedIn: true });
+    const { router } = props;
+    subject({ props, mockStore });
+    expect(router.push.calledWith('/next')).to.be.true;
+  });
+
+  it('should redirect to root path when logged in and no next page is found', () => {
+    const { props, mockStore } = getData({ loggedIn: true });
+    props.route.pageList = [{ path: '/current-page' }];
     const { router } = props;
     subject({ props, mockStore });
     expect(router.push.calledWith('/')).to.be.true;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes a routing bug in the HCA application that caused logged-in users to be incorrectly routed through the identity verification page (`/id-form`), resulting in unnecessary redirects or redirect loops. The changes ensure that the user's login state is included in the form data, and that page navigation logic properly respects this state, skipping the identity page for logged-in users. The updates also include comprehensive unit and E2E tests to verify the fix.

**Bug fix and navigation improvements:**

* The `prefillTransformer` now always sets the `view:isLoggedIn` field in `formData` based on the Redux state, ensuring that the user's login status is available for page logic even when no other prefill data exists.
* The `IdentityPage` container now redirects logged-in users to the next valid page using `getNextPagePath()` instead of always redirecting to `'/'`, preventing redirect loops and ensuring correct navigation flow.

**Testing and validation:**

* The E2E Cypress test for the routing bug was rewritten to verify that logged-in users skip the `/id-form` page and do not encounter redirect loops, and to clarify the root cause and fixes in comments.
* Unit tests for the `prefillTransformer` were updated and expanded to check that `view:isLoggedIn` is correctly set in all scenarios, and that the form data includes this field regardless of other prefill data presence.
* Unit tests for `IdentityPage` were updated to assert that the router redirects to the correct next page for logged-in users, or to `'/'` if no next page is found.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#132234

## Testing done

- Noted in the summary above

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Users are correctly routed through the form based on their authentication status

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
