### PR TITLE
[4593] Prefill pattern inconsistencies

### DIFF
--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
@@ -214,17 +214,7 @@ export const PersonalInformation = ({
                   Date of birth:
                 </dt>
                 <dd
-                  className="dd-privacy-mask medium-screen:vads-u-display--inline-block vads-u-display--none"
-                  data-dd-action-name="Veteran's date of birth"
-                >
-                  {isValid(dobDateObj) ? (
-                    format(dobDateObj, FORMAT_READABLE_DATE_FNS)
-                  ) : (
-                    <span data-testid="dob-not-available">Not available</span>
-                  )}
-                </dd>
-                <dd
-                  className="dd-privacy-mask vads-u-display--inline-block medium-screen:vads-u-display--none"
+                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans"
                   data-dd-action-name="Veteran's date of birth"
                 >
                   {isValid(dobDateObj) ? (

--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
@@ -151,85 +151,108 @@ export const PersonalInformation = ({
       {header || <DefaultHeader />}
       <div className="vads-u-display--flex">
         <va-card background={background}>
-          {cardHeader || <DefaultCardHeader />}
-          {finalConfig.name?.show && (
-            <p>
-              <strong
-                className="name dd-privacy-hidden"
-                data-dd-action-name="Veteran's name"
-              >
-                Name:{' '}
-              </strong>
-              {first || last ? (
-                `${first || ''} ${middle || ''} ${last || ''}`
-              ) : (
-                <span data-testid="name-not-available">Not available</span>
-              )}
-              {suffix ? `, ${suffix}` : null}
-            </p>
-          )}
-          {finalConfig.ssn?.show && (
-            <p>
-              <strong>{getSSNTitle()}</strong>
-              {ssn ? (
-                <span
-                  className="dd-privacy-mask"
+          <div className="vads-u-margin-bottom--2">
+            {cardHeader || <DefaultCardHeader />}
+          </div>
+          <dl className="vads-u-padding-y--0 vads-u-margin-y--0">
+            {finalConfig.name?.show && (
+              <div className="vads-u-margin-bottom--2">
+                <dt className="vads-u-visibility--screen-reader">Full name:</dt>
+                <dd
+                  className="dd-privacy-hidden"
+                  data-dd-action-name="Veteran's name"
+                >
+                  <strong>Name: </strong>
+                  {first || last ? (
+                    `${first || ''} ${middle || ''} ${last || ''}`
+                  ) : (
+                    <span data-testid="name-not-available">Not available</span>
+                  )}
+                  {suffix ? `, ${suffix}` : null}
+                </dd>
+              </div>
+            )}
+            {finalConfig.ssn?.show && (
+              <div className="vads-u-margin-bottom--2">
+                <dt className="vads-u-display--inline-block vads-u-font-weight--bold vads-u-margin-right--0p5">
+                  {getSSNTitle()}
+                </dt>
+                <dd
+                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans"
                   data-dd-action-name="Veteran's SSN"
                 >
-                  {renderSSN()}
-                </span>
-              ) : (
-                <span data-testid="ssn-not-available">Not available</span>
-              )}
-            </p>
-          )}
-          {finalConfig.vaFileNumber?.show && (
-            <p>
-              <strong>Last 4 digits of VA file number: </strong>
-              {vaFileLastFour ? (
-                <span
-                  className="dd-privacy-mask"
+                  {ssn ? (
+                    renderSSN()
+                  ) : (
+                    <span data-testid="ssn-not-available">Not available</span>
+                  )}
+                </dd>
+              </div>
+            )}
+            {finalConfig.vaFileNumber?.show && (
+              <div className="vads-u-margin-bottom--2">
+                <dt className="vads-u-display--inline-block vads-u-font-weight--bold vads-u-margin-right--0p5">
+                  Last 4 digits of VA file number:
+                </dt>
+                <dd
+                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans"
                   data-dd-action-name="Veteran's VA file number"
                 >
-                  {formatNumberForScreenReader(vaFileLastFour)}
-                </span>
-              ) : (
-                <span data-testid="va-file-number-not-available">
-                  Not available
-                </span>
-              )}
-            </p>
-          )}
-          {finalConfig.dateOfBirth?.show && (
-            <p>
-              <strong>Date of birth: </strong>
-              {isValid(dobDateObj) ? (
-                <span
-                  className="dob dd-privacy-mask"
+                  {vaFileLastFour ? (
+                    formatNumberForScreenReader(vaFileLastFour)
+                  ) : (
+                    <span data-testid="va-file-number-not-available">
+                      Not available
+                    </span>
+                  )}
+                </dd>
+              </div>
+            )}
+            {finalConfig.dateOfBirth?.show && (
+              <div className="vads-u-margin-bottom--2">
+                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5 vads-u-font-weight--bold">
+                  Date of birth:
+                </dt>
+                <dd
+                  className="dd-privacy-mask medium-screen:vads-u-display--inline-block vads-u-display--none"
                   data-dd-action-name="Veteran's date of birth"
                 >
-                  {format(dobDateObj, FORMAT_READABLE_DATE_FNS)}
-                </span>
-              ) : (
-                <span data-testid="dob-not-available">Not available</span>
-              )}
-            </p>
-          )}
-          {finalConfig.sex?.show && (
-            <p>
-              <strong>Sex: </strong>
-              {gender ? (
-                <span
-                  className="sex dd-privacy-hidden"
+                  {isValid(dobDateObj) ? (
+                    format(dobDateObj, FORMAT_READABLE_DATE_FNS)
+                  ) : (
+                    <span data-testid="dob-not-available">Not available</span>
+                  )}
+                </dd>
+                <dd
+                  className="dd-privacy-mask vads-u-display--inline-block medium-screen:vads-u-display--none"
+                  data-dd-action-name="Veteran's date of birth"
+                >
+                  {isValid(dobDateObj) ? (
+                    format(dobDateObj, FORMAT_READABLE_DATE_FNS)
+                  ) : (
+                    <span data-testid="dob-not-available">Not available</span>
+                  )}
+                </dd>
+              </div>
+            )}
+            {finalConfig.sex?.show && (
+              <div className="vads-u-margin-bottom--2">
+                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5 vads-u-font-weight--bold">
+                  Sex:
+                </dt>
+                <dd
+                  className="vads-u-display--inline-block dd-privacy-hidden"
                   data-dd-action-name="Veteran's sex"
                 >
-                  {genderLabels?.[gender]}
-                </span>
-              ) : (
-                <span data-testid="sex-not-available">Not available</span>
-              )}
-            </p>
-          )}
+                  {gender ? (
+                    genderLabels?.[gender]
+                  ) : (
+                    <span data-testid="sex-not-available">Not available</span>
+                  )}
+                </dd>
+              </div>
+            )}
+          </dl>
         </va-card>
       </div>
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR refactors the PersonalInformation component to include definition list tags and datadog privacy classes.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4593

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|<img width="1463" height="889" alt="image" src="https://github.com/user-attachments/assets/2c37138f-e80a-4643-8797-19ef8361d80f" />|<img width="1459" height="881" alt="image" src="https://github.com/user-attachments/assets/0751028d-b421-420a-86ff-1c25203fc32b" />|

## What areas of the site does it impact?

Prefill pattern in forms system
