### PR TITLE
[ARC/131723] - removing label from link for voice control

### DIFF
--- a/src/applications/representative-form-upload/containers/IntroductionPageITF.jsx
+++ b/src/applications/representative-form-upload/containers/IntroductionPageITF.jsx
@@ -27,7 +27,6 @@ const IntroductionPageITF = ({ route, router }) => {
       return (
         <VaLinkAction
           href="#start"
-          label="Start form upload and submission"
           class=" representative-form__start"
           text="Start the submission"
           onClick={startForm}


### PR DESCRIPTION
removing extra label from start link under forms, see ticket:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/131723