### PR TITLE
Adding human readable messages where missing

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -28,15 +28,27 @@ export const uiSchema = {
         'ui:title': 'First name',
         'ui:autocomplete': 'given-name',
         'ui:required': hasAlternateName,
+        'ui:errorMessages': {
+          pattern:
+            "Name may only contain letters, numbers, spaces, and these special characters: - / '",
+        },
       },
       middle: {
         'ui:title': 'Middle name',
         'ui:autocomplete': 'additional-name',
+        'ui:errorMessages': {
+          pattern:
+            "Name may only contain letters, numbers, spaces, and these special characters: - / '",
+        },
       },
       last: {
         'ui:title': 'Last name',
         'ui:autocomplete': 'family-name',
         'ui:required': hasAlternateName,
+        'ui:errorMessages': {
+          pattern:
+            "Name may only contain letters, numbers, spaces, and these special characters: - / '",
+        },
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -22,7 +22,13 @@ export const uiSchema = {
         from: dateUI('Obligation start date'),
         to: dateUI('Obligation end date'),
       },
-      unitName: { 'ui:title': 'Unit name' },
+      unitName: {
+        'ui:title': 'Unit name',
+        'ui:errorMessages': {
+          pattern:
+            "Unit name may only contain letters, numbers, spaces, and these special characters: - ' . #",
+        },
+      },
     },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -51,6 +51,10 @@ export const uiSchema = {
       },
       treatmentCenterName: {
         'ui:title': 'Name of VA medical facility',
+        'ui:errorMessages': {
+          pattern:
+            'Facility name may only contain letters, numbers, spaces, and these special characters: - " / & ( ) \' . #',
+        },
       },
       treatedDisabilityNames: {
         'ui:title':
@@ -159,6 +163,9 @@ export const uiSchema = {
           'ui:title': 'City',
           'ui:autocomplete': 'off',
           'ui:validations': [validateMilitaryTreatmentCity],
+          'ui:errorMessages': {
+            pattern: 'Please enter a valid city',
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary

- When a form field's value fails JSON schema `pattern` validation and no `ui:errorMessages` override is defined, the platform falls back to the raw `jsonschema` library error, exposing the regex directly to the user (e.g. `does not match pattern "^([-a-zA-Z0-9\/&()'.#][ ]?)+$"`).
- Several fields across the Form 526 disability benefits application were missing `ui:errorMessages` `pattern` overrides, meaning Veterans could see cryptic regex strings instead of helpful guidance.
- This PR adds human-readable `pattern` error messages to all affected fields:
  - `treatmentCenterName` (VA medical facility name)
  - `treatmentCenterAddress.city` (VA treatment center city)
  - `alternateNames.first`, `alternateNames.middle`, `alternateNames.last` (service names)
  - `unitName` (Reserves/National Guard unit name)
- Team: Benefits Disability Experience (DBEX) — Team 1
- No flipper needed; these are purely additive `ui:errorMessages` properties.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- **Old behavior:** When a Veteran entered a character not matching the field's regex pattern (e.g. a comma in "VA Medical Center, Tampa"), the error message displayed was the raw regex: `does not match pattern "^([-a-zA-Z0-9"\/&()'.#]+( [-a-zA-Z0-9"\/&()'.#]+)*)$"`. This is confusing and unhelpful.
- **New behavior:** The same validation failure now shows a clear message like: `Facility name may only contain letters, numbers, spaces, and these special characters: - " / & ( ) ' . #`
- **Steps to verify:**
  1. Navigate to the 526 form (disability benefits application)
  2. On the VA Medical Records page, enter a facility name with an unsupported character (e.g. `VA Medical Center, Tampa` — note the comma)
  3. Confirm the error message shown is the human-readable string, not a raw regex
  4. Repeat for the other affected fields:
     - Alternate names page → enter a name with `@` or `,`
     - Reserves/National Guard page → enter a unit name with `@` or `,`
     - VA treatment center address city → enter a city with `@` or `,`
- **Tests:** These changes are additive `ui:errorMessages` config properties. Existing unit tests continue to pass. The form schema and validation logic are unchanged — only the message displayed to the user on pattern failure is affected.

## Screenshots

_N/A — Error messages are rendered by the existing forms-system platform error UI. No visual/layout changes. The only difference is the text content of the error string._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | Raw regex shown as error text | Human-readable message |
| Desktop | Raw regex shown as error text | Human-readable message |

## What areas of the site does it impact?

The following pages within the Form 526 disability compensation application:
- **VA Medical Records** (`vaMedicalRecords.js`) — facility name and city fields
- **Alternate Names** (`alternateNames.js`) — first, middle, and last name fields
- **Reserves & National Guard Service** (`reservesNationalGuardService.jsx`) — unit name field

No other areas of the site are impacted. All changes are scoped to `ui:errorMessages` within page-level uiSchema definitions.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a low-risk, additive-only change — we are only adding `ui:errorMessages` `pattern` keys to uiSchema definitions. No validation logic, form schema, or submission behavior is modified. The only user-facing impact is replacing raw regex strings with human-readable error messages when pattern validation fails.

During the investigation, the following fields were confirmed to **not** need changes:
- `homelessnessContact.name` — already strips the `pattern` from the schema via `_.omit('pattern', ...)`
- `providerFacilityName` (form 4142) — has no `pattern` in the JSON schema, only `minLength`/`maxLength`
- `separationLocationName` — uses autosuggest (users select from a list, preventing free-typed invalid characters)
- Form 0781 incident address fields — already covered by `addressUISchema()` which provides proper error messages