### PR TITLE
Micahalconcel/130183 0779 fe interim fix long names

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-personal-info.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-personal-info.js
@@ -11,6 +11,47 @@ import {
   dateOfBirthSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+import { isValidNameLength } from '../../shared/utils/validators/validators';
+
+const customVeteranNameUISchema = () => {
+  const baseSchema = fullNameNoSuffixUI();
+  return {
+    ...baseSchema,
+    first: {
+      ...baseSchema.first,
+      'ui:title': 'First or given name',
+      'ui:validations': [
+        ...baseSchema.first['ui:validations'],
+        (errors = {}, _fieldData, formData) => {
+          isValidNameLength(
+            errors,
+            formData?.claimantPersonalInfo?.claimantFullName?.first,
+            12,
+          );
+        },
+      ],
+    },
+    middle: {
+      ...baseSchema.middle,
+      'ui:title': 'Middle initial',
+    },
+    last: {
+      ...baseSchema.last,
+      'ui:title': 'Last or family name',
+      'ui:validations': [
+        ...baseSchema.last['ui:validations'],
+        (errors = {}, _fieldData, formData) => {
+          isValidNameLength(
+            errors,
+            formData?.claimantPersonalInfo?.claimantFullName?.last,
+            18,
+          );
+        },
+      ],
+    },
+  };
+};
+
 /**
  * uiSchema for Claimant Personal Info page
  * Collects patient name and date of birth when patient is spouse or parent
@@ -19,13 +60,7 @@ export const claimantPersonalInfoUiSchema = {
   'ui:title': "Patient's name and date of birth",
   'ui:description': 'Tell us about the patient in the nursing home',
   claimantPersonalInfo: {
-    claimantFullName: {
-      ...fullNameNoSuffixUI(),
-      middle: {
-        ...fullNameNoSuffixUI().middle,
-        'ui:title': 'Middle initial',
-      },
-    },
+    claimantFullName: customVeteranNameUISchema(),
     claimantDateOfBirth: dateOfBirthUI(),
   },
 };
@@ -40,7 +75,6 @@ const fullNameSchemaWithMiddleInitial = {
     ...fullNameNoSuffixSchema.properties,
     first: {
       type: 'string',
-      maxLength: 12,
     },
     middle: {
       type: 'string',
@@ -48,7 +82,6 @@ const fullNameSchemaWithMiddleInitial = {
     },
     last: {
       type: 'string',
-      maxLength: 18,
     },
   },
 };

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-personal-info.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-personal-info.unit.spec.jsx
@@ -1,0 +1,44 @@
+/**
+ * @module tests/pages/benefits-details.unit.spec
+ * @description Unit tests for Benefits Details page dynamic title logic
+ * VA Form 21-4192 - Request for Employment Information
+ */
+
+import { expect } from 'chai';
+
+import { claimantPersonalInfoUiSchema } from './claimant-personal-info';
+
+describe('Claimant Personal Info Page', () => {
+  describe('validate name lengths', () => {
+    let errorMessages = [];
+
+    const errors = {
+      addError: message => {
+        errorMessages.push(message || '');
+      },
+    };
+
+    beforeEach(() => {
+      errorMessages = [];
+    });
+
+    it('should show a validation error if first name is longer than 12 characters', () => {
+      const formData = {
+        claimantPersonalInfo: {
+          claimantFullName: { first: 'ThisIsAVeryLongFirstName', last: 'Doe' },
+        },
+      };
+
+      // expect a validation error for the first name field
+      const firstNameValidation =
+        claimantPersonalInfoUiSchema.claimantPersonalInfo.claimantFullName
+          .first['ui:validations'][1];
+      firstNameValidation(errors, null, formData);
+
+      expect(errorMessages[0]).to.exist;
+      expect(errorMessages[0]).to.equal(
+        'Please enter a name under 12 characters. If your name is longer, enter the first 12 characters only.',
+      );
+    });
+  });
+});

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-personal-info.js
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-personal-info.js
@@ -12,6 +12,46 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import { isPatientVeteran } from '../utils';
+import { isValidNameLength } from '../../shared/utils/validators/validators';
+
+const customVeteranNameUISchema = () => {
+  const baseSchema = fullNameNoSuffixUI();
+  return {
+    ...baseSchema,
+    first: {
+      ...baseSchema.first,
+      'ui:title': 'First or given name',
+      'ui:validations': [
+        ...baseSchema.first['ui:validations'],
+        (errors = {}, _fieldData, formData) => {
+          isValidNameLength(
+            errors,
+            formData?.veteranPersonalInfo?.fullName?.first,
+            12,
+          );
+        },
+      ],
+    },
+    middle: {
+      ...baseSchema.middle,
+      'ui:title': 'Middle initial',
+    },
+    last: {
+      ...baseSchema.last,
+      'ui:title': 'Last or family name',
+      'ui:validations': [
+        ...baseSchema.last['ui:validations'],
+        (errors = {}, _fieldData, formData) => {
+          isValidNameLength(
+            errors,
+            formData?.veteranPersonalInfo?.fullName?.last,
+            18,
+          );
+        },
+      ],
+    },
+  };
+};
 
 /**
  * uiSchema for Veteran Personal Info page
@@ -20,13 +60,7 @@ import { isPatientVeteran } from '../utils';
 export const veteranPersonalInfoUiSchema = {
   'ui:title': "Veteran's name and date of birth",
   veteranPersonalInfo: {
-    fullName: {
-      ...fullNameNoSuffixUI(),
-      middle: {
-        ...fullNameNoSuffixUI().middle,
-        'ui:title': 'Middle initial',
-      },
-    },
+    fullName: customVeteranNameUISchema(),
     dateOfBirth: dateOfBirthUI(),
   },
   'ui:options': {
@@ -55,7 +89,6 @@ const fullNameSchemaWithMiddleInitial = {
     ...fullNameNoSuffixSchema.properties,
     first: {
       type: 'string',
-      maxLength: 12,
     },
     middle: {
       type: 'string',
@@ -63,7 +96,6 @@ const fullNameSchemaWithMiddleInitial = {
     },
     last: {
       type: 'string',
-      maxLength: 18,
     },
   },
 };

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-personal-info.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-personal-info.unit.spec.jsx
@@ -1,0 +1,45 @@
+/**
+ * @module tests/pages/benefits-details.unit.spec
+ * @description Unit tests for Benefits Details page dynamic title logic
+ * VA Form 21-4192 - Request for Employment Information
+ */
+
+import { expect } from 'chai';
+
+import { veteranPersonalInfoUiSchema } from './veteran-personal-info';
+
+describe('Veteran Personal Info Page', () => {
+  describe('validate name lengths', () => {
+    let errorMessages = [];
+
+    const errors = {
+      addError: message => {
+        errorMessages.push(message || '');
+      },
+    };
+
+    beforeEach(() => {
+      errorMessages = [];
+    });
+
+    it('should show a validation error if first name is longer than 12 characters', () => {
+      const formData = {
+        veteranPersonalInfo: {
+          fullName: { first: 'ThisIsAVeryLongFirstName', last: 'Doe' },
+        },
+      };
+
+      // expect a validation error for the first name field
+      const firstNameValidation =
+        veteranPersonalInfoUiSchema.veteranPersonalInfo.fullName.first[
+          'ui:validations'
+        ][1];
+      firstNameValidation(errors, null, formData);
+
+      expect(errorMessages[0]).to.exist;
+      expect(errorMessages[0]).to.equal(
+        'Please enter a name under 12 characters. If your name is longer, enter the first 12 characters only.',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Limiting first and last name characters to match backend limits - if a longer name is entered, displays an error notifying them to only put the first 12 (18 for last name) characters

### Issue
The FE for the form is restricted to 12 and 18 characters, respectively. This matches the backend limits, but if the user's name is longer than allowed, there's no instruction telling them to limit it to the first 12 or 18 characters.

### Solution
Updated the FE to display an error message if the user attempts to enter a name longer than the BE limits.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-0779 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 130183](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130183)

## Testing done

### Old behavior
* The form FE was limiting to 12 and 18 characters for the first and last names, respectively

### New behavior
* The form FE allows over 12 and 18 characters but displays an error message if the first name is over 12 characters or the last name is over 18 characters

### Verification Steps
*  Unit tests: verified existing unit tests still pass, added test to make sure validation error displays if long name is entered on veteran personal info and claimant personal info pages
*  Manual testing in local environment verified that inputting a long name displays a validation error and prevents the form from moving forward or submitting
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="571" height="427" alt="name before" src="https://github.com/user-attachments/assets/10de31f2-1241-49fa-8f07-97e9ef4f33f3" /> | <img width="599" height="569" alt="name after" src="https://github.com/user-attachments/assets/2488eb1e-7819-4b61-aea8-e70eba37ba65" /> |

## What areas of the site does it impact?

This change affects form 21-0779, specifically on the Veteran Personal Info and Claimant Personal Info pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
