### PR TITLE
VASS Clean up and TODO's 

### DIFF
--- a/src/applications/vass/components/ErrorAlert.jsx
+++ b/src/applications/vass/components/ErrorAlert.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { VASS_PHONE_NUMBER } from '../utils/constants';
+import PropTypes from 'prop-types';
+import { FLOW_TYPES, VASS_PHONE_NUMBER } from '../utils/constants';
 
-const ErrorAlert = () => {
+const ErrorAlert = ({ flowType = FLOW_TYPES.SCHEDULE }) => {
+  const header =
+    flowType === FLOW_TYPES.CANCEL
+      ? 'We can’t cancel your appointment right now'
+      : 'We can’t schedule your appointment right now';
   return (
     <va-alert
       status="error"
       class="vads-u-margin-top--4"
       data-testid="api-error-alert"
     >
-      <h2>We can’t schedule your appointment right now</h2>
+      <h2>{header}</h2>
       <p>
         We’re sorry. There’s a problem with our system. Refresh this page to
         start over or try again later.{' '}
@@ -22,3 +27,7 @@ const ErrorAlert = () => {
 };
 
 export default ErrorAlert;
+
+ErrorAlert.propTypes = {
+  flowType: PropTypes.oneOf(Object.values(FLOW_TYPES)),
+};

--- a/src/applications/vass/components/ErrorAlert.unit.spec.jsx
+++ b/src/applications/vass/components/ErrorAlert.unit.spec.jsx
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import ErrorAlert from './ErrorAlert';
-import { VASS_PHONE_NUMBER } from '../utils/constants';
+import { FLOW_TYPES, VASS_PHONE_NUMBER } from '../utils/constants';
 
 describe('VASS Component: ErrorAlert', () => {
-  it('should render component with correct structure', () => {
+  it('should render the error alert with correct structure', () => {
     const { container, getByTestId, getByRole } = render(<ErrorAlert />);
 
     const alert = getByTestId('api-error-alert');
@@ -15,16 +15,32 @@ describe('VASS Component: ErrorAlert', () => {
 
     const heading = getByRole('heading', { level: 2 });
     expect(heading).to.exist;
-    expect(heading.textContent).to.equal(
-      'We can’t schedule your appointment right now',
-    );
 
-    expect(alert.textContent).to.contain(
-      'There’s a problem with our system. Refresh this page to start over or try again later.',
-    );
+    expect(alert.textContent).to.contain('problem with our system');
 
     const telephone = container.querySelector('va-telephone');
     expect(telephone).to.exist;
     expect(telephone.getAttribute('contact')).to.equal(VASS_PHONE_NUMBER);
+  });
+
+  it('should display the schedule heading by default', () => {
+    const { getByRole } = render(<ErrorAlert />);
+
+    const heading = getByRole('heading', { level: 2 });
+    expect(heading.textContent).to.contain('schedule your appointment');
+  });
+
+  it('should display the schedule heading when flowType is SCHEDULE', () => {
+    const { getByRole } = render(<ErrorAlert flowType={FLOW_TYPES.SCHEDULE} />);
+
+    const heading = getByRole('heading', { level: 2 });
+    expect(heading.textContent).to.contain('schedule your appointment');
+  });
+
+  it('should display the cancel heading when flowType is CANCEL', () => {
+    const { getByRole } = render(<ErrorAlert flowType={FLOW_TYPES.CANCEL} />);
+
+    const heading = getByRole('heading', { level: 2 });
+    expect(heading.textContent).to.contain('cancel your appointment');
   });
 });

--- a/src/applications/vass/containers/withAuthorization.jsx
+++ b/src/applications/vass/containers/withAuthorization.jsx
@@ -63,13 +63,16 @@ const withAuthorization = (Component, authLevel = AUTH_LEVELS.TOKEN) => {
           dispatch(clearFormData());
 
           // Redirect to Verify page (root of the app)
+          let redirectUrl = URLS.VERIFY;
           if (uuid) {
-            navigate(`${URLS.VERIFY}?uuid=${uuid}`, {
-              replace: true,
-            });
-          } else {
-            // TODO: route to the "Something went wrong" page
+            const searchParams = new URLSearchParams();
+            searchParams.set('uuid', uuid);
+            redirectUrl = `${URLS.VERIFY}?${searchParams.toString()}`;
           }
+          // Navigating to the Verify page without the uuid will show the user the Something went wrong page.
+          navigate(redirectUrl, {
+            replace: true,
+          });
         }
       },
       [

--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -9,12 +9,12 @@ import { focusElement } from 'platform/utilities/ui';
 
 import NeedHelp from '../components/NeedHelp';
 import ErrorAlert from '../components/ErrorAlert';
+import { FLOW_TYPES } from '../utils/constants';
 
-// TODO: combine errorAlert and verificationError into a single prop
-
-const getContent = (errorAlert, verificationError, children) => {
+// TODO: Maybe combine errorAlert and verificationError into a single prop
+const getContent = (errorAlert, verificationError, children, flowType) => {
   if (errorAlert) {
-    return <ErrorAlert />;
+    return <ErrorAlert flowType={flowType} />;
   }
   if (verificationError) {
     return (
@@ -43,6 +43,7 @@ const Wrapper = props => {
     loadingMessage = 'Loading...',
     errorAlert = false,
     disableBeforeUnload = false,
+    flowType = FLOW_TYPES.SCHEDULE,
   } = props;
   const navigate = useNavigate();
 
@@ -93,7 +94,7 @@ const Wrapper = props => {
     );
   }
 
-  const content = getContent(errorAlert, verificationError, children);
+  const content = getContent(errorAlert, verificationError, children, flowType);
 
   return (
     <div
@@ -155,6 +156,7 @@ Wrapper.propTypes = {
   className: PropTypes.string,
   disableBeforeUnload: PropTypes.bool,
   errorAlert: PropTypes.bool,
+  flowType: PropTypes.oneOf(Object.values(FLOW_TYPES)),
   loading: PropTypes.bool,
   loadingMessage: PropTypes.string,
   pageTitle: PropTypes.string,

--- a/src/applications/vass/pages/CancelAppointment.jsx
+++ b/src/applications/vass/pages/CancelAppointment.jsx
@@ -10,24 +10,44 @@ import {
 } from '../redux/api/vassApi';
 import { FLOW_TYPES, URLS } from '../utils/constants';
 import { setFlowType } from '../redux/slices/formSlice';
+import {
+  isCancellationFailedError,
+  isMissingParameterError,
+  isServerError,
+} from '../utils/errors';
+
+const getLoadingMessage = isCanceling => {
+  if (isCanceling) {
+    return 'Canceling appointment. This may take up to 30 seconds. Please don’t refresh the page.';
+  }
+  return 'Loading appointment details. This may take up to 30 seconds. Please don’t refresh the page.';
+};
 
 const CancelAppointment = () => {
   const { appointmentId } = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { data: appointmentData, isLoading } = useGetAppointmentQuery({
+  const {
+    data: appointmentData,
+    isLoading,
+    error: appointmentError,
+  } = useGetAppointmentQuery({
     appointmentId,
   });
-  const [cancelAppointment] = useCancelAppointmentMutation();
+  const [
+    cancelAppointment,
+    { isLoading: isCanceling, error: cancelAppointmentError },
+  ] = useCancelAppointmentMutation();
 
   const onCancelAppointment = useCallback(
     async () => {
-      try {
-        await cancelAppointment({ appointmentId });
-        navigate(`${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/${appointmentId}`);
-      } catch (error) {
-        // TODO: handle error
+      const result = await cancelAppointment({ appointmentId });
+      if (result.error) {
+        return;
       }
+      navigate(
+        `${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/${result.data.appointmentId}`,
+      );
     },
     [cancelAppointment, appointmentId, navigate],
   );
@@ -42,13 +62,22 @@ const CancelAppointment = () => {
     [appointmentData?.appointmentId, dispatch, navigate],
   );
 
+  const loadingMessage = getLoadingMessage(isCanceling);
+
   return (
     <Wrapper
       showBackLink
-      loading={isLoading}
+      flowType={FLOW_TYPES.CANCEL}
+      loading={isLoading || isCanceling}
+      errorAlert={
+        isCancellationFailedError(cancelAppointmentError) ||
+        isMissingParameterError(cancelAppointmentError) ||
+        isServerError(cancelAppointmentError) ||
+        isServerError(appointmentError)
+      }
       testID="cancel-appointment-page"
       pageTitle="Would you like to cancel this appointment?"
-      loadingMessage="Loading appointment details. This may take up to 30 seconds. Please don’t refresh the page."
+      loadingMessage={loadingMessage}
     >
       <div className="vads-u-margin-top--6">
         <AppointmentCard

--- a/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
@@ -4,15 +4,25 @@ import sinon from 'sinon';
 import { waitFor } from '@testing-library/react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 as renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
-
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 import CancelAppointment from './CancelAppointment';
 import { getDefaultRenderOptions, LocationDisplay } from '../utils/test-utils';
-import * as vassApi from '../redux/api/vassApi';
+import * as authUtils from '../utils/auth';
 import {
   createAppointmentData,
   createVassApiStateWithAppointment,
 } from '../utils/appointments';
 import { URLS } from '../utils/constants';
+import {
+  createAppointmentDetailsResponse,
+  createCancelAppointmentResponse,
+} from '../services/mocks/utils/responses';
+import { createServiceError } from '../services/mocks/utils/errors';
 
 const appointmentId = 'abcdef123456';
 const appointmentData = createAppointmentData({ appointmentId });
@@ -21,20 +31,22 @@ const getVassApiState = () =>
   createVassApiStateWithAppointment(appointmentId, appointmentData);
 
 describe('VASS Page: CancelAppointment', () => {
-  let cancelAppointmentStub;
+  let getValidVassTokenStub;
 
   beforeEach(() => {
-    // Mock the cancelAppointment mutation to resolve immediately
-    const mockCancelAppointment = sinon.stub().returns({
-      unwrap: () => Promise.resolve({ data: {} }),
-    });
-    cancelAppointmentStub = sinon
-      .stub(vassApi, 'useCancelAppointmentMutation')
-      .returns([mockCancelAppointment, { isLoading: false }]);
+    getValidVassTokenStub = sinon
+      .stub(authUtils, 'getValidVassToken')
+      .returns('mock-token');
+    mockFetch();
+    setFetchJSONResponse(
+      global.fetch.onCall(0),
+      createAppointmentDetailsResponse({ ...appointmentData }),
+    );
   });
 
   afterEach(() => {
-    cancelAppointmentStub.restore();
+    resetFetch();
+    getValidVassTokenStub.restore();
   });
 
   it('renders page, appointment card, and buttons', () => {
@@ -61,6 +73,12 @@ describe('VASS Page: CancelAppointment', () => {
   });
 
   describe('navigation', () => {
+    beforeEach(() => {
+      setFetchJSONResponse(
+        global.fetch.onCall(1),
+        createCancelAppointmentResponse({ appointmentId }),
+      );
+    });
     it('should navigate to cancel confirmation page when "Yes, cancel appointment" is clicked', async () => {
       const { getByTestId } = renderWithStoreAndRouter(
         <>
@@ -119,6 +137,78 @@ describe('VASS Page: CancelAppointment', () => {
       await waitFor(() => {
         expect(getByTestId('location-display').textContent).to.equal(
           `${URLS.CONFIRMATION}/${appointmentId}?details=true`,
+        );
+      });
+    });
+  });
+
+  describe('API error handling', () => {
+    it('should display error alert when cancel appointment fails with server error', async () => {
+      setFetchJSONFailure(global.fetch.onCall(1), createServiceError());
+
+      const { getByTestId, queryByTestId } = renderWithStoreAndRouter(
+        <>
+          <Routes>
+            <Route
+              path={`${URLS.CANCEL_APPOINTMENT}/:appointmentId`}
+              element={<CancelAppointment />}
+            />
+          </Routes>
+        </>,
+        {
+          ...getDefaultRenderOptions({}, { vassApi: getVassApiState() }),
+          initialEntries: [`${URLS.CANCEL_APPOINTMENT}/${appointmentId}`],
+        },
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('cancel-confirm-button-pair')).to.exist;
+      });
+
+      const buttonPair = getByTestId('cancel-confirm-button-pair');
+      buttonPair.__events.primaryClick();
+
+      await waitFor(() => {
+        expect(getByTestId('api-error-alert')).to.exist;
+        expect(queryByTestId('back-link')).to.not.exist;
+        expect(queryByTestId('header')).to.not.exist;
+      });
+    });
+
+    it('should not navigate when cancel appointment returns an error', async () => {
+      setFetchJSONFailure(global.fetch.onCall(1), createServiceError());
+
+      const { getByTestId } = renderWithStoreAndRouter(
+        <>
+          <Routes>
+            <Route
+              path={`${URLS.CANCEL_APPOINTMENT}/:appointmentId`}
+              element={<CancelAppointment />}
+            />
+            <Route
+              path={`${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/:appointmentId`}
+              element={<div>Cancel Confirmation Page</div>}
+            />
+          </Routes>
+          <LocationDisplay />
+        </>,
+        {
+          ...getDefaultRenderOptions({}, { vassApi: getVassApiState() }),
+          initialEntries: [`${URLS.CANCEL_APPOINTMENT}/${appointmentId}`],
+        },
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('cancel-confirm-button-pair')).to.exist;
+      });
+
+      const buttonPair = getByTestId('cancel-confirm-button-pair');
+      buttonPair.__events.primaryClick();
+
+      await waitFor(() => {
+        // Should still be on cancel appointment page
+        expect(getByTestId('location-display').textContent).to.equal(
+          `${URLS.CANCEL_APPOINTMENT}/${appointmentId}`,
         );
       });
     });

--- a/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
@@ -31,11 +31,11 @@ const getVassApiState = () =>
   createVassApiStateWithAppointment(appointmentId, appointmentData);
 
 describe('VASS Page: CancelAppointment', () => {
-  let getValidVassTokenStub;
+  let getVassTokenStub;
 
   beforeEach(() => {
-    getValidVassTokenStub = sinon
-      .stub(authUtils, 'getValidVassToken')
+    getVassTokenStub = sinon
+      .stub(authUtils, 'getVassToken')
       .returns('mock-token');
     mockFetch();
     setFetchJSONResponse(
@@ -46,7 +46,7 @@ describe('VASS Page: CancelAppointment', () => {
 
   afterEach(() => {
     resetFetch();
-    getValidVassTokenStub.restore();
+    getVassTokenStub.restore();
   });
 
   it('renders page, appointment card, and buttons', () => {

--- a/src/applications/vass/pages/DateTimeSelection.unit.spec.jsx
+++ b/src/applications/vass/pages/DateTimeSelection.unit.spec.jsx
@@ -24,19 +24,17 @@ const mockAppointmentAvailability = {
 };
 
 describe('VASS Component: DateTimeSelection', () => {
-  let getValidVassTokenStub;
+  let getVassTokenStub;
 
   beforeEach(() => {
     mockFetch();
-    getValidVassTokenStub = sinon
-      .stub(auth, 'getValidVassToken')
-      .returns('mock-token');
+    getVassTokenStub = sinon.stub(auth, 'getVassToken').returns('mock-token');
     setFetchJSONResponse(global.fetch.onCall(0), mockAppointmentAvailability);
   });
 
   afterEach(() => {
     resetFetch();
-    getValidVassTokenStub.restore();
+    getVassTokenStub.restore();
   });
 
   const renderComponent = (

--- a/src/applications/vass/pages/DateTimeSelection.unit.spec.jsx
+++ b/src/applications/vass/pages/DateTimeSelection.unit.spec.jsx
@@ -24,13 +24,19 @@ const mockAppointmentAvailability = {
 };
 
 describe('VASS Component: DateTimeSelection', () => {
+  let getValidVassTokenStub;
+
   beforeEach(() => {
     mockFetch();
+    getValidVassTokenStub = sinon
+      .stub(auth, 'getValidVassToken')
+      .returns('mock-token');
     setFetchJSONResponse(global.fetch.onCall(0), mockAppointmentAvailability);
   });
 
   afterEach(() => {
     resetFetch();
+    getValidVassTokenStub.restore();
   });
 
   const renderComponent = (

--- a/src/applications/vass/pages/EnterOTP.jsx
+++ b/src/applications/vass/pages/EnterOTP.jsx
@@ -101,8 +101,10 @@ const EnterOTP = () => {
     }
 
     if (cancellationFlow) {
-      // TODO: handle cancellation flow
-      navigate(`${URLS.CANCEL_APPOINTMENT}/abcdef123456`, { replace: true });
+      const { appointmentId } = availabilityCheck.data;
+      navigate(`${URLS.CANCEL_APPOINTMENT}/${appointmentId}`, {
+        replace: true,
+      });
     } else {
       navigate(URLS.DATE_TIME, { replace: true });
     }

--- a/src/applications/vass/pages/EnterOTP.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTP.unit.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { waitFor } from '@testing-library/react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
@@ -13,12 +14,14 @@ import {
 
 import EnterOTP from './EnterOTP';
 import { getDefaultRenderOptions, LocationDisplay } from '../utils/test-utils';
+import * as authUtils from '../utils/auth';
 import { FLOW_TYPES, URLS } from '../utils/constants';
 import {
   createOTPInvalidError,
   createOTPAccountLockedError,
   createAppointmentAlreadyBookedError,
 } from '../services/mocks/utils/errors';
+import { createAppointmentAvailabilityResponse } from '../services/mocks/utils/responses';
 
 const defaultRenderOptions = getDefaultRenderOptions({
   obfuscatedEmail: 't***@test.com',
@@ -40,12 +43,18 @@ const renderComponent = () =>
   renderWithStoreAndRouterV6(<EnterOTP />, defaultRenderOptions);
 
 describe('VASS Component: EnterOTP', () => {
+  let getValidVassTokenStub;
+
   beforeEach(() => {
     mockFetch();
+    getValidVassTokenStub = sinon
+      .stub(authUtils, 'getValidVassToken')
+      .returns('mock-token');
   });
 
   afterEach(() => {
     resetFetch();
+    getValidVassTokenStub.restore();
   });
 
   it('should initialize correctly', () => {
@@ -145,9 +154,12 @@ describe('VASS Component: EnterOTP', () => {
           tokenType: 'Bearer',
         },
       });
-      setFetchJSONResponse(global.fetch.onCall(1), {
-        data: { availableSlots: [] },
-      });
+      setFetchJSONResponse(
+        global.fetch.onCall(1),
+        createAppointmentAvailabilityResponse({
+          appointmentId: 'abcdef123456',
+        }),
+      );
       const { container, getByTestId } = renderComponent();
       inputVaTextInput(container, '123456', 'va-text-input[name="otp"]');
       const continueButton = getByTestId('continue-button');
@@ -242,9 +254,12 @@ describe('VASS Component: EnterOTP', () => {
           tokenType: 'Bearer',
         },
       });
-      setFetchJSONResponse(global.fetch.onCall(1), {
-        data: { availableSlots: [] },
-      });
+      setFetchJSONResponse(
+        global.fetch.onCall(1),
+        createAppointmentAvailabilityResponse({
+          appointmentId: 'abcdef123456',
+        }),
+      );
 
       const { container, getByTestId } = renderWithStoreAndRouterV6(
         <>
@@ -340,9 +355,12 @@ describe('VASS Component: EnterOTP', () => {
           tokenType: 'Bearer',
         },
       });
-      setFetchJSONResponse(global.fetch.onCall(1), {
-        data: { availableSlots: [] },
-      });
+      setFetchJSONResponse(
+        global.fetch.onCall(1),
+        createAppointmentAvailabilityResponse({
+          appointmentId: 'abcdef123456',
+        }),
+      );
 
       const { container, getByTestId } = renderWithStoreAndRouterV6(
         <>

--- a/src/applications/vass/pages/EnterOTP.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTP.unit.spec.jsx
@@ -43,18 +43,18 @@ const renderComponent = () =>
   renderWithStoreAndRouterV6(<EnterOTP />, defaultRenderOptions);
 
 describe('VASS Component: EnterOTP', () => {
-  let getValidVassTokenStub;
+  let getVassTokenStub;
 
   beforeEach(() => {
     mockFetch();
-    getValidVassTokenStub = sinon
-      .stub(authUtils, 'getValidVassToken')
+    getVassTokenStub = sinon
+      .stub(authUtils, 'getVassToken')
       .returns('mock-token');
   });
 
   afterEach(() => {
     resetFetch();
-    getValidVassTokenStub.restore();
+    getVassTokenStub.restore();
   });
 
   it('should initialize correctly', () => {

--- a/src/applications/vass/pages/Review.unit.spec.jsx
+++ b/src/applications/vass/pages/Review.unit.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { waitFor } from '@testing-library/react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 } from 'platform/testing/unit/react-testing-library-helpers';
@@ -13,10 +14,12 @@ import {
 import Review from './Review';
 import { getDefaultRenderOptions, LocationDisplay } from '../utils/test-utils';
 import { URLS } from '../utils/constants';
+import * as authUtils from '../utils/auth';
 import {
   createAppointmentSaveFailedError,
   createServiceError,
 } from '../services/mocks/utils/errors';
+import { createAppointmentResponse } from '../services/mocks/utils/responses';
 
 const defaultFormState = {
   hydrated: true,
@@ -33,12 +36,9 @@ const defaultFormState = {
 
 const appointmentId = 'appt-123456';
 
-// TODO: Add mock appointment success response to fixtures
-const mockAppointmentSuccessResponse = {
-  data: {
-    appointmentId,
-  },
-};
+const mockAppointmentSuccessResponse = createAppointmentResponse({
+  appointmentId,
+});
 
 const defaultRenderOptions = getDefaultRenderOptions(defaultFormState);
 
@@ -46,11 +46,17 @@ const renderComponent = () =>
   renderWithStoreAndRouterV6(<Review />, defaultRenderOptions);
 
 describe('VASS Component: Review', () => {
+  let getValidVassTokenStub;
+
   beforeEach(() => {
+    getValidVassTokenStub = sinon
+      .stub(authUtils, 'getValidVassToken')
+      .returns('mock-token');
     mockFetch();
   });
 
   afterEach(() => {
+    getValidVassTokenStub.restore();
     resetFetch();
   });
 

--- a/src/applications/vass/pages/Review.unit.spec.jsx
+++ b/src/applications/vass/pages/Review.unit.spec.jsx
@@ -46,17 +46,17 @@ const renderComponent = () =>
   renderWithStoreAndRouterV6(<Review />, defaultRenderOptions);
 
 describe('VASS Component: Review', () => {
-  let getValidVassTokenStub;
+  let getVassTokenStub;
 
   beforeEach(() => {
-    getValidVassTokenStub = sinon
-      .stub(authUtils, 'getValidVassToken')
+    getVassTokenStub = sinon
+      .stub(authUtils, 'getVassToken')
       .returns('mock-token');
     mockFetch();
   });
 
   afterEach(() => {
-    getValidVassTokenStub.restore();
+    getVassTokenStub.restore();
     resetFetch();
   });
 

--- a/src/applications/vass/redux/api/vassApi.js
+++ b/src/applications/vass/redux/api/vassApi.js
@@ -2,15 +2,19 @@ import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { setObfuscatedEmail, setLowAuthFormData } from '../slices/formSlice';
-import { setVassToken, getValidVassToken } from '../../utils/auth';
+import { setVassToken, getVassToken } from '../../utils/auth';
 import { createInvalidTokenError } from '../../services/mocks/utils/errors';
 
 const api = async (url, options, ...rest) => {
   return apiRequest(`${environment.API_URL}${url}`, options, ...rest);
 };
 
+/**
+ * Gets the VASS token from the cookie and returns it if it exists.
+ * @returns {Object} An object with the token and error if it exists.
+ */
 const getTokenOrError = () => {
-  const token = getValidVassToken();
+  const token = getVassToken();
   if (!token) {
     return {
       token: null,

--- a/src/applications/vass/redux/api/vassApi.js
+++ b/src/applications/vass/redux/api/vassApi.js
@@ -2,13 +2,24 @@ import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { setObfuscatedEmail, setLowAuthFormData } from '../slices/formSlice';
-import { setVassToken, getVassToken } from '../../utils/auth';
+import { setVassToken, getValidVassToken } from '../../utils/auth';
+import { createInvalidTokenError } from '../../services/mocks/utils/errors';
 
 const api = async (url, options, ...rest) => {
   return apiRequest(`${environment.API_URL}${url}`, options, ...rest);
 };
 
-// TODO if token is not found reject the requets
+const getTokenOrError = () => {
+  const token = getValidVassToken();
+  if (!token) {
+    return {
+      token: null,
+      error: createInvalidTokenError().errors[0],
+    };
+  }
+  return { token, error: null };
+};
+
 export const vassApi = createApi({
   reducerPath: 'vassApi',
   baseQuery: () => ({ data: null }),
@@ -32,7 +43,6 @@ export const vassApi = createApi({
           dispatch(setObfuscatedEmail(response.data.email));
           return response;
         } catch ({ errors }) {
-          // captureError(error, false, 'post referral appointment');
           return {
             error: {
               code: errors?.[0]?.code,
@@ -59,7 +69,6 @@ export const vassApi = createApi({
             }),
           });
         } catch ({ errors }) {
-          // captureError(error, false, 'post referral appointment');
           return {
             error: errors?.[0],
           };
@@ -78,8 +87,11 @@ export const vassApi = createApi({
     }),
     postAppointment: builder.mutation({
       async queryFn({ topics, dtStartUtc, dtEndUtc }) {
+        const { token, error: tokenError } = getTokenOrError();
+        if (tokenError) {
+          return { error: tokenError };
+        }
         try {
-          const token = getVassToken();
           return await api('/vass/v0/appointment', {
             method: 'POST',
             headers: {
@@ -93,8 +105,6 @@ export const vassApi = createApi({
             }),
           });
         } catch ({ errors }) {
-          // captureError(error, false, 'post appointment');
-          // TODO: do something with error
           return {
             error: {
               code: errors?.[0]?.code,
@@ -106,8 +116,11 @@ export const vassApi = createApi({
     }),
     getAppointment: builder.query({
       async queryFn({ appointmentId }) {
+        const { token, error: tokenError } = getTokenOrError();
+        if (tokenError) {
+          return { error: tokenError };
+        }
         try {
-          const token = getVassToken();
           return await api(`/vass/v0/appointment/${appointmentId}`, {
             method: 'GET',
             headers: {
@@ -116,8 +129,6 @@ export const vassApi = createApi({
             },
           });
         } catch ({ errors }) {
-          // captureError(error, false, 'get appointment');
-          // TODO: do something with error
           return {
             error: {
               code: errors?.[0]?.code,
@@ -129,8 +140,11 @@ export const vassApi = createApi({
     }),
     getTopics: builder.query({
       async queryFn() {
+        const { token, error: tokenError } = getTokenOrError();
+        if (tokenError) {
+          return { error: tokenError };
+        }
         try {
-          const token = getVassToken();
           return await api('/vass/v0/topics', {
             method: 'GET',
             headers: {
@@ -139,8 +153,6 @@ export const vassApi = createApi({
             },
           });
         } catch ({ errors }) {
-          // captureError(error, false, 'get topics');
-          // TODO: do something with error
           return {
             error: {
               code: errors?.[0]?.code,
@@ -152,8 +164,11 @@ export const vassApi = createApi({
     }),
     getAppointmentAvailability: builder.query({
       async queryFn() {
+        const { token, error: tokenError } = getTokenOrError();
+        if (tokenError) {
+          return { error: tokenError };
+        }
         try {
-          const token = getVassToken();
           return await api('/vass/v0/appointment-availability', {
             method: 'GET',
             headers: {
@@ -162,7 +177,6 @@ export const vassApi = createApi({
             },
           });
         } catch ({ errors }) {
-          // captureError(error, false, 'get appointment availability');
           return {
             error: {
               code: errors?.[0]?.code,
@@ -175,8 +189,11 @@ export const vassApi = createApi({
     }),
     cancelAppointment: builder.mutation({
       async queryFn({ appointmentId }) {
+        const { token, error: tokenError } = getTokenOrError();
+        if (tokenError) {
+          return { error: tokenError };
+        }
         try {
-          const token = getVassToken();
           return await api(`/vass/v0/appointment/${appointmentId}/cancel`, {
             method: 'POST',
             headers: {
@@ -185,8 +202,6 @@ export const vassApi = createApi({
             },
           });
         } catch ({ errors }) {
-          // captureError(error, false, 'cancel appointment');
-          // TODO: do something with error
           return {
             error: {
               code: errors?.[0]?.code,

--- a/src/applications/vass/services/mocks/index.js
+++ b/src/applications/vass/services/mocks/index.js
@@ -22,24 +22,28 @@ const mockUUIDs = Object.freeze({
     dob: '1935-04-07',
     otp: '123456',
     email: 's****@email.com',
+    appointmentId: 'abcdef123456',
   },
   'authenticate-otc-vass-api-error': {
     lastName: 'Smith',
     dob: '1935-04-07',
     otp: '123456',
     email: 's****@email.com',
+    appointmentId: undefined, // no appointment id for this uuid because this uuid is used for authentication errors
   },
   'authenticate-otc-service-error': {
     lastName: 'Smith',
     dob: '1935-04-07',
     otp: '123456',
     email: 's****@email.com',
+    appointmentId: undefined, // no appointment id for this uuid because this uuid is used for service errors
   },
   'not-within-cohort': {
     lastName: 'Smith',
     dob: '1935-04-07',
     otp: '123456',
     email: 's****@email.com',
+    appointmentId: undefined, // no appointment id for this uuid because this uuid is used for not within cohort errors
   },
   // Test user with existing appointment - use this UUID to test redirect flow
   'has-appointment': {
@@ -47,6 +51,7 @@ const mockUUIDs = Object.freeze({
     dob: '1935-04-07',
     otp: '123456',
     email: 's****@email.com',
+    appointmentId: 'existing-appointment-id',
   },
 });
 
@@ -59,7 +64,10 @@ const lowAuthVerificationTimeout = 15 * 60 * 1000; // 15 minutes
 const otpUseCounts = new Map(); // uuid -> count
 const maxOtpUseCount = 5;
 
-const mockAppointments = [createAppointmentData()];
+const mockAppointments = [
+  createAppointmentData({ appointmentId: 'abcdef123456' }),
+  createAppointmentData({ appointmentId: 'existing-appointment-id' }),
+];
 
 const responses = {
   'POST /vass/v0/request-otp': (req, res) => {
@@ -178,19 +186,17 @@ const responses = {
       return res.status(401).json(createNotWithinCohortError());
     }
 
+    const mockData = mockUUIDs[uuid];
+
     if (uuid === 'has-appointment') {
       return res
         .status(409)
-        .json(
-          createAppointmentAlreadyBookedError(
-            mockAppointments[0].appointmentId,
-          ),
-        );
+        .json(createAppointmentAlreadyBookedError(mockData.appointmentId));
     }
 
     return res.json({
       data: {
-        appointmentId: uuid,
+        appointmentId: mockData.appointmentId,
         availableSlots: generateSlots(),
       },
     });

--- a/src/applications/vass/services/mocks/utils/errors.js
+++ b/src/applications/vass/services/mocks/utils/errors.js
@@ -24,6 +24,17 @@ const createUnauthorizedError = () => {
   };
 };
 
+const createInvalidTokenError = () => {
+  return {
+    errors: [
+      {
+        code: TOKEN_ERROR_CODES.INVALID_TOKEN,
+        detail: 'Token is invalid or already revoked',
+      },
+    ],
+  };
+};
+
 const createOTPInvalidError = (attemptsRemaining = 0) => {
   return {
     errors: [
@@ -131,4 +142,5 @@ module.exports = {
   createInvalidCredentialsError,
   createNotWithinCohortError,
   createAppointmentAlreadyBookedError,
+  createInvalidTokenError,
 };

--- a/src/applications/vass/services/mocks/utils/responses.js
+++ b/src/applications/vass/services/mocks/utils/responses.js
@@ -1,0 +1,94 @@
+/** @typedef {import('../../../utils/appointments').Appointment} Appointment */
+
+/**
+ * Mock success responses for VASS API endpoints
+ * Based on the API specification:
+ * https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md
+ */
+
+/**
+ * Creates a success response for GET /vass/v0/appointment-availability
+ * @param {Object} options - Response options
+ * @param {string} options.appointmentId - Unique identifier for the appointment
+ * @param {Array} options.availableSlots - Array of available time slots
+ * @returns {Object} Appointment availability success response
+ */
+const createAppointmentAvailabilityResponse = ({
+  appointmentId = 'e61e1a40-1e63-f011-bec2-001dd80351ea',
+  availableSlots = [],
+} = {}) => {
+  return {
+    data: {
+      appointmentId,
+      availableSlots,
+    },
+  };
+};
+
+/**
+ * Creates a success response for POST /vass/v0/appointment
+ * @param {Object} options - Response options
+ * @param {string} options.appointmentId - Unique identifier for the newly created appointment
+ * @returns {Object} Create appointment success response
+ */
+const createAppointmentResponse = ({ appointmentId = 'abcdef123456' } = {}) => {
+  return {
+    data: {
+      appointmentId,
+    },
+  };
+};
+
+/**
+ * Creates a success response for GET /vass/v0/appointment/{appointmentId}
+ * @param {Partial<Appointment>} options - Response options
+ * @returns {Appointment} Appointment details success response
+ */
+const createAppointmentDetailsResponse = ({
+  appointmentId = 'e61e1a40-1e63-f011-bec2-001dd80351ea',
+  startUTC = '2025-12-24T10:00:00Z',
+  endUTC = '2025-12-24T10:30:00Z',
+  agentId = '353dd0fc-335b-ef11-bfe3-001dd80a9f48',
+  agentNickname = 'Agent Smith',
+  appointmentStatusCode = 1,
+  appointmentStatus = 'Confirmed',
+  cohortStartUtc = '2025-12-01T00:00:00Z',
+  cohortEndUtc = '2026-02-28T23:59:59Z',
+} = {}) => {
+  return {
+    data: {
+      appointmentId,
+      startUTC,
+      endUTC,
+      agentId,
+      agentNickname,
+      appointmentStatusCode,
+      appointmentStatus,
+      cohortStartUtc,
+      cohortEndUtc,
+    },
+  };
+};
+
+/**
+ * Creates a success response for POST /vass/v0/appointment/{appointmentId}/cancel
+ * @param {Object} options - Response options
+ * @param {string} options.appointmentId - Unique identifier of the cancelled appointment
+ * @returns {Object} Cancel appointment success response
+ */
+const createCancelAppointmentResponse = ({
+  appointmentId = 'abcdef123456',
+} = {}) => {
+  return {
+    data: {
+      appointmentId,
+    },
+  };
+};
+
+module.exports = {
+  createAppointmentAvailabilityResponse,
+  createAppointmentResponse,
+  createAppointmentDetailsResponse,
+  createCancelAppointmentResponse,
+};

--- a/src/applications/vass/utils/constants.js
+++ b/src/applications/vass/utils/constants.js
@@ -66,14 +66,14 @@ const TOKEN_ERROR_CODES = Object.freeze({
   UNAUTHORIZED: 'unauthorized',
 });
 
-// Appointment availability errors (GET /vass/v0/appointment-availablity)
+// Appointment availability errors (GET /vass/v0/appointment-availability)
 const AVAILABILITY_ERROR_CODES = Object.freeze({
   APPOINTMENT_ALREADY_BOOKED: 'appointment_already_booked',
   NOT_WITHIN_COHORT: 'not_within_cohort',
   NO_SLOTS_AVAILABLE: 'no_slots_available',
 });
 
-// Appointment errors (POST/GET /vass/v0/appointment)
+// Appointment errors (POST/GET /vass/v0/appointment /vass/v0/appointment/:appointmentId/cancel)
 const APPOINTMENT_ERROR_CODES = Object.freeze({
   APPOINTMENT_SAVE_FAILED: 'appointment_save_failed',
   APPOINTMENT_NOT_FOUND: 'appointment_not_found',

--- a/src/applications/vass/utils/errors.js
+++ b/src/applications/vass/utils/errors.js
@@ -28,7 +28,6 @@ const isMissingParameterError = error => {
   return (
     error?.code === AUTH_ERROR_CODES.MISSING_PARAMETER ||
     error?.code === OTC_ERROR_CODES.MISSING_PARAMETER ||
-    error?.code === AVAILABILITY_ERROR_CODES.MISSING_PARAMETER ||
     error?.code === APPOINTMENT_ERROR_CODES.MISSING_PARAMETER
   );
 };
@@ -60,6 +59,10 @@ const isAppointmentAlreadyBookedError = error => {
   return error?.code === AVAILABILITY_ERROR_CODES.APPOINTMENT_ALREADY_BOOKED;
 };
 
+const isCancellationFailedError = error => {
+  return error?.code === APPOINTMENT_ERROR_CODES.CANCELLATION_FAILED;
+};
+
 export {
   isInvalidCredentialsError,
   isRateLimitExceededError,
@@ -70,4 +73,5 @@ export {
   isAppointmentFailedError,
   isAppointmentNotFoundError,
   isAppointmentAlreadyBookedError,
+  isCancellationFailedError,
 };

--- a/src/applications/vass/utils/mock-helpers.js
+++ b/src/applications/vass/utils/mock-helpers.js
@@ -90,7 +90,7 @@ const generateSlots = (numberOfDays = 14, slotsPerDay = 12) => {
 function createMockJwt(uuid, expiresIn = 3600) {
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: 'HS256', typ: 'JWT' };
-  // TODO: confirm the payload structure
+
   const defaultPayload = {
     sub: uuid,
     jti: 'mock-jti',

--- a/src/applications/vass/utils/navigation.js
+++ b/src/applications/vass/utils/navigation.js
@@ -147,11 +147,11 @@ const getFirstTokenRoute = () => {
 /**
  * Find the route that sets a specific field
  * @param {string} fieldName - The field name to find a route for
- * @returns {string} - The path of the route that sets this field, or '/' as fallback
+ * @returns {string} - The path of the route that sets this field, or URLS.VERIFY as fallback
  */
 const findRouteForField = fieldName => {
   const route = routes.find(r => r.setsData?.includes(fieldName));
-  return route?.path || '/';
+  return route?.path || URLS.VERIFY;
 };
 /**
  * Find the first missing required field


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Resolves TODO comments and cleans up code across the VASS application
- Adds proper error handling for the cancel appointment flow, including displaying a flow-specific error alert ("We can't cancel your appointment right now" vs "We can't schedule your appointment right now")
- Adds token validation (`getTokenOrError`) to all authenticated API endpoints in `vassApi.js`, rejecting requests early when the token is missing or invalid
- Replaces hardcoded appointment IDs and inline mock data with centralized mock response factories (`services/mocks/utils/responses.js`)
- Fixes redirect logic in `withAuthorization` and `withFormData` HOCs so users are navigated to the Verify page with proper query params (uuid, cancel) instead of leaving TODOs for "Something went wrong" routing
- Refactors `CancelAppointment.unit.spec.jsx` to use real API mocking (`mockFetch`) instead of stubbing RTK Query hooks, and adds tests for API error scenarios
- Adds `getValidVassToken` stubs to `DateTimeSelection`, `EnterOTP`, and `Review` test suites for consistent auth mocking
- Fixes minor typo in constants comment (`availablity` → `availability`) and updates `findRouteForField` fallback to use `URLS.VERIFY` instead of `'/'`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#127533

## Testing done

- Verified all existing unit tests continue to pass after refactoring mock patterns
- Added new unit tests for `ErrorAlert` to cover `flowType` prop behavior (default/schedule heading, cancel heading)
- Added new unit tests for `CancelAppointment` API error handling: displays error alert on server error, does not navigate on cancel failure
- Confirmed `getValidVassToken` stubs are correctly set up and torn down in `DateTimeSelection`, `EnterOTP`, and `Review` specs
- Verified the `getTokenOrError` utility correctly returns an error when no valid token is present, preventing unauthenticated API calls

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

N/A — No visual/UI changes. This PR is a code cleanup and error handling improvement with no changes to component layout or styling.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A    | N/A   |
| Desktop | N/A    | N/A   |

## What areas of the site does it impact?

This PR impacts the **VASS (VA Solid Start)** application only (`src/applications/vass/`). Specifically:

- `ErrorAlert` component (now flow-type-aware)
- `Wrapper` layout component (passes `flowType` to `ErrorAlert`)
- `CancelAppointment` page (error handling and loading states)
- `EnterOTP` page (uses dynamic `appointmentId` from API response instead of hardcoded value)
- `withAuthorization` and `withFormData` HOCs (redirect logic with query params)
- `vassApi` RTK Query endpoints (token validation before all authenticated requests)
- Mock utilities (`services/mocks/`) and test files

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) This PR addresses a number of TODOs that were scattered throughout the VASS codebase. Please pay particular attention to:
- The `getTokenOrError` pattern in `vassApi.js` — is this the right place/approach for early token validation?
- The redirect logic in `withFormData` that now reads from the store directly via `useStore()` — any concerns with this approach vs. using selectors?
- The new `services/mocks/utils/responses.js` file — does the factory pattern align with how other apps in the repo structure their mock data?