### PR TITLE
132591 - removing message from sorting

### DIFF
--- a/src/applications/accredited-representative-portal/components/SortForm.jsx
+++ b/src/applications/accredited-representative-portal/components/SortForm.jsx
@@ -73,7 +73,6 @@ const SortForm = ({ options, defaults }) => {
       <VaSelect
         onVaSelect={handleChange}
         label="Sort by"
-        message-aria-describedby="Sort ordering"
         name="options"
         className="poa-request__select"
         value={sort ? `${sort}` : `${defaults.SORT_ORDER}`}


### PR DESCRIPTION
removing extra sort by message that appears under sorting in requests and submissions, see ticket for video
https://github.com/department-of-veterans-affairs/va.gov-team/issues/131774

message is no longer showing up, see before and after:
<img width="385" height="412" alt="sort order - after" src="https://github.com/user-attachments/assets/47cdc79b-42c2-4ddd-b2cf-370331841e9b" />
<img width="374" height="218" alt="sort order - before" src="https://github.com/user-attachments/assets/f4ed3ed8-6e35-4b46-b169-d4eb4d337329" />
