### PR TITLE
Revert "Profile Missing Email Validation"

### DIFF
--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -89,8 +89,7 @@ const ContactInfo = ({
       : profile.vapContactInfo || {};
 
   const dataWrap = data[keys.wrapper] || {};
-  const email =
-    dataWrap[keys.email]?.emailAddress || dataWrap[keys.email] || '';
+  const email = dataWrap[keys.email] || '';
   const homePhone = dataWrap[keys.homePhone] || {};
   const mobilePhone = dataWrap[keys.mobilePhone] || {};
   const address = dataWrap[keys.address] || {};
@@ -167,7 +166,7 @@ const ContactInfo = ({
           );
         }
         if (keys.email) {
-          wrapper[keys.email] = contactInfo.email;
+          wrapper[keys.email] = contactInfo.email?.emailAddress;
         }
         setFormData({ ...data, [keys.wrapper]: wrapper });
       }
@@ -291,7 +290,7 @@ const ContactInfo = ({
         </Headers>
         {showSuccessAlert('email', content.email)}
         <span className="dd-privacy-hidden" data-dd-action-name="email">
-          {dataWrap[keys.email]?.emailAddress || dataWrap[keys.email] || ''}
+          {dataWrap[keys.email] || ''}
         </span>
         {loggedIn && (
           <p className="vads-u-margin-top--0p5">

--- a/src/platform/forms-system/src/js/utilities/data/profile.js
+++ b/src/platform/forms-system/src/js/utilities/data/profile.js
@@ -412,8 +412,6 @@ export const getMissingInfo = ({ data, keys, content, requiredKeys = [] }) => {
 
   const homePhoneObj = data[keys.homePhone] || {};
   const mobilePhoneObj = data[keys.mobilePhone] || {};
-  const emailObj = data[keys.email] || {};
-  const addressObject = data[keys.address] || {};
 
   const isValidHomePhone =
     homePhoneObj.isInternational || isValidPhone(getPhoneString(homePhoneObj));
@@ -421,10 +419,6 @@ export const getMissingInfo = ({ data, keys, content, requiredKeys = [] }) => {
   const isValidMobilePhone =
     mobilePhoneObj.isInternational ||
     isValidPhone(getPhoneString(mobilePhoneObj));
-
-  const isValidEmailAddress = isValidEmail(
-    (emailObj.emailAddress || '').trim(),
-  );
 
   if (keys.homePhone && keys.mobilePhone && eitherPhone) {
     missingInfo.push(
@@ -440,9 +434,10 @@ export const getMissingInfo = ({ data, keys, content, requiredKeys = [] }) => {
     }
   }
   if (keys.email && requiredKeys.includes(keys.email)) {
-    missingInfo.push(isValidEmailAddress ? '' : content.missingEmail);
+    missingInfo.push(data[keys.email] ? '' : content.missingEmail);
   }
   if (keys.address && requiredKeys.includes(keys.address)) {
+    const addressObject = data[keys.address] || {};
     const isUS = addressObject.addressType !== ADDRESS_TYPES.international;
     const hasRequiredAddressFields =
       addressObject.countryName &&

--- a/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
@@ -28,7 +28,7 @@ const getData = ({
 } = {}) => ({
   data: {
     veteran: {
-      email: email ? vapProfile.email : null,
+      email: email ? vapProfile.email.emailAddress : null,
       mobilePhone: mobile ? vapProfile.mobilePhone : null,
       homePhone: home ? vapProfile.homePhone : null,
       mailingAddress: address ? vapProfile.mailingAddress : null,
@@ -108,7 +108,7 @@ describe('<ContactInfo>', () => {
     // data exists (no error) & shouldn't show success message after updating
     const data = {
       veteran: {
-        email: { emailAddress: 'x@x.com', updatedAt: '' },
+        email: 'x@x.com',
         mobilePhone: { ...vapProfile.mobilePhone, updatedAt: '' },
         homePhone: { ...vapProfile.homePhone, updatedAt: '' },
         mailingAddress: { ...vapProfile.mailingAddress, updatedAt: '' },

--- a/src/platform/forms-system/test/js/utilities/profile.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/utilities/profile.unit.spec.jsx
@@ -141,7 +141,7 @@ describe('profile utilities', () => {
         city: a ? 'City' : '',
         zipCode: a ? '12345' : '',
       },
-      e: { emailAddress: e ? 'x@x.com' : '' },
+      e: e ? 'x@x.com' : '',
       h: { areaCode: h ? '123' : '', phoneNumber: h ? '5551212' : '' },
       m: { areaCode: m ? '234' : '', phoneNumber: m ? '5551313' : '' },
     });


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#41934

Slack threads:
- https://dsva.slack.com/archives/C5HP4GN3F/p1771015956950929
- https://dsva.slack.com/archives/C5AGLBNRK/p1771016980329019

Prior to this commit, the `veteran.email` was a string, and after this commit, it is an object.

<img width="450" alt="Screenshot 2026-02-13 at 3 54 11 PM" src="https://github.com/user-attachments/assets/f28a6194-8a11-459a-a09e-7c1f84263c5b" />

This is causing an issue in the code in [profile.js](https://github.com/department-of-veterans-affairs/vets-website/blob/58e357fce4d46c6c22d39d19edea5532c75a11e2/src/platform/forms-system/src/js/utilities/data/profile.js#L332) because it is attempting to `.trim()` an object rather than a string.

<img width="560" alt="Screenshot 2026-02-13 at 3 12 26 PM" src="https://github.com/user-attachments/assets/ff2a697a-38c4-498a-9854-8ed97df6c249" />
<img width="658" height="135" alt="Screenshot 2026-02-13 at 2 51 24 PM" src="https://github.com/user-attachments/assets/1ba1467b-814b-4d03-b2b5-d79145de998e" />

We discovered the problem in our Decision Reviews apps in staging. We are unable to get the `/review-and-submit` page to load on our forms because of the below error.

- [Supplemental Claims](https://staging.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start)
- [Higher-Level Review](https://staging.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start)
- [Notice of Disagreement](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction)

Because the code has already been deployed to production, presumably our apps are affected there as well.