### PR TITLE
Update AVS binary fetch to use the right appointment id

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -442,10 +442,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         );
         if (toFetch.length) {
           // Waits for all AVS PDFs for appointment detail to be fetched before completing action
-          const fetchedAndProcessedPdfs = await fetchAvsPdfBinaries(
-            appointment.id,
-            toFetch,
-          );
+          const fetchedAndProcessedPdfs = await fetchAvsPdfBinaries(toFetch);
           appointment.avsPdf = [...fetchedAndProcessedPdfs, ...doNotFetch];
         }
       }

--- a/src/applications/vaos/services/avs/index.js
+++ b/src/applications/vaos/services/avs/index.js
@@ -32,11 +32,11 @@ function mergeAvsPdfData(avsPdfArray) {
 
 /**
  * Fetch AVS PDF binaries for a given appointment and merge with existing AVS PDF metadata.
- * @param {string} appointmentId
  * @param {AvsObj[]} avsPdfArray
  * @returns {Promise<AvsObj[]>} Merged AVS PDFs with binaries and errors if they exist
  */
-export async function fetchAvsPdfBinaries(appointmentId, avsPdfArray) {
+export async function fetchAvsPdfBinaries(avsPdfArray) {
+  const appointmentId = avsPdfArray[0]?.apptId;
   const ids = avsPdfArray.map(avsPdfObj => avsPdfObj.id).join(',');
   return apiRequestWithUrl(
     `/vaos/v2/appointments/avs_binaries/${appointmentId}?doc_ids=${ids}`,

--- a/src/applications/vaos/services/avs/index.unit.spec.jsx
+++ b/src/applications/vaos/services/avs/index.unit.spec.jsx
@@ -9,7 +9,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should fetch AVS PDF binaries and merge with metadata', async () => {
-      const appointmentId = 'AVS_PDF_Test_1';
       const avsPdfArray = [
         {
           id: '208750417891',
@@ -50,11 +49,11 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       // Verify the API call was made correctly
       expect(global.fetch.firstCall.args[0]).to.contain(
-        `/vaos/v2/appointments/avs_binaries/${appointmentId}`,
+        `/vaos/v2/appointments/avs_binaries/AVS_PDF_Test_1`,
       );
       expect(global.fetch.firstCall.args[0]).to.contain(
         'doc_ids=208750417891,208750417892',
@@ -80,7 +79,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should handle single AVS PDF', async () => {
-      const appointmentId = 'AVS_PDF_Test_2';
       const avsPdfArray = [
         {
           id: '208750417893',
@@ -106,7 +104,7 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       expect(global.fetch.firstCall.args[0]).to.contain('doc_ids=208750417893');
       expect(result).to.have.lengthOf(1);
@@ -118,7 +116,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should handle mixed success and error responses', async () => {
-      const appointmentId = 'AVS_PDF_Test_5';
       const avsPdfArray = [
         {
           id: '208750417896',
@@ -159,7 +156,7 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       expect(result).to.have.lengthOf(2);
       expect(result[0].binary).to.equal(
@@ -173,7 +170,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should handle retrieval errors', async () => {
-      const appointmentId = 'AVS_PDF_Test_6';
       const avsPdfArray = [
         {
           id: '208750417898',
@@ -199,7 +195,7 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       expect(result).to.have.lengthOf(1);
       expect(result[0]).to.deep.include({
@@ -210,7 +206,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should preserve all metadata fields when merging', async () => {
-      const appointmentId = 'AVS_PDF_Test_7';
       const avsPdfArray = [
         {
           id: '208750417899',
@@ -253,7 +248,7 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       expect(result).to.have.lengthOf(2);
 
@@ -275,7 +270,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should handle empty avsPdfArray', async () => {
-      const appointmentId = 'AVS_PDF_Test_Empty';
       const avsPdfArray = [];
 
       const mockResponse = {
@@ -284,18 +278,17 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       expect(global.fetch.firstCall.args[0]).to.contain('doc_ids=');
       expect(result).to.have.lengthOf(0);
     });
 
     it('should construct correct URL with query parameters', async () => {
-      const appointmentId = 'TEST_APPT_123';
       const avsPdfArray = [
-        { id: 'DOC_001' },
-        { id: 'DOC_002' },
-        { id: 'DOC_003' },
+        { id: 'DOC_001', apptId: 'TEST_APPT_123' },
+        { id: 'DOC_002', apptId: 'TEST_APPT_123' },
+        { id: 'DOC_003', apptId: 'TEST_APPT_123' },
       ];
 
       const mockResponse = {
@@ -317,7 +310,7 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      await fetchAvsPdfBinaries(avsPdfArray);
 
       const fetchUrl = global.fetch.firstCall.args[0];
       expect(fetchUrl).to.contain(
@@ -327,7 +320,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should set binary and error to null when not present in response', async () => {
-      const appointmentId = 'AVS_PDF_Test_Null';
       const avsPdfArray = [
         {
           id: '208750417999',
@@ -349,7 +341,7 @@ describe('VAOS Services: AVS', () => {
 
       setFetchJSONResponse(global.fetch, mockResponse);
 
-      const result = await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+      const result = await fetchAvsPdfBinaries(avsPdfArray);
 
       expect(result).to.have.lengthOf(1);
       expect(result[0]).to.deep.include({
@@ -361,7 +353,6 @@ describe('VAOS Services: AVS', () => {
     });
 
     it('should handle API errors', async () => {
-      const appointmentId = 'AVS_PDF_Test_Error';
       const avsPdfArray = [
         {
           id: '208750417999',
@@ -372,7 +363,7 @@ describe('VAOS Services: AVS', () => {
       global.fetch.rejects(new Error('Network error'));
 
       try {
-        await fetchAvsPdfBinaries(appointmentId, avsPdfArray);
+        await fetchAvsPdfBinaries(avsPdfArray);
         expect.fail('Should have thrown an error');
       } catch (error) {
         expect(error.message).to.equal('Network error');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We need to use the OH appointment identifier instead of the VAOS appointment ID
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130977

## Testing done

- Tested locally and on staging using Silva

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

