### PR TITLE
fix(script): use double quotes for env var expansion in review-entrypoint.sh

### DIFF
--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -4,11 +4,11 @@
 set -e
 yarn install --ignore-scripts --production=false
 yarn postinstall
-npm run build -- --buildtype=localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}'
+npm run build -- --buildtype=localhost --api="${API_URL}" --host="${WEB_HOST}" --port="${WEB_PORT}"
 
 # Build content-build and serve site
 cd ../content-build
 cp .env.example .env && yarn install-safe --production=false
 npm run fetch-drupal-cache
-npm run build -- --buildtype=localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}' --apps-directory-name=application
+npm run build -- --buildtype=localhost --api="${API_URL}" --host="${WEB_HOST}" --port="${WEB_PORT}" --apps-directory-name=application
 npm run heroku-serve -- build/localhost -p 3002


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Review instances have broken sign-in because `${API_URL}` is passed literally (URL-encoded as `$%7BAPI_URL%7D`) instead of being resolved to the actual API hostname.
- **Root cause**: The upgrade from Node 14 (npm 6) to Node 22 (npm 10) in #41426 changed how npm handles `--` arguments. npm 6 re-interpreted arguments through a shell (expanding `${VAR}` even inside single quotes), while npm 10 passes them literally. The single-quoted `'${API_URL}'` in `review-entrypoint.sh` relied on this npm 6 behavior.
- **Fix**: Change single quotes to double quotes on the `npm run build` lines so the shell expands `${API_URL}`, `${WEB_HOST}`, and `${WEB_PORT}` before npm receives them.
- Platform team owns this infrastructure script.

## Related issue(s)

- Related to department-of-veterans-affairs/vets-website#41426 (Node 22 upgrade)

## Testing done

- Reproduced the issue by testing npm argument passing behavior across versions:
  - **npm 6 (Node 14)**: `npm run echo -- '--api=${API_URL}'` expands to `--api=https://test-api.example.com` (shell expansion happens)
  - **npm 10 (Node 22)**: `npm run echo -- '--api=${API_URL}'` passes literal `--api=${API_URL}` (no expansion)
  - **npm 10 with double quotes**: `npm run echo -- "--api=${API_URL}"` expands to `--api=https://test-api.example.com` (fix works)
- Verified no other instances of this pattern exist in the codebase via grep search across both vets-website and devops repos.

## Screenshots

N/A - Infrastructure script change, no UI modifications.

## What areas of the site does it impact?

Review instances only. This fix restores authentication (sign-in) functionality on review instances by ensuring the API URL is correctly passed to the webpack build.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - No unit tests exist for this shell script; verified via manual testing of npm argument behavior across versions.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated - N/A
- [ ] Screenshot of the developed feature is added - N/A, no UI change
- [ ] Accessibility testing has been performed - N/A, no UI change

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
  - This fix specifically restores the ability to authenticate on review instances. Verification requires deploying a review instance with this change.

## Requested Feedback

This is a one-line quoting fix (single to double quotes) on two `npm run build` commands. The root cause is a behavioral change in npm 10 vs npm 6 regarding shell expansion of `--` arguments. Would appreciate a quick review and merge to unblock review instance testing.
