### PR TITLE
fix: update SM expand/collapse all tests for component-library 54.7.0

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -50,7 +50,9 @@ class PatientMessageDetailsPage {
     cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
       .should('be.visible')
       .shadow()
-      .findByText('Expand all')
+      .find('va-button-icon[data-testid="expand-all-accordions"]')
+      .shadow()
+      .find('button')
       .click({ force: true });
   };
 
@@ -58,7 +60,9 @@ class PatientMessageDetailsPage {
     cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
       .should('be.visible')
       .shadow()
-      .findByText('Collapse all')
+      .find('va-button-icon[data-testid="collapse-all-accordions"]')
+      .shadow()
+      .find('button')
       .click({ force: true });
   };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The component-library upgrade from 54.6.2 to 54.7.0 changed `va-accordion`'s expand/collapse-all button from a text-based `<button>` to separate `<va-button-icon>` elements with `data-testid="expand-all-accordions"` and `data-testid="collapse-all-accordions"`.
- The `expandAllThreadMessages` and `collapseAllThreadMessages` methods in `PatientMessageDetailsPage.js` searched the accordion's shadow DOM for "Expand all" / "Collapse all" text, which no longer exists.
- The fix updates both methods to target the new `va-button-icon` elements by `data-testid` and click the `<button>` inside their shadow DOM.
- This is a test-only fix with no production code changes.

## Related issue(s)

- Root cause: component-library 54.6.2 → 54.7.0 upgrade changed `va-accordion` internal structure

## Testing done

- Verified the new `va-accordion` shadow DOM structure contains `va-button-icon[data-testid="expand-all-accordions"]` and `va-button-icon[data-testid="collapse-all-accordions"]`
- The fix targets these elements and clicks the `<button>` within their shadow DOM

## Screenshots

N/A — test-only change, no UI modifications.

## What areas of the site does it impact?

Only the `secure-messaging-message-thread-details-expand-all.cypress.spec.js` Cypress E2E test. No production code is changed.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (N/A)
- [ ] Screenshot of the developed feature is added (N/A — test-only change)
- [x] Accessibility testing has been performed (N/A — test-only change)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution (N/A)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — test-only fix)

## Requested Feedback

This is the same component-library 54.7.0 accordion breakage affecting multiple apps (medications, letters, secure-messaging). Similar fixes are needed for those tests.
