### PR TITLE
Remove inaccurate content from alert

### DIFF
--- a/src/platform/mhv/components/CernerFacilityAlert/constants.js
+++ b/src/platform/mhv/components/CernerFacilityAlert/constants.js
@@ -95,12 +95,12 @@ export const CernerAlertContent = {
     bodyIntro: 'Some of your secure messages may be in a different portal.',
     // Migration alert configuration
     warningPhases: ['p1', 'p2'],
-    warningMessage: `you won’t be able to send or receive new messages or reply to conversations with providers at`,
+    warningMessage: `you won't be able to send new messages or reply to conversations with providers at`,
     warningGetNote: facilityText =>
       `During this time, you can still call ${facilityText} to contact your provider.`,
     errorPhases: ['p3', 'p4', 'p5'],
     errorHeadline: `You can’t use messages to contact providers at some facilities right now`,
-    errorMessage: `You can’t send or receive new messages or reply to conversations with providers at`,
+    errorMessage: `You can't send new messages or reply to conversations with providers at`,
     errorNote:
       'If you need to contact your provider now, call the facility directly.',
     errorStartDate: 'p3',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed "or receive" from the secure messaging Oracle Health (OH) facility transition alerts in the `CernerFacilityAlert` constants.
- Updated `warningMessage` from `"you won't be able to send or receive new messages or reply to conversations with providers at"` to `"you won't be able to send new messages or reply to conversations with providers at"`.
- Updated `errorMessage` from `"You can't send or receive new messages or reply to conversations with providers at"` to `"You can't send new messages or reply to conversations with providers at"`.
- Content-only change to `src/platform/mhv/components/CernerFacilityAlert/constants.js`.
- MHV on VA.gov team owns this component.

## Related issue(s)

Closes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/132910

## Testing done

- Verified the old behavior: the warning and error alert messages for secure messaging included "or receive" phrasing (e.g., "you won't be able to send or receive new messages").
- After the change, confirmed the alert messages no longer include "or receive" in the `warningMessage` and `errorMessage` fields.
- Ran unit tests for `CernerFacilityAlert` and `MigratingFacilitiesAlerts` — all 77 tests pass.
  - `yarn test:unit src/platform/mhv/tests/components/CernerFacilityAlert.unit.spec.jsx src/platform/mhv/tests/components/MigratingFacilitiesAlerts.unit.spec.jsx`

## Screenshots

N/A — content-only change to alert text strings; no visual/layout changes.

## What areas of the site does it impact?

The OH facility transition alerts shown on the MHV secure messaging page for users registered at facilities undergoing Oracle Health migration.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a straightforward content change — only two string values were updated in `src/platform/mhv/components/CernerFacilityAlert/constants.js`. The phone-based call-to-action strings (`warningGetNote`, `errorNote`) are unchanged since they don't reference "or receive".