### PR TITLE
fix(mhv-secure-messaging): use v2 prescriptions API for Cerner pilot in Rx renewal flow

### DIFF
--- a/src/applications/mhv-secure-messaging/actions/prescription.js
+++ b/src/applications/mhv-secure-messaging/actions/prescription.js
@@ -1,15 +1,26 @@
 import { dataDogLogger } from 'platform/monitoring/Datadog';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { Actions } from '../util/actionTypes';
 import { getPrescriptionById as apiGetPrescriptionById } from '../api/RxApi';
 
-export const getPrescriptionById = prescriptionId => async dispatch => {
+export const getPrescriptionById = prescriptionId => async (
+  dispatch,
+  getState,
+) => {
   dispatch({ type: Actions.Prescriptions.CLEAR_PRESCRIPTION });
   try {
     dispatch({ type: Actions.Prescriptions.IS_LOADING });
     if (!prescriptionId || prescriptionId === 'undefined') {
       throw new Error('Prescription ID is required');
     }
-    const response = await apiGetPrescriptionById(prescriptionId);
+    const isCernerPilot =
+      getState()?.featureToggles?.[
+        FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot
+      ] || false;
+    const response = await apiGetPrescriptionById(
+      prescriptionId,
+      isCernerPilot,
+    );
     if (response?.errors) {
       const error = new Error(
         response.errors[0]?.title || 'API returned errors',

--- a/src/applications/mhv-secure-messaging/actions/prescription.js
+++ b/src/applications/mhv-secure-messaging/actions/prescription.js
@@ -13,10 +13,10 @@ export const getPrescriptionById = prescriptionId => async (
     if (!prescriptionId || prescriptionId === 'undefined') {
       throw new Error('Prescription ID is required');
     }
+    const { featureToggles } = getState();
     const isCernerPilot =
-      getState()?.featureToggles?.[
-        FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot
-      ] || false;
+      !featureToggles?.loading &&
+      featureToggles?.[FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot] === true;
     const response = await apiGetPrescriptionById(
       prescriptionId,
       isCernerPilot,

--- a/src/applications/mhv-secure-messaging/api/RxApi.js
+++ b/src/applications/mhv-secure-messaging/api/RxApi.js
@@ -1,15 +1,17 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/exports';
 
-const apiBasePath = `${environment.API_URL}/my_health/v1`;
-
 /**
  * Gets a prescription by its ID
  * @param {Long} prescriptionId - The ID of the prescription to retrieve
+ * @param {boolean} isCernerPilot - Whether to use v2 API for Oracle Health patients
  * @returns {Promise} - Promise resolving to the prescription data
  */
-export const getPrescriptionById = prescriptionId => {
-  const path = `${apiBasePath}/prescriptions/${prescriptionId}`;
+export const getPrescriptionById = (prescriptionId, isCernerPilot = false) => {
+  const version = isCernerPilot ? 'v2' : 'v1';
+  const path = `${
+    environment.API_URL
+  }/my_health/${version}/prescriptions/${prescriptionId}`;
   return apiRequest(path, {
     headers: {
       'Content-Type': 'application/json',

--- a/src/applications/mhv-secure-messaging/tests/actions/prescription.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/actions/prescription.unit.spec.jsx
@@ -3,6 +3,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { Actions } from '../../util/actionTypes';
 import {
   getPrescriptionById,
@@ -46,6 +47,40 @@ describe('prescription actions', () => {
       mockApiRequest(mockResponse);
 
       const store = mockStore();
+      await store.dispatch(getPrescriptionById(prescriptionId));
+
+      const actions = store.getActions();
+      expect(actions[0]).to.deep.equal({
+        type: Actions.Prescriptions.CLEAR_PRESCRIPTION,
+      });
+      expect(actions[1]).to.deep.equal({
+        type: Actions.Prescriptions.IS_LOADING,
+      });
+      expect(actions[2]).to.deep.equal({
+        type: Actions.Prescriptions.GET_PRESCRIPTION_BY_ID,
+        payload: mockResponse.data.attributes,
+      });
+    });
+
+    it('should dispatch success action using v2 API when Cerner pilot is enabled', async () => {
+      const prescriptionId = '456';
+      const mockResponse = {
+        data: {
+          attributes: {
+            id: prescriptionId,
+            name: 'OH Prescription',
+            prescriptionName: 'OH Prescription',
+            prescriptionNumber: 'RX789',
+          },
+        },
+      };
+      mockApiRequest(mockResponse);
+
+      const store = mockStore({
+        featureToggles: {
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
+        },
+      });
       await store.dispatch(getPrescriptionById(prescriptionId));
 
       const actions = store.getActions();

--- a/src/applications/mhv-secure-messaging/tests/actions/prescription.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/actions/prescription.unit.spec.jsx
@@ -78,10 +78,15 @@ describe('prescription actions', () => {
 
       const store = mockStore({
         featureToggles: {
+          loading: false,
           [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
         },
       });
       await store.dispatch(getPrescriptionById(prescriptionId));
+
+      // Verify the v2 endpoint was called
+      const fetchUrl = global.fetch.firstCall.args[0];
+      expect(fetchUrl).to.include('/my_health/v2/prescriptions/456');
 
       const actions = store.getActions();
       expect(actions[0]).to.deep.equal({
@@ -94,6 +99,33 @@ describe('prescription actions', () => {
         type: Actions.Prescriptions.GET_PRESCRIPTION_BY_ID,
         payload: mockResponse.data.attributes,
       });
+    });
+
+    it('should fall back to v1 API when feature toggles are still loading', async () => {
+      const prescriptionId = '789';
+      const mockResponse = {
+        data: {
+          attributes: {
+            id: prescriptionId,
+            name: 'Test Prescription',
+            prescriptionName: 'Test Prescription',
+            prescriptionNumber: 'RX111',
+          },
+        },
+      };
+      mockApiRequest(mockResponse);
+
+      const store = mockStore({
+        featureToggles: {
+          loading: true,
+          [FEATURE_FLAG_NAMES.mhvMedicationsCernerPilot]: true,
+        },
+      });
+      await store.dispatch(getPrescriptionById(prescriptionId));
+
+      // Verify the v1 endpoint was called despite toggle being true
+      const fetchUrl = global.fetch.firstCall.args[0];
+      expect(fetchUrl).to.include('/my_health/v1/prescriptions/789');
     });
 
     it('should dispatch error action when prescriptionId is not provided', async () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -55,6 +55,7 @@ export const Paths = {
     SENT_THREADS: '/my_health/v1/messaging/folders/-1/threads*',
     SENT_SEARCH: '/my_health/v1/messaging/folders/-1/search*',
     PRESCRIPTIONS: '/my_health/v1/prescriptions/',
+    PRESCRIPTIONS_V2: '/my_health/v2/prescriptions/',
   },
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
- [x] No

## Summary

- **Bug:** Oracle Health patients in the Cerner pilot could not get medication info prefilled when composing a renewal message via secure messaging. The browser inspector showed the v1 prescriptions endpoint (`/my_health/v1/prescriptions/{id}`) being called, which is VistA-only and returned a 404 for Oracle Health prescriptions.
- **Root cause:** `RxApi.js` in mhv-secure-messaging hardcoded the v1 API base path. The mhv-medications app correctly switches between v1/v2 based on the `mhvMedicationsCernerPilot` feature toggle, but mhv-secure-messaging never checked this toggle during the renewal flow.
- **Solution:** Read the `mhvMedicationsCernerPilot` feature toggle from Redux state in the prescription action creator (via `getState()`) and pass it to `RxApi.getPrescriptionById()`, which now dynamically constructs the URL with `/my_health/v2/` or `/my_health/v1/` accordingly.
- **Team:** MHV Secure Messaging / MHV Medications

## Related issue(s)

- _To be linked by team_

## Testing done

- **Old behavior:** Oracle Health patient in Cerner pilot clicks "Request renewal" in mhv-medications → redirected to secure messaging compose page → v1 prescriptions endpoint returns 404 → medication info is not prefilled in the message body.
- **New behavior:** The same flow correctly calls the v2 prescriptions endpoint (`/my_health/v2/prescriptions/{id}`) → prescription data is returned → medication info is prefilled in the message body.
- **Unit tests:** Added test for Cerner pilot toggle enabled path in `prescription.unit.spec.jsx`. All 1127 unit tests pass (1 pre-existing unrelated failure in `ManageFolderButtons`).
- **E2E tests:** Added two new Cypress tests in the renewal spec verifying: (1) successful v2 API fetch with Cerner pilot enabled, and (2) 404 error handling from v2 API.

## Screenshots

N/A — No UI changes. The fix is in API routing logic only.

## What areas of the site does it impact?

MHV Secure Messaging — specifically the medication renewal compose flow (`/my-health/secure-messages/new-message?prescriptionId={id}`). Only affects users with the `mhvMedicationsCernerPilot` feature toggle enabled.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A - no documentation changes needed)
- [ ] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] Accessibility testing has been performed (axe checks included in new E2E tests)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (existing Datadog logging preserved)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (existing monitoring covers this)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a targeted fix that aligns the prescription API version selection in mhv-secure-messaging with the existing pattern in mhv-medications. Please verify that the `mhvMedicationsCernerPilot` toggle name is the correct one to gate the v2 endpoint for this use case.