### PR TITLE
Adjust order of expenses on review page (#129393)

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import ExpenseCardList from './ExpenseCardList';
 import { getExpenseType } from '../../../util/complex-claims-helper';
+import { EXPENSE_TYPES } from '../../../constants';
 
 const ExpensesAccordion = ({
   documents = [],
@@ -28,6 +29,10 @@ const ExpensesAccordion = ({
   );
 
   const expenseEntries = Object.entries(groupedExpenses);
+  const expenseTypeOrder = Object.keys(EXPENSE_TYPES);
+  expenseEntries.sort(([a], [b]) => {
+    return expenseTypeOrder.indexOf(a) - expenseTypeOrder.indexOf(b);
+  });
   const hasExpenses = expenseEntries.length > 0;
 
   // No expenses case

--- a/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
@@ -53,7 +53,7 @@ const ReviewPage = () => {
     [alertMessage],
   );
 
-  // Get total by expense type and return expenses alphabetically
+  // Get total by expense type and return expenses in EXPENSE_TYPES order
   const totalByExpenseType = Object.fromEntries(
     Object.entries(
       expenses.reduce((acc, expense) => {
@@ -62,7 +62,10 @@ const ReviewPage = () => {
           (acc[expenseType] || 0) + (expense.costRequested || 0);
         return acc;
       }, {}),
-    ).sort(([a], [b]) => a.localeCompare(b)),
+    ).sort(([a], [b]) => {
+      const order = Object.keys(EXPENSE_TYPES);
+      return order.indexOf(a) - order.indexOf(b);
+    }),
   );
 
   // Create a grouped version of expenses by expenseType
@@ -146,7 +149,7 @@ const ReviewPage = () => {
             groupAccordionItemsByType
             headerLevel={3}
           />
-          <div className="vads-u-margin-top--1">
+          <div className="vads-u-margin-top--3">
             <va-card data-testid="summary-box" background>
               <h2 className="vads-u-margin-top--1">Estimated reimbursement</h2>
               <ul>

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
@@ -226,6 +226,45 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
     );
   });
 
+  it('sorts expense groups in EXPENSE_TYPES order regardless of input order', () => {
+    const outOfOrderExpenses = [
+      {
+        id: 'exp-toll',
+        expenseType: 'Toll',
+        costRequested: 5.0,
+        dateIncurred: '2025-10-15',
+      },
+      {
+        id: 'exp-parking',
+        expenseType: 'Parking',
+        description: 'Parking at hospital',
+        costRequested: 10.0,
+        dateIncurred: '2025-10-15',
+      },
+      {
+        id: 'exp-mileage',
+        expenseType: 'Mileage',
+        costRequested: 15.0,
+        tripType: 'RoundTrip',
+        dateIncurred: '2025-10-15',
+      },
+    ];
+
+    renderAccordion({
+      expenses: outOfOrderExpenses,
+      documents: [],
+      groupAccordionItemsByType: true,
+    });
+
+    const accordionItems = document.querySelectorAll('va-accordion-item');
+    expect(accordionItems.length).to.equal(3);
+
+    // Should be sorted: Mileage, Parking, Toll (matching EXPENSE_TYPES order)
+    expect(accordionItems[0].getAttribute('header')).to.include('Mileage');
+    expect(accordionItems[1].getAttribute('header')).to.include('Parking');
+    expect(accordionItems[2].getAttribute('header')).to.include('Toll');
+  });
+
   it('renders headers for each expense group inside accordion item', () => {
     renderAccordion({ expenses, documents });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Ensure that the order of expenses is the same as that for the radio buttons.
- This is done by calling Object.keys on the EXPENSE_TYPES constant, which in practice as a frozen object literal should always come back in the order they're written: mileage, parking, toll, etc. in accordance with ES2015+ spec.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129398

## Testing done

- If a veteran added lodging, parking, and mileage expenses in this order, the expenses will be listed out of the order of the radio buttons for adding expenses, potentially leading to confusion.
- Also, the review page would show the added expenses in alphabetical order.
- These were changed to show expenses in the same order as that in the radio buttons.
- Space was added between the accordion of expenses and the card.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |    <img width="379" height="626" alt="Image" src="https://github.com/user-attachments/assets/492e27e4-ef2e-4566-9a54-1d7a700541cc" />    |  <img width="500" height="765" alt="Screenshot 2026-02-13 at 08 20 11" src="https://github.com/user-attachments/assets/daf2b94c-865d-4e4e-8d2c-dfc2c85f1c8e" />     |

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

