### PR TITLE
Remove mhvLandingPageShowShareMyHealthDataLink feature toggle

### DIFF
--- a/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
@@ -4,7 +4,6 @@ const { snakeCase } = require('lodash');
 const APPLICATION_FEATURE_TOGGLES = Object.freeze({
   mhvVaHealthChatEnabled: true,
   mhvLandingPagePersonalization: true,
-  mhvLandingPageShowShareMyHealthDataLink: true,
   mhvMilestone2ChangesEnabled: true,
   mhvEmailConfirmation: true,
   travelPayPowerSwitch: true,

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -142,9 +142,7 @@ const resolveLandingPageLinks = (
 
   const medicalRecordsLinks = [
     HEALTH_TOOL_LINKS.MEDICAL_RECORDS[0],
-    featureToggles[
-      FEATURE_FLAG_NAMES.mhvLandingPageShowShareMyHealthDataLink
-    ] && {
+    {
       href: resolveSHMDLink,
       text:
         'Share your personal health data on the Share My Health Data website',
@@ -172,12 +170,6 @@ const resolveLandingPageLinks = (
     {
       title: HEALTH_TOOL_HEADINGS.MEDICAL_RECORDS,
       icon: 'note_add',
-      ...(!featureToggles[
-        FEATURE_FLAG_NAMES.mhvLandingPageShowShareMyHealthDataLink
-      ] && {
-        introduction:
-          'Get quick, easy access to your medical records. Now you can print or download what you need, when you need it.',
-      }),
       links: medicalRecordsLinks,
     },
     {

--- a/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
@@ -107,12 +107,9 @@ describe('Landing Page', () => {
           loading: false,
         },
       },
-      /* eslint-disable camelcase */
       featureToggles: {
         loading: false,
-        mhv_landing_page_show_share_my_health_data_link: true,
       },
-      /* eslint-enable camelcase */
       ...initialState,
     };
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -178,7 +178,6 @@
   "mhvBypassDowntimeNotification": "mhv_bypass_downtime_notification",
   "mhvEmailConfirmation": "mhv_email_confirmation",
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",
-  "mhvLandingPageShowShareMyHealthDataLink": "mhv_landing_page_show_share_my_health_data_link",
   "mhvMedicalRecordsCcdExtendedFileTypes": "mhv_medical_records_ccd_extended_file_types",
   "mhvMedicalRecordsCcdOH": "mhv_medical_records_ccd_oh",
   "mhvMedicalRecordsFilterAndSort": "mhv_medical_records_filter_and_sort",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed the `mhvLandingPageShowShareMyHealthDataLink` feature toggle from the FE
- **Bug**: The "Share My Health Data" link on the MHV landing page Medical Records card was randomly disappearing for users in production (reported during OH trusted user testing on 1/27/2026)
- **Root cause**: The toggle value could be `undefined` during a race condition with the feature toggle service, causing the link to not render
- **Solution**: Since this toggle is fully enabled in production and only controls link visibility (no backend logic depends on it), removed the toggle checks entirely so the link always renders
- **Team**: MHV Medical Records
- **Flipper**: No longer needed. A follow-up after will remove the flag definition from `features.yml` in vets-api and clean up Flipper

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132068

## Manual testing done

## Screenshots

N/A — No visual change. The link was already showing when the toggle was `true`. This fix ensures it never disappears.

## What areas of the site does it impact?

MHV landing page — specifically the Medical Records card.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated — N/A, no documentation changes needed
- [x] Screenshot of the developed feature is added — N/A, no visual change
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed — N/A, no accessibility impact

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution — N/A, no new logging
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, existing monitoring sufficient

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user