### PR TITLE
133143: fix how setError is used

### DIFF
--- a/src/applications/pensions/components/DisabilityRatingAlert.jsx
+++ b/src/applications/pensions/components/DisabilityRatingAlert.jsx
@@ -30,7 +30,7 @@ const DisabilityRatingAlert = () => {
         }
       } catch (err) {
         if (isMounted) {
-          setError(true);
+          setError(err);
         }
       } finally {
         if (isMounted) setLoading(false);

--- a/src/applications/pensions/tests/unit/components/DisabilityRatingAlert.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/components/DisabilityRatingAlert.unit.spec.jsx
@@ -103,7 +103,7 @@ describe('DisabilityRatingAlert component', () => {
       expect(ddLoggerStub.args[0][0]).to.deep.equal({
         message: 'Pension disability rating fetch error',
         attributes: {
-          error: 'unknown error',
+          error: 'Network error',
           state: 'visible',
           alertType: 'info',
         },


### PR DESCRIPTION
Frontend logging issue - In vets-website/src/applications/pensions/components/DisabilityRatingAlert.jsx, errors are being logged as "unknown error" because error.message is empty or null:
error: error?.message || 'unknown error'

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update `setError()` to use the err object instead of a Boolean

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133143

## What areas of the site does it impact?

*Disability rating alert*
