### PR TITLE
[Disability Benefits] Clarify form is for mental health conditions only

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -17,54 +17,10 @@ import { checkValidations } from '../../utils/submit';
 import { form0781WorkflowChoices } from './workflowChoices';
 
 export const workflowChoicePageTitle =
-  'Option to add a statement in support of mental health conditions';
-
-const isPlaceholderRated = v => v === 'Rated Disability';
-
-const conditionSelections = formData => {
-  const conditions = Array.isArray(formData?.newDisabilities)
-    ? formData.newDisabilities
-        .filter(
-          d => typeof d?.condition === 'string' && d.condition.trim() !== '',
-        )
-        .filter(d => !isPlaceholderRated(d.condition))
-        .map(d => {
-          const base = d.condition.trim();
-          const side =
-            typeof d?.sideOfBody === 'string'
-              ? d.sideOfBody.trim().toLowerCase()
-              : '';
-
-          const full = side ? `${base}, ${side}` : base;
-
-          return full.charAt(0).toUpperCase() + full.slice(1);
-        })
-        .filter(
-          (() => {
-            const seen = new Set();
-            return label => (seen.has(label) ? false : (seen.add(label), true));
-          })(),
-        )
-    : [];
-
-  if (conditions.length === 0) return null;
-
-  return (
-    <div>
-      <p>Your claim includes these new conditions:</p>
-      <ul>
-        {conditions.map((condition, index) => (
-          <li key={index}>
-            <strong>{condition}</strong>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-};
+  'Optional statement if your claim includes mental health conditions';
 
 export const form0781WorkflowChoiceDescription =
-  'Do you want to add a statement in support of mental health conditions?';
+  'Do you want to add a statement to support mental health conditions related to traumatic events?';
 
 export const form0781WorkflowChoiceLabels = Object.freeze({
   [form0781WorkflowChoices.COMPLETE_ONLINE_FORM]:
@@ -72,17 +28,30 @@ export const form0781WorkflowChoiceLabels = Object.freeze({
   [form0781WorkflowChoices.SUBMIT_PAPER_FORM]:
     'Yes, and I want to fill out a PDF to upload.',
   [form0781WorkflowChoices.OPT_OUT_OF_FORM0781]:
-    'No, I don’t want to add this form to my claim.',
+    'No, I don’t want to add this statement to my claim.',
 });
 
-export const workflowChoicePageDescription = formData => {
+export const workflowChoicePageDescription = () => {
   return (
     <>
-      {conditionSelections(formData)}
       <p>
-        We encourage you to submit this optional statement for any new mental
-        health conditions related to a traumatic event that happened during your
-        military service. We’ll use the information to support your claim.
+        We encourage you to submit this optional statement if both of these
+        descriptions are true for you:
+      </p>
+      <ul>
+        <li>
+          Your claim includes one or more mental health conditions,{' '}
+          <strong>and</strong>
+        </li>
+        <li>
+          The mental health conditions relate to a traumatic event that happened
+          during your military service
+        </li>
+      </ul>
+      <p>We’ll use the information you provide to support your claim.</p>
+      <p>
+        If these descriptions don’t apply to you, you can skip adding this
+        statement.
       </p>
       <p>
         <strong>Here’s what to know before you decide:</strong>
@@ -554,7 +523,7 @@ const WorkflowChoicePage = props => {
           {titleWithTag(workflowChoicePageTitle, form0781HeadingTag)}
         </legend>
         <div>
-          {workflowChoicePageDescription(data)}
+          {workflowChoicePageDescription()}
           <div>
             <VaRadio
               label={form0781WorkflowChoiceDescription}
@@ -615,7 +584,7 @@ const WorkflowChoicePage = props => {
                 <va-link
                   external
                   href="https://www.va.gov/find-forms/about-form-21-0781/"
-                  text="Download VA Form 21-0781"
+                  text="Download VA Form 21-0781 to submit your statement"
                 />
               </p>
             </div>

--- a/src/applications/disability-benefits/all-claims/pages/form0781/workflowChoicePage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/workflowChoicePage.js
@@ -14,7 +14,7 @@ import { form0781WorkflowChoices } from '../../content/form0781/workflowChoices'
 export default {
   uiSchema: {
     'ui:title': titleWithTag(workflowChoicePageTitle, form0781HeadingTag),
-    'ui:description': ({ formData }) => workflowChoicePageDescription(formData),
+    'ui:description': () => workflowChoicePageDescription(),
     mentalHealthWorkflowChoice: radioUI({
       title: form0781WorkflowChoiceDescription,
       labelHeaderLevel: '4',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Update content on 0781 intro page to reflect the changes captured in the [Figma artboard called "proposed"](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/Initiative-%E2%80%A2-0781-Paper-Sync?node-id=23712-33577&t=Aqi3rGAiswMphAeV-1)
- _(If bug, how to reproduce)_
  - n/a
- _(What is the solution, why is this the solution)_
  - Update heading wording to to make it clear right up top that this isn't optional for all claims, just some
  - Remove dynamic condition list to prevent assumption that this form should be filled out for all conditions
  - Update content and format of second copy block to align with eligibility criteria content pattern; also adding an “if these don’t apply” to further clarify that it’s ok to skip this form
  - Update input label wording to reenforce relationship of this form to events
  - Update language to reference a "statement" instead of the form to align w/ the page heading
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - 🌊 Disability Benefits Pathways team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - n/a

## Related issue(s)

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/131725

## Testing done

- _Describe what the old behavior was prior to the change_
  - Mental Health Statement orientation page content has been reported as being confusing to Veterans
- _Describe the steps required to verify your changes are working as expected_
  1. logged in to file a disability benefit claim,
  2. complete required parts of the form, and
  3. continue to `/disability/file-disability-claim-form-21-526ez/mental-health-form-0781/workflow`, or
  4. use the side nav navigate to the "**Step 3: Mental health statement**", then
  5. view content
- _Describe the tests completed and the results_
  - no spec changes are required for the updates to `workflowChoicePageDescription` or the workflow choice page; existing tests remain valid

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="339" height="844" alt="Screenshot 2026-02-13 at 3 35 07 PM" src="https://github.com/user-attachments/assets/4748bc28-8b99-491c-b60d-732da2d996b4" /> | <img width="320" height="955" alt="Screenshot 2026-02-13 at 5 02 27 PM" src="https://github.com/user-attachments/assets/d0606862-9343-4c6c-9881-70f122c15631" /> |
| Desktop | <img width="325" height="771" alt="Screenshot 2026-02-13 at 3 32 41 PM" src="https://github.com/user-attachments/assets/45c09e66-8ba3-4780-8cbb-64b932915751" /> | <img width="314" height="809" alt="Screenshot 2026-02-13 at 4 59 59 PM" src="https://github.com/user-attachments/assets/555f3644-4016-402a-a972-cf29821d1e34" /> |

## What areas of the site does it impact?

Content on the Mental Health Statement intro/orientation page of Form 526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
