### PR TITLE
526 Sidenav - reducing border thickness

### DIFF
--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -318,7 +318,7 @@ article[data-location="supporting-evidence/evidence-types-bdd"] {
 .claim-form-sidenav-wrapper {
   va-sidenav::part(accordion-content) {
     background-color: var(--vads-color-white) !important;
-    border: 0.2rem solid var(--vads-color-primary) !important;
+    border: 0.15rem solid var(--vads-color-primary) !important;
     border-top: none !important;
     border-radius: 0 0 4px 4px;
     margin-top: -4px;
@@ -326,7 +326,7 @@ article[data-location="supporting-evidence/evidence-types-bdd"] {
 
   va-sidenav::part(accordion-header) {
     background-color: var(--vads-color-white) !important;
-    border: 0.2rem solid var(--vads-color-primary) !important;
+    border: 0.15rem solid var(--vads-color-primary) !important;
     color: var(--vads-color-primary) !important;
     border-radius: 4px;
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
Reducing border width for sidenav mobile accordion

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#130919
- _Previous change_
department-of-veterans-affairs/vets-website/pull/42069

## Testing done
Manual testing complete, all tests passing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="495" height="394" alt="image" src="https://github.com/user-attachments/assets/3483c42a-53e3-4ead-84f0-66d7f6bc8fee" /> | <img width="496" height="390" alt="image" src="https://github.com/user-attachments/assets/85b731a7-a83b-46d0-8673-0966a4904f82" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
