### PR TITLE
534ez add mailing address to confirmation page

### DIFF
--- a/src/applications/survivors-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/survivors-benefits/containers/ConfirmationPage.jsx
@@ -25,6 +25,29 @@ export const ConfirmationPage = props => {
       <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList />
+      <h2>If you need to submit supporting documents</h2>
+      <p>
+        If you didn’t already submit your supporting documents and additional
+        evidence, you can submit copies of your documents by mail.
+      </p>
+      <p>Mail and supporting documents to this address:</p>
+      <p className="va-address-block">
+        Department of Veterans Affairs
+        <br />
+        Pension Intake Center
+        <br />
+        PO Box 5365
+        <br />
+        Janesville, WI 53547-5365
+        <br />
+        United States of America
+        <br />
+      </p>
+      <p>
+        <span className="vads-u-font-weight--bold">Note:</span> Mail us copies
+        of your documents only. Don’t send us your original documents. We can’t
+        return them.
+      </p>
       <ConfirmationView.HowToContact />
       <ConfirmationView.GoBackLink />
       <ConfirmationView.NeedHelp />

--- a/src/applications/survivors-benefits/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('ConfirmationPage', () => {
     cleanup();
   });
 
-  it('shows success alert, heading, and confirmation number', () => {
+  it('shows success alert, heading, mailing address, and confirmation number', () => {
     const { container, cleanupAnchor } = initConfirmationPage();
     const alert = container.querySelector('va-alert');
     expect(alert).to.exist;
@@ -46,6 +46,15 @@ describe('ConfirmationPage', () => {
     expect(alert.textContent).to.include(
       'Your confirmation number is 1234567890.',
     );
+    const mailingAddress = container.querySelector('.va-address-block');
+    expect(mailingAddress).to.exist;
+    expect(mailingAddress.textContent).to.include(
+      'Department of Veterans Affairs',
+    );
+    expect(mailingAddress.textContent).to.include('Pension Intake Center');
+    expect(mailingAddress.textContent).to.include('PO Box 5365');
+    expect(mailingAddress.textContent).to.include('Janesville, WI 53547-5365');
+    expect(mailingAddress.textContent).to.include('United States of America');
     cleanupAnchor();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add mailing address for required forms to confirmation page

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131247

## Testing done

- Manual testing
- Added unit test

## Screenshots
<img width="867" height="1050" alt="Screenshot 2026-02-16 at 3 27 06 PM" src="https://github.com/user-attachments/assets/061a04e5-9c9d-432e-a7b0-6590231dc232" />



## What areas of the site does it impact?

Content on confirmation page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
