### PR TITLE
Add skip to failing test

### DIFF
--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.non-oracle-user.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/labs-and-tests/view-labs-and-tests-list.unified-data.non-oracle-user.cypress.spec.js
@@ -38,7 +38,7 @@ describe('Medical Records View Lab and Tests - Non-Oracle Health User', () => {
     cy.intercept('POST', '/v0/datadog_action', {}).as('datadogAction');
   });
 
-  it('renders the legacy labs and tests list for a non-Cerner user', () => {
+  it.skip('renders the legacy labs and tests list for a non-Cerner user', () => {
     site.loadPage();
 
     // Check for labs and tests link on the landing page


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
- [x] No

## Summary

- Skip failing e2e test `view-labs-and-tests-list.unified-data.non-oracle-user.cypress.spec.js` that is blocking all MHV Medical Records PRs
- Test was introduced in PR #42298 and is failing on main
- Team: MHV Medical Records

## Related issue(s)

- Related to PR #42298

## Testing done

- Verified test fails on main branch (not caused by any specific PR)
- Skipping test to unblock deployments, will follow up with Mark Dewey to fix properly

## What areas of the site does it impact?

None - test skip only

## Acceptance criteria

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated - N/A
- [x] Screenshot of the developed feature is added - N/A, no UI changes
- [x] Accessibility testing has been performed - N/A, no UI changes

### Error Handling
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution - N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user - N/A, test change only