### PR TITLE
8416 add onFormLoaded to fix international phone

### DIFF
--- a/src/applications/medical-expense-report/config/form.js
+++ b/src/applications/medical-expense-report/config/form.js
@@ -26,6 +26,7 @@ import supportingDocuments from './chapters/03-additional-information/supporting
 import uploadDocuments from './chapters/03-additional-information/uploadDocuments';
 import expensesReview from './chapters/02-expenses/expensesReview';
 import GetFormHelp from '../components/GetFormHelp';
+import { onFormLoaded } from './onFormLoaded';
 import { hasNoExpenses, hasCareExpenses } from './chapters/02-expenses/helpers';
 
 /** @type {FormConfig} */
@@ -57,6 +58,7 @@ const formConfig = {
       saved: 'We saved your medical expense report',
     },
   },
+  onFormLoaded,
   version: 0,
   formSavedPage: FormSavedPage,
   savedFormMessages: {

--- a/src/applications/medical-expense-report/config/onFormLoaded.js
+++ b/src/applications/medical-expense-report/config/onFormLoaded.js
@@ -1,0 +1,38 @@
+/**
+ * Update claimantPhone fields to match mapping.
+ * Remove when mappings are no longer underscore prefixed.
+ * @param {Object} formData - Form data from save-in-progress
+ * @param {String} returnUrl - URL of last saved page
+ * @param {Object} formConfig - Full form config
+ * @param {Object} router - React router
+ */
+const validateInternationalPhoneNumbers = props => {
+  const { formData, router, returnUrl } = props;
+  if (
+    formData?.primaryPhone &&
+    typeof formData.primaryPhone === 'object' &&
+    formData.primaryPhone.contact
+  ) {
+    if (!formData.primaryPhone._isValid) {
+      formData.primaryPhone._isValid =
+        formData.primaryPhone.isValid || formData.primaryPhone.IsValid;
+    }
+    if (!formData.primaryPhone._error) {
+      formData.primaryPhone._error =
+        formData.primaryPhone.error ?? formData.primaryPhone.Error ?? null;
+    }
+    if (!formData.primaryPhone._touched) {
+      formData.primaryPhone._touched =
+        formData.primaryPhone.touched || formData.primaryPhone.Touched;
+    }
+    if (!formData.primaryPhone._required) {
+      formData.primaryPhone._required =
+        formData.primaryPhone.required || formData.primaryPhone.Required;
+    }
+  }
+  router.push(returnUrl);
+};
+
+export const onFormLoaded = props => {
+  validateInternationalPhoneNumbers(props);
+};

--- a/src/applications/medical-expense-report/tests/fixtures/mocks/completed-form.json
+++ b/src/applications/medical-expense-report/tests/fixtures/mocks/completed-form.json
@@ -1,129 +1,129 @@
 {
-    "claimantNotVeteran": true,
-    "claimantFullName": {
-        "first": "Jane",
-        "middle": "A.",
-        "last": "Doe",
-        "suffix": "Jr."
+  "claimantNotVeteran": true,
+  "claimantFullName": {
+    "first": "Jane",
+    "middle": "A.",
+    "last": "Doe",
+    "suffix": "Jr."
+  },
+  "claimantAddress": {
+    "country": "USA",
+    "street": "123 Main St",
+    "street2": "Apt 4B",
+    "city": "Anytown",
+    "state": "VA",
+    "postalCode": "12345"
+  },
+  "email": "jane.doe@example.com",
+  "primaryPhone": {
+    "countryCode": "US",
+    "contact": "5551234567",
+    "callingCode": 1,
+    "Error": null,
+    "IsValid": true,
+    "Required": true,
+    "Touched": true
+  },
+  "veteranFullName": {
+    "first": "John",
+    "middle": "B.",
+    "last": "Doe",
+    "suffix": "Sr."
+  },
+  "veteranSocialSecurityNumber": {
+    "ssn": "123111234"
+  },
+  "veteranDateOfBirth": "1970-01-01",
+  "isOver65": true,
+  "firstTimeReporting": true,
+  "reportingPeriod": {
+    "from": "2023-01-01",
+    "to": "2023-12-31"
+  },
+  "view:careExpensesList": true,
+  "careExpenses": [
+    {
+      "recipient": "SPOUSE",
+      "provider": "Dr. Smith",
+      "hoursPerWeek": "10",
+      "careDate": {
+        "from": "2023-01-14",
+        "to": "2023-01-15"
+      },
+      "paymentPeriod": "monthly",
+      "paymentAmount": 25,
+      "hourlyRate": 50,
+      "typeOfCare": "RESIDENTIAL",
+      "monthlyAmount": 100
     },
-    "veteranAddress": {
-        "country": "USA",
-        "street": "123 Main St",
-        "street2": "Apt 4B",
-        "city": "Anytown",
-        "state": "VA",
-        "postalCode": "12345"
+    {
+      "recipient": "CHILD",
+      "fullNameRecipient": "Baby Doe",
+      "provider": "Dr. Smith",
+      "hoursPerWeek": "50",
+      "careDate": {
+        "from": "2023-02-01",
+        "to": "2023-03-15"
+      },
+      "paymentPeriod": "monthly",
+      "paymentAmount": 25,
+      "hourlyRate": 50,
+      "typeOfCare": "RESIDENTIAL",
+      "monthlyAmount": 100
+    }
+  ],
+  "hasMedicalExpenses": true,
+  "medicalExpenses": [
+    {
+      "recipient": "VETERAN",
+      "provider": "5A (5)",
+      "purpose": "5A (6)",
+      "paymentDate": "2001-01-01",
+      "paymentFrequency": "ONCE_MONTH",
+      "paymentAmount": 123456.78
     },
-    "email": "jane.doe@example.com",
-    "primaryPhone": {
-        "countryCode": "US",
-        "contact": "5551234567",
-        "callingCode": 1,
-        "_error": null,
-        "_isValid": true,
-        "_required": true,
-        "_touched": true
+    {
+      "recipient": "SPOUSE",
+      "fullNameRecipient": "Jane Spouse",
+      "provider": "5B (5)",
+      "purpose": "5B (6)",
+      "paymentDate": "2002-02-02",
+      "paymentFrequency": "ONCE_YEAR",
+      "paymentAmount": 876543.21
+    }
+  ],
+  "hasMileage": true,
+  "mileageExpenses": [
+    {
+      "traveler": "OTHER",
+      "fullNameTraveler": "Tom Otherson",
+      "travelLocation": "OTHER",
+      "otherTravelLocation": "Some Other Place",
+      "travelMilesTraveled": "10",
+      "travelDate": "2002-02-20",
+      "travelReimbursed": true,
+      "travelReimbursementAmount": 125.67
     },
-    "veteranFullName": {
-        "first": "John",
-        "middle": "B.",
-        "last": "Doe",
-        "suffix": "Sr."
+    {
+      "traveler": "VETERAN",
+      "travelLocation": "HOSPITAL",
+      "travelMilesTraveled": "10",
+      "travelDate": "2001-01-10",
+      "travelReimbursed": false
+    }
+  ],
+  "files": [
+    {
+      "name": "test-upload.pdf",
+      "size": 15306,
+      "confirmationCode": "10c55013-b881-453f-bc10-fbc29e3bc517",
+      "isEncrypted": false
     },
-    "veteranSocialSecurityNumber": {
-      "ssn": "123111234"
-    },
-    "veteranDateOfBirth": "1970-01-01",
-    "isOver65": true,
-    "firstTimeReporting": true,
-    "reportingPeriod": {
-        "from": "2023-01-01",
-        "to": "2023-12-31"
-    },
-    "view:careExpensesList": true,
-    "careExpenses": [
-        {
-            "recipient": "SPOUSE",
-            "provider": "Dr. Smith",
-            "hoursPerWeek": "10",
-            "careDateRange": {
-                "from": "2023-01-14",
-                "to": "2023-01-15"
-            },
-            "paymentPeriod": "monthly",
-            "paymentAmount": 25,
-            "hourlyRate": 50,
-            "typeOfCare": "RESIDENTIAL",
-            "monthlyAmount": 100
-        },
-        {
-            "recipient": "DEPENDENT",
-            "fullNameRecipient": "Baby Doe",
-            "provider": "Dr. Smith",
-            "hoursPerWeek": "50",
-            "careDateRange": {
-                "from": "2023-02-01",
-                "to": "2023-03-15"
-            },
-            "paymentPeriod": "monthly",
-            "paymentAmount": 25,
-            "hourlyRate": 50,
-            "typeOfCare": "RESIDENTIAL",
-            "monthlyAmount": 100
-        }
-    ],
-    "hasMedicalExpenses": true,
-    "medicalExpenses": [
-        {
-          "recipient": "VETERAN",
-          "provider": "5A (5)",
-          "purpose": "5A (6)",
-          "paymentDate": "2001-01-01",
-          "paymentFrequency": "ONCE_MONTH",
-          "paymentAmount": 123456.78
-        },
-        {
-          "recipient": "DEPENDENT",
-          "fullNameRecipient": "Jane Spouse",
-          "provider": "5B (5)",
-          "purpose": "5B (6)",
-          "paymentDate": "2002-02-02",
-          "paymentFrequency": "ONCE_YEAR",
-          "paymentAmount": 876543.21
-        }
-    ],
-    "hasMileage": true,
-    "mileageExpenses": [
-        {
-          "traveler": "OTHER",
-          "fullNameTraveler": "Tom Otherson",
-          "travelLocation": "OTHER",
-          "travelLocationOther": "Some Other Place",
-          "travelMilesTraveled": "10",
-          "travelDate": "2002-02-20",
-          "travelReimbursed": true,
-          "travelReimbursementAmount": 125.67
-        },
-        {
-          "traveler": "VETERAN",
-          "travelLocation": "HOSPITAL",
-          "travelMilesTraveled": "10",
-          "travelDate": "2001-01-10",
-          "travelReimbursed": false
-        }
-    ],
-    "files": [
-        {
-            "name": "test-upload.pdf",
-            "size": 15306,
-            "confirmationCode": "10c55013-b881-453f-bc10-fbc29e3bc517",
-            "isEncrypted": false
-        },
-        {
-            "name": "test-png.png",
-            "size": 999,
-            "confirmationCode": "10c55013-b881-453f-bc10-1234567890ab",
-            "isEncrypted": false
-        }
-    ]
+    {
+      "name": "test-png.png",
+      "size": 999,
+      "confirmationCode": "10c55013-b881-453f-bc10-1234567890ab",
+      "isEncrypted": false
+    }
+  ]
 }

--- a/src/applications/medical-expense-report/tests/unit/utils/onFormLoaded.unit.spec.jsx
+++ b/src/applications/medical-expense-report/tests/unit/utils/onFormLoaded.unit.spec.jsx
@@ -1,0 +1,138 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { onFormLoaded } from '../../../config/onFormLoaded';
+
+describe('validateInternationalPhoneNumbers', () => {
+  const router = { push: sinon.spy() };
+  it('should transform formData properly with title case', () => {
+    const formData = {
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        contact: '5551113333',
+        IsValid: true,
+        Error: null,
+        Touched: true,
+        Required: true,
+      },
+    };
+    onFormLoaded({ formData, router, returnUrl: '/test' });
+    expect(router.push.calledWith('/test')).to.be.true;
+    expect(formData).to.deep.equal({
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        contact: '5551113333',
+        IsValid: true,
+        Error: null,
+        Touched: true,
+        Required: true,
+        _isValid: true,
+        _error: null,
+        _touched: true,
+        _required: true,
+      },
+    });
+  });
+
+  it('should transform formData properly with lowercase', () => {
+    const formData = {
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        contact: '5551113333',
+        isValid: true,
+        error: null,
+        touched: true,
+        required: true,
+      },
+    };
+    onFormLoaded({ formData, router, returnUrl: '/test' });
+    expect(router.push.calledWith('/test')).to.be.true;
+    expect(formData).to.deep.equal({
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        contact: '5551113333',
+        isValid: true,
+        error: null,
+        touched: true,
+        required: true,
+        _isValid: true,
+        _error: null,
+        _touched: true,
+        _required: true,
+      },
+    });
+  });
+
+  it('should not change the data if contact does not exist', () => {
+    const formData = {
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        // contact is missing
+        IsValid: true,
+        Error: null,
+        Touched: true,
+        Required: true,
+      },
+    };
+    onFormLoaded({ formData, router, returnUrl: '/test' });
+    expect(router.push.calledWith('/test')).to.be.true;
+    expect(formData).to.deep.equal({
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        // contact is still missing
+        IsValid: true,
+        Error: null,
+        Touched: true,
+        Required: true,
+      },
+    });
+  });
+
+  it('should not change the data if primary phone is not an object', () => {
+    const formData = {
+      primaryPhone: '555-111-3333',
+    };
+    onFormLoaded({ formData, router, returnUrl: '/test' });
+    expect(router.push.calledWith('/test')).to.be.true;
+    expect(formData).to.deep.equal({
+      primaryPhone: '555-111-3333',
+    });
+  });
+  it('should not change the data if primary phone is undefined', () => {
+    const formData = {};
+    onFormLoaded({ formData, router, returnUrl: '/test' });
+    expect(router.push.calledWith('/test')).to.be.true;
+    expect(formData).to.deep.equal({});
+  });
+  it('should not change the data if primary phone is correct', () => {
+    const formData = {
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        contact: '5551113333',
+        _isValid: true,
+        _error: null,
+        _touched: true,
+        _required: true,
+      },
+    };
+    onFormLoaded({ formData, router, returnUrl: '/test' });
+    expect(router.push.calledWith('/test')).to.be.true;
+    expect(formData).to.deep.equal({
+      primaryPhone: {
+        callingCode: 1,
+        countryCode: 'US',
+        contact: '5551113333',
+        _isValid: true,
+        _error: null,
+        _touched: true,
+        _required: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes an issue with international phone numbers on save in progress
- Visit the form and use save in progress on the last page, trying to submit will present a console error and you can't submit the form. 
- This adds an onFormLoaded function to transform the save in progress international phone fields to use the correct field mapping of a prefixed underscore instead of the capital letter that comes back from SIP 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133337

## Testing done

- Manual testing locally
- Added unit tests for the new function

## Screenshots

N/A

## What areas of the site does it impact?

Save in progress and submit on the 8416

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A