### PR TITLE
133272 datadog rum pii follow up

### DIFF
--- a/src/applications/claims-status/components/Notification.jsx
+++ b/src/applications/claims-status/components/Notification.jsx
@@ -9,7 +9,9 @@ export default function Notification({
   type,
   onClose,
   onSetFocus,
-  maskTitle = false,
+  // Security: Defaults to true to mask PII (file names) in Datadog RUM session replays.
+  // Set to false only for titles that we are certain contain no PII.
+  maskTitle = true,
 }) {
   const closeable = !!onClose;
   useEffect(
@@ -52,6 +54,7 @@ export default function Notification({
 
 Notification.defaultProps = {
   type: 'success',
+  maskTitle: true, // Secure by default - masks title in Datadog RUM session replays
 };
 
 Notification.propTypes = {

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -87,7 +87,7 @@ function ClaimsStatusApp({
     beforeSend: event => {
       if (event.action?.type === 'click') {
         // eslint-disable-next-line no-param-reassign
-        event.action.target.name = 'Clicked item';
+        event.action.target.name = 'Clicked sensitive item';
       }
       return true;
     },

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -275,7 +275,7 @@ describe('<ClaimsStatusApp> - Platform DataDog RUM Integration', () => {
       },
     };
     expect(beforeSend(clickEvent)).to.be.true;
-    expect(clickEvent.action.target.name).to.equal('Clicked item');
+    expect(clickEvent.action.target.name).to.equal('Clicked sensitive item');
   });
 
   it('should call platform useBrowserMonitoring with loggedIn false when user not logged in', () => {

--- a/src/applications/claims-status/tests/components/Notification.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/Notification.unit.spec.jsx
@@ -70,4 +70,79 @@ describe('<Notification>', () => {
     expect(selector).to.exist;
     expect(selector).to.have.attr('role', 'alert');
   });
+
+  describe('maskTitle prop (PII protection)', () => {
+    it('should mask title by default (secure by default)', () => {
+      const { container } = render(
+        <Notification title="medical-records.pdf" body={body} />,
+      );
+
+      const titleElement = container.querySelector('h2');
+      expect(titleElement).to.exist;
+      expect(titleElement).to.have.attr('data-dd-privacy', 'mask');
+      expect(titleElement).to.have.attr(
+        'data-dd-action-name',
+        'notification title with filename',
+      );
+    });
+
+    it('should mask title when maskTitle={true}', () => {
+      const { container } = render(
+        <Notification
+          title="upload-failed-document.pdf"
+          body={body}
+          maskTitle
+        />,
+      );
+
+      const titleElement = container.querySelector('h2');
+      expect(titleElement).to.exist;
+      expect(titleElement).to.have.attr('data-dd-privacy', 'mask');
+      expect(titleElement).to.have.attr(
+        'data-dd-action-name',
+        'notification title with filename',
+      );
+    });
+
+    it('should NOT mask title when maskTitle={false}', () => {
+      const { container } = render(
+        <Notification
+          title="Your claim was submitted"
+          body={body}
+          maskTitle={false}
+        />,
+      );
+
+      const titleElement = container.querySelector('h2');
+      expect(titleElement).to.exist;
+      expect(titleElement).to.not.have.attr('data-dd-privacy');
+      expect(titleElement).to.not.have.attr('data-dd-action-name');
+    });
+
+    it('should mask error notifications with file names', () => {
+      const fileNameTitle = 'Upload failed: john-smith-medical.pdf';
+      const { container } = render(
+        <Notification title={fileNameTitle} body={body} type="error" />,
+      );
+
+      const titleElement = container.querySelector('h2');
+      expect(titleElement).to.exist;
+      expect(titleElement).to.have.attr('data-dd-privacy', 'mask');
+    });
+
+    it('should support explicit false for success messages', () => {
+      const { container } = render(
+        <Notification
+          title="Upload successful"
+          body="Your document was uploaded"
+          type="success"
+          maskTitle={false}
+        />,
+      );
+
+      const titleElement = container.querySelector('h2');
+      expect(titleElement).to.exist;
+      expect(titleElement).to.not.have.attr('data-dd-privacy');
+    });
+  });
 });


### PR DESCRIPTION
This PR is a follow up to "[Mask file names in Datadog RUM to prevent PII exposure](https://github.com/department-of-veterans-affairs/vets-website/pull/42272)" that addresses dfitchett's suggested changes. 

### What does this PR do?

Enhances PII protection by making the Notification component secure by default and improving click action naming for better analytics clarity. Prevents future accidental PII exposure when developers forget to explicitly mask sensitive content.