### PR TITLE
enable DD RUM for prod, disable replay

### DIFF
--- a/src/applications/benefits-optimization-aquia/shared/hooks/useDatadogRum.jsx
+++ b/src/applications/benefits-optimization-aquia/shared/hooks/useDatadogRum.jsx
@@ -20,23 +20,29 @@ const DATADOG_CONFIG = {
   service: 'benefits-intake-optimization',
   env: environment.vspEnvironment(),
   sessionSampleRate: 100,
-  sessionReplaySampleRate: 20,
+  sessionReplaySampleRate: 0,
   trackUserInteractions: true,
   trackFrustrations: true,
   trackResources: true,
   trackLongTasks: true,
   trackBfcacheViews: true,
-  defaultPrivacyLevel: 'mask-user-input',
+  defaultPrivacyLevel: 'mask',
+  beforeSend: event => {
+    // Prevent PII from being sent to Datadog with click actions.
+    if (event.action?.type === 'click') {
+      // eslint-disable-next-line no-param-reassign
+      event.action.target.name = 'Form interaction';
+    }
+    return true;
+  },
 };
 
 const SUPPORTED_FORMS = ['21-0779', '21-2680', '21-4192', '21p-530a'];
 
 // Helper functions
 const shouldRumBeEnabled = () => {
-  const isNotLocalhost = environment.BASE_URL.indexOf('localhost') < 0;
-  const isNotTest = !window.Mocha;
-  const isStagingOnly = environment.vspEnvironment() === 'staging';
-  return isNotLocalhost && isNotTest && isStagingOnly;
+  // Prevent RUM from running on local/CI environments.
+  return environment.BASE_URL.indexOf('localhost') < 0 && !window.Mocha;
 };
 
 const isRumConfigured = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

## Summary

- Updated Datadog RUM configuration for benefits optimization forms to enable production monitoring without PII/PHI risks
- Disabled session replay (`sessionReplaySampleRate: 0`) while maintaining interaction and frustration tracking
- Enhanced privacy settings by changing `defaultPrivacyLevel` from `'mask-user-input'` to `'mask'`
- Added `beforeSend` event handler to sanitize click action target names, preventing PII from being captured in interaction events
- Simplified environment checks to enable RUM in all non-localhost/non-test environments (staging and production)
- Team: Benefits Intake Optimization, Aquia - owns maintenance of these forms and monitoring infrastructure
- No feature flipper required; configuration change only

## Related issue(s)

- Datadog RUM PII/PHI protection for forms 21-0779, 21-2680, 21-4192, and 21p-530a
- Related to ongoing effort to improve form monitoring while maintaining HIPAA compliance

## Testing done

**Old behavior:**
- Datadog RUM was configured with session replay enabled (20% sample rate)
- RUM was limited to staging environment only
- Privacy level was `'mask-user-input'` which only masked form inputs
- Click action target names could contain PII from button/link text

**New behavior:**
- Session replay completely disabled (`sessionReplaySampleRate: 0`)
- RUM enabled in both staging and production
- Privacy level set to `'mask'` for comprehensive text masking (when replay is enabled)
- Click action target names sanitized to generic "Form interaction" label

**Testing completed:**
- Verified RUM initializes correctly in non-localhost environments
- Confirmed session replay does not start (sample rate = 0)
- Validated that interaction tracking and frustration tracking remain active
- Tested that `beforeSend` handler properly sanitizes click event target names
- Reviewed Datadog configuration to ensure no PII-sensitive settings are enabled
- Confirmed performance monitoring (resources, long tasks) continues to function

## What areas of the site does it impact?

This change only impacts the four benefits optimization forms:
- 21-0779 (Nursing Home Information)
- 21-2680 (House Bound Status)
- 21-4192 (Employment Information)
- 21p-530a (Interment Allowance)

No other applications or site areas are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable) - Configuration change only, no test updates needed
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (inline JSDoc comments reflect new configuration)
- [ ] Screenshot of the developed feature is added - Not applicable for configuration change
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed - Not applicable for monitoring configuration

### Error Handling

- [x] Browser console contains no warnings or errors
- [x] Events are being sent to the appropriate logging solution (Datadog RUM)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - This change enables Datadog monitoring

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user - Configuration does not affect authentication; RUM disabled on localhost

## Requested Feedback

This change prioritizes PII/PHI protection by completely disabling session replay while maintaining valuable interaction and performance monitoring. The team determined that interaction tracking and frustration signals provide sufficient value for troubleshooting without the privacy risks of session replay recordings.

Reviewers should verify:
1. The `beforeSend` handler adequately sanitizes click action data
2. Disabling session replay is the correct approach vs. implementing comprehensive `data-dd-privacy="mask"` attributes throughout all form components
3. The simplified environment check (blocking only localhost/Mocha) is appropriate for production deployment