### PR TITLE
fix: add file upload intercept for 21a-multiform-upload Cypress test

### DIFF
--- a/src/applications/accreditation/21a/tests/e2e/21a-multiform-upload.cypress.spec.js
+++ b/src/applications/accreditation/21a/tests/e2e/21a-multiform-upload.cypress.spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
+// no-op change to repro test failure
 import 'cypress-axe';
 import { setFeatureToggles } from './intercepts/feature-toggles';
 import inProgressFormsResponse from './fixtures/mocks/in-progress-forms-response.json';

--- a/src/applications/accreditation/21a/tests/e2e/21a-multiform-upload.cypress.spec.js
+++ b/src/applications/accreditation/21a/tests/e2e/21a-multiform-upload.cypress.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 import 'cypress-axe';
+import { makeMinimalPDF } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 import { setFeatureToggles } from './intercepts/feature-toggles';
 import inProgressFormsResponse from './fixtures/mocks/in-progress-forms-response.json';
 
@@ -160,10 +161,13 @@ describe('21A — resume to Conviction (yes/no)', () => {
       },
     );
 
-    cy.fillVaFileInputMultiple(
-      'root_convictionDetailsDocuments',
-      uploadImgDetails(convictionSupportingDocument1),
-    );
+    cy.then(() => makeMinimalPDF()).then(pdfFile => {
+      cy.fillVaFileInputMultiple(
+        'root_convictionDetailsDocuments',
+        uploadImgDetails(convictionSupportingDocument1),
+        [pdfFile],
+      );
+    });
 
     cy.injectAxe();
     cy.axeCheck();

--- a/src/applications/accreditation/21a/tests/e2e/21a-multiform-upload.cypress.spec.js
+++ b/src/applications/accreditation/21a/tests/e2e/21a-multiform-upload.cypress.spec.js
@@ -1,5 +1,4 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-// no-op change to repro test failure
 import 'cypress-axe';
 import { setFeatureToggles } from './intercepts/feature-toggles';
 import inProgressFormsResponse from './fixtures/mocks/in-progress-forms-response.json';
@@ -113,6 +112,23 @@ describe('21A — resume to Conviction (yes/no)', () => {
       '**/accredited_representative_portal/v0/in_progress_forms/21a*',
       inProgressFormsResponse,
     ).as('saveInProgressForm');
+
+    cy.intercept(
+      'POST',
+      '**/accredited_representative_portal/v0/form21a/conviction-details',
+      {
+        statusCode: 200,
+        body: {
+          data: {
+            attributes: {
+              confirmationCode: 'fake-confirmation-code',
+              name: 'conviction_supporting_document_1.pdf',
+              size: 2783621,
+            },
+          },
+        },
+      },
+    ).as('uploadConvictionDocument');
 
     cy.seedUserWith21aSIP('/conviction');
     cy.stub21aFormDataExact('/conviction');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- PR #42243 ("File input multiple cypress tests") removed the `environment.isTest()` bypass in `VaFileInputMultipleField.jsx`. Previously, Cypress tests would skip the actual file upload network call and directly set form data. Now the component performs real uploads in test environments.
- The `21a-multiform-upload.cypress.spec.js` test did not mock the file upload endpoint, so the upload fails and the form cannot advance past the conviction-details page.
- The fix adds a `cy.intercept` for `POST **/accredited_representative_portal/v0/form21a/conviction-details` that returns a mock successful upload response.
- The Accreditation team owns this test. This is a test-only fix with no production code changes.

## Related issue(s)

- Root cause: department-of-veterans-affairs/vets-website#42243
- Reproduced failure: https://github.com/department-of-veterans-affairs/vets-website/actions/runs/22154204799/job/64053912564?pr=42424

## Testing done

- Confirmed the test fails on main with a webpack build (not rspack-related) by creating this branch with a no-op change and observing CI failure.
- Added the file upload endpoint intercept to mock the POST response.
- The test should now pass since the component receives a valid upload response and can advance to the next page (`/under-charges`).

## Screenshots

N/A — test-only change, no UI modifications.

## What areas of the site does it impact?

Only the `21a-multiform-upload.cypress.spec.js` Cypress E2E test for the Accreditation 21a form. No production code is changed.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A)
- [ ] Screenshot of the developed feature is added (N/A — test-only change)
- [x] Accessibility testing has been performed (N/A — test-only change)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution (N/A)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — test-only fix)

## Requested Feedback

This is a minimal fix to unblock the E2E test suite. The broader question of whether other Cypress tests using `fillVaFileInputMultiple` with `skipUpload: false` also need upload endpoint intercepts (after the #42243 change) should be investigated separately.
