### PR TITLE
Add filterLabel const to account for a single record

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -207,7 +207,7 @@ class YourClaimsPageV2 extends React.Component {
       !claimsLoading && !appealsLoading && !stemClaimsLoading;
     const emptyFilteredList = !(filteredList && filteredList.length);
     const { claimsFilter } = this.state;
-    const filterLabel =
+    let filterLabel =
       claimsFilter === 'all' ? 'records' : `${claimsFilter} records`;
 
     // Wait for all requests to complete before rendering results
@@ -218,6 +218,10 @@ class YourClaimsPageV2 extends React.Component {
       const listLen = filteredList.length;
       const numPages = Math.ceil(listLen / ITEMS_PER_PAGE);
       const shouldPaginate = numPages > 1;
+
+      const recordText = listLen === 1 ? 'record' : 'records';
+      filterLabel =
+        claimsFilter === 'all' ? recordText : `${claimsFilter} ${recordText}`;
 
       const pageItems = getVisibleRows(filteredList, this.state.page);
 

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -364,6 +364,20 @@ describe('<YourClaimsPageV2>', () => {
       );
       expect(container.textContent).to.include('Showing 1-10 of 12 records');
     });
+
+    it('should use singular "record" when there is only one item', () => {
+      const props = {
+        ...filterProps,
+        list: [defaultProps.list[0]],
+      };
+      const { container } = renderWithRouter(
+        <Provider store={mockStore}>
+          <YourClaimsPageV2 {...props} />
+        </Provider>,
+      );
+      expect(container.textContent).to.include('Showing 1-1 of 1 record');
+      expect(container.textContent).to.not.include('records');
+    });
   });
 
   describe('rendering mixed appeals and claims', () => {


### PR DESCRIPTION
### Fix pagination text pluralization for single record 
REFERENCE TICKET: [Add singular version for x of y records label 133423](https://github.com/orgs/department-of-veterans-affairs/projects/1549/views/3?pane=issue&itemId=157850531&issue=department-of-veterans-affairs%7Cva.gov-team%7C133429)                                                                                                                           
                                                                                                                                                                                                
Problem:                                                                                                                                                                                      
When displaying only one claim/appeal, the pagination text incorrectly showed "Showing 1-1 of 1 records" (plural) instead of "Showing 1-1 of 1 record" (singular).    

BEFORE: 
<img width="713" height="707" alt="Screenshot 2026-02-18 at 8 36 36 AM" src="https://github.com/user-attachments/assets/e011b2d3-e1ed-45dd-af1f-d8a5e5b7b540" />
<img width="728" height="687" alt="Screenshot 2026-02-18 at 8 36 43 AM" src="https://github.com/user-attachments/assets/ce1dcf53-a145-474b-928d-410e7660d00c" />
<img width="701" height="257" alt="Screenshot 2026-02-18 at 8 36 52 AM" src="https://github.com/user-attachments/assets/ff8a5d06-0250-44d6-9cc5-81f318909336" />


AFTER: 
(with single claim) 
<img width="751" height="719" alt="Screenshot 2026-02-18 at 8 44 13 AM" src="https://github.com/user-attachments/assets/36b49131-148c-41c1-b263-ba8d923d71e4" />
<img width="746" height="718" alt="Screenshot 2026-02-18 at 8 44 20 AM" src="https://github.com/user-attachments/assets/60d13f47-cdaa-42c5-b84d-d149b5047449" />
<img width="590" height="242" alt="Screenshot 2026-02-18 at 8 44 31 AM" src="https://github.com/user-attachments/assets/b3e07a72-3285-4819-a63d-8caf09856bee" />

(closed claim example - with single claim) 
<img width="705" height="548" alt="Screenshot 2026-02-18 at 12 11 13 PM" src="https://github.com/user-attachments/assets/f5141250-0a2a-4100-bcd1-7c2617424585" />

(with multiple claims - no change)
<img width="755" height="688" alt="Screenshot 2026-02-18 at 12 46 41 PM" src="https://github.com/user-attachments/assets/1f99c489-be4b-484f-8f81-1dd3fe8431d0" />
<img width="724" height="685" alt="Screenshot 2026-02-18 at 12 46 48 PM" src="https://github.com/user-attachments/assets/d25d3374-af1c-4a12-94cb-9e02e912ede8" />
<img width="745" height="457" alt="Screenshot 2026-02-18 at 12 46 55 PM" src="https://github.com/user-attachments/assets/a4c7d734-3496-46c6-9bb9-e10d98a0ee24" />

