### PR TITLE
[Disability Benefits] Delete evidence keys on remove

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
@@ -9,7 +9,6 @@ import _ from 'platform/utilities/data';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { scrollToFirstError } from 'platform/utilities/scroll';
 import { checkValidations } from '../utils/submit';
-import { hasVAEvidence, hasPrivateEvidence } from '../utils';
 import {
   evidenceRequestAdditionalInfo,
   evidenceRequestQuestion,
@@ -125,22 +124,17 @@ export const EvidenceRequestPage = ({
         scrollToFirstError();
       } else if (hasMedicalRecords === false && hasEvidenceToRemove()) {
         setModalVisible(true);
-      } else if (hasMedicalRecords === false && hasVAEvidence(data)) {
+      } else if (hasMedicalRecords === false) {
         const updatedFormData = { ...data };
         updatedFormData['view:selectableEvidenceTypes'] = {
           ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
           'view:hasVaMedicalRecords': false,
-        };
-        setFormData(updatedFormData);
-        setAlertVisible(false);
-      } else if (hasMedicalRecords === false && hasPrivateEvidence(data)) {
-        const updatedFormData = { ...data };
-        updatedFormData['view:selectableEvidenceTypes'] = {
-          ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
           'view:hasPrivateMedicalRecords': false,
         };
+        updatedFormData.patient4142Acknowledgement = false;
         setFormData(updatedFormData);
         setAlertVisible(false);
+        goForward(updatedFormData);
       } else {
         setAlertVisible(false);
         goForward(data);

--- a/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
@@ -103,6 +103,13 @@ export const EvidenceRequestPage = ({
             'view:hasPrivateMedicalRecords': false,
           };
         }
+      } else if (privateFacility.length > 0) {
+        delete updatedFormData.providerFacility;
+        setAlertType(prevState => [...prevState, 'privateFacility']);
+        updatedFormData['view:selectableEvidenceTypes'] = {
+          ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
+          'view:hasPrivateMedicalRecords': false,
+        };
       }
       setFormData(updatedFormData);
       setModalVisible(false);

--- a/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
@@ -79,7 +79,7 @@ export const EvidenceRequestPage = ({
       const updatedFormData = { ...data };
 
       if (hasVAEvidence(data)) {
-        updatedFormData.vaTreatmentFacilities = [];
+        delete updatedFormData.vaTreatmentFacilities;
         updatedFormData['view:selectableEvidenceTypes'] = {
           ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
           'view:hasVaMedicalRecords': false,
@@ -90,11 +90,11 @@ export const EvidenceRequestPage = ({
         const hasPrivateUploads = privateEvidenceUploads.length > 0;
         const hasPrivateFacilities = privateFacility.length > 0;
         if (hasPrivateUploads) {
-          updatedFormData.privateMedicalRecordAttachments = [];
+          delete updatedFormData.privateMedicalRecordAttachments;
           setAlertType(prevState => [...prevState, 'privateMedicalRecords']);
         }
         if (hasPrivateFacilities) {
-          updatedFormData.providerFacility = [];
+          delete updatedFormData.providerFacility;
           setAlertType(prevState => [...prevState, 'privateFacility']);
         }
         if (hasPrivateUploads || hasPrivateFacilities) {

--- a/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/EvidenceRequestPage.jsx
@@ -49,8 +49,8 @@ export const EvidenceRequestPage = ({
 
   const hasEvidenceToRemove = () => {
     return (
-      (hasVAEvidence(data) && vaEvidence.length > 0) ||
-      (hasPrivateEvidence(data) && privateEvidenceUploads.length > 0) ||
+      vaEvidence.length > 0 ||
+      privateEvidenceUploads.length > 0 ||
       privateFacility.length > 0
     );
   };
@@ -77,40 +77,26 @@ export const EvidenceRequestPage = ({
   const handlers = {
     onChangeAndRemove: () => {
       const updatedFormData = { ...data };
+      const selectableEvidenceTypes = {
+        ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
+      };
 
-      if (hasVAEvidence(data)) {
+      if (vaEvidence.length > 0) {
         delete updatedFormData.vaTreatmentFacilities;
-        updatedFormData['view:selectableEvidenceTypes'] = {
-          ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
-          'view:hasVaMedicalRecords': false,
-        };
+        selectableEvidenceTypes['view:hasVaMedicalRecords'] = false;
         setAlertType(prevState => [...prevState, 'va']);
       }
-      if (hasPrivateEvidence(data)) {
-        const hasPrivateUploads = privateEvidenceUploads.length > 0;
-        const hasPrivateFacilities = privateFacility.length > 0;
-        if (hasPrivateUploads) {
-          delete updatedFormData.privateMedicalRecordAttachments;
-          setAlertType(prevState => [...prevState, 'privateMedicalRecords']);
-        }
-        if (hasPrivateFacilities) {
-          delete updatedFormData.providerFacility;
-          setAlertType(prevState => [...prevState, 'privateFacility']);
-        }
-        if (hasPrivateUploads || hasPrivateFacilities) {
-          updatedFormData['view:selectableEvidenceTypes'] = {
-            ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
-            'view:hasPrivateMedicalRecords': false,
-          };
-        }
-      } else if (privateFacility.length > 0) {
-        delete updatedFormData.providerFacility;
-        setAlertType(prevState => [...prevState, 'privateFacility']);
-        updatedFormData['view:selectableEvidenceTypes'] = {
-          ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
-          'view:hasPrivateMedicalRecords': false,
-        };
+      if (privateEvidenceUploads.length > 0) {
+        delete updatedFormData.privateMedicalRecordAttachments;
+        selectableEvidenceTypes['view:hasPrivateMedicalRecords'] = false;
+        setAlertType(prevState => [...prevState, 'privateMedicalRecords']);
       }
+      if (privateFacility.length > 0) {
+        delete updatedFormData.providerFacility;
+        selectableEvidenceTypes['view:hasPrivateMedicalRecords'] = false;
+        setAlertType(prevState => [...prevState, 'privateFacility']);
+      }
+      updatedFormData['view:selectableEvidenceTypes'] = selectableEvidenceTypes;
       setFormData(updatedFormData);
       setModalVisible(false);
       setAlertVisible(true);
@@ -259,20 +245,18 @@ export const EvidenceRequestPage = ({
         primaryButtonText="Change and remove"
         secondaryButtonText="Cancel change"
       >
-        {hasVAEvidence(data) &&
-          vaEvidence.length > 0 && (
-            <>
-              {vaEvidenceContent}
-              {renderFacilityList(vaEvidence, 'treatmentCenterName')}
-            </>
-          )}
-        {hasPrivateEvidence(data) &&
-          privateEvidenceUploads.length > 0 && (
-            <>
-              {privateEvidenceContent}
-              {renderFileList(privateEvidenceUploads)}
-            </>
-          )}
+        {vaEvidence.length > 0 && (
+          <>
+            {vaEvidenceContent}
+            {renderFacilityList(vaEvidence, 'treatmentCenterName')}
+          </>
+        )}
+        {privateEvidenceUploads.length > 0 && (
+          <>
+            {privateEvidenceContent}
+            {renderFileList(privateEvidenceUploads)}
+          </>
+        )}
         {privateFacility.length > 0 && (
           <>
             {privateFacilityContent}

--- a/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
@@ -447,6 +447,32 @@ describe('EvidenceRequestPage', () => {
     });
   });
 
+  it('should set evidence flags and patient4142Acknowledgement to false and go forward when No selected after evidence removed', () => {
+    const setFormData = sinon.spy();
+    const goForward = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {
+        'view:hasVaMedicalRecords': true,
+        'view:hasPrivateMedicalRecords': true,
+      },
+      patient4142Acknowledgement: true,
+    };
+
+    const { container } = render(page({ data, setFormData, goForward }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    expect(setFormData.called).to.be.true;
+    const updatedData = setFormData.firstCall.args[0];
+    const selectableTypes = updatedData['view:selectableEvidenceTypes'] || {};
+    expect(selectableTypes['view:hasVaMedicalRecords']).to.be.false;
+    expect(selectableTypes['view:hasPrivateMedicalRecords']).to.be.false;
+    expect(updatedData.patient4142Acknowledgement).to.be.false;
+
+    expect(goForward.called).to.be.true;
+    expect(goForward.firstCall.args[0]).to.deep.equal(updatedData);
+  });
+
   it('should render update button on review page', () => {
     const { container } = render(page({ onReviewPage: true }));
 

--- a/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
@@ -273,6 +273,34 @@ describe('EvidenceRequestPage', () => {
     });
   });
 
+  it('should delete vaTreatmentFacilities when confirming modal even when hasVAEvidence is false', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {},
+      vaTreatmentFacilities: [{ treatmentCenterName: 'VA Hospital 1' }],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property('vaTreatmentFacilities');
+      const selectableTypes = updatedData['view:selectableEvidenceTypes'] || {};
+      expect(selectableTypes['view:hasVaMedicalRecords']).to.be.false;
+    });
+  });
+
   it('should delete providerFacility when confirming modal even when hasPrivateEvidence is false', async () => {
     const setFormData = sinon.spy();
     const data = {
@@ -296,6 +324,36 @@ describe('EvidenceRequestPage', () => {
       expect(setFormData.called).to.be.true;
       const updatedData = setFormData.firstCall.args[0];
       expect(updatedData).to.not.have.property('providerFacility');
+      const selectableTypes = updatedData['view:selectableEvidenceTypes'] || {};
+      expect(selectableTypes['view:hasPrivateMedicalRecords']).to.be.false;
+    });
+  });
+
+  it('should delete privateMedicalRecordAttachments when confirming modal even when hasPrivateEvidence is false', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {},
+      privateMedicalRecordAttachments: [{ name: 'record1.pdf' }],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property(
+        'privateMedicalRecordAttachments',
+      );
       const selectableTypes = updatedData['view:selectableEvidenceTypes'] || {};
       expect(selectableTypes['view:hasPrivateMedicalRecords']).to.be.false;
     });

--- a/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
@@ -273,6 +273,34 @@ describe('EvidenceRequestPage', () => {
     });
   });
 
+  it('should delete providerFacility when confirming modal even when hasPrivateEvidence is false', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {},
+      providerFacility: [{ providerFacilityName: 'Private Clinic 1' }],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property('providerFacility');
+      const selectableTypes = updatedData['view:selectableEvidenceTypes'] || {};
+      expect(selectableTypes['view:hasPrivateMedicalRecords']).to.be.false;
+    });
+  });
+
   it('should show success alert after removing evidence', async () => {
     const setFormData = sinon.spy();
     const data = {

--- a/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
@@ -177,7 +177,7 @@ describe('EvidenceRequestPage', () => {
     });
   });
 
-  it('should remove private medical record attachments when confirming modal', async () => {
+  it('should delete privateMedicalRecordAttachments when confirming modal (private uploads only)', async () => {
     const setFormData = sinon.spy();
     const data = {
       'view:hasMedicalRecords': false,
@@ -204,15 +204,12 @@ describe('EvidenceRequestPage', () => {
       expect(updatedData).to.not.have.property(
         'privateMedicalRecordAttachments',
       );
-      expect(
-        updatedData['view:selectableEvidenceTypes'][
-          'view:hasPrivateMedicalRecords'
-        ],
-      ).to.be.false;
+      const selectableTypes1 = updatedData['view:selectableEvidenceTypes'];
+      expect(selectableTypes1['view:hasPrivateMedicalRecords']).to.be.false;
     });
   });
 
-  it('should remove private provider facilities when confirming modal', async () => {
+  it('should delete providerFacility when confirming modal (private facilities only)', async () => {
     const setFormData = sinon.spy();
     const data = {
       'view:hasMedicalRecords': false,
@@ -237,15 +234,12 @@ describe('EvidenceRequestPage', () => {
       expect(setFormData.called).to.be.true;
       const updatedData = setFormData.firstCall.args[0];
       expect(updatedData).to.not.have.property('providerFacility');
-      expect(
-        updatedData['view:selectableEvidenceTypes'][
-          'view:hasPrivateMedicalRecords'
-        ],
-      ).to.be.false;
+      const selectableTypes2 = updatedData['view:selectableEvidenceTypes'];
+      expect(selectableTypes2['view:hasPrivateMedicalRecords']).to.be.false;
     });
   });
 
-  it('should remove both private uploads and facilities when confirming modal', async () => {
+  it('should delete both private evidence keys when confirming modal (uploads and facilities)', async () => {
     const setFormData = sinon.spy();
     const data = {
       'view:hasMedicalRecords': false,
@@ -274,11 +268,8 @@ describe('EvidenceRequestPage', () => {
         'privateMedicalRecordAttachments',
       );
       expect(updatedData).to.not.have.property('providerFacility');
-      expect(
-        updatedData['view:selectableEvidenceTypes'][
-          'view:hasPrivateMedicalRecords'
-        ],
-      ).to.be.false;
+      const selectableTypes3 = updatedData['view:selectableEvidenceTypes'];
+      expect(selectableTypes3['view:hasPrivateMedicalRecords']).to.be.false;
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
@@ -170,7 +170,7 @@ describe('EvidenceRequestPage', () => {
     await waitFor(() => {
       expect(setFormData.called).to.be.true;
       const updatedData = setFormData.firstCall.args[0];
-      expect(updatedData.vaTreatmentFacilities).to.deep.equal([]);
+      expect(updatedData).to.not.have.property('vaTreatmentFacilities');
       expect(
         updatedData['view:selectableEvidenceTypes']['view:hasVaMedicalRecords'],
       ).to.be.false;

--- a/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx
@@ -177,6 +177,111 @@ describe('EvidenceRequestPage', () => {
     });
   });
 
+  it('should remove private medical record attachments when confirming modal', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {
+        'view:hasPrivateMedicalRecords': true,
+      },
+      privateMedicalRecordAttachments: [{ name: 'record1.pdf' }],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property(
+        'privateMedicalRecordAttachments',
+      );
+      expect(
+        updatedData['view:selectableEvidenceTypes'][
+          'view:hasPrivateMedicalRecords'
+        ],
+      ).to.be.false;
+    });
+  });
+
+  it('should remove private provider facilities when confirming modal', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {
+        'view:hasPrivateMedicalRecords': true,
+      },
+      providerFacility: [{ providerFacilityName: 'Private Clinic 1' }],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property('providerFacility');
+      expect(
+        updatedData['view:selectableEvidenceTypes'][
+          'view:hasPrivateMedicalRecords'
+        ],
+      ).to.be.false;
+    });
+  });
+
+  it('should remove both private uploads and facilities when confirming modal', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasMedicalRecords': false,
+      'view:selectableEvidenceTypes': {
+        'view:hasPrivateMedicalRecords': true,
+      },
+      privateMedicalRecordAttachments: [{ name: 'record1.pdf' }],
+      providerFacility: [{ providerFacilityName: 'Private Clinic 1' }],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property(
+        'privateMedicalRecordAttachments',
+      );
+      expect(updatedData).to.not.have.property('providerFacility');
+      expect(
+        updatedData['view:selectableEvidenceTypes'][
+          'view:hasPrivateMedicalRecords'
+        ],
+      ).to.be.false;
+    });
+  });
+
   it('should show success alert after removing evidence', async () => {
     const setFormData = sinon.spy();
     const data = {

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx
@@ -9,6 +9,10 @@ import {
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import formConfig from '../../config/form';
+import {
+  schema as pageSchema,
+  uiSchema as pageUiSchema,
+} from '../../pages/evidenceRequest';
 
 describe('evidenceRequest', () => {
   const {
@@ -16,91 +20,101 @@ describe('evidenceRequest', () => {
     uiSchema,
   } = formConfig.chapters.supportingEvidence.pages.evidenceRequest;
 
-  it('should render', () => {
-    const { container } = render(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-      />,
-    );
-
-    expect($$('va-radio-option').length).to.equal(2);
-
-    const question = container.querySelector('va-radio');
-    expect(question).to.have.attribute(
-      'label',
-      'Are there medical records related to your claim that you’d like us to access on your behalf from VA or private medical centers?',
-    );
-    expect(question).to.have.attribute(
-      'hint',
-      'If you select “Yes,” we’ll request these records from VA or private medical centers. Or you can upload copies of your private medical records.',
-    );
-    expect(container.querySelector('va-radio-option[label="Yes"]')).to.exist;
-    expect(container.querySelector('va-radio-option[label="No"]')).to.exist;
-  });
-
-  it('should submit when no medical records selected', () => {
-    const onSubmit = sinon.spy();
-    const { getByText, container } = render(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    $('va-radio', container).__events.vaValueChange({
-      detail: { value: 'N' },
+  describe('page module (evidenceRequest.js)', () => {
+    it('schema requires view:hasMedicalRecords', () => {
+      expect(pageSchema.required).to.include('view:hasMedicalRecords');
     });
-    const submitButton = getByText(/submit/i);
-    userEvent.click(submitButton);
-    expect($('va-radio').error).to.be.null;
-    expect(onSubmit.calledOnce).to.be.true;
-  });
 
-  it('should submit when medical records selected', () => {
-    const onSubmit = sinon.spy();
-    const { getByText, container } = render(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    $('va-radio', container).__events.vaValueChange({
-      detail: { value: 'Y' },
+    it('schema has view:hasMedicalRecords property', () => {
+      expect(pageSchema.properties).to.have.property('view:hasMedicalRecords');
     });
-    const submitButton = getByText(/submit/i);
-    userEvent.click(submitButton);
-    expect($('va-radio').error).to.be.null;
-    expect(onSubmit.calledOnce).to.be.true;
+
+    it('uiSchema has page title', () => {
+      expect(pageUiSchema['ui:title']).to.exist;
+    });
   });
 
-  it('should require a response before submitting', () => {
-    const onSubmit = sinon.spy();
-    const { getByText } = render(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-        onSubmit={onSubmit}
-      />,
-    );
+  describe('rendered via form config', () => {
+    it('should render page title and yes/no radios from schema', () => {
+      const { container } = render(
+        <DefinitionTester
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={{}}
+          formData={{}}
+        />,
+      );
 
-    const submitButton = getByText(/submit/i);
-    userEvent.click(submitButton);
-    expect(onSubmit.called).to.be.false;
+      const pageTitle = container.querySelector('h3');
+      expect(pageTitle?.textContent).to.include(
+        'Medical records that support your disability claim',
+      );
+
+      expect($$('va-radio-option').length).to.equal(2);
+      // Radio label, hint, and Yes/No options asserted in EvidenceRequestPage.unit.spec.jsx
+    });
+
+    it('should submit when no medical records selected', () => {
+      const onSubmit = sinon.spy();
+      const { getByText, container } = render(
+        <DefinitionTester
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={{}}
+          formData={{}}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      $('va-radio', container).__events.vaValueChange({
+        detail: { value: 'N' },
+      });
+      const submitButton = getByText(/submit/i);
+      userEvent.click(submitButton);
+      expect($('va-radio').error).to.be.null;
+      expect(onSubmit.calledOnce).to.be.true;
+    });
+
+    it('should submit when medical records selected', () => {
+      const onSubmit = sinon.spy();
+      const { getByText, container } = render(
+        <DefinitionTester
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={{}}
+          formData={{}}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      $('va-radio', container).__events.vaValueChange({
+        detail: { value: 'Y' },
+      });
+      const submitButton = getByText(/submit/i);
+      userEvent.click(submitButton);
+      expect($('va-radio').error).to.be.null;
+      expect(onSubmit.calledOnce).to.be.true;
+    });
+
+    it('should require a response before submitting', () => {
+      const onSubmit = sinon.spy();
+      const { getByText } = render(
+        <DefinitionTester
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={{}}
+          formData={{}}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      const submitButton = getByText(/submit/i);
+      userEvent.click(submitButton);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - When the user confirms “Change and remove” in the modal, the code now removes the evidence keys from form data (`vaTreatmentFacilities`, `privateMedicalRecordAttachments`, `providerFacility`) instead of setting them to empty arrays.
- _(If bug, how to reproduce)_
  1. Start an all-claims disability form and go to the evidence request flow (supporting evidence).
  2. Add VA and/or private medical evidence (facilities or uploads).
  3. Navigate back to the “Medical records that support your disability claim” page.
  4. Choose No for “Are there medical records… you’d like us to access?”
  5. Click Continue. When the confirmation modal appears, click Change and remove.
  6. Choose Yes and add VA facility again.
  7. Return to VA facility details page and see section without fields.
- _(What is the solution, why is this the solution)_
  - When the user confirms “Change and remove” in the modal, remove the evidence keys from form data instead of setting them to []. Form data should represent “no evidence” by not having those keys, not by having them with empty arrays.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - 🌊 Disability Benefits Pathways team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `disability526SupportingEvidenceEnhancement` toggle used to safely test and roll out content and design enhancements

## Related issue(s)

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/132490
- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/133017

## Testing done

- _Describe what the old behavior was prior to the change_
  - When the user chose “No” for medical records and confirmed “Change and remove” in the modal, the code left the evidence keys in form data and set their values to empty arrays. The keys stayed present; only their contents were cleared.
- _Describe the steps required to verify your changes are working as expected_
  - **Manual**
    1. Start an all-claims disability application and go to Supporting Evidence.
    2. Add VA and/or private evidence (facilities or uploads), then continue to the “Medical records that support your disability claim” page.
    3. Select **No** and click **Continue**.
    4. In the “Change your medical records?” modal, click **Change and remove**.
    5. Verify: In form state, confirm that `vaTreatmentFacilities`, `privateMedicalRecordAttachments`, and `providerFacility` are **absent** (not present as `[]`).
    6. Verify: Return to page to add VA facility details and observe section with fields, without having to click **Edit**.
- _Describe the tests completed and the results_
  - **Automated**
    - Run the evidence-request unit tests:
      - `src/applications/disability-benefits/all-claims/tests/components/EvidenceRequestPage.unit.spec.jsx`
      - `src/applications/disability-benefits/all-claims/tests/pages/evidenceRequest.unit.spec.jsx`
  All tests should pass.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| VA provider details | <img width="315" height="351" alt="Screenshot 2026-02-12 at 5 01 23 PM" src="https://github.com/user-attachments/assets/c7a6961b-87f0-466b-8fce-b87198737290" /> | <img width="315" height="834" alt="Screenshot 2026-02-12 at 5 04 41 PM" src="https://github.com/user-attachments/assets/6bbb338b-fc9e-4eeb-9ee4-ce52792c6375" /> |
| confirmation alert | <img width="315" height="366" alt="Screenshot 2026-02-12 at 5 02 30 PM" src="https://github.com/user-attachments/assets/7d0fe9a5-a4bb-44fe-931a-bd7ff6aff8ac" /> | <img width="315" height="427" alt="Screenshot 2026-02-12 at 5 06 25 PM" src="https://github.com/user-attachments/assets/ce35f786-5e90-4cf6-a780-d38dc38112bb" /> |

## What areas of the site does it impact?

Supporting evidence section of Form 526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
