### PR TITLE
Prefill logging

### DIFF
--- a/src/platform/forms/tests/save-in-progress/actions-logging.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/actions-logging.unit.spec.jsx
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { VA_FORM_IDS } from 'platform/forms/constants';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { server, rest } from '../mock-sip-handlers';
+import * as datadogUtilities from '../../../monitoring/Datadog/utilities';
+
+import { fetchInProgressForm } from '../../save-in-progress/actions';
+import { inProgressApi } from '../../helpers';
+
+const getState = () => ({
+  form: { trackingPrefix: 'test', pages: {} },
+});
+
+const formId = VA_FORM_IDS.FORM_10_10EZ;
+
+const setupGet = (response, status = 200) => {
+  server.use(
+    rest.get(inProgressApi(formId), (req, res, ctx) =>
+      res(ctx.status(status), ctx.json(response)),
+    ),
+  );
+};
+
+const successData = {
+  formData: { field: 'value' },
+  metadata: { version: 0, prefill: true },
+};
+
+const brokenMigration = [
+  () => {
+    throw new Error('Migration broke');
+  },
+];
+
+describe('Save-in-progress Datadog logging', () => {
+  let ddStub;
+  let warnStub;
+  let localhostStub;
+
+  beforeEach(() => {
+    ddStub = sinon.stub(datadogUtilities, 'dataDogLogger');
+    warnStub = sinon.stub(console, 'warn');
+  });
+
+  afterEach(() => {
+    ddStub.restore();
+    warnStub.restore();
+    if (localhostStub) {
+      localhostStub.restore();
+      localhostStub = null;
+    }
+  });
+
+  it('logs to Datadog when migration throws', () => {
+    setupGet(successData);
+    const dispatch = sinon.spy();
+
+    return fetchInProgressForm(formId, brokenMigration)(
+      dispatch,
+      getState,
+    ).then(() => {
+      expect(ddStub.calledOnce).to.be.true;
+      const args = ddStub.firstCall.args[0];
+      expect(args.message).to.equal('vets_sip_error_migration');
+      expect(args.status).to.equal('error');
+      expect(args.error).to.be.an.instanceOf(Error);
+      expect(args.attributes).to.have.property('metadata');
+    });
+  });
+
+  it('logs to Datadog when prefillTransformer throws', () => {
+    setupGet(successData);
+    const dispatch = sinon.spy();
+
+    return fetchInProgressForm(formId, {}, true, () => {
+      throw new Error('Prefill broke');
+    })(dispatch, getState).then(() => {
+      expect(ddStub.called).to.be.true;
+      expect(ddStub.firstCall.args[0].message).to.equal(
+        'vets_sip_error_migration',
+      );
+      expect(ddStub.firstCall.args[0].error.message).to.equal('Prefill broke');
+    });
+  });
+
+  it('shows console.warn on localhost', () => {
+    localhostStub = sinon.stub(environment, 'isLocalhost').returns(true);
+    setupGet(successData);
+    const dispatch = sinon.spy();
+
+    return fetchInProgressForm(formId, brokenMigration)(
+      dispatch,
+      getState,
+    ).then(() => {
+      expect(warnStub.called).to.be.true;
+      expect(warnStub.firstCall.args[0]).to.include('SiP');
+    });
+  });
+
+  it('does NOT show console.warn in non-localhost environments', () => {
+    localhostStub = sinon.stub(environment, 'isLocalhost').returns(false);
+    setupGet(successData);
+    const dispatch = sinon.spy();
+
+    return fetchInProgressForm(formId, brokenMigration)(
+      dispatch,
+      getState,
+    ).then(() => {
+      expect(warnStub.called).to.be.false;
+      expect(ddStub.called).to.be.true;
+    });
+  });
+
+  it('logs to Datadog on network error', () => {
+    server.use(
+      rest.get(inProgressApi(formId), (req, res) =>
+        res.networkError('SIP Network Error'),
+      ),
+    );
+    const dispatch = sinon.spy();
+
+    return fetchInProgressForm(formId, {})(dispatch, getState).then(() => {
+      const call = ddStub
+        .getCalls()
+        .find(c => c.args[0].message === 'vets_sip_error_fetch');
+      expect(call).to.exist;
+      expect(call.args[0].status).to.equal('error');
+    });
+  });
+
+  it('does NOT log to Datadog on successful load', () => {
+    setupGet(successData);
+    const dispatch = sinon.spy();
+
+    return fetchInProgressForm(formId, {})(dispatch, getState).then(() => {
+      expect(ddStub.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added Datadog logging and localhost `console.warn` to Save-in-Progress (SiP) error paths in `actions.js` and `api.js` to improve observability when migrations, prefill transformers, fetch errors, save errors, or delete errors occur.
- **Problem**: When SiP migrations or prefill transformers throw errors, there was no logging to Datadog and no local developer feedback, making these failures silent and difficult to debug.


## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5133

## Testing done

- **Old behavior**: SiP migration/prefill/fetch/save/delete errors were caught but not logged to Datadog and not surfaced to developers on localhost.
- **New behavior**: Errors are now logged to Datadog with structured messages and surfaced via `console.warn` on localhost.
- **Steps to verify**:
  1. Signed in with a working test user, pasted `window.DD_LOGS` mock into console, intentionally broke a prefillTransformer, and confirmed the Datadog mock log and `console.warn` fired in the browser console.
  - Dispatches `invalidData` status when migration throws
  - Dispatches `prefillComplete` when prefillTransformer throws
  - Does NOT `console.warn` when not on localhost
  - Does NOT `console.warn` on successful form load

## Screenshots

<img width="713" height="77" alt="Screenshot 2026-02-17 at 10 24 25 AM" src="https://github.com/user-attachments/assets/dee9e9d9-0997-4318-acaa-06bb083fae6c" />


## What areas of the site does it impact?

All VA.gov forms that use the Save-in-Progress (SiP) platform (`src/platform/forms/save-in-progress/`) sad paths.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

