### PR TITLE
Micahalconcel/130191 530a fe interim fix long names

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-personal-information.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/pages/veteran-personal-information.js
@@ -4,25 +4,52 @@ import {
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+import { isValidNameLength } from '../../shared/utils/validators/validators';
+
+const customVeteranNameUISchema = () => {
+  const baseSchema = fullNameNoSuffixUI();
+  return {
+    ...baseSchema,
+    first: {
+      ...baseSchema.first,
+      'ui:title': 'First or given name',
+      'ui:validations': [
+        ...baseSchema.first['ui:validations'],
+        (errors = {}, _fieldData, formData) => {
+          isValidNameLength(
+            errors,
+            formData?.veteranInformation?.fullName?.first,
+            12,
+          );
+        },
+      ],
+    },
+    middle: {
+      ...baseSchema.middle,
+      'ui:title': 'Middle initial',
+    },
+    last: {
+      ...baseSchema.last,
+      'ui:title': 'Last or family name',
+      'ui:validations': [
+        ...baseSchema.last['ui:validations'],
+        (errors = {}, _fieldData, formData) => {
+          isValidNameLength(
+            errors,
+            formData?.veteranInformation?.fullName?.last,
+            18,
+          );
+        },
+      ],
+    },
+  };
+};
+
 export const veteranPersonalInformationPage = {
   uiSchema: {
     ...titleUI("Veteran's name"),
     veteranInformation: {
-      fullName: {
-        ...fullNameNoSuffixUI(),
-        first: {
-          ...fullNameNoSuffixUI().first,
-          'ui:title': 'First or given name',
-        },
-        middle: {
-          ...fullNameNoSuffixUI().middle,
-          'ui:title': 'Middle initial',
-        },
-        last: {
-          ...fullNameNoSuffixUI().last,
-          'ui:title': 'Last or family name',
-        },
-      },
+      fullName: customVeteranNameUISchema(),
     },
   },
   schema: {
@@ -38,7 +65,6 @@ export const veteranPersonalInformationPage = {
               ...fullNameNoSuffixSchema.properties,
               first: {
                 ...fullNameNoSuffixSchema.properties.first,
-                maxLength: 12,
               },
               middle: {
                 ...fullNameNoSuffixSchema.properties.middle,
@@ -46,7 +72,6 @@ export const veteranPersonalInformationPage = {
               },
               last: {
                 ...fullNameNoSuffixSchema.properties.last,
-                maxLength: 18,
               },
             },
           },

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/pages/veteran-personal-information.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/tests/pages/veteran-personal-information.unit.spec.jsx
@@ -54,15 +54,6 @@ describe('21p-530a veteran personal information', () => {
     expect(container.querySelector('button[type="submit"]')).to.exist;
   });
 
-  it('should have proper max lengths for name fields', () => {
-    const nameProps =
-      schema.properties.veteranInformation.properties.fullName.properties;
-
-    expect(nameProps.first.maxLength).to.equal(12);
-    expect(nameProps.middle.maxLength).to.equal(1);
-    expect(nameProps.last.maxLength).to.equal(18);
-  });
-
   it('should validate first name does not exceed max length', async () => {
     const onSubmit = sinon.spy();
     const formData = {
@@ -162,17 +153,52 @@ describe('21p-530a veteran personal information', () => {
     });
   });
 
-  it('should accept valid names within max length limits', () => {
-    const nameProps =
-      schema.properties.veteranInformation.properties.fullName.properties;
+  it('should show a validation error if first name is longer than 12 characters', () => {
+    const errorMessages = [];
 
-    // Test that names at the limit are acceptable
-    const validFirst = 'a'.repeat(12);
-    const validMiddle = 'a'.repeat(1);
-    const validLast = 'a'.repeat(18);
+    const errors = {
+      addError: message => {
+        errorMessages.push(message || '');
+      },
+    };
 
-    expect(validFirst.length).to.equal(nameProps.first.maxLength);
-    expect(validMiddle.length).to.equal(nameProps.middle.maxLength);
-    expect(validLast.length).to.equal(nameProps.last.maxLength);
+    const formData = {
+      veteranInformation: {
+        fullName: { first: 'ThisIsAVeryLongFirstName', last: 'Doe' },
+      },
+    };
+
+    // expect a validation error for the first name field
+    const firstNameValidation =
+      uiSchema.veteranInformation.fullName.first['ui:validations'][1];
+    firstNameValidation(errors, null, formData);
+
+    expect(errorMessages[0]).to.exist;
+    expect(errorMessages[0]).to.equal(
+      'Please enter a name under 12 characters. If your name is longer, enter the first 12 characters only.',
+    );
+  });
+
+  it('should not show a validation error if first name is 12 characters or less', () => {
+    const errorMessages = [];
+
+    const errors = {
+      addError: message => {
+        errorMessages.push(message || '');
+      },
+    };
+
+    const formData = {
+      veteranInformation: {
+        fullName: { first: 'John', last: 'Doe' },
+      },
+    };
+
+    // expect no validation error for the first name field
+    const firstNameValidation =
+      uiSchema.veteranInformation.fullName.first['ui:validations'][1];
+    firstNameValidation(errors, null, formData);
+
+    expect(errorMessages.length).to.equal(0);
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Limiting first and last name characters to match backend limits - if a longer name is entered, displays an error notifying them to only put the first 12 (18 for last name) characters

### Issue
The FE for the form is restricted to 12 and 18 characters, respectively. This matches the backend limits, but if the user's name is longer than allowed, there's no instruction telling them to limit it to the first 12 or 18 characters.

### Solution
Updated the FE to display an error message if the user attempts to enter a name longer than the BE limits

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21p-530a form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 130191](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130191)

## Testing done

### Old behavior
* The form FE was allowing 30 characters for the first and last name

### New behavior
* The form FE displays an error message if the first name is over 12 characters or the last name is over 18 characters

### Verification Steps
*  Unit tests: verified existing unit tests still pass, added test to make sure validation error displays if long name is entered
*  Manual testing in local environment verified that inputting a long name displays a validation error and prevents the form from moving forward or submitting
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="574" height="415" alt="before name" src="https://github.com/user-attachments/assets/99911a0f-164f-44bf-a289-208a325efa17" /> | <img width="561" height="675" alt="after name" src="https://github.com/user-attachments/assets/8e83031e-97bd-43cb-8b92-9e3335a91389" /> |

## What areas of the site does it impact?

This change affects form 21p-530a, specifically on the Veteran Personal Information page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
