### PR TITLE
[132762] Update .github/instructions/mhv-medical-records.instructions.md

### DIFF
--- a/.github/instructions/mhv-medical-records.instructions.md
+++ b/.github/instructions/mhv-medical-records.instructions.md
@@ -152,6 +152,11 @@ Update this file when you:
   - `OH_ONLY`: User has only Oracle Health (Cerner) facilities
   - `VISTA_AND_OH`: User has both VistA and Oracle Health facilities
 - **studyJobStatus**: Image study request statuses (`NEW`, `QUEUED`, `PROCESSING`, `COMPLETE`, `ERROR`)
+- **ohFacilityTransitionTable**: Maps Oracle Health facility IDs to their VistA-to-OH cutover dates
+  - Used to display date-qualified facility names in CCD download sections
+  - Keys are facility IDs (e.g., `'668'`, `'757'`)
+  - Values contain `cutoverDate` in `YYYY-MM-DD` format
+  - Example: `{ '757': { cutoverDate: '2022-04-30' } }`
 
 ### Helper Functions (`util/helpers.js`)
 
@@ -220,6 +225,31 @@ Update this file when you:
 - **focusOnErrorField()**: Focus on first error field in form
 - **decodeBase64Report(data)**: Decode base64 report data to UTF-8 string
 - **getFailedDomainList(failed, displayMap)**: Format failed domain list with display names
+
+### Facility Helpers (`util/facilityHelpers.js`)
+Utility functions for formatting and displaying facility names, particularly for CCD download sections.
+
+#### Facility List Formatting
+- **formatFacilityUnorderedList(facilities)**: Formats facilities as `<ul>` with `<li>` items
+  - Accepts strings or objects with `{ id, content }` structure
+  - Returns `NONE_RECORDED` for empty/null input
+
+#### Cutover Date Helpers
+These helpers create facility name arrays with date suffixes for transitioned OH facilities.
+Used in CCD download sections to distinguish records before vs after VistA-to-OH transition.
+
+- **formatCutoverDate(dateString)**: Formats `YYYY-MM-DD` to readable format (e.g., `"April 30, 2022"`)
+- **createBeforeCutoverFacilityNames(ohFacilities, ehrDataByVhaId, transitionTable, getNameFn)**:
+  - Returns `Array<{ id: string, content: JSX.Element|string }>`
+  - Appends `"<strong>(before date)</strong>"` suffix for facilities in transition table
+  - Only appends suffix if cutover date is current date or older (future dates show plain name)
+  - Plain facility name for facilities not in transition table
+- **createAfterCutoverFacilityNames(ohFacilities, ehrDataByVhaId, transitionTable, getNameFn)**:
+  - Returns `Array<{ id: string, content: JSX.Element|string }>`
+  - Appends `"<strong>(date-present)</strong>"` suffix for facilities in transition table
+  - Only appends suffix if cutover date is current date or older (future dates show plain name)
+  - Plain facility name for facilities not in transition table
+
 
 ## Business Logic & Requirements
 


### PR DESCRIPTION
This pull request updates the documentation for the MHV Medical Records instructions to add details about new utilities for handling Oracle Health (OH) facility transitions and for formatting facility lists, especially for CCD download sections. The main changes clarify the structure and usage of the new `ohFacilityTransitionTable` and introduce a new set of helper functions in `util/facilityHelpers.js` for displaying facilities before and after their VistA-to-OH cutover dates.

Key documentation updates:

**Facility Transition Table Documentation**
- Added a section describing the `ohFacilityTransitionTable`, which maps Oracle Health facility IDs to their VistA-to-OH cutover dates, including structure, usage, and an example.

**Facility Formatting Helpers**
- Documented new utility functions in `util/facilityHelpers.js` for:
  - Formatting facility lists as unordered HTML lists.
  - Formatting cutover dates into a readable format.
  - Creating arrays of facility names with date-based suffixes to distinguish records before and after VistA-to-OH transitions, including logic for handling current and future cutover dates.**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.