### PR TITLE
534ez add migrations updates

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
@@ -194,7 +194,7 @@ const dobPlacePage = {
         'Enter 1 or 2 digits for the month and day and 4 digits for the year.',
       required: formData => !formData['view:dateOfBirth'],
     }),
-    bornOutsideUS: checkboxUI({
+    bornOutsideUs: checkboxUI({
       title: 'They were born outside the U.S.',
     }),
     birthPlace: {
@@ -209,13 +209,13 @@ const dobPlacePage = {
         'ui:required': (formData, index) => {
           const item = formData?.veteransChildren?.[index];
           const currentPageData = formData;
-          return !(item?.bornOutsideUS || currentPageData?.bornOutsideUS);
+          return !(item?.bornOutsideUs || currentPageData?.bornOutsideUs);
         },
         'ui:options': {
           hideIf: (formData, index) => {
             const item = formData?.veteransChildren?.[index];
             const currentPageData = formData;
-            return item?.bornOutsideUS || currentPageData?.bornOutsideUS;
+            return item?.bornOutsideUs || currentPageData?.bornOutsideUs;
           },
         },
         'ui:errorMessages': {
@@ -227,13 +227,13 @@ const dobPlacePage = {
         'ui:required': (formData, index) => {
           const item = formData?.veteransChildren?.[index];
           const currentPageData = formData;
-          return item?.bornOutsideUS || currentPageData?.bornOutsideUS;
+          return item?.bornOutsideUs || currentPageData?.bornOutsideUs;
         },
         'ui:options': {
           hideIf: (formData, index) => {
             const item = formData?.veteransChildren?.[index];
             const currentPageData = formData;
-            return !(item?.bornOutsideUS || currentPageData?.bornOutsideUS);
+            return !(item?.bornOutsideUs || currentPageData?.bornOutsideUs);
           },
           labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
             acc[value] = COUNTRY_NAMES[idx];
@@ -251,7 +251,7 @@ const dobPlacePage = {
     required: ['birthPlace', 'childDateOfBirth'],
     properties: {
       childDateOfBirth: currentOrPastDateSchema,
-      bornOutsideUS: checkboxSchema,
+      bornOutsideUs: checkboxSchema,
       birthPlace: customAddressSchema,
     },
   },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranEndInfo.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranEndInfo.js
@@ -27,16 +27,16 @@ export default {
       title: 'Date marriage ended',
       monthSelect: false,
     }),
-    marriageToVeteranEndOutsideUS: checkboxUI({
+    marriageToVeteranEndOutsideUs: checkboxUI({
       title: 'My marriage ended outside the U.S.',
     }),
     marriageToVeteranEndLocation: {
       city: textUI('City'),
       state: {
         ...selectUI('State'),
-        'ui:required': formData => !formData?.marriageToVeteranEndOutsideUS,
+        'ui:required': formData => !formData?.marriageToVeteranEndOutsideUs,
         'ui:options': {
-          hideIf: formData => formData?.marriageToVeteranEndOutsideUS,
+          hideIf: formData => formData?.marriageToVeteranEndOutsideUs,
           labels: STATE_VALUES.reduce((acc, value, idx) => {
             acc[value] = STATE_NAMES[idx];
             return acc;
@@ -48,9 +48,9 @@ export default {
       },
       otherCountry: {
         ...selectUI('Country'),
-        'ui:required': formData => formData?.marriageToVeteranEndOutsideUS,
+        'ui:required': formData => formData?.marriageToVeteranEndOutsideUs,
         'ui:options': {
-          hideIf: formData => !formData?.marriageToVeteranEndOutsideUS,
+          hideIf: formData => !formData?.marriageToVeteranEndOutsideUs,
           labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
             acc[value] = COUNTRY_NAMES[idx];
             return acc;
@@ -67,7 +67,7 @@ export default {
     required: ['marriageToVeteranEndDate', 'marriageToVeteranEndLocation'],
     properties: {
       marriageToVeteranEndDate: currentOrPastDateSchema,
-      marriageToVeteranEndOutsideUS: checkboxSchema,
+      marriageToVeteranEndOutsideUs: checkboxSchema,
       marriageToVeteranEndLocation: customAddressSchema,
     },
   },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranLocation.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranLocation.js
@@ -24,16 +24,16 @@ export default {
       title: 'Date of marriage',
       monthSelect: false,
     }),
-    marriageToVeteranStartOutsideUS: checkboxUI({
+    marriageToVeteranStartOutsideUs: checkboxUI({
       title: 'I got married outside the U.S.',
     }),
     marriageToVeteranStartLocation: {
       city: textUI('City'),
       state: {
         ...selectUI('State'),
-        'ui:required': formData => !formData?.marriageToVeteranStartOutsideUS,
+        'ui:required': formData => !formData?.marriageToVeteranStartOutsideUs,
         'ui:options': {
-          hideIf: formData => formData?.marriageToVeteranStartOutsideUS,
+          hideIf: formData => formData?.marriageToVeteranStartOutsideUs,
           labels: STATE_VALUES.reduce((acc, value, idx) => {
             acc[value] = STATE_NAMES[idx];
             return acc;
@@ -45,9 +45,9 @@ export default {
       },
       otherCountry: {
         ...selectUI('Country'),
-        'ui:required': formData => formData?.marriageToVeteranStartOutsideUS,
+        'ui:required': formData => formData?.marriageToVeteranStartOutsideUs,
         'ui:options': {
-          hideIf: formData => !formData?.marriageToVeteranStartOutsideUS,
+          hideIf: formData => !formData?.marriageToVeteranStartOutsideUs,
           labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
             acc[value] = COUNTRY_NAMES[idx];
             return acc;
@@ -64,7 +64,7 @@ export default {
     required: ['marriageToVeteranStartDate', 'marriageToVeteranStartLocation'],
     properties: {
       marriageToVeteranStartDate: currentOrPastDateSchema,
-      marriageToVeteranStartOutsideUS: checkboxSchema,
+      marriageToVeteranStartOutsideUs: checkboxSchema,
       marriageToVeteranStartLocation: customAddressSchema,
     },
   },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -45,8 +45,8 @@ export const options = {
     !item?.spouseFullName?.last ||
     !item?.dateOfMarriage ||
     !item?.locationOfMarriage?.city ||
-    (!item?.marriedOutsideUS && !item?.locationOfMarriage?.state) ||
-    (item?.marriedOutsideUS && !item?.locationOfMarriage?.otherCountry) ||
+    (!item?.marriedOutsideUs && !item?.locationOfMarriage?.state) ||
+    (item?.marriedOutsideUs && !item?.locationOfMarriage?.otherCountry) ||
     !item?.reasonForSeparation ||
     (item?.reasonForSeparation === 'OTHER' && !item?.separationExplanation),
   maxItems: 2,
@@ -179,7 +179,7 @@ const marriageDateAndLocationPage = {
       title: 'Date of marriage',
       monthSelect: false,
     }),
-    marriedOutsideUS: checkboxUI({
+    marriedOutsideUs: checkboxUI({
       title: 'I got married outside the U.S.',
     }),
     locationOfMarriage: {
@@ -189,13 +189,13 @@ const marriageDateAndLocationPage = {
         'ui:required': (formData, index) => {
           const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
-          return !(item?.marriedOutsideUS || currentPageData?.marriedOutsideUS);
+          return !(item?.marriedOutsideUs || currentPageData?.marriedOutsideUs);
         },
         'ui:options': {
           hideIf: (formData, index) => {
             const item = formData?.spouseMarriages?.[index];
             const currentPageData = formData;
-            return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
+            return item?.marriedOutsideUs || currentPageData?.marriedOutsideUs;
           },
           labels: STATE_VALUES.reduce((acc, value, idx) => {
             acc[value] = STATE_NAMES[idx];
@@ -211,14 +211,14 @@ const marriageDateAndLocationPage = {
         'ui:required': (formData, index) => {
           const item = formData?.spouseMarriages?.[index];
           const currentPageData = formData;
-          return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
+          return item?.marriedOutsideUs || currentPageData?.marriedOutsideUs;
         },
         'ui:options': {
           hideIf: (formData, index) => {
             const item = formData?.spouseMarriages?.[index];
             const currentPageData = formData;
             return !(
-              item?.marriedOutsideUS || currentPageData?.marriedOutsideUS
+              item?.marriedOutsideUs || currentPageData?.marriedOutsideUs
             );
           },
           labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
@@ -237,7 +237,7 @@ const marriageDateAndLocationPage = {
     required: ['dateOfMarriage', 'locationOfMarriage'],
     properties: {
       dateOfMarriage: currentOrPastDateSchema,
-      marriedOutsideUS: checkboxSchema,
+      marriedOutsideUs: checkboxSchema,
       locationOfMarriage: customAddressSchema,
     },
   },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -162,7 +162,7 @@ const marriageDatePlacePage = {
         'Enter 1 or 2 digits for the month and day and 4 digits for the year.',
       required: formData => !formData['view:marriageDate'],
     }),
-    marriedOutsideUS: checkboxUI({
+    marriedOutsideUs: checkboxUI({
       title: 'They got married outside the U.S.',
     }),
     locationOfMarriage: {
@@ -172,13 +172,13 @@ const marriageDatePlacePage = {
         'ui:required': (formData, index) => {
           const item = formData?.veteranMarriages?.[index];
           const currentPageData = formData;
-          return !(item?.marriedOutsideUS || currentPageData?.marriedOutsideUS);
+          return !(item?.marriedOutsideUs || currentPageData?.marriedOutsideUs);
         },
         'ui:options': {
           hideIf: (formData, index) => {
             const item = formData?.veteranMarriages?.[index];
             const currentPageData = formData;
-            return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
+            return item?.marriedOutsideUs || currentPageData?.marriedOutsideUs;
           },
         },
       },
@@ -187,14 +187,14 @@ const marriageDatePlacePage = {
         'ui:required': (formData, index) => {
           const item = formData?.veteranMarriages?.[index];
           const currentPageData = formData;
-          return item?.marriedOutsideUS || currentPageData?.marriedOutsideUS;
+          return item?.marriedOutsideUs || currentPageData?.marriedOutsideUs;
         },
         'ui:options': {
           hideIf: (formData, index) => {
             const item = formData?.veteranMarriages?.[index];
             const currentPageData = formData;
             return !(
-              item?.marriedOutsideUS || currentPageData?.marriedOutsideUS
+              item?.marriedOutsideUs || currentPageData?.marriedOutsideUs
             );
           },
           labels: COUNTRY_VALUES.reduce((acc, value, idx) => {
@@ -213,7 +213,7 @@ const marriageDatePlacePage = {
     required: ['locationOfMarriage', 'dateOfMarriage'],
     properties: {
       dateOfMarriage: currentOrPastDateSchema,
-      marriedOutsideUS: checkboxSchema,
+      marriedOutsideUs: checkboxSchema,
       locationOfMarriage: customAddressSchema,
     },
   },

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -74,6 +74,8 @@ import IncorrectForm from '../containers/IncorrectForm';
 // TODO: Will be added after mvp release
 // import reviewDocuments from './chapters/07-additional-information/reviewDocuments';
 import { transform } from './submit-transformer';
+import migrations from '../utils/migrations';
+// import prefillTransformer from './prefill-transformer';
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -84,6 +86,7 @@ const formConfig = {
   trackingPrefix: 'survivors-534ez',
   v3SegmentedProgressBar: true,
   prefillEnabled: true,
+  // prefillTransformer,
   dev: {
     disableWindowUnloadInCI: true,
     showNavLinks: true,
@@ -102,6 +105,7 @@ const formConfig = {
     },
   },
   version: 0,
+  migrations,
   formSavedPage: FormSavedPage,
   defaultDefinitions,
   savedFormMessages: {

--- a/src/applications/survivors-benefits/config/form.js
+++ b/src/applications/survivors-benefits/config/form.js
@@ -128,8 +128,7 @@ const formConfig = {
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   errorText: ErrorText,
-  // Commenting out to troubleshoot error on staging.
-  // showReviewErrors: !environment.isProduction() && !environment.isStaging(),
+  showReviewErrors: !environment.isProduction() && !environment.isStaging(),
   chapters: {
     // Chapter 1 - Veteran Information
     veteranInformation: {

--- a/src/applications/survivors-benefits/config/prefill-transformer.js
+++ b/src/applications/survivors-benefits/config/prefill-transformer.js
@@ -1,0 +1,7 @@
+export default function prefillTransformer(pages, formData, metadata) {
+  return {
+    pages,
+    formData: {},
+    metadata,
+  };
+}

--- a/src/applications/survivors-benefits/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/survivors-benefits/tests/e2e/fixtures/data/maximal-test.json
@@ -77,7 +77,7 @@
     },
     "marriedToVeteranAtTimeOfDeath": true,
     "marriageToVeteranStartDate": "2010-01-01",
-    "marriageToVeteranStartOutsideUS": false,
+    "marriageToVeteranStartOutsideUs": false,
     "marriageToVeteranStartLocation": {
       "city": "Anytown",
       "state": "OH"
@@ -87,7 +87,7 @@
     "marriageEndReason": "OTHER",
     "marriageEndOtherReason": "Custom End Reason",
     "marriageToVeteranEndDate": "2020-01-01",
-    "marriageToVeteranEndOutsideUS": false,
+    "marriageToVeteranEndOutsideUs": false,
     "marriageToVeteranEndLocation": {
       "city": "Anytown",
       "state": "OH"

--- a/src/applications/survivors-benefits/tests/e2e/survivors-benefits.cypress.spec.js
+++ b/src/applications/survivors-benefits/tests/e2e/survivors-benefits.cypress.spec.js
@@ -150,10 +150,10 @@ const testConfig = createTestConfig(
                 data.marriageToVeteranStartDate,
               );
             }
-            if (data.marriageToVeteranStartOutsideUS !== undefined) {
+            if (data.marriageToVeteranStartOutsideUs !== undefined) {
               cy.selectVaCheckbox(
                 'root_marriageToVeteranStartOutsideUS',
-                data.marriageToVeteranStartOutsideUS,
+                data.marriageToVeteranStartOutsideUs,
               );
             }
             if (data.marriageToVeteranStartLocation) {
@@ -175,10 +175,10 @@ const testConfig = createTestConfig(
                 data.marriageToVeteranEndDate,
               );
             }
-            if (data.marriageToVeteranEndOutsideUS !== undefined) {
+            if (data.marriageToVeteranEndOutsideUs !== undefined) {
               cy.selectVaCheckbox(
                 'root_marriageToVeteranEndOutsideUS',
-                data.marriageToVeteranEndOutsideUS,
+                data.marriageToVeteranEndOutsideUs,
               );
             }
             if (data.marriageToVeteranEndLocation) {
@@ -254,10 +254,10 @@ const testConfig = createTestConfig(
                 data.spouseMarriages[index].marriageToVeteranDate,
               );
             }
-            if (data?.spouseMarriages[index]?.marriedOutsideUS !== undefined) {
+            if (data?.spouseMarriages[index]?.marriedOutsideUs !== undefined) {
               cy.selectVaCheckbox(
                 'root_marriedOutsideUS',
-                data.spouseMarriages[index].marriedOutsideUS,
+                data.spouseMarriages[index].marriedOutsideUs,
               );
             }
             if (data?.spouseMarriages[index]?.marriageLocation) {
@@ -312,10 +312,10 @@ const testConfig = createTestConfig(
                 data.veteranMarriages[index].marriageDate,
               );
             }
-            if (data?.veteranMarriages[index]?.marriedOutsideUS !== undefined) {
+            if (data?.veteranMarriages[index]?.marriedOutsideUs !== undefined) {
               cy.selectVaCheckbox(
                 'root_marriedOutsideUS',
-                data.veteranMarriages[index].marriedOutsideUS,
+                data.veteranMarriages[index].marriedOutsideUs,
               );
             }
             if (data?.veteranMarriages[index]?.marriageLocation) {
@@ -371,10 +371,10 @@ const testConfig = createTestConfig(
                 data.dependents[index].dateOfBirth,
               );
             }
-            if (data?.dependents[index]?.bornOutsideUS !== undefined) {
+            if (data?.dependents[index]?.bornOutsideUs !== undefined) {
               cy.selectVaCheckbox(
                 'root_bornOutsideUS',
-                data.dependents[index].bornOutsideUS,
+                data.dependents[index].bornOutsideUs,
               );
             }
             if (data?.dependents[index]?.birthPlace) {

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -249,7 +249,7 @@
         "city": "Hamburg",
         "otherCountry": "DEU"
       },
-      "bornOutsideUS": true,
+      "bornOutsideUs": true,
       "relationship": "ADOPTED",
       "inSchool": false,
       "seriouslyDisabled": true,
@@ -272,7 +272,7 @@
         "state": "OH",
         "otherCountry": "USA"
       },
-      "bornOutsideUS": false,
+      "bornOutsideUs": false,
       "relationship": "BIOLOGICAL",
       "inSchool": true,
       "seriouslyDisabled": false,
@@ -294,7 +294,7 @@
         "state": "MO",
         "otherCountry": "USA"
       },
-      "bornOutsideUS": false,
+      "bornOutsideUs": false,
       "relationship": "STEPCHILD",
       "inSchool": true,
       "seriouslyDisabled": false,
@@ -320,6 +320,7 @@
     {
       "reasonForSeparation": "OTHER",
       "separationExplanation": "Some other reason",
+      "marriedOutsideUs": true,
       "dateOfMarriage": "1990-01-01",
       "dateOfSeparation": "2000-01-01",
       "locationOfSeparation": {
@@ -328,7 +329,7 @@
       },
       "locationOfMarriage": {
         "city": "Another City",
-        "state": "TX"
+        "otherCountry": "ALB"
       },
       "spouseFullName": {
         "first": "SpouseFirst",
@@ -380,11 +381,12 @@
     },
     {
       "reasonForSeparation": "DIVORCE",
+      "marriedOutsideUs": true,
       "dateOfMarriage": "2002-01-01",
       "dateOfSeparation": "2012-01-01",
       "locationOfSeparation": {
         "city": "City2",
-        "state": "PA"
+        "state": "ALB"
       },
       "locationOfMarriage": {
         "city": "City1",

--- a/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/survivors-benefits/tests/fixtures/mocks/completed-form.json
@@ -386,11 +386,11 @@
       "dateOfSeparation": "2012-01-01",
       "locationOfSeparation": {
         "city": "City2",
-        "state": "ALB"
+         "state": "PA"
       },
       "locationOfMarriage": {
         "city": "City1",
-        "state": "PA"
+        "otherCountry": "ALB"
       },
       "spouseFullName": {
         "first": "Spouse2Fi",

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
@@ -124,17 +124,17 @@ describe('Dependents Pages', () => {
     expect(ssnElUnset.getAttribute('required')).to.equal('true');
   });
 
-  it('birthPlace state/country is displayed when bornOutsideUS is true', () => {
+  it('birthPlace state/country is displayed when bornOutsideUs is true', () => {
     const { dependentDobPlace: page } = dependentsPages;
 
-    // bornOutsideUS => city shown and required, country shown and required
+    // bornOutsideUs => city shown and required, country shown and required
     const form = render(
       <DefinitionTester
         arrayPath="veteransChildren"
         schema={page.schema}
         uiSchema={page.uiSchema}
         pagePerItemIndex={0}
-        data={{ veteransChildren: [{ bornOutsideUS: true }] }}
+        data={{ veteransChildren: [{ bornOutsideUs: true }] }}
       />,
     );
     const formDOM = getFormDOM(form);
@@ -151,7 +151,7 @@ describe('Dependents Pages', () => {
     expect(countrySelect.getAttribute('required')).to.equal('true');
   });
 
-  it('birthPlace city/state is displayed when bornOutsideUS does not exist', () => {
+  it('birthPlace city/state is displayed when bornOutsideUs does not exist', () => {
     const { dependentDobPlace: page } = dependentsPages;
 
     // bornInsideUS => state shown and required, country hidden and not required

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/previousMarriagesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/previousMarriagesPages.unit.spec.jsx
@@ -175,7 +175,7 @@ describe('Previous marriages pages', () => {
       .false;
   });
 
-  it('toggles state/country visibility and requiredness based on marriedOutsideUS', () => {
+  it('toggles state/country visibility and requiredness based on marriedOutsideUs', () => {
     const itemUi = findItemUi(previousMarriageDateAndLocationPage);
     expect(itemUi, 'marriage date/location item UI not found').to.exist;
     const stateOptions = itemUi.locationOfMarriage.state['ui:options'];
@@ -184,13 +184,13 @@ describe('Previous marriages pages', () => {
     const countryRequired =
       itemUi.locationOfMarriage.otherCountry['ui:required'];
 
-    const itemBornOutside = { spouseMarriages: [{ marriedOutsideUS: true }] };
+    const itemBornOutside = { spouseMarriages: [{ marriedOutsideUs: true }] };
     expect(stateOptions.hideIf(itemBornOutside, 0)).to.be.true;
     expect(Boolean(stateRequired(itemBornOutside, 0))).to.be.false;
     expect(countryOptions.hideIf(itemBornOutside, 0)).to.be.false;
     expect(Boolean(countryRequired(itemBornOutside, 0))).to.be.true;
 
-    const topBornOutside = { marriedOutsideUS: true };
+    const topBornOutside = { marriedOutsideUs: true };
     expect(stateOptions.hideIf(topBornOutside, 0)).to.be.true;
     expect(Boolean(stateRequired(topBornOutside, 0))).to.be.false;
     expect(countryOptions.hideIf(topBornOutside, 0)).to.be.false;
@@ -320,7 +320,7 @@ describe('Previous marriages pages', () => {
       spouseFullName: { first: 'John', last: 'Doe' },
       dateOfMarriage: '2000-01-01',
       locationOfMarriage: { city: 'Somewhere', state: 'VA' },
-      marriedOutsideUS: false,
+      marriedOutsideUs: false,
       reasonForSeparation: 'DIVORCE',
     };
 
@@ -328,7 +328,7 @@ describe('Previous marriages pages', () => {
       spouseFullName: { first: '', last: 'Doe' },
       dateOfMarriage: '2000-01-01',
       locationOfMarriage: { city: 'Somewhere', state: 'VA' },
-      marriedOutsideUS: false,
+      marriedOutsideUs: false,
       reasonForSeparation: 'DIVORCE',
     };
 
@@ -336,23 +336,23 @@ describe('Previous marriages pages', () => {
       spouseFullName: { first: 'John', last: '' },
       dateOfMarriage: '2000-01-01',
       locationOfMarriage: { city: 'Somewhere', state: 'VA' },
-      marriedOutsideUS: false,
+      marriedOutsideUs: false,
       reasonForSeparation: 'DIVORCE',
     };
 
     const missingState = {
       spouseFullName: { first: 'John', last: 'Doe' },
       dateOfMarriage: '2000-01-01',
-      locationOfMarriage: { city: 'Somewhere' }, // missing state when marriedOutsideUS false
-      marriedOutsideUS: false,
+      locationOfMarriage: { city: 'Somewhere' }, // missing state when marriedOutsideUs false
+      marriedOutsideUs: false,
       reasonForSeparation: 'DIVORCE',
     };
 
     const missingCountry = {
       spouseFullName: { first: 'John', last: 'Doe' },
       dateOfMarriage: '2000-01-01',
-      locationOfMarriage: { city: 'Somewhere' }, // missing country when marriedOutsideUS true
-      marriedOutsideUS: true,
+      locationOfMarriage: { city: 'Somewhere' }, // missing country when marriedOutsideUs true
+      marriedOutsideUs: true,
       reasonForSeparation: 'DIVORCE',
     };
 
@@ -360,7 +360,7 @@ describe('Previous marriages pages', () => {
       spouseFullName: { first: 'John', last: 'Doe' },
       dateOfMarriage: '2000-01-01',
       locationOfMarriage: { city: 'Somewhere', state: 'VA' },
-      marriedOutsideUS: false,
+      marriedOutsideUs: false,
       reasonForSeparation: 'OTHER',
       reasonForSeparationreasonForSeparationExplanation: '',
     };

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/veteranMarriagesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/veteranMarriagesPages.unit.spec.jsx
@@ -138,7 +138,7 @@ describe('Veteran Previous Marriages pages', () => {
     }
   });
 
-  it('marriage date/place state/country hideIf and required respond to marriedOutsideUS', () => {
+  it('marriage date/place state/country hideIf and required respond to marriedOutsideUs', () => {
     const itemUi = findItemUi(veteranMarriageDatePlace);
     expect(itemUi, 'marriage date/place item UI not found').to.exist;
     const stateOptions = itemUi.locationOfMarriage.state['ui:options'];
@@ -147,7 +147,7 @@ describe('Veteran Previous Marriages pages', () => {
     const countryRequired =
       itemUi.locationOfMarriage.otherCountry['ui:required'];
 
-    const itemBornOutside = { veteranMarriages: [{ marriedOutsideUS: true }] };
+    const itemBornOutside = { veteranMarriages: [{ marriedOutsideUs: true }] };
     expect(Boolean(stateOptions.hideIf(itemBornOutside, 0))).to.be.true;
     expect(Boolean(stateRequired(itemBornOutside, 0))).to.be.false;
     expect(Boolean(countryOptions.hideIf(itemBornOutside, 0))).to.be.false;

--- a/src/applications/survivors-benefits/utils/migrations/index.js
+++ b/src/applications/survivors-benefits/utils/migrations/index.js
@@ -1,0 +1,4 @@
+import validateInternationalPhoneNumbers from './validateInternationalPhoneNumbers';
+import validateDICLabel from './validateDICLabel';
+
+export default [validateInternationalPhoneNumbers, validateDICLabel];

--- a/src/applications/survivors-benefits/utils/migrations/validateDICLabel.js
+++ b/src/applications/survivors-benefits/utils/migrations/validateDICLabel.js
@@ -1,0 +1,11 @@
+export default function validateDICLabel(savedData) {
+  const { formData, metadata } = savedData;
+  if (formData?.claims?.dic) {
+    formData.claims.DIC = formData.claims.dic;
+    delete formData.claims.dic;
+  }
+  return {
+    formData,
+    metadata,
+  };
+}

--- a/src/applications/survivors-benefits/utils/migrations/validateInternationalPhoneNumbers.js
+++ b/src/applications/survivors-benefits/utils/migrations/validateInternationalPhoneNumbers.js
@@ -1,0 +1,19 @@
+export default function validateInternationalPhoneNumbers(savedData) {
+  const { formData, metadata } = savedData;
+  if (
+    formData?.claimantPhone &&
+    typeof formData.claimantPhone === 'object' &&
+    formData.claimantPhone.contact
+  ) {
+    formData.claimantPhone._isValid =
+      formData.claimantPhone.isValid || formData.claimantPhone.IsValid;
+    formData.claimantPhone._error =
+      formData.claimantPhone.error ?? formData.claimantPhone.Error ?? null;
+    formData.claimantPhone._touched =
+      formData.claimantPhone.touched || formData.claimantPhone.Touched;
+  }
+  return {
+    formData,
+    metadata,
+  };
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add migration functions to update save in progress data for international phone and claim type. 
- Updated the helper form fields of marriage location and born that ended in `US` to `Us` to match the return from sasve in progress.
- When using save in progress, the data coming back from the endpoint had mismatched keys with what we had in the form.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- Manual testing locally with vets-api and save in progress tools

## Screenshots

N/A

## What areas of the site does it impact?

Save in progress on 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
