### PR TITLE
Partial reversion of vets-website PR 42117

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1773,20 +1773,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
-          # Shallow clone - we'll fetch main separately for the diff
-          fetch-depth: 1
-
-      - name: Fetch origin/main for diff
-        # Fetch only main branch with limited depth instead of full history (37k+ commits)
-        # --depth=300 covers PRs up to ~2 weeks behind main (~150 commits/week)
-        # If the merge-base isn't in the shallow history (e.g. long-lived branches
-        # like update-node-22), falls back to a full fetch of main
-        run: |
-          git fetch origin main:refs/remotes/origin/main --depth=300
-          if ! git merge-base --is-ancestor $(git merge-base origin/main HEAD 2>/dev/null || echo "missing") HEAD 2>/dev/null; then
-            echo "Merge-base not found in shallow history — falling back to full fetch of main"
-            git fetch origin main:refs/remotes/origin/main --unshallow 2>/dev/null || git fetch origin main:refs/remotes/origin/main
-          fi
+          fetch-depth: 0
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -1800,18 +1787,15 @@ jobs:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-      # Lightweight install - only @actions/core is needed for the scripts in this job
-      - name: Get Node version
-        id: get-node-version
-        run: echo NODE_VERSION=$(cat .nvmrc) >> $GITHUB_OUTPUT
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
         with:
-          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-
-      - name: Install minimal dependencies
-        run: npm install @actions/core
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
 
       - name: Get changed applications
         id: get-changed-apps


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _[CI workflow failures based in the QA Merge Status job proliferated into all `vets-website` branches created after yesterday afternoon](https://dsva.slack.com/archives/CBU0KDSB1/p1770993147866319)._
- _[This PR](https://github.com/department-of-veterans-affairs/vets-website/pull/42117) was intended to help speed up CI runs, in part, by introducing a more lightweight `install dependencies` command that utilized `npm` instead of `yarn`._
- _This PR is a partial reversion that removes the use of `npm` and restores the use of the original yarn command, due to differences in tool behavior._
- _Alarmingly, Github was showing CI runs that were failing at this step as both passing and failing, when viewed from this UI: https://github.com/department-of-veterans-affairs/vets-website/actions/workflows/continuous-integration.yml_


## Related issue(s)

- _[Platform FE CoP thread](https://dsva.slack.com/archives/C04868KS69L/p1771014007570459)_
- Support ticket linked above

## Testing done

- _CI now successfully runs the QA Merge Status job_
