### PR TITLE
fixes form subtitle to use correct form name (21-530a to 21P-530a)

### DIFF
--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/constants/constants.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/constants/constants.js
@@ -6,7 +6,7 @@
 export const TITLE =
   'Apply for a VA interment allowance for a state or tribal organization';
 export const SUBTITLE =
-  'State or Tribal Organization Application for Interment Allowance (Under 38 U.S.C. Chapter 23) (VA Form 21-530a)';
+  'State or Tribal Organization Application for Interment Allowance (Under 38 U.S.C. Chapter 23) (VA Form 21P-530a)';
 
 /**
  * Tracking prefix for analytics

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/constants/constants.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/constants/constants.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('Constants', () => {
     it('should have correct subtitle', () => {
       expect(SUBTITLE).to.exist;
       expect(SUBTITLE).to.equal(
-        'State or Tribal Organization Application for Interment Allowance (Under 38 U.S.C. Chapter 23) (VA Form 21-530a)',
+        'State or Tribal Organization Application for Interment Allowance (Under 38 U.S.C. Chapter 23) (VA Form 21P-530a)',
       );
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing subtitle on 21P-530a to use correct form name

### Issue
The subtitle for form 21P-530a calls the form 21-530a (missing the P)

### Solution
Updated the subtitle to use the correct form name

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21p-530a form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 129228](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129228)

## Testing done

### Old behavior
* The form subtitle uses 21-530a as the form name

### New behavior
* The form subtitle uses 21P-530a as the form name

### Verification Steps
*  Unit tests: verified existing unit tests still pass, modified subtitle unit test to use new subtitle
*  Manual testing in local environment verified that the new subtitle is displaying
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  |  |
| Desktop | <img width="722" height="275" alt="name before" src="https://github.com/user-attachments/assets/2af52d19-5eaa-42f2-9896-f98671e1f460" /> | <img width="764" height="272" alt="name after" src="https://github.com/user-attachments/assets/f2b7d192-72ba-4bf5-b590-15ef104bded8" /> |

## What areas of the site does it impact?

This change affects form 21p-530a, specifically on the introduction page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user