### PR TITLE
VEBT-4555: 10278 convert to auth only

### DIFF
--- a/src/applications/edu-benefits/10278/containers/App.jsx
+++ b/src/applications/edu-benefits/10278/containers/App.jsx
@@ -1,11 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { isLoggedIn } from 'platform/user/selectors';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 import Breadcrumbs from '../components/Breadcrumbs';
 import NeedHelp from '../components/NeedHelp';
+import manifest from '../manifest.json';
 
 export default function App({ location, children }) {
+  const userLoggedIn = useSelector(state => isLoggedIn(state));
+
+  useEffect(
+    () => {
+      if (!userLoggedIn && location.pathname !== '/introduction') {
+        window.location.href = manifest.rootUrl;
+      }
+    },
+    [userLoggedIn, location],
+  );
+
   return (
     <div className="form-22-10278-container row">
       <div className="vads-u-padding-left--0">

--- a/src/applications/edu-benefits/10278/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10278/containers/IntroductionPage.jsx
@@ -72,7 +72,8 @@ export const IntroductionPage = props => {
             formConfig={formConfig}
             pageList={pageList}
             startText="Start your Authorization to disclose personal information"
-            unauthStartText="Sign in or create an account"
+            unauthStartText="Sign in to start your form"
+            hideUnauthedStartLink={!userLoggedIn}
           />
         ) : (
           <SaveInProgressIntro

--- a/src/applications/edu-benefits/10278/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/10278/tests/containers/IntroductionPage.unit.spec.jsx
@@ -117,7 +117,7 @@ describe('22-10278 <IntroductionPage>', () => {
       expect(signInButton).to.exist;
       expect(signInButton).to.have.attribute(
         'text',
-        'Sign in or create an account',
+        'Sign in to start your form',
       );
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Make edu form 22-10278 auth only

## Related issue(s)

https://jira.devops.va.gov/browse/VEBT-4555

## Testing done
<img width="1438" height="427" alt="Screenshot 2026-02-17 at 2 06 28 PM" src="https://github.com/user-attachments/assets/0179df0b-3ecf-4640-916a-6a53a35c83f5" />



## Screenshots

Before
<img width="730" height="558" alt="Screenshot 2026-02-17 at 2 07 57 PM" src="https://github.com/user-attachments/assets/bf1dfbb2-0a51-44e5-b91a-c8d29893755b" />


After
<img width="732" height="458" alt="Screenshot 2026-02-17 at 2 07 28 PM" src="https://github.com/user-attachments/assets/643ab10e-7b61-4a65-815e-3e9093f81038" />



## What areas of the site does it impact?

edu-benefits/10278

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
