### PR TITLE
[5717] Prefill - Edit note on Personal Information component

### DIFF
--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
@@ -250,20 +250,19 @@ export const PersonalInformation = ({
         <div className="vads-u-margin-bottom--4" data-testid="default-note">
           <p>
             <strong>Note:</strong> To protect your personal information, we
-            don’t allow online changes to your name, Social Security number, or
-            date of birth. If you need to change this information, call us at{' '}
+            don’t allow online changes to your name, date of birth, or Social
+            Security number. If you need to change this information, call us at{' '}
             <va-telephone contact={CONTACTS.VA_BENEFITS} /> (
             <va-telephone contact="711" tty />
             ). We’re here Monday through Friday, between 8:00 a.m. and 9:00 p.m.
-            ET. We’ll give you instructions for how to change your information.
-            Or you can learn how to change your legal name on file with VA.{' '}
+            ET.
           </p>
           <va-link
             external
             href={`${
               environment.BASE_URL
             }/resources/how-to-change-your-legal-name-on-file-with-va/`}
-            text="Learn how to change your legal name"
+            text="Find more detailed instructions for how to change your legal name"
           />
         </div>
       )}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates to the note on prefill pattern's PersonalInformation component.
This note exist on the pattern by default and does not need to be manually added by teams.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5717

## Testing done

Unit and local testing

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="675" height="857" alt="image" src="https://github.com/user-attachments/assets/accdcc2c-b227-4339-98a5-42975dfcb227" />|<img width="659" height="834" alt="image" src="https://github.com/user-attachments/assets/68326f80-ac1e-4690-8118-1a8f21c2a034" />|

## What areas of the site does it impact?

Prefill pattern in forms-system