### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VA.gov ![Build Status](https://github.com/department-of-veterans-affairs/vets-website/actions/workflows/continuous-integration.yml/badge.svg?branch=main)
+# VA.gov ![Build Status](https://github.com/department-of-veterans-affairs/vets-website/actions/workflows/continuous-integration.yml/badge.svg?branch=main) [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/department-of-veterans-affairs/vets-website)
 
 ## Table of Contents
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/department-of-veterans-affairs/vets-website) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.