### PR TITLE
Add ARP claimant details feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -1,4 +1,5 @@
 {
+  "accreditedRepresentativePortalClaimantDetails": "accredited_representative_portal_claimaint_details",
   "accreditedRepresentativePortalFrontend": "accredited_representative_portal_frontend",
   "accreditedRepresentativePortalForm21a": "accredited_representative_portal_form_21a",
   "aedpVADX": "aedp_vadx",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -1,5 +1,5 @@
 {
-  "accreditedRepresentativePortalClaimantDetails": "accredited_representative_portal_claimaint_details",
+  "accreditedRepresentativePortalClaimantDetails": "accredited_representative_portal_claimant_details",
   "accreditedRepresentativePortalFrontend": "accredited_representative_portal_frontend",
   "accreditedRepresentativePortalForm21a": "accredited_representative_portal_form_21a",
   "aedpVADX": "aedp_vadx",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add feature flag to do claimant details work on vets-website behind.

## Related issue(s)

[Create feature flag for Claimant Details MVP #132590](https://github.com/department-of-veterans-affairs/va.gov-team/issues/132590)

