### PR TITLE
changes gross monthly amount of benefit and last 12 months earnings f…

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/submit-transformer/submit-transformer.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/config/submit-transformer/submit-transformer.unit.spec.jsx
@@ -766,7 +766,7 @@ describe('Submit Transformer', () => {
       const form = {
         data: {
           employmentEarningsHours: {
-            amountEarned: '$999,999,999.99',
+            amountEarned: '$999999.99',
           },
         },
       };
@@ -775,7 +775,7 @@ describe('Submit Transformer', () => {
 
       expect(
         result.employmentInformation.amountEarnedLast12MonthsOfEmployment,
-      ).to.equal(999999999.99);
+      ).to.equal(999999.99);
     });
 
     it('should handle zero currency values', () => {

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/benefits-details.js
@@ -60,9 +60,11 @@ export const benefitsDetailsUiSchema = {
     }),
     grossMonthlyAmount: currencyUI({
       title: 'Gross monthly amount of benefit',
+      max: 999999.99,
       errorMessages: {
         required: 'Gross monthly amount is required',
         min: 'Gross monthly amount must be at least $0',
+        max: 'Gross monthly amount cannot exceed $999,999.99',
       },
     }),
     startReceivingDate: currentOrPastDateUI({

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-earnings-hours.js
@@ -99,9 +99,11 @@ export const employmentEarningsHoursUiSchema = {
     }),
     amountEarned: currencyUI({
       title: 'Amount earned',
+      max: 999999.99,
       errorMessages: {
         required: 'Amount earned is required',
         min: 'Amount earned must be at least $0',
+        max: 'Amount earned cannot exceed $999,999.99',
       },
     }),
     timeLost: textUI({


### PR DESCRIPTION
…ields to be limited to 999,999.99 to prevent overflow on backend

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Changing gross monthly amount of benefit and last 12 months earnings to be limited to $999,999.99

### Issue
The default limit for currencyUI is 999,999,999.00. The paper form only allows up to 999,999.99. 

### Solution
Overrode the limit for these two fields to fit in the PDF's limits.

### Team Information
* Team: Benefits Intake Optimization - Aquia Team
* Team Ownership: Yes, our team maintains the 21-4192 form
* No feature flipper required - This is a configuration fix

## Related issue(s)

[Issue 130373](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130373)

## Testing done

### Old behavior
* The form was allowing up to 999,999,999.00 for last 12 months earnings and gross benefit amount

### New behavior
* The form now limits these two fields to 999,999.99

### Verification Steps
*  Unit tests: verified existing unit tests still pass (modified one unit test to use new limits)
*  Manual testing in local environment verified that the field is properly limiting to 999,999.99 on both fields
* E2E tests: all existing tests pass, no modifications needed to any E2E tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | |  |
| Desktop | <img width="554" height="142" alt="currency before" src="https://github.com/user-attachments/assets/8f8fb536-e847-44d1-8ea1-f1e5f336c12d" /> | <img width="605" height="193" alt="currency after" src="https://github.com/user-attachments/assets/5181849e-36bd-4a59-a250-d0713ef0ef03" /> |

## What areas of the site does it impact?

This change affects form 21-4192 specifically on the Employment Earnings and Benefits Details pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user