### PR TITLE
2389 create veteran status card alert component

### DIFF
--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
@@ -134,3 +134,75 @@ export const SystemErrorAlert = () => {
     />
   );
 };
+
+/**
+ * Renders a dynamic alert body item based on its type
+ * @param {Object} item - The body item from the API response
+ * @param {number} index - The item index for key
+ */
+const renderBodyItem = (item, index) => {
+  switch (item.type) {
+    case 'text':
+      return (
+        <p key={index} className="vads-u-margin-y--1">
+          {item.value}
+        </p>
+      );
+    case 'phone':
+      return (
+        <p key={index} className="vads-u-margin-y--1">
+          <va-telephone contact={item.value} />
+          {item.tty && (
+            <>
+              {' '}
+              (<va-telephone contact="711" tty />)
+            </>
+          )}
+        </p>
+      );
+    case 'link':
+      return (
+        <p key={index} className="vads-u-margin-y--1">
+          <va-link href={item.url} text={item.value} />
+        </p>
+      );
+    default:
+      return null;
+  }
+};
+
+/**
+ * Dynamic alert component for veteran status alerts
+ * Renders alerts based on the new shared service API response structure
+ */
+export const DynamicVeteranStatusAlert = ({ attributes }) => {
+  const { header, body, alert_type: alertType } = attributes;
+
+  return (
+    <va-alert
+      class="vads-u-margin-bottom--4"
+      close-btn-aria-label="Close notification"
+      status={alertType || 'warning'}
+      visible
+    >
+      {header && <h2 slot="headline">{header}</h2>}
+      <div>{body?.map((item, index) => renderBodyItem(item, index))}</div>
+    </va-alert>
+  );
+};
+
+DynamicVeteranStatusAlert.propTypes = {
+  attributes: PropTypes.shape({
+    // eslint-disable-next-line camelcase -- API response uses snake_case
+    alert_type: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
+    body: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.oneOf(['text', 'phone', 'link']),
+        url: PropTypes.string,
+        value: PropTypes.string,
+        tty: PropTypes.bool,
+      }),
+    ),
+    header: PropTypes.string,
+  }),
+};

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
@@ -166,9 +166,7 @@ const renderBodyItem = (item, index) => {
   }
 };
 
-export const DynamicVeteranStatusAlert = ({ attributes }) => {
-  const { header, body, alert_type: alertType } = attributes;
-
+export const DynamicVeteranStatusAlert = ({ alertType, body, header }) => {
   return (
     <va-alert
       class="vads-u-margin-bottom--4"
@@ -183,17 +181,14 @@ export const DynamicVeteranStatusAlert = ({ attributes }) => {
 };
 
 DynamicVeteranStatusAlert.propTypes = {
-  attributes: PropTypes.shape({
-    // eslint-disable-next-line camelcase -- API response uses snake_case
-    alert_type: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
-    body: PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.oneOf(['text', 'phone', 'link']),
-        url: PropTypes.string,
-        value: PropTypes.string,
-        tty: PropTypes.bool,
-      }),
-    ),
-    header: PropTypes.string,
-  }),
+  alertType: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
+  body: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.oneOf(['text', 'phone', 'link']),
+      url: PropTypes.string,
+      value: PropTypes.string,
+      tty: PropTypes.bool,
+    }),
+  ),
+  header: PropTypes.string,
 };

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
@@ -135,11 +135,6 @@ export const SystemErrorAlert = () => {
   );
 };
 
-/**
- * Renders a dynamic alert body item based on its type
- * @param {Object} item - The body item from the API response
- * @param {number} index - The item index for key
- */
 const renderBodyItem = (item, index) => {
   switch (item.type) {
     case 'text':
@@ -171,10 +166,6 @@ const renderBodyItem = (item, index) => {
   }
 };
 
-/**
- * Dynamic alert component for veteran status alerts
- * Renders alerts based on the new shared service API response structure
- */
 export const DynamicVeteranStatusAlert = ({ attributes }) => {
   const { header, body, alert_type: alertType } = attributes;
 

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
@@ -1,0 +1,250 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { generatePdf } from '~/platform/pdf';
+import { captureError } from '~/platform/user/profile/vap-svc/util/analytics';
+import { apiRequest } from '~/platform/utilities/api';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
+import DowntimeNotification, {
+  externalServices,
+} from '~/platform/monitoring/DowntimeNotification';
+import { datadogRum } from '@datadog/browser-rum';
+import { getServiceBranchDisplayName } from '../../helpers';
+import Headline from '../ProfileSectionHeadline';
+import VeteranStatusCard from './VeteranStatusCard';
+import FrequentlyAskedQuestions from './FrequentlyAskedQuestions';
+import { DynamicVeteranStatusAlert } from './VeteranStatusAlerts';
+import LoadFail from '../alerts/LoadFail';
+import '../../sass/veteran-status-card.scss';
+import { useBrowserMonitoring } from './hooks/useBrowserMonitoring';
+
+const VeteranStatusSharedService = ({
+  totalDisabilityRating,
+  edipi,
+  mockUserAgent,
+}) => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [pdfError, setPdfError] = useState(false);
+
+  const {
+    TOGGLE_NAMES,
+    useToggleValue,
+    useToggleLoadingValue,
+  } = useFeatureToggle();
+
+  const userAgent =
+    mockUserAgent || navigator.userAgent || navigator.vendor || window.opera;
+
+  const isMobile =
+    (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) ||
+    /android/i.test(userAgent);
+
+  useEffect(() => {
+    document.title = `Veteran Status Card | Veterans Affairs`;
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchVeteranStatusCard = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const path = '/veteran_status_card';
+        const response = await apiRequest(path);
+        if (isMounted) {
+          setData(response);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err);
+          captureError(err, {
+            eventName: 'vet-status-shared-service-fetch',
+          });
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+    fetchVeteranStatusCard();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  // Determine if we should show the card based on the new API response
+  const isCardEligible =
+    data?.type === 'veteran_status_card' &&
+    data?.veteran_status === 'confirmed';
+
+  // Get formatted full name from the new API response
+  const formattedFullName = data?.attributes?.full_name || '';
+
+  // Get latest service info from the new API response
+  const getLatestService = () => {
+    const latestServiceData = data?.attributes?.latest_service;
+    if (latestServiceData) {
+      const {
+        branch,
+        begin_date: beginDate,
+        end_date: endDate,
+      } = latestServiceData;
+      const serviceStartYear = beginDate ? beginDate.substring(0, 4) : '';
+      const serviceEndYear = endDate ? endDate.substring(0, 4) : '';
+      const latestServiceDateRange =
+        serviceStartYear.length || serviceEndYear.length
+          ? `${serviceStartYear}–${serviceEndYear}`
+          : '';
+      return `${getServiceBranchDisplayName(
+        branch,
+      )} • ${latestServiceDateRange}`;
+    }
+    return null;
+  };
+
+  const latestService = getLatestService();
+
+  // Get disability rating from API response or fall back to Redux state
+  const disabilityRating =
+    data?.attributes?.disability_rating ?? totalDisabilityRating;
+
+  // Get EDIPI from API response or fall back to Redux state
+  const cardEdipi = data?.attributes?.edipi ?? edipi;
+
+  const pdfData = {
+    title: `Veteran status card for ${formattedFullName}`,
+    details: {
+      fullName: formattedFullName,
+      latestService,
+      totalDisabilityRating: disabilityRating,
+      edipi: cardEdipi,
+      image: {
+        title: 'VA logo',
+        url: '/img/design/logo/logo-black-and-white.png',
+      },
+      seal: {
+        title: 'VA Seal',
+        url: '/img/design/logo/seal-black-and-white.png',
+      },
+      scissors: {
+        title: 'Scissors icon',
+        url: '/img/scissors-black.png',
+      },
+    },
+  };
+
+  useBrowserMonitoring();
+
+  const isLoadingFeatureFlags = useToggleLoadingValue();
+  const monitorPdfGeneration = useToggleValue(TOGGLE_NAMES.vetStatusPdfLogging);
+  const monitoringEnabled =
+    isLoadingFeatureFlags === false && monitorPdfGeneration === true;
+
+  const createPdf = async () => {
+    try {
+      await generatePdf(
+        'veteranStatusNew',
+        'Veteran status card',
+        pdfData,
+        !isMobile,
+      );
+    } catch (err) {
+      setPdfError(true);
+      if (monitoringEnabled) {
+        datadogRum.addError(
+          err,
+          'Profile - Veteran Status Card - PDF generation error',
+        );
+      }
+      captureError(err, { eventName: 'vet-status-pdf-download' });
+    }
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <va-loading-indicator
+          set-focus
+          message="Checking your eligibility..."
+          data-testid="veteran-status-loading-indicator"
+        />
+      );
+    }
+
+    // Handle fetch error
+    if (error) {
+      return <LoadFail />;
+    }
+
+    // Handle alert response type (ineligible or error scenarios)
+    if (data?.type === 'veteran_status_alert') {
+      return (
+        <>
+          <p>
+            This card makes it easy to prove your service and access Veteran
+            discounts, all while keeping your personal information secure.
+          </p>
+          <DynamicVeteranStatusAlert attributes={data.attributes} />
+          <FrequentlyAskedQuestions createPdf={null} pdfError={pdfError} />
+        </>
+      );
+    }
+
+    // Handle card response type (eligible)
+    return (
+      <>
+        <p>
+          This card makes it easy to prove your service and access Veteran
+          discounts, all while keeping your personal information secure.
+        </p>
+        {isCardEligible && (
+          <div className="vads-l-grid-container--full">
+            <div className="vads-l-row">
+              <VeteranStatusCard
+                edipi={cardEdipi}
+                formattedFullName={formattedFullName}
+                latestService={latestService}
+                totalDisabilityRating={disabilityRating}
+              />
+            </div>
+          </div>
+        )}
+        <FrequentlyAskedQuestions
+          createPdf={isCardEligible ? createPdf : null}
+          pdfError={pdfError}
+        />
+      </>
+    );
+  };
+
+  return (
+    <>
+      <Headline>Veteran Status Card</Headline>
+      <DowntimeNotification
+        appTitle="Veteran Status Card page"
+        dependencies={[externalServices.VAPRO_MILITARY_INFO]}
+      >
+        {renderContent()}
+      </DowntimeNotification>
+    </>
+  );
+};
+
+VeteranStatusSharedService.propTypes = {
+  edipi: PropTypes.number,
+  mockUserAgent: PropTypes.string,
+  totalDisabilityRating: PropTypes.number,
+};
+
+const mapStateToProps = state => ({
+  totalDisabilityRating: state.totalRating?.totalDisabilityRating,
+  edipi: state.user?.profile?.edipi,
+});
+
+export default connect(mapStateToProps)(VeteranStatusSharedService);

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
@@ -79,19 +79,14 @@ const VeteranStatusSharedService = ({
   }, []);
 
   const isCardEligible =
-    data?.type === 'veteran_status_card' &&
-    data?.veteran_status === 'confirmed';
+    data?.type === 'veteran_status_card' && data?.veteranStatus === 'confirmed';
 
-  const formattedFullName = data?.attributes?.full_name || '';
+  const formattedFullName = data?.attributes?.fullName || '';
 
   const getLatestService = () => {
-    const latestServiceData = data?.attributes?.latest_service;
+    const latestServiceData = data?.attributes?.latestService;
     if (latestServiceData) {
-      const {
-        branch,
-        begin_date: beginDate,
-        end_date: endDate,
-      } = latestServiceData;
+      const { branch, beginDate, endDate } = latestServiceData;
       const serviceStartYear = beginDate ? beginDate.substring(0, 4) : '';
       const serviceEndYear = endDate ? endDate.substring(0, 4) : '';
       const latestServiceDateRange =
@@ -108,7 +103,7 @@ const VeteranStatusSharedService = ({
   const latestService = getLatestService();
 
   const disabilityRating =
-    data?.attributes?.disability_rating ?? totalDisabilityRating;
+    data?.attributes?.disabilityRating ?? totalDisabilityRating;
 
   const cardEdipi = data?.attributes?.edipi ?? edipi;
 
@@ -184,7 +179,7 @@ const VeteranStatusSharedService = ({
             discounts, all while keeping your personal information secure.
           </p>
           <DynamicVeteranStatusAlert
-            alertType={data.attributes?.alert_type}
+            alertType={data.attributes?.alertType}
             body={data.attributes?.body}
             header={data.attributes?.header}
           />

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
@@ -183,7 +183,11 @@ const VeteranStatusSharedService = ({
             This card makes it easy to prove your service and access Veteran
             discounts, all while keeping your personal information secure.
           </p>
-          <DynamicVeteranStatusAlert attributes={data.attributes} />
+          <DynamicVeteranStatusAlert
+            alertType={data.attributes?.alert_type}
+            body={data.attributes?.body}
+            header={data.attributes?.header}
+          />
           <FrequentlyAskedQuestions createPdf={null} pdfError={pdfError} />
         </>
       );

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
@@ -78,15 +78,12 @@ const VeteranStatusSharedService = ({
     };
   }, []);
 
-  // Determine if we should show the card based on the new API response
   const isCardEligible =
     data?.type === 'veteran_status_card' &&
     data?.veteran_status === 'confirmed';
 
-  // Get formatted full name from the new API response
   const formattedFullName = data?.attributes?.full_name || '';
 
-  // Get latest service info from the new API response
   const getLatestService = () => {
     const latestServiceData = data?.attributes?.latest_service;
     if (latestServiceData) {
@@ -110,11 +107,9 @@ const VeteranStatusSharedService = ({
 
   const latestService = getLatestService();
 
-  // Get disability rating from API response or fall back to Redux state
   const disabilityRating =
     data?.attributes?.disability_rating ?? totalDisabilityRating;
 
-  // Get EDIPI from API response or fall back to Redux state
   const cardEdipi = data?.attributes?.edipi ?? edipi;
 
   const pdfData = {
@@ -177,12 +172,10 @@ const VeteranStatusSharedService = ({
       );
     }
 
-    // Handle fetch error
     if (error) {
       return <LoadFail />;
     }
 
-    // Handle alert response type (ineligible or error scenarios)
     if (data?.type === 'veteran_status_alert') {
       return (
         <>
@@ -196,7 +189,6 @@ const VeteranStatusSharedService = ({
       );
     }
 
-    // Handle card response type (eligible)
     return (
       <>
         <p>

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusWrapper.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusWrapper.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import VeteranStatus from './VeteranStatus';
+import VeteranStatusSharedService from './VeteranStatusSharedService';
 
 /**
  * Wrapper component that toggles between the old VeteranStatus component
@@ -9,13 +10,18 @@ import VeteranStatus from './VeteranStatus';
  * Feature toggle: cveVeteranStatusNewService
  * - When enabled (true): renders VeteranStatusSharedService (new API: /v0/veteran_status_card)
  * - When disabled (false): renders VeteranStatus (old API: /profile/vet_verification_status)
- *
- * TODO: Import and render VeteranStatusSharedService when feature toggle is enabled
  */
 const VeteranStatusWrapper = props => {
-  const { useToggleLoadingValue } = useFeatureToggle();
+  const {
+    TOGGLE_NAMES,
+    useToggleValue,
+    useToggleLoadingValue,
+  } = useFeatureToggle();
 
   const isLoading = useToggleLoadingValue();
+  const useSharedService = useToggleValue(
+    TOGGLE_NAMES.cveVeteranStatusNewService,
+  );
 
   // Show loading indicator while feature toggles are loading
   if (isLoading) {
@@ -28,8 +34,11 @@ const VeteranStatusWrapper = props => {
     );
   }
 
-  // TODO: Add feature toggle check to render VeteranStatusSharedService
-  // when cveVeteranStatusNewService is enabled
+  // Render the appropriate component based on the feature toggle
+  if (useSharedService) {
+    return <VeteranStatusSharedService {...props} />;
+  }
+
   return <VeteranStatus {...props} />;
 };
 

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusWrapper.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusWrapper.jsx
@@ -23,7 +23,6 @@ const VeteranStatusWrapper = props => {
     TOGGLE_NAMES.cveVeteranStatusNewService,
   );
 
-  // Show loading indicator while feature toggles are loading
   if (isLoading) {
     return (
       <va-loading-indicator
@@ -34,7 +33,6 @@ const VeteranStatusWrapper = props => {
     );
   }
 
-  // Render the appropriate component based on the feature toggle
   if (useSharedService) {
     return <VeteranStatusSharedService {...props} />;
   }

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -67,7 +67,6 @@ const groupItemReducer = facilities => (groups, group) => {
   const newGroup = { ...group };
   const filteredItems = newGroup.communicationItems
     .filter(item => {
-      // Removes the RX tracking item if there are no facilities that support that
       if (item.id === 4) {
         return facilities.some(facility =>
           RX_TRACKING_SUPPORTING_FACILITIES.has(facility.facilityId),

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -67,6 +67,7 @@ const groupItemReducer = facilities => (groups, group) => {
   const newGroup = { ...group };
   const filteredItems = newGroup.communicationItems
     .filter(item => {
+      // Removes the RX tracking item if there are no facilities that support that
       if (item.id === 4) {
         return facilities.some(facility =>
           RX_TRACKING_SUPPORTING_FACILITIES.has(facility.facilityId),

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -138,21 +138,20 @@ const responses = {
     );
   },
   // New veteran status card endpoint (shared service)
-  /* eslint-disable camelcase */
   'GET /v0/veteran_status_card': (_req, res) => {
     // Eligible response - shows the veteran status card
     return res.json({
       type: 'veteran_status_card',
-      veteran_status: 'confirmed',
-      service_summary_code: 'A1',
-      not_confirmed_reason: null,
+      veteranStatus: 'confirmed',
+      serviceSummaryCode: 'A1',
+      notConfirmedReason: null,
       attributes: {
-        full_name: 'Jane Veteran',
-        disability_rating: 50,
-        latest_service: {
+        fullName: 'Jane Veteran',
+        disabilityRating: 50,
+        latestService: {
           branch: 'Army',
-          begin_date: '2010-01-01',
-          end_date: '2020-12-31',
+          beginDate: '2010-01-01',
+          endDate: '2020-12-31',
         },
         edipi: 1234567890,
       },
@@ -161,9 +160,9 @@ const responses = {
     // Warning alert - dishonorable discharge
     // return res.json({
     //   type: 'veteran_status_alert',
-    //   veteran_status: 'not confirmed',
-    //   service_summary_code: 'A5',
-    //   not_confirmed_reason: 'DISHONORABLE_DISCHARGE',
+    //   veteranStatus: 'not confirmed',
+    //   serviceSummaryCode: 'A5',
+    //   notConfirmedReason: 'DISHONORABLE_DISCHARGE',
     //   attributes: {
     //     header: "You're not eligible for a Veteran Status Card",
     //     body: [
@@ -184,16 +183,16 @@ const responses = {
     //           'https://www.archives.gov/veterans/military-service-records/correct-service-records.html',
     //       },
     //     ],
-    //     alert_type: 'warning',
+    //     alertType: 'warning',
     //   },
     // });
 
     // Warning alert - person not found
     // return res.json({
     //   type: 'veteran_status_alert',
-    //   veteran_status: 'not confirmed',
-    //   service_summary_code: 'D',
-    //   not_confirmed_reason: 'PERSON_NOT_FOUND',
+    //   veteranStatus: 'not confirmed',
+    //   serviceSummaryCode: 'D',
+    //   notConfirmedReason: 'PERSON_NOT_FOUND',
     //   attributes: {
     //     header: "You're not eligible for a Veteran Status Card",
     //     body: [
@@ -204,16 +203,16 @@ const responses = {
     //       },
     //       { type: 'phone', value: '800-698-2411', tty: true },
     //     ],
-    //     alert_type: 'warning',
+    //     alertType: 'warning',
     //   },
     // });
 
     // Error alert - system error
     // return res.json({
     //   type: 'veteran_status_alert',
-    //   veteran_status: 'not confirmed',
-    //   service_summary_code: 'VNA',
-    //   not_confirmed_reason: 'ERROR',
+    //   veteranStatus: 'not confirmed',
+    //   serviceSummaryCode: 'VNA',
+    //   notConfirmedReason: 'ERROR',
     //   attributes: {
     //     header: 'Something went wrong',
     //     body: [
@@ -223,11 +222,10 @@ const responses = {
     //           "We're sorry. We can't access your Veteran status information right now. Please try again later.",
     //       },
     //     ],
-    //     alert_type: 'error',
+    //     alertType: 'error',
     //   },
     // });
   },
-  /* eslint-enable camelcase */
   'GET /v0/user': (_req, res) => {
     const [shouldReturnUser, updatedUserResponse] = handleUserUpdate(
       requestHistory,

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -131,11 +131,103 @@ const responses = {
             vreCutoverNotice: true,
             vrePrefillName: true,
             mhvEmailConfirmation: true,
+            cveVeteranStatusNewService: true,
           }),
         ),
       secondsOfDelay,
     );
   },
+  // New veteran status card endpoint (shared service)
+  /* eslint-disable camelcase */
+  'GET /v0/veteran_status_card': (_req, res) => {
+    // Eligible response - shows the veteran status card
+    return res.json({
+      type: 'veteran_status_card',
+      veteran_status: 'confirmed',
+      service_summary_code: 'A1',
+      not_confirmed_reason: null,
+      attributes: {
+        full_name: 'Jane Veteran',
+        disability_rating: 50,
+        latest_service: {
+          branch: 'Army',
+          begin_date: '2010-01-01',
+          end_date: '2020-12-31',
+        },
+        edipi: 1234567890,
+      },
+    });
+    // Uncomment below for ineligible/alert response scenarios:
+    // Warning alert - dishonorable discharge
+    // return res.json({
+    //   type: 'veteran_status_alert',
+    //   veteran_status: 'not confirmed',
+    //   service_summary_code: 'A5',
+    //   not_confirmed_reason: 'DISHONORABLE_DISCHARGE',
+    //   attributes: {
+    //     header: "You're not eligible for a Veteran Status Card",
+    //     body: [
+    //       {
+    //         type: 'text',
+    //         value:
+    //           "Our records show you don't meet the service or discharge requirements for a Veteran Status Card.",
+    //       },
+    //       {
+    //         type: 'text',
+    //         value:
+    //           'If you think this information is wrong, you can request to correct your military records.',
+    //       },
+    //       {
+    //         type: 'link',
+    //         value: 'Learn how to correct your military records',
+    //         url:
+    //           'https://www.archives.gov/veterans/military-service-records/correct-service-records.html',
+    //       },
+    //     ],
+    //     alert_type: 'warning',
+    //   },
+    // });
+
+    // Warning alert - person not found
+    // return res.json({
+    //   type: 'veteran_status_alert',
+    //   veteran_status: 'not confirmed',
+    //   service_summary_code: 'D',
+    //   not_confirmed_reason: 'PERSON_NOT_FOUND',
+    //   attributes: {
+    //     header: "You're not eligible for a Veteran Status Card",
+    //     body: [
+    //       { type: 'text', value: "Our records don't show you're a Veteran." },
+    //       {
+    //         type: 'text',
+    //         value: 'If you have questions, call the VA.gov help desk.',
+    //       },
+    //       { type: 'phone', value: '800-698-2411', tty: true },
+    //     ],
+    //     alert_type: 'warning',
+    //   },
+    // });
+
+    // Error alert - system error
+    // return res.json({
+    //   type: 'veteran_status_alert',
+    //   veteran_status: 'not confirmed',
+    //   service_summary_code: 'VNA',
+    //   not_confirmed_reason: 'ERROR',
+    //   attributes: {
+    //     header: 'Something went wrong',
+    //     body: [
+    //       {
+    //         type: 'text',
+    //         value:
+    //           "We're sorry. We can't access your Veteran status information right now. Please try again later.",
+    //       },
+    //     ],
+    //     alert_type: 'error',
+    //   },
+    // });
+  },
+  /* eslint-enable camelcase */
   'GET /v0/user': (_req, res) => {
     const [shouldReturnUser, updatedUserResponse] = handleUserUpdate(
       requestHistory,

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
@@ -6,6 +6,7 @@ import {
   NotConfirmedAlert,
   PDFErrorAlert,
   SystemErrorAlert,
+  DynamicVeteranStatusAlert,
 } from '../../../components/veteran-status-card/VeteranStatusAlerts';
 
 describe('VeteranStatusAlerts', () => {
@@ -105,6 +106,143 @@ describe('VeteranStatusAlerts', () => {
       expect(
         getByText('We’re sorry. Try to view your Veteran Status Card later.'),
       ).to.exist;
+    });
+  });
+
+  describe('DynamicVeteranStatusAlert', () => {
+    it('renders alert with header and text body items', () => {
+      const attributes = {
+        header: 'Test Alert Header',
+        body: [
+          { type: 'text', value: 'First text message' },
+          { type: 'text', value: 'Second text message' },
+        ],
+        alert_type: 'warning', // eslint-disable-line camelcase -- API response uses snake_case
+      };
+      const { getByText } = render(
+        <DynamicVeteranStatusAlert attributes={attributes} />,
+      );
+      expect(getByText('Test Alert Header')).to.exist;
+      expect(getByText('First text message')).to.exist;
+      expect(getByText('Second text message')).to.exist;
+    });
+
+    it('renders alert with phone body items', () => {
+      const attributes = {
+        header: 'Contact Us',
+        body: [{ type: 'phone', value: '800-698-2411', tty: true }],
+        alert_type: 'warning', // eslint-disable-line camelcase -- API response uses snake_case
+      };
+      const { getByText } = render(
+        <DynamicVeteranStatusAlert attributes={attributes} />,
+      );
+      expect(getByText('Contact Us')).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '800-698-2411'
+          );
+        }),
+      ).to.exist;
+      // Check for TTY telephone
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '711' &&
+            element.hasAttribute('tty')
+          );
+        }),
+      ).to.exist;
+    });
+
+    it('renders alert with link body items', () => {
+      const attributes = {
+        header: 'Learn More',
+        body: [
+          {
+            type: 'link',
+            value: 'Learn how to correct your records',
+            url: 'https://example.com/correct-records',
+          },
+        ],
+        alert_type: 'info', // eslint-disable-line camelcase -- API response uses snake_case
+      };
+      const { getByText } = render(
+        <DynamicVeteranStatusAlert attributes={attributes} />,
+      );
+      expect(getByText('Learn More')).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-link' &&
+            element.getAttribute('href') ===
+              'https://example.com/correct-records' &&
+            element.getAttribute('text') === 'Learn how to correct your records'
+          );
+        }),
+      ).to.exist;
+    });
+
+    it('renders alert with mixed body item types', () => {
+      const attributes = {
+        header: 'Mixed Content Alert',
+        body: [
+          { type: 'text', value: 'You are not eligible.' },
+          { type: 'phone', value: '866-279-3677', tty: false },
+          { type: 'link', value: 'Get help', url: 'https://va.gov/help' },
+        ],
+        alert_type: 'error', // eslint-disable-line camelcase -- API response uses snake_case
+      };
+      const { getByText, container } = render(
+        <DynamicVeteranStatusAlert attributes={attributes} />,
+      );
+      expect(getByText('Mixed Content Alert')).to.exist;
+      expect(getByText('You are not eligible.')).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '866-279-3677'
+          );
+        }),
+      ).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-link' &&
+            element.getAttribute('text') === 'Get help'
+          );
+        }),
+      ).to.exist;
+      // Check alert status
+      const alert = container.querySelector('va-alert');
+      expect(alert.getAttribute('status')).to.equal('error');
+    });
+
+    it('defaults to warning status when alert_type is not provided', () => {
+      const attributes = {
+        header: 'Default Status Alert',
+        body: [{ type: 'text', value: 'Some message' }],
+      };
+      const { container } = render(
+        <DynamicVeteranStatusAlert attributes={attributes} />,
+      );
+      const alert = container.querySelector('va-alert');
+      expect(alert.getAttribute('status')).to.equal('warning');
+    });
+
+    it('renders without header when header is not provided', () => {
+      const attributes = {
+        body: [{ type: 'text', value: 'Message without header' }],
+        alert_type: 'info', // eslint-disable-line camelcase -- API response uses snake_case
+      };
+      const { getByText, container } = render(
+        <DynamicVeteranStatusAlert attributes={attributes} />,
+      );
+      expect(getByText('Message without header')).to.exist;
+      expect(container.querySelector('h2[slot="headline"]')).to.be.null;
     });
   });
 });

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
@@ -111,16 +111,15 @@ describe('VeteranStatusAlerts', () => {
 
   describe('DynamicVeteranStatusAlert', () => {
     it('renders alert with header and text body items', () => {
-      const attributes = {
-        header: 'Test Alert Header',
-        body: [
-          { type: 'text', value: 'First text message' },
-          { type: 'text', value: 'Second text message' },
-        ],
-        alert_type: 'warning', // eslint-disable-line camelcase -- API response uses snake_case
-      };
       const { getByText } = render(
-        <DynamicVeteranStatusAlert attributes={attributes} />,
+        <DynamicVeteranStatusAlert
+          header="Test Alert Header"
+          body={[
+            { type: 'text', value: 'First text message' },
+            { type: 'text', value: 'Second text message' },
+          ]}
+          alertType="warning"
+        />,
       );
       expect(getByText('Test Alert Header')).to.exist;
       expect(getByText('First text message')).to.exist;
@@ -128,13 +127,12 @@ describe('VeteranStatusAlerts', () => {
     });
 
     it('renders alert with phone body items', () => {
-      const attributes = {
-        header: 'Contact Us',
-        body: [{ type: 'phone', value: '800-698-2411', tty: true }],
-        alert_type: 'warning', // eslint-disable-line camelcase -- API response uses snake_case
-      };
       const { getByText } = render(
-        <DynamicVeteranStatusAlert attributes={attributes} />,
+        <DynamicVeteranStatusAlert
+          header="Contact Us"
+          body={[{ type: 'phone', value: '800-698-2411', tty: true }]}
+          alertType="warning"
+        />,
       );
       expect(getByText('Contact Us')).to.exist;
       expect(
@@ -145,7 +143,6 @@ describe('VeteranStatusAlerts', () => {
           );
         }),
       ).to.exist;
-      // Check for TTY telephone
       expect(
         getByText((content, element) => {
           return (
@@ -158,19 +155,18 @@ describe('VeteranStatusAlerts', () => {
     });
 
     it('renders alert with link body items', () => {
-      const attributes = {
-        header: 'Learn More',
-        body: [
-          {
-            type: 'link',
-            value: 'Learn how to correct your records',
-            url: 'https://example.com/correct-records',
-          },
-        ],
-        alert_type: 'info', // eslint-disable-line camelcase -- API response uses snake_case
-      };
       const { getByText } = render(
-        <DynamicVeteranStatusAlert attributes={attributes} />,
+        <DynamicVeteranStatusAlert
+          header="Learn More"
+          body={[
+            {
+              type: 'link',
+              value: 'Learn how to correct your records',
+              url: 'https://example.com/correct-records',
+            },
+          ]}
+          alertType="info"
+        />,
       );
       expect(getByText('Learn More')).to.exist;
       expect(
@@ -186,17 +182,16 @@ describe('VeteranStatusAlerts', () => {
     });
 
     it('renders alert with mixed body item types', () => {
-      const attributes = {
-        header: 'Mixed Content Alert',
-        body: [
-          { type: 'text', value: 'You are not eligible.' },
-          { type: 'phone', value: '866-279-3677', tty: false },
-          { type: 'link', value: 'Get help', url: 'https://va.gov/help' },
-        ],
-        alert_type: 'error', // eslint-disable-line camelcase -- API response uses snake_case
-      };
       const { getByText, container } = render(
-        <DynamicVeteranStatusAlert attributes={attributes} />,
+        <DynamicVeteranStatusAlert
+          header="Mixed Content Alert"
+          body={[
+            { type: 'text', value: 'You are not eligible.' },
+            { type: 'phone', value: '866-279-3677', tty: false },
+            { type: 'link', value: 'Get help', url: 'https://va.gov/help' },
+          ]}
+          alertType="error"
+        />,
       );
       expect(getByText('Mixed Content Alert')).to.exist;
       expect(getByText('You are not eligible.')).to.exist;
@@ -216,30 +211,27 @@ describe('VeteranStatusAlerts', () => {
           );
         }),
       ).to.exist;
-      // Check alert status
       const alert = container.querySelector('va-alert');
       expect(alert.getAttribute('status')).to.equal('error');
     });
 
-    it('defaults to warning status when alert_type is not provided', () => {
-      const attributes = {
-        header: 'Default Status Alert',
-        body: [{ type: 'text', value: 'Some message' }],
-      };
+    it('defaults to warning status when alertType is not provided', () => {
       const { container } = render(
-        <DynamicVeteranStatusAlert attributes={attributes} />,
+        <DynamicVeteranStatusAlert
+          header="Default Status Alert"
+          body={[{ type: 'text', value: 'Some message' }]}
+        />,
       );
       const alert = container.querySelector('va-alert');
       expect(alert.getAttribute('status')).to.equal('warning');
     });
 
     it('renders without header when header is not provided', () => {
-      const attributes = {
-        body: [{ type: 'text', value: 'Message without header' }],
-        alert_type: 'info', // eslint-disable-line camelcase -- API response uses snake_case
-      };
       const { getByText, container } = render(
-        <DynamicVeteranStatusAlert attributes={attributes} />,
+        <DynamicVeteranStatusAlert
+          body={[{ type: 'text', value: 'Message without header' }]}
+          alertType="info"
+        />,
       );
       expect(getByText('Message without header')).to.exist;
       expect(container.querySelector('h2[slot="headline"]')).to.be.null;

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import { expect } from 'chai';
+import * as api from '~/platform/utilities/api';
+import * as pdf from '~/platform/pdf';
+import { fireEvent, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { addDays, subDays, format } from 'date-fns';
+import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
+import { externalServices } from '~/platform/monitoring/DowntimeNotification';
+import { renderWithProfileReducers } from '../../unit-test-helpers';
+import VeteranStatusSharedService from '../../../components/veteran-status-card/VeteranStatusSharedService';
+
+// Mock downtime data
+const downtime = maintenanceWindows => {
+  return createServiceMap(
+    maintenanceWindows.map(maintenanceWindow => {
+      return {
+        attributes: {
+          externalService: maintenanceWindow,
+          status: 'down',
+          startTime: format(subDays(new Date(), 1), "yyyy-LL-dd'T'HH:mm:ss"),
+          endTime: format(addDays(new Date(), 1), "yyyy-LL-dd'T'HH:mm:ss"),
+        },
+      };
+    }),
+  );
+};
+
+// Mock API responses for the new shared service endpoint
+/* eslint-disable camelcase */
+const veteranStatusCardConfirmed = {
+  type: 'veteran_status_card',
+  veteran_status: 'confirmed',
+  service_summary_code: 'A1',
+  not_confirmed_reason: null,
+  attributes: {
+    full_name: 'John Doe',
+    disability_rating: 40,
+    latest_service: {
+      branch: 'Army',
+      begin_date: '2009-04-12',
+      end_date: '2013-04-11',
+    },
+    edipi: 1234567890,
+  },
+};
+
+const veteranStatusAlertWarning = {
+  type: 'veteran_status_alert',
+  veteran_status: 'not confirmed',
+  service_summary_code: 'D',
+  not_confirmed_reason: 'PERSON_NOT_FOUND',
+  attributes: {
+    header: "You're not eligible for a Veteran Status Card",
+    body: [
+      { type: 'text', value: "Our records don't show you're a Veteran." },
+      { type: 'phone', value: '800-698-2411', tty: true },
+    ],
+    alert_type: 'warning',
+  },
+};
+
+const veteranStatusAlertError = {
+  type: 'veteran_status_alert',
+  veteran_status: 'not confirmed',
+  service_summary_code: 'VNA',
+  not_confirmed_reason: 'ERROR',
+  attributes: {
+    header: 'Something went wrong',
+    body: [
+      {
+        type: 'text',
+        value:
+          "We're sorry. We can't access your Veteran status information right now.",
+      },
+    ],
+    alert_type: 'error',
+  },
+};
+/* eslint-enable camelcase */
+
+// Mock function to create a basic initial state
+function createBasicInitialState() {
+  return {
+    featureToggles: {
+      loading: false,
+    },
+    scheduledDowntime: {
+      globalDowntime: null,
+      isReady: true,
+      isPending: false,
+      serviceMap: {
+        get() {},
+      },
+      dismissedDowntimeWarnings: [],
+    },
+    user: {
+      profile: {
+        edipi: 1234567890,
+        veteranStatus: {
+          status: 'OK',
+        },
+      },
+    },
+    totalRating: {
+      totalDisabilityRating: 40,
+    },
+  };
+}
+
+// Function to find the PDF link in the view
+function pdfLink(view) {
+  return view.container.querySelector(
+    'va-link[text="Print your Veteran Status Card (PDF)"]',
+  );
+}
+
+describe('VeteranStatusSharedService', () => {
+  let apiRequestStub;
+  let generatePdfStub;
+
+  beforeEach(() => {
+    apiRequestStub = sinon.stub(api, 'apiRequest');
+    generatePdfStub = sinon.stub(pdf, 'generatePdf');
+  });
+
+  afterEach(() => {
+    apiRequestStub.restore();
+    generatePdfStub.restore();
+  });
+
+  describe('when the user is eligible for a Veteran Status Card', () => {
+    it('should render the loading indicator, then the card with user data from API', async () => {
+      apiRequestStub.resolves(veteranStatusCardConfirmed);
+      const initialState = createBasicInitialState();
+      const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
+        initialState,
+      });
+
+      // Check that the loading indicator is rendered
+      expect(view.getByTestId('veteran-status-loading-indicator')).to.exist;
+
+      // Check that the heading is rendered
+      expect(
+        view.getByRole('heading', {
+          name: 'Veteran Status Card',
+          level: 1,
+        }),
+      ).to.exist;
+
+      await waitFor(() => {
+        sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
+
+        // Check that the description is rendered
+        expect(
+          view.getByText(
+            'This card makes it easy to prove your service and access Veteran discounts, all while keeping your personal information secure.',
+          ),
+        ).to.exist;
+
+        // Check that the user's full name from API is rendered on the card
+        expect(view.getByText('John Doe')).to.exist;
+
+        // Check that service history is rendered
+        expect(view.getByText('United States Army • 2009–2013')).to.exist;
+
+        // Check that the FAQ section is rendered
+        expect(view.getByText('Frequently asked questions')).to.exist;
+      });
+
+      // Check that the PDF download link exists and can be clicked
+      generatePdfStub.resolves();
+      expect(pdfLink(view)).to.exist;
+      fireEvent.click(pdfLink(view));
+      await waitFor(() => {
+        expect(generatePdfStub.calledOnce).to.be.true;
+      });
+    });
+  });
+
+  describe('when the user is not eligible for a Veteran Status Card', () => {
+    it('should render the DynamicVeteranStatusAlert with warning status', async () => {
+      apiRequestStub.resolves(veteranStatusAlertWarning);
+      const initialState = createBasicInitialState();
+      const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
+
+        // Check that the alert header is rendered
+        expect(view.getByText("You're not eligible for a Veteran Status Card"))
+          .to.exist;
+
+        // Check that alert body text is rendered
+        expect(view.getByText("Our records don't show you're a Veteran.")).to
+          .exist;
+
+        // Check that phone number is rendered
+        expect(
+          view.getByText((content, element) => {
+            return (
+              element.tagName.toLowerCase() === 'va-telephone' &&
+              element.getAttribute('contact') === '800-698-2411'
+            );
+          }),
+        ).to.exist;
+
+        // Check that the FAQ section is still rendered
+        expect(view.getByText('Frequently asked questions')).to.exist;
+
+        // Check that the PDF download link is NOT rendered
+        expect(pdfLink(view)).to.not.exist;
+      });
+    });
+
+    it('should render the DynamicVeteranStatusAlert with error status', async () => {
+      apiRequestStub.resolves(veteranStatusAlertError);
+      const initialState = createBasicInitialState();
+      const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
+
+        // Check that the alert header is rendered
+        expect(view.getByText('Something went wrong')).to.exist;
+
+        // Check that alert body text is rendered
+        expect(
+          view.getByText(
+            "We're sorry. We can't access your Veteran status information right now.",
+          ),
+        ).to.exist;
+
+        // Check that the PDF download link is NOT rendered
+        expect(pdfLink(view)).to.not.exist;
+      });
+    });
+
+    it('should render the LoadFail alert when an API error occurs', async () => {
+      apiRequestStub.rejects(new Error('API Error'));
+      const initialState = createBasicInitialState();
+      const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
+        expect(view.getByText("This page isn't available right now.")).to.exist;
+
+        // Check that the description is not rendered
+        expect(
+          view.queryByText(
+            'This card makes it easy to prove your service and access Veteran discounts, all while keeping your personal information secure.',
+          ),
+        ).to.be.null;
+
+        // Check that the FAQ section is not rendered
+        expect(view.queryByText('Frequently asked questions')).to.not.exist;
+
+        // Check that the PDF download link is not rendered
+        expect(pdfLink(view)).to.not.exist;
+      });
+    });
+  });
+
+  describe('when military information is unavailable due to a maintenance window', () => {
+    it('should render the Downtime Notification alert', () => {
+      const initialState = createBasicInitialState();
+      initialState.scheduledDowntime = {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap: downtime([externalServices.VAPRO_MILITARY_INFO]),
+        dismissedDowntimeWarnings: [],
+      };
+
+      const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
+        initialState,
+      });
+      expect(view.getByText('This application is down for maintenance')).to
+        .exist;
+    });
+  });
+
+  describe('PDF generation', () => {
+    it('should show PDF error alert when PDF generation fails', async () => {
+      apiRequestStub.resolves(veteranStatusCardConfirmed);
+      const initialState = createBasicInitialState();
+      const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        expect(pdfLink(view)).to.exist;
+      });
+
+      // Mock PDF generation failure
+      generatePdfStub.rejects(new Error('PDF Error'));
+      fireEvent.click(pdfLink(view));
+
+      await waitFor(() => {
+        expect(
+          view.getByText(
+            'We’re sorry. Try to print your Veteran Status Card later.',
+          ),
+        ).to.exist;
+      });
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -178,7 +178,7 @@ describe('VeteranStatusSharedService', () => {
     });
   });
 
-  describe('when the user is not eligible for a Veteran Status Card', () => {
+  describe('when the user is not eligible for a Veteran Status Card (warning)', () => {
     it('should render the DynamicVeteranStatusAlert with warning status', async () => {
       apiRequestStub.resolves(veteranStatusAlertWarning);
       const initialState = createBasicInitialState();
@@ -214,7 +214,9 @@ describe('VeteranStatusSharedService', () => {
         expect(pdfLink(view)).to.not.exist;
       });
     });
+  });
 
+  describe('when the user is not eligible for a Veteran Status Card (error)', () => {
     it('should render the DynamicVeteranStatusAlert with error status', async () => {
       apiRequestStub.resolves(veteranStatusAlertError);
       const initialState = createBasicInitialState();
@@ -239,7 +241,9 @@ describe('VeteranStatusSharedService', () => {
         expect(pdfLink(view)).to.not.exist;
       });
     });
+  });
 
+  describe('when an API error occurs', () => {
     it('should render the LoadFail alert when an API error occurs', async () => {
       apiRequestStub.rejects(new Error('API Error'));
       const initialState = createBasicInitialState();

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -27,19 +27,18 @@ const downtime = maintenanceWindows => {
 };
 
 // Mock API responses for the new shared service endpoint
-/* eslint-disable camelcase */
 const veteranStatusCardConfirmed = {
   type: 'veteran_status_card',
-  veteran_status: 'confirmed',
-  service_summary_code: 'A1',
-  not_confirmed_reason: null,
+  veteranStatus: 'confirmed',
+  serviceSummaryCode: 'A1',
+  notConfirmedReason: null,
   attributes: {
-    full_name: 'John Doe',
-    disability_rating: 40,
-    latest_service: {
+    fullName: 'John Doe',
+    disabilityRating: 40,
+    latestService: {
       branch: 'Army',
-      begin_date: '2009-04-12',
-      end_date: '2013-04-11',
+      beginDate: '2009-04-12',
+      endDate: '2013-04-11',
     },
     edipi: 1234567890,
   },
@@ -47,24 +46,24 @@ const veteranStatusCardConfirmed = {
 
 const veteranStatusAlertWarning = {
   type: 'veteran_status_alert',
-  veteran_status: 'not confirmed',
-  service_summary_code: 'D',
-  not_confirmed_reason: 'PERSON_NOT_FOUND',
+  veteranStatus: 'not confirmed',
+  serviceSummaryCode: 'D',
+  notConfirmedReason: 'PERSON_NOT_FOUND',
   attributes: {
     header: "You're not eligible for a Veteran Status Card",
     body: [
       { type: 'text', value: "Our records don't show you're a Veteran." },
       { type: 'phone', value: '800-698-2411', tty: true },
     ],
-    alert_type: 'warning',
+    alertType: 'warning',
   },
 };
 
 const veteranStatusAlertError = {
   type: 'veteran_status_alert',
-  veteran_status: 'not confirmed',
-  service_summary_code: 'VNA',
-  not_confirmed_reason: 'ERROR',
+  veteranStatus: 'not confirmed',
+  serviceSummaryCode: 'VNA',
+  notConfirmedReason: 'ERROR',
   attributes: {
     header: 'Something went wrong',
     body: [
@@ -74,10 +73,9 @@ const veteranStatusAlertError = {
           "We're sorry. We can't access your Veteran status information right now.",
       },
     ],
-    alert_type: 'error',
+    alertType: 'error',
   },
 };
-/* eslint-enable camelcase */
 
 // Mock function to create a basic initial state
 function createBasicInitialState() {

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import * as api from '~/platform/utilities/api';
 import { waitFor } from '@testing-library/react';
 import sinon from 'sinon';
+import { TOGGLE_NAMES } from '~/platform/utilities/feature-toggles';
 import { renderWithProfileReducers } from '../../unit-test-helpers';
 import VeteranStatusWrapper from '../../../components/veteran-status-card/VeteranStatusWrapper';
 
@@ -30,32 +31,29 @@ const vetStatusConfirmed = {
   },
 };
 
-/* eslint-disable camelcase */
 const veteranStatusCardConfirmed = {
   type: 'veteran_status_card',
-  veteran_status: 'confirmed',
-  service_summary_code: 'A1',
-  not_confirmed_reason: null,
+  veteranStatus: 'confirmed',
+  serviceSummaryCode: 'A1',
+  notConfirmedReason: null,
   attributes: {
-    full_name: 'John Doe',
-    disability_rating: 40,
-    latest_service: {
+    fullName: 'John Doe',
+    disabilityRating: 40,
+    latestService: {
       branch: 'Army',
-      begin_date: '2009-04-12',
-      end_date: '2013-04-11',
+      beginDate: '2009-04-12',
+      endDate: '2013-04-11',
     },
     edipi: 1234567890,
   },
 };
-/* eslint-enable camelcase */
 
 // Mock function to create a basic initial state
 function createBasicInitialState(useSharedService = false) {
   return {
     featureToggles: {
       loading: false,
-      // eslint-disable-next-line camelcase
-      cve_veteran_status_new_service: useSharedService,
+      [TOGGLE_NAMES.cveVeteranStatusNewService]: useSharedService,
     },
     scheduledDowntime: {
       globalDowntime: null,

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
@@ -30,11 +30,32 @@ const vetStatusConfirmed = {
   },
 };
 
+/* eslint-disable camelcase */
+const veteranStatusCardConfirmed = {
+  type: 'veteran_status_card',
+  veteran_status: 'confirmed',
+  service_summary_code: 'A1',
+  not_confirmed_reason: null,
+  attributes: {
+    full_name: 'John Doe',
+    disability_rating: 40,
+    latest_service: {
+      branch: 'Army',
+      begin_date: '2009-04-12',
+      end_date: '2013-04-11',
+    },
+    edipi: 1234567890,
+  },
+};
+/* eslint-enable camelcase */
+
 // Mock function to create a basic initial state
-function createBasicInitialState() {
+function createBasicInitialState(useSharedService = false) {
   return {
     featureToggles: {
       loading: false,
+      // eslint-disable-next-line camelcase
+      cve_veteran_status_new_service: useSharedService,
     },
     scheduledDowntime: {
       globalDowntime: null,
@@ -97,17 +118,17 @@ describe('VeteranStatusWrapper', () => {
     });
   });
 
-  describe('when feature toggles have loaded', () => {
-    it('should render the VeteranStatus component', async () => {
+  describe('when feature toggle cveVeteranStatusNewService is disabled', () => {
+    it('should render the old VeteranStatus component', async () => {
       apiRequestStub.resolves(vetStatusConfirmed);
-      const initialState = createBasicInitialState();
+      const initialState = createBasicInitialState(false);
 
       const view = renderWithProfileReducers(<VeteranStatusWrapper />, {
         initialState,
       });
 
       await waitFor(() => {
-        // VeteranStatus component calls the old API endpoint
+        // Old component calls the old API endpoint
         sinon.assert.calledWith(
           apiRequestStub,
           '/profile/vet_verification_status',
@@ -124,5 +145,30 @@ describe('VeteranStatusWrapper', () => {
     });
   });
 
-  // TODO: Add test for VeteranStatusSharedService when feature toggle is enabled
+  describe('when feature toggle cveVeteranStatusNewService is enabled', () => {
+    it('should render the new VeteranStatusSharedService component', async () => {
+      apiRequestStub.resolves(veteranStatusCardConfirmed);
+      const initialState = createBasicInitialState(true);
+
+      const view = renderWithProfileReducers(<VeteranStatusWrapper />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        // New component calls the new API endpoint
+        sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
+
+        // Check that the heading is rendered
+        expect(
+          view.getByRole('heading', {
+            name: 'Veteran Status Card',
+            level: 1,
+          }),
+        ).to.exist;
+
+        // Check that the user's full name from the new API is rendered
+        expect(view.getByText('John Doe')).to.exist;
+      });
+    });
+  });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add new Veteran Status Card Component
- the code in VeteranStatusSharedService.jsx is based on https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/2389

## Testing done

- Unit tests
- Manual test using mock api

## Screenshots

_Note: T
his field is mandatory for UI changes (non-component work should NOT have screenshots)._
- Successful 
<img width="1039" height="463" alt="Screenshot 2026-02-23 at 9 18 04 AM" src="https://github.com/user-attachments/assets/c2c680bd-7f53-47a5-b663-8ab9eec57c27" />

- Warning alert - dishonorable discharge
<img width="944" height="372" alt="Screenshot 2026-02-23 at 9 19 30 AM" src="https://github.com/user-attachments/assets/11798fcb-db8d-4f13-a3dd-5c632939d588" />

- Warning alert - person not found
<img width="840" height="323" alt="Screenshot 2026-02-23 at 9 21 17 AM" src="https://github.com/user-attachments/assets/60c11b9c-067e-4cdf-a951-b88bc87e8861" />

- Error alert - system error
<img width="886" height="298" alt="Screenshot 2026-02-23 at 9 22 00 AM" src="https://github.com/user-attachments/assets/bf4ae1c8-81fd-4586-a3f5-6651338f5c7d" />

## What areas of the site does it impact?
Veteran Status Card page 

## Acceptance criteria
- [x] New Alert component created for vet status card. We might be able to just use the existing [VeteranStatusAlert](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx#L32) component

- [ ] Release Notes Updated

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
