### PR TITLE
Fixed ToU Redirect Bug

### DIFF
--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -45,7 +45,7 @@ export default function TermsOfUse() {
         });
       }
 
-      if (redirectUrl) {
+      if (redirectUrl && !redirectUrl.includes('/auth/login/callback')) {
         sessionStorage.setItem(
           AUTHN_SETTINGS.RETURN_URL,
           parseRedirectUrl(redirectUrl),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed ToU always redirecting users to the homepage. New behavior should match sign-in.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1089)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running: `yarn test:unit src/applications/terms-of-use/tests/*.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts Terms of Use.

## Acceptance criteria
- [x] ToU redirect behavior matches sign-in