### PR TITLE
[Ask VA] Split inbox into data-fetching and UI-rendering layers

### DIFF
--- a/src/applications/ask-va/components/Announcements.jsx
+++ b/src/applications/ask-va/components/Announcements.jsx
@@ -2,7 +2,7 @@ import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatDateTimeForAnnouncements } from '../config/helpers';
-import { URL, envUrl, mockTestingFlagforAPI } from '../constants';
+import { URL, envUrl, mockTestingFlagForAPI } from '../constants';
 import { mockAnnouncementsResponse } from '../utils/mockData';
 
 const Announcements = () => {
@@ -37,7 +37,7 @@ const Announcements = () => {
         setVisibleAlerts(visibilityMap);
       };
 
-      if (mockTestingFlagforAPI) {
+      if (mockTestingFlagForAPI) {
         const raw = mockAnnouncementsResponse?.data || [];
         processAnnouncements(raw);
         return;

--- a/src/applications/ask-va/components/Announcements.jsx
+++ b/src/applications/ask-va/components/Announcements.jsx
@@ -2,7 +2,7 @@ import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatDateTimeForAnnouncements } from '../config/helpers';
-import { URL, envUrl, mockTestingFlagForAPI } from '../constants';
+import { URL, envApiUrl, mockTestingFlagForAPI } from '../constants';
 import { mockAnnouncementsResponse } from '../utils/mockData';
 
 const Announcements = () => {
@@ -56,7 +56,7 @@ const Announcements = () => {
 
   useEffect(
     () => {
-      getApiData(`${envUrl}${URL.ANNOUNCEMENTS}`);
+      getApiData(`${envApiUrl}${URL.ANNOUNCEMENTS}`);
     },
     [getApiData],
   );

--- a/src/applications/ask-va/components/EducationFacilitySearch.jsx
+++ b/src/applications/ask-va/components/EducationFacilitySearch.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 
 import { VaRadioOption } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { URL, envUrl } from '../constants';
+import { URL, envApiUrl } from '../constants';
 import { convertLocation } from '../utils/mapbox';
 import EducationSearchItem from './search/EducationSearchItem';
 import SearchControls from './search/SearchControls';
@@ -55,19 +55,19 @@ export default function EducationFacilitySearch({ onChange }) {
   const getFacilitiesFromLocation = async input => {
     const place = await convertLocation(input);
     const getLocation = place.zipCode[0].text;
-    const url = `${envUrl}${URL.GET_SCHOOL}search?name=${getLocation}`;
+    const url = `${envApiUrl}${URL.GET_SCHOOL}search?name=${getLocation}`;
     await getApiData(url);
     setPageURL(url);
   };
 
   const getFacilities = async input => {
-    const url = `${envUrl}${URL.GET_SCHOOL}search?name=${input}`;
+    const url = `${envApiUrl}${URL.GET_SCHOOL}search?name=${input}`;
     await getApiData(url);
     setPageURL(url);
   };
 
   const getFacilitiesByCode = async input => {
-    const url = `${envUrl}${URL.GET_SCHOOL}${input}`;
+    const url = `${envApiUrl}${URL.GET_SCHOOL}${input}`;
     await getApiData(url);
     setPageURL(url);
   };

--- a/src/applications/ask-va/components/FormFields/AddressValidationRadio.jsx
+++ b/src/applications/ask-va/components/FormFields/AddressValidationRadio.jsx
@@ -5,7 +5,7 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import { URL, envUrl } from '../../constants';
+import { URL, envApiUrl } from '../../constants';
 import { formatAddress } from '../../utils/helpers';
 
 const AddressValidationRadio = props => {
@@ -79,7 +79,7 @@ const AddressValidationRadio = props => {
   };
 
   useEffect(() => {
-    getApiData(`${envUrl}${URL.ADDRESS_VALIDATION}`);
+    getApiData(`${envApiUrl}${URL.ADDRESS_VALIDATION}`);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/applications/ask-va/components/inbox/InboxLayout.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayout.jsx
@@ -175,7 +175,7 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
             slim
           >
             <p className="vads-u-margin-y--0">
-              You haven’t submitted a question yet.
+              You haven't submitted a question yet.
             </p>
           </va-alert>
         </div>

--- a/src/applications/ask-va/components/inbox/InboxLayout.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayout.jsx
@@ -175,7 +175,7 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
             slim
           >
             <p className="vads-u-margin-y--0">
-              You haven't submitted a question yet.
+              You haven’t submitted a question yet.
             </p>
           </va-alert>
         </div>

--- a/src/applications/ask-va/components/inbox/InboxLayout.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayout.jsx
@@ -1,0 +1,198 @@
+import {
+  VaButtonPair,
+  VaSelect,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import React, { useEffect, useState } from 'react';
+import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
+import PropTypes from 'prop-types';
+import InquiriesList from './InquiriesList';
+import { filterAndSort } from '../../utils/inbox';
+
+/**
+ * @typedef {import('./InquiryCard').Inquiry} Inquiry
+ */
+
+/**
+ * @typedef {Object} Props
+ * @property {string[]} categories
+ * @property {{ business: Inquiry[], personal: Inquiry[] }} inquiries
+ */
+
+/**
+ * @param {Props} props
+ */
+export default function InboxLayout({ inquiries, categories }) {
+  const [statusFilter, setStatusFilter] = useState('All');
+  const [categoryFilter, setCategoryFilter] = useState('All');
+  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
+  const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
+  const [query, setQuery] = useState('');
+  const [pendingQuery, setPendingQuery] = useState('');
+
+  useEffect(
+    () => {
+      setPendingStatusFilter(statusFilter);
+      setPendingCategoryFilter(categoryFilter);
+    },
+    [statusFilter, categoryFilter],
+  );
+
+  return (
+    <div id="inbox">
+      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
+        Your questions
+      </h2>
+      {inquiries.personal.length || inquiries.business.length ? (
+        <>
+          <div className="filter-container">
+            <div className="search-container">
+              <VaTextInput
+                value={pendingQuery}
+                label="Search"
+                inputMode="search"
+                onVaInput={e => {
+                  setPendingQuery(e.target.value);
+                }}
+              />
+            </div>
+            <div>
+              <VaSelect
+                hint={null}
+                label="Filter by status"
+                name="status"
+                value={pendingStatusFilter}
+                onVaSelect={event => {
+                  setPendingStatusFilter(
+                    event.target.value ? event.target.value : 'All',
+                  );
+                }}
+              >
+                <option value="All">All</option>
+                <option value="In progress">In progress</option>
+                <option value="Replied">Replied</option>
+                <option value="Reopened">Reopened</option>
+              </VaSelect>
+            </div>
+            <div className="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--0">
+              <VaSelect
+                hint={null}
+                label="Filter by category"
+                name="category"
+                value={pendingCategoryFilter}
+                onVaSelect={event => {
+                  setPendingCategoryFilter(
+                    event.target.value ? event.target.value : 'All',
+                  );
+                }}
+              >
+                <option value="All">All</option>
+                {categories.map(category => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </VaSelect>
+            </div>
+
+            <div
+              // Keeps button pair aligned in parent correctly on mobile & desktop
+              className="vads-u-margin-bottom--neg0p5 medium-screen:vads-u-padding-right--0p5 vads-u-margin-x--neg0p5 medium-screen:vads-u-margin-x--0"
+            >
+              <VaButtonPair
+                primaryLabel="Apply filters"
+                secondaryLabel="Clear all filters"
+                onPrimaryClick={() => {
+                  setStatusFilter(pendingStatusFilter);
+                  setCategoryFilter(pendingCategoryFilter);
+                  setQuery(pendingQuery);
+                  focusElement('#search-description');
+                }}
+                onSecondaryClick={() => {
+                  setStatusFilter('All');
+                  setCategoryFilter('All');
+                  setQuery('');
+                  setPendingQuery('');
+                  setPendingStatusFilter('All');
+                  setPendingCategoryFilter('All');
+                  focusElement('#search-description');
+                }}
+                leftButtonText="Apply"
+                rightButtonText="Clear"
+              />
+            </div>
+          </div>
+
+          {inquiries.business?.length ? (
+            <div className="tabs">
+              <Tabs className="inbox-tab-container">
+                <TabList className="inbox-tab-list">
+                  <Tab className="inbox-tab">Business</Tab>
+                  <Tab className="inbox-tab">Personal</Tab>
+                </TabList>
+                <TabPanel>
+                  <InquiriesList
+                    inquiries={filterAndSort({
+                      inquiriesArray: inquiries.business,
+                      categoryFilter,
+                      statusFilter,
+                      query,
+                    })}
+                    tabName="Business"
+                    {...{ categoryFilter, statusFilter, query }}
+                  />
+                </TabPanel>
+                <TabPanel>
+                  <InquiriesList
+                    inquiries={filterAndSort({
+                      inquiriesArray: inquiries.personal,
+                      categoryFilter,
+                      statusFilter,
+                      query,
+                    })}
+                    tabName="Personal"
+                    {...{ categoryFilter, statusFilter, query }}
+                  />
+                </TabPanel>
+              </Tabs>
+            </div>
+          ) : (
+            <>
+              <InquiriesList
+                inquiries={filterAndSort({
+                  inquiriesArray: inquiries.personal,
+                  categoryFilter,
+                  statusFilter,
+                  query,
+                })}
+                {...{ categoryFilter, statusFilter, query }}
+              />
+            </>
+          )}
+        </>
+      ) : (
+        <div className="vads-u-margin-bottom--5">
+          <va-alert
+            disable-analytics="false"
+            full-width="false"
+            status="info"
+            visible="true"
+            slim
+          >
+            <p className="vads-u-margin-y--0">
+              You haven’t submitted a question yet.
+            </p>
+          </va-alert>
+        </div>
+      )}
+    </div>
+  );
+}
+InboxLayout.propTypes = {
+  categories: PropTypes.arrayOf(PropTypes.string).isRequired,
+  inquiries: PropTypes.shape({
+    business: InquiriesList.propTypes.inquiries.isRequired,
+    personal: InquiriesList.propTypes.inquiries.isRequired,
+  }),
+};

--- a/src/applications/ask-va/components/inbox/InboxLayout.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayout.jsx
@@ -16,14 +16,14 @@ import { filterAndSort } from '../../utils/inbox';
 
 /**
  * @typedef {Object} Props
- * @property {string[]} categories
+ * @property {string[]} categoryOptions
  * @property {{ business: Inquiry[], personal: Inquiry[] }} inquiries
  */
 
 /**
  * @param {Props} props
  */
-export default function InboxLayout({ inquiries, categories }) {
+export default function InboxLayout({ inquiries, categoryOptions }) {
   const [statusFilter, setStatusFilter] = useState('All');
   const [categoryFilter, setCategoryFilter] = useState('All');
   const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
@@ -88,7 +88,7 @@ export default function InboxLayout({ inquiries, categories }) {
                 }}
               >
                 <option value="All">All</option>
-                {categories.map(category => (
+                {categoryOptions.map(category => (
                   <option key={category} value={category}>
                     {category}
                   </option>
@@ -189,8 +189,9 @@ export default function InboxLayout({ inquiries, categories }) {
     </div>
   );
 }
+
 InboxLayout.propTypes = {
-  categories: PropTypes.arrayOf(PropTypes.string).isRequired,
+  categoryOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
   inquiries: PropTypes.shape({
     business: InquiriesList.propTypes.inquiries.isRequired,
     personal: InquiriesList.propTypes.inquiries.isRequired,

--- a/src/applications/ask-va/components/inbox/InboxLayout.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayout.jsx
@@ -4,7 +4,7 @@ import {
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import PropTypes from 'prop-types';
 import InquiriesList from './InquiriesList';
@@ -24,20 +24,14 @@ import { filterAndSort } from '../../utils/inbox';
  * @param {Props} props
  */
 export default function InboxLayout({ inquiries, categoryOptions }) {
-  const [statusFilter, setStatusFilter] = useState('All');
-  const [categoryFilter, setCategoryFilter] = useState('All');
-  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
   const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
-  const [query, setQuery] = useState('');
+  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
   const [pendingQuery, setPendingQuery] = useState('');
-
-  useEffect(
-    () => {
-      setPendingStatusFilter(statusFilter);
-      setPendingCategoryFilter(categoryFilter);
-    },
-    [statusFilter, categoryFilter],
-  );
+  const [filters, setFilters] = useState({
+    status: 'All',
+    category: 'All',
+    query: '',
+  });
 
   return (
     <div id="inbox">
@@ -53,7 +47,7 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
                 label="Search"
                 inputMode="search"
                 onVaInput={e => {
-                  setPendingQuery(e.target.value);
+                  setPendingQuery(e.target.value || '');
                 }}
               />
             </div>
@@ -64,9 +58,7 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
                 name="status"
                 value={pendingStatusFilter}
                 onVaSelect={event => {
-                  setPendingStatusFilter(
-                    event.target.value ? event.target.value : 'All',
-                  );
+                  setPendingStatusFilter(event.target.value || 'All');
                 }}
               >
                 <option value="All">All</option>
@@ -82,9 +74,7 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
                 name="category"
                 value={pendingCategoryFilter}
                 onVaSelect={event => {
-                  setPendingCategoryFilter(
-                    event.target.value ? event.target.value : 'All',
-                  );
+                  setPendingCategoryFilter(event.target.value || 'All');
                 }}
               >
                 <option value="All">All</option>
@@ -104,18 +94,22 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
                 primaryLabel="Apply filters"
                 secondaryLabel="Clear all filters"
                 onPrimaryClick={() => {
-                  setStatusFilter(pendingStatusFilter);
-                  setCategoryFilter(pendingCategoryFilter);
-                  setQuery(pendingQuery);
+                  setFilters(() => ({
+                    category: pendingCategoryFilter,
+                    status: pendingStatusFilter,
+                    query: pendingQuery,
+                  }));
                   focusElement('#search-description');
                 }}
                 onSecondaryClick={() => {
-                  setStatusFilter('All');
-                  setCategoryFilter('All');
-                  setQuery('');
-                  setPendingQuery('');
+                  setFilters(() => ({
+                    status: 'All',
+                    category: 'All',
+                    query: '',
+                  }));
                   setPendingStatusFilter('All');
                   setPendingCategoryFilter('All');
+                  setPendingQuery('');
                   focusElement('#search-description');
                 }}
                 leftButtonText="Apply"
@@ -135,24 +129,24 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
                   <InquiriesList
                     inquiries={filterAndSort({
                       inquiriesArray: inquiries.business,
-                      categoryFilter,
-                      statusFilter,
-                      query,
+                      filters,
                     })}
                     tabName="Business"
-                    {...{ categoryFilter, statusFilter, query }}
+                    categoryFilter={filters.category}
+                    statusFilter={filters.status}
+                    query={filters.query}
                   />
                 </TabPanel>
                 <TabPanel>
                   <InquiriesList
                     inquiries={filterAndSort({
                       inquiriesArray: inquiries.personal,
-                      categoryFilter,
-                      statusFilter,
-                      query,
+                      filters,
                     })}
                     tabName="Personal"
-                    {...{ categoryFilter, statusFilter, query }}
+                    categoryFilter={filters.category}
+                    statusFilter={filters.status}
+                    query={filters.query}
                   />
                 </TabPanel>
               </Tabs>
@@ -162,11 +156,11 @@ export default function InboxLayout({ inquiries, categoryOptions }) {
               <InquiriesList
                 inquiries={filterAndSort({
                   inquiriesArray: inquiries.personal,
-                  categoryFilter,
-                  statusFilter,
-                  query,
+                  filters,
                 })}
-                {...{ categoryFilter, statusFilter, query }}
+                categoryFilter={filters.category}
+                statusFilter={filters.status}
+                query={filters.query}
               />
             </>
           )}

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -49,9 +49,6 @@ export const URL = {
   GET_HEALTH_FACILITY: `${baseURL}/health_facilities`,
   GET_SCHOOL: `${baseURL}/education_facilities/`,
   SEND_REPLY: `/reply/new`,
-  GET_INQUIRIES: `${baseURL}/inquiries`,
-  INQUIRIES: `${baseURL}/inquiries`,
-  AUTH_INQUIRIES: `${baseURL}/inquiries/auth`,
   DOWNLOAD_ATTACHMENT: `${baseURL}/download_attachment?id=`,
 };
 

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -1,7 +1,7 @@
 // import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
-export const envUrl = environment.API_URL;
+export const envApiUrl = environment.API_URL;
 
 export const baseURL = '/ask_va_api/v0';
 
@@ -18,7 +18,7 @@ export const baseURL = '/ask_va_api/v0';
 // const isMockApiEnabled = useToggleValue(toggleName);
 // const isLoadingFeatureFlags = useToggleLoadingValue(toggleName);
 
-// const isLocalhost = envUrl === 'http://localhost:3000';
+// const isLocalhost = envApiUrl === 'http://localhost:3000';
 // const isToggleEnabled = !isLoadingFeatureFlags && isMockApiEnabled;
 // const isProduction = environment.isProduction();
 
@@ -26,7 +26,8 @@ export const baseURL = '/ask_va_api/v0';
 //   (isToggleEnabled || isLocalhost) && !isProduction;
 
 export const mockTestingFlagForAPI =
-  envUrl === 'http://localhost:3000' || envUrl === 'http://127.0.0.1:3000'; // enable this flag when testing locally for API calls
+  envApiUrl === 'http://localhost:3000' ||
+  envApiUrl === 'http://127.0.0.1:3000'; // enable this flag when testing locally for API calls
 
 // Overridable for testing
 export const getMockTestingFlagForAPI = () => mockTestingFlagForAPI;
@@ -67,7 +68,7 @@ export const getApiUrl = (url, params) => {
       apiUrl = apiUrl.replace(`%${key}%`, params[key]);
     });
   }
-  return envUrl + apiUrl;
+  return envApiUrl + apiUrl;
 };
 
 export const branchesOfService = [

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -22,28 +22,28 @@ export const baseURL = '/ask_va_api/v0';
 // const isToggleEnabled = !isLoadingFeatureFlags && isMockApiEnabled;
 // const isProduction = environment.isProduction();
 
-// export const mockTestingFlagforAPI =
+// export const mockTestingFlagForAPI =
 //   (isToggleEnabled || isLocalhost) && !isProduction;
 
-export const mockTestingFlagforAPI =
+export const mockTestingFlagForAPI =
   envUrl === 'http://localhost:3000' || envUrl === 'http://127.0.0.1:3000'; // enable this flag when testing locally for API calls
 
 // Overridable for testing
-export const getMockTestingFlagforAPI = () => mockTestingFlagforAPI;
+export const getMockTestingFlagForAPI = () => mockTestingFlagForAPI;
 
 export const URL = {
   GET_CATEGORIES: `${baseURL}/contents?type=category${
-    mockTestingFlagforAPI ? '&user_mock_data=true' : ''
+    mockTestingFlagForAPI ? '&user_mock_data=true' : ''
   }`,
   GET_TOPICS: `${baseURL}/contents?type=topic&parent_id=%PARENT_ID%${
-    mockTestingFlagforAPI ? '&user_mock_data=true' : ''
+    mockTestingFlagForAPI ? '&user_mock_data=true' : ''
   }`,
   GET_SUBTOPICS: `${baseURL}/contents?type=subtopic&parent_id=%PARENT_ID%${
-    mockTestingFlagforAPI ? '&user_mock_data=true' : ''
+    mockTestingFlagForAPI ? '&user_mock_data=true' : ''
   }`,
   ADDRESS_VALIDATION: `${baseURL}/address_validation`,
   ANNOUNCEMENTS: `${baseURL}/announcements${
-    mockTestingFlagforAPI ? '?user_mock_data=true' : ''
+    mockTestingFlagForAPI ? '?user_mock_data=true' : ''
   }`,
   GET_HEALTH_FACILITY: `${baseURL}/health_facilities`,
   GET_SCHOOL: `${baseURL}/education_facilities/`,

--- a/src/applications/ask-va/containers/Inbox.jsx
+++ b/src/applications/ask-va/containers/Inbox.jsx
@@ -2,7 +2,7 @@ import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/a
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ServerErrorAlert } from '../config/helpers';
-import { URL, envUrl, mockTestingFlagforAPI } from '../constants';
+import { URL, envUrl, mockTestingFlagForAPI } from '../constants';
 import { mockInquiries } from '../utils/mockData';
 import { categorizeByLOA } from '../utils/inbox';
 import InboxLayout from '../components/inbox/InboxLayout';
@@ -25,7 +25,7 @@ export default function Inbox() {
   const getApiData = useCallback(url => {
     setLoading(true);
 
-    if (mockTestingFlagforAPI && !window.Cypress) {
+    if (mockTestingFlagForAPI && !window.Cypress) {
       saveInState(mockInquiries.data);
       return Promise.resolve();
     }

--- a/src/applications/ask-va/containers/Inbox.jsx
+++ b/src/applications/ask-va/containers/Inbox.jsx
@@ -1,7 +1,7 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import React, { useEffect, useState } from 'react';
 import { ServerErrorAlert } from '../config/helpers';
-import { URL, envUrl, mockTestingFlagForAPI } from '../constants';
+import { URL, envApiUrl, mockTestingFlagForAPI } from '../constants';
 import { mockInquiries } from '../utils/mockData';
 import { categorizeByLOA } from '../utils/inbox';
 import InboxLayout from '../components/inbox/InboxLayout';
@@ -28,7 +28,7 @@ export default function Inbox() {
       if (mockTestingFlagForAPI && !window.Cypress) {
         saveInState(mockInquiries.data);
       } else {
-        apiRequest(`${envUrl}${URL.GET_INQUIRIES}`)
+        apiRequest(`${envApiUrl}${URL.GET_INQUIRIES}`)
           .then(res => saveInState(res.data))
           .catch(() => {
             setIsLoading(false);

--- a/src/applications/ask-va/containers/Inbox.jsx
+++ b/src/applications/ask-va/containers/Inbox.jsx
@@ -1,10 +1,10 @@
-import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import React, { useEffect, useState } from 'react';
 import { ServerErrorAlert } from '../config/helpers';
-import { URL, envApiUrl, mockTestingFlagForAPI } from '../constants';
+import { mockTestingFlagForAPI } from '../constants';
 import { mockInquiries } from '../utils/mockData';
 import { categorizeByLOA } from '../utils/inbox';
 import InboxLayout from '../components/inbox/InboxLayout';
+import { getAllInquiries } from '../utils/api';
 
 export default function Inbox() {
   const [hasError, setHasError] = useState(false);
@@ -28,7 +28,7 @@ export default function Inbox() {
       if (mockTestingFlagForAPI && !window.Cypress) {
         saveInState(mockInquiries.data);
       } else {
-        apiRequest(`${envApiUrl}${URL.GET_INQUIRIES}`)
+        getAllInquiries()
           .then(res => saveInState(res.data))
           .catch(() => {
             setIsLoading(false);

--- a/src/applications/ask-va/containers/Inbox.jsx
+++ b/src/applications/ask-va/containers/Inbox.jsx
@@ -1,29 +1,17 @@
-import {
-  VaButtonPair,
-  VaSelect,
-  VaTextInput,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import { ServerErrorAlert } from '../config/helpers';
 import { URL, envUrl, mockTestingFlagforAPI } from '../constants';
 import { mockInquiries } from '../utils/mockData';
-import { categorizeByLOA, filterAndSort } from '../utils/inbox';
-import InquiriesList from '../components/inbox/InquiriesList';
+import { categorizeByLOA } from '../utils/inbox';
+import InboxLayout from '../components/inbox/InboxLayout';
 
 export default function Inbox() {
   const [error, hasError] = useState(false);
   const [inquiries, setInquiries] = useState({ business: [], personal: [] });
   const [categories, setCategories] = useState([]);
-  const [statusFilter, setStatusFilter] = useState('All');
-  const [categoryFilter, setCategoryFilter] = useState('All');
-  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
-  const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
   const [loading, setLoading] = useState(true);
-  const [query, setQuery] = useState('');
-  const [pendingQuery, setPendingQuery] = useState('');
 
   const saveInState = rawInquiries => {
     const { business, personal, uniqueCategories } = categorizeByLOA(
@@ -65,14 +53,6 @@ export default function Inbox() {
     [getApiData],
   );
 
-  useEffect(
-    () => {
-      setPendingStatusFilter(statusFilter);
-      setPendingCategoryFilter(categoryFilter);
-    },
-    [statusFilter, categoryFilter],
-  );
-
   if (error) {
     return (
       <va-alert status="info" className="vads-u-margin-y--4">
@@ -90,153 +70,5 @@ export default function Inbox() {
     );
   }
 
-  return (
-    <div id="inbox">
-      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
-        Your questions
-      </h2>
-      {inquiries.personal.length || inquiries.business.length ? (
-        <>
-          <div className="filter-container">
-            <div className="search-container">
-              <VaTextInput
-                value={pendingQuery}
-                label="Search"
-                inputMode="search"
-                onVaInput={e => {
-                  setPendingQuery(e.target.value);
-                }}
-              />
-            </div>
-            <div>
-              <VaSelect
-                hint={null}
-                label="Filter by status"
-                name="status"
-                value={pendingStatusFilter}
-                onVaSelect={event => {
-                  setPendingStatusFilter(
-                    event.target.value ? event.target.value : 'All',
-                  );
-                }}
-              >
-                <option value="All">All</option>
-                <option value="In progress">In progress</option>
-                <option value="Replied">Replied</option>
-                <option value="Reopened">Reopened</option>
-              </VaSelect>
-            </div>
-            <div className="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--0">
-              <VaSelect
-                hint={null}
-                label="Filter by category"
-                name="category"
-                value={pendingCategoryFilter}
-                onVaSelect={event => {
-                  setPendingCategoryFilter(
-                    event.target.value ? event.target.value : 'All',
-                  );
-                }}
-              >
-                <option value="All">All</option>
-                {categories.map(category => (
-                  <option key={category} value={category}>
-                    {category}
-                  </option>
-                ))}
-              </VaSelect>
-            </div>
-
-            <div
-              // Keeps button pair aligned in parent correctly on mobile & desktop
-              className="vads-u-margin-bottom--neg0p5 medium-screen:vads-u-padding-right--0p5 vads-u-margin-x--neg0p5 medium-screen:vads-u-margin-x--0"
-            >
-              <VaButtonPair
-                primaryLabel="Apply filters"
-                secondaryLabel="Clear all filters"
-                onPrimaryClick={() => {
-                  setStatusFilter(pendingStatusFilter);
-                  setCategoryFilter(pendingCategoryFilter);
-                  setQuery(pendingQuery);
-                  focusElement('#search-description');
-                }}
-                onSecondaryClick={() => {
-                  setStatusFilter('All');
-                  setCategoryFilter('All');
-                  setQuery('');
-                  setPendingQuery('');
-                  setPendingStatusFilter('All');
-                  setPendingCategoryFilter('All');
-                  focusElement('#search-description');
-                }}
-                leftButtonText="Apply"
-                rightButtonText="Clear"
-              />
-            </div>
-          </div>
-
-          {inquiries.business?.length ? (
-            <div className="tabs">
-              <Tabs className="inbox-tab-container">
-                <TabList className="inbox-tab-list">
-                  <Tab className="inbox-tab">Business</Tab>
-                  <Tab className="inbox-tab">Personal</Tab>
-                </TabList>
-                <TabPanel>
-                  <InquiriesList
-                    inquiries={filterAndSort({
-                      inquiriesArray: inquiries.business,
-                      categoryFilter,
-                      statusFilter,
-                      query,
-                    })}
-                    tabName="Business"
-                    {...{ categoryFilter, statusFilter, query }}
-                  />
-                </TabPanel>
-                <TabPanel>
-                  <InquiriesList
-                    inquiries={filterAndSort({
-                      inquiriesArray: inquiries.personal,
-                      categoryFilter,
-                      statusFilter,
-                      query,
-                    })}
-                    tabName="Personal"
-                    {...{ categoryFilter, statusFilter, query }}
-                  />
-                </TabPanel>
-              </Tabs>
-            </div>
-          ) : (
-            <>
-              <InquiriesList
-                inquiries={filterAndSort({
-                  inquiriesArray: inquiries.personal,
-                  categoryFilter,
-                  statusFilter,
-                  query,
-                })}
-                {...{ categoryFilter, statusFilter, query }}
-              />
-            </>
-          )}
-        </>
-      ) : (
-        <div className="vads-u-margin-bottom--5">
-          <va-alert
-            disable-analytics="false"
-            full-width="false"
-            status="info"
-            visible="true"
-            slim
-          >
-            <p className="vads-u-margin-y--0">
-              You haven’t submitted a question yet.
-            </p>
-          </va-alert>
-        </div>
-      )}
-    </div>
-  );
+  return <InboxLayout {...{ inquiries, categories }} />;
 }

--- a/src/applications/ask-va/containers/IntroductionPage.jsx
+++ b/src/applications/ask-va/containers/IntroductionPage.jsx
@@ -30,7 +30,7 @@ import {
   getVAStatusFromCRM,
   getVAStatusIconAndMessage,
 } from '../config/helpers';
-import { envUrl, mockTestingFlagForAPI } from '../constants';
+import { envApiUrl, mockTestingFlagForAPI } from '../constants';
 import { mockInquiryStatusResponse } from '../utils/mockData';
 import Inbox from './Inbox';
 
@@ -122,7 +122,7 @@ const IntroductionPage = props => {
   };
 
   const handleSearchByReferenceNumber = async () => {
-    const url = `${envUrl}/ask_va_api/v0/inquiries/${searchReferenceNumber}/status`;
+    const url = `${envApiUrl}/ask_va_api/v0/inquiries/${searchReferenceNumber}/status`;
     await getApiData(url);
     const headingElement = document.querySelector(
       '[data-testid="status-message"] h3, [data-testid="error-message"] p:first-child',

--- a/src/applications/ask-va/containers/IntroductionPage.jsx
+++ b/src/applications/ask-va/containers/IntroductionPage.jsx
@@ -30,7 +30,7 @@ import {
   getVAStatusFromCRM,
   getVAStatusIconAndMessage,
 } from '../config/helpers';
-import { envUrl, mockTestingFlagforAPI } from '../constants';
+import { envUrl, mockTestingFlagForAPI } from '../constants';
 import { mockInquiryStatusResponse } from '../utils/mockData';
 import Inbox from './Inbox';
 
@@ -107,7 +107,7 @@ const IntroductionPage = props => {
     // Mocking the API response for testing when searching for reference number
     // A-20250106-308944
     if (
-      mockTestingFlagforAPI &&
+      mockTestingFlagForAPI &&
       searchReferenceNumber === 'A-20250106-308944'
     ) {
       setInquiryData(mockInquiryStatusResponse.data);

--- a/src/applications/ask-va/containers/ResponseInboxPage.jsx
+++ b/src/applications/ask-va/containers/ResponseInboxPage.jsx
@@ -25,7 +25,7 @@ import {
   getVAStatusFromCRM,
 } from '../config/helpers';
 import {
-  envUrl,
+  envApiUrl,
   getMockTestingFlagForAPI,
   RESPONSE_PAGE,
   URL,
@@ -107,7 +107,7 @@ const ResponseInboxPage = ({ router }) => {
     event.preventDefault();
     if (sendReply.reply) {
       postApiData(
-        `${envUrl}${URL.GET_INQUIRIES}/${inquiryId}${URL.SEND_REPLY}`,
+        `${envApiUrl}${URL.GET_INQUIRIES}/${inquiryId}${URL.SEND_REPLY}`,
       );
     } else {
       setReplyTextError('Enter your message');
@@ -196,7 +196,8 @@ const ResponseInboxPage = ({ router }) => {
 
   useEffect(
     () => {
-      if (inquiryId) getApiData(`${envUrl}${URL.GET_INQUIRIES}/${inquiryId}`);
+      if (inquiryId)
+        getApiData(`${envApiUrl}${URL.GET_INQUIRIES}/${inquiryId}`);
     },
     [inquiryId, getApiData],
   );
@@ -433,7 +434,7 @@ const ResponseInboxPage = ({ router }) => {
                                 text={file.name}
                                 onClick={() =>
                                   getDownloadData(
-                                    `${envUrl}${URL.DOWNLOAD_ATTACHMENT}${
+                                    `${envApiUrl}${URL.DOWNLOAD_ATTACHMENT}${
                                       file.id
                                     }`,
                                   )

--- a/src/applications/ask-va/containers/ResponseInboxPage.jsx
+++ b/src/applications/ask-va/containers/ResponseInboxPage.jsx
@@ -26,7 +26,7 @@ import {
 } from '../config/helpers';
 import {
   envUrl,
-  getMockTestingFlagforAPI,
+  getMockTestingFlagForAPI,
   RESPONSE_PAGE,
   URL,
 } from '../constants';
@@ -72,7 +72,7 @@ const ResponseInboxPage = ({ router }) => {
 
       setLoading(true);
 
-      if (getMockTestingFlagforAPI()) {
+      if (getMockTestingFlagForAPI()) {
         // Simulate API delay
         return new Promise(resolve => {
           setTimeout(() => {
@@ -118,7 +118,7 @@ const ResponseInboxPage = ({ router }) => {
     setLoading(true);
     setError(false);
 
-    if (getMockTestingFlagforAPI() && !window.Cypress) {
+    if (getMockTestingFlagForAPI() && !window.Cypress) {
       // Simulate API delay
       return new Promise(resolve => {
         setTimeout(() => {
@@ -168,7 +168,7 @@ const ResponseInboxPage = ({ router }) => {
   const getDownloadData = url => {
     setError(false);
 
-    if (getMockTestingFlagforAPI()) {
+    if (getMockTestingFlagForAPI()) {
       // Simulate API delay
       return new Promise(resolve => {
         setTimeout(() => {

--- a/src/applications/ask-va/containers/YourVAHealthFacility.jsx
+++ b/src/applications/ask-va/containers/YourVAHealthFacility.jsx
@@ -7,7 +7,7 @@ import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavBut
 import SearchControls from '../components/search/SearchControls';
 import SearchItem from '../components/search/SearchItem';
 import { getHealthFacilityTitle } from '../config/helpers';
-import { CHAPTER_3, URL, envUrl, getMockTestingFlagforAPI } from '../constants';
+import { CHAPTER_3, URL, envUrl, getMockTestingFlagForAPI } from '../constants';
 import { convertToLatLng } from '../utils/mapbox';
 import { mockHealthFacilityResponse } from '../utils/mockData';
 
@@ -42,7 +42,7 @@ const YourVAHealthFacilityPage = props => {
   const getApiData = url => {
     setIsSearching(true);
 
-    if (getMockTestingFlagforAPI()) {
+    if (getMockTestingFlagForAPI()) {
       // Simulate API delay
       return new Promise(resolve => {
         setTimeout(() => {

--- a/src/applications/ask-va/containers/YourVAHealthFacility.jsx
+++ b/src/applications/ask-va/containers/YourVAHealthFacility.jsx
@@ -7,7 +7,12 @@ import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavBut
 import SearchControls from '../components/search/SearchControls';
 import SearchItem from '../components/search/SearchItem';
 import { getHealthFacilityTitle } from '../config/helpers';
-import { CHAPTER_3, URL, envUrl, getMockTestingFlagForAPI } from '../constants';
+import {
+  CHAPTER_3,
+  URL,
+  envApiUrl,
+  getMockTestingFlagForAPI,
+} from '../constants';
 import { convertToLatLng } from '../utils/mapbox';
 import { mockHealthFacilityResponse } from '../utils/mockData';
 
@@ -64,7 +69,7 @@ const YourVAHealthFacilityPage = props => {
   };
 
   const getFacilitiesFromLocation = async input => {
-    const url = `${envUrl}${URL.GET_HEALTH_FACILITY}?type=health&lat=${
+    const url = `${envApiUrl}${URL.GET_HEALTH_FACILITY}?type=health&lat=${
       input[1]
     }&long=${input[0]}&radius=50`;
     await getApiData(url);
@@ -80,9 +85,9 @@ const YourVAHealthFacilityPage = props => {
       setPageURL('/error');
       setApiData(facilities);
     } else {
-      const url = `${envUrl}${URL.GET_HEALTH_FACILITY}?lat=${latLong[1]}&long=${
-        latLong[0]
-      }&radius=50&type=health`;
+      const url = `${envApiUrl}${URL.GET_HEALTH_FACILITY}?lat=${
+        latLong[1]
+      }&long=${latLong[0]}&radius=50&type=health`;
       await getApiData(url);
       setPageURL(url);
     }

--- a/src/applications/ask-va/tests/components/Announcements.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/Announcements.unit.spec.jsx
@@ -53,7 +53,7 @@ describe('<Announcements />', () => {
       .resolves(mockAnnouncementsResponse);
 
     // Mock the constants
-    constantsStub = sinon.stub(constants, 'mockTestingFlagforAPI');
+    constantsStub = sinon.stub(constants, 'mockTestingFlagForAPI');
   });
 
   afterEach(() => {
@@ -373,7 +373,7 @@ describe('<Announcements />', () => {
     await findByText('Ending Now Announcement');
   });
 
-  it('should use mock data when mockTestingFlagforAPI is true', async () => {
+  it('should use mock data when mockTestingFlagForAPI is true', async () => {
     constantsStub.get(() => true);
 
     const store = generateStore();
@@ -388,7 +388,7 @@ describe('<Announcements />', () => {
     expect(announcements).to.have.length.greaterThan(0);
   });
 
-  it('should make API call when mockTestingFlagforAPI is false', async () => {
+  it('should make API call when mockTestingFlagForAPI is false', async () => {
     constantsStub.get(() => false);
 
     const store = generateStore();

--- a/src/applications/ask-va/tests/components/Announcements.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/Announcements.unit.spec.jsx
@@ -403,7 +403,7 @@ describe('<Announcements />', () => {
     expect(elements.length).to.be.greaterThan(0);
     expect(apiRequestStub.called).to.be.true;
     expect(apiRequestStub.firstCall.args[0]).to.equal(
-      `${constants.envUrl}${constants.URL.ANNOUNCEMENTS}`,
+      `${constants.envApiUrl}${constants.URL.ANNOUNCEMENTS}`,
     );
   });
 });

--- a/src/applications/ask-va/tests/components/inbox/InboxLayout.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayout.unit.spec.jsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import InboxLayout from '~/applications/ask-va/components/inbox/InboxLayout';
+import { categorizeByLOA } from '~/applications/ask-va/utils/inbox';
+import { expect } from 'chai';
+import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
+
+describe('<InboxLayout />', () => {
+  const mockInquiries = categorizeByLOA(rawInquiries);
+  const selectedStatus = 'In progress';
+
+  it('displays a message when there are no inquiries', () => {
+    const view = render(
+      <InboxLayout
+        categoryOptions={mockInquiries.uniqueCategories}
+        inquiries={{ personal: [], business: [] }}
+      />,
+    );
+
+    const emptyInboxAlert = view.getByText(
+      "You haven't submitted a question yet.",
+    );
+    const inquiryResult = view.queryByTestId('inquiry-card');
+    expect(emptyInboxAlert).to.exist;
+    expect(inquiryResult).to.not.exist;
+  });
+
+  it('renders a list of inquiries', () => {
+    const view = render(
+      <InboxLayout
+        categoryOptions={mockInquiries.uniqueCategories}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    const inquiryResults = view.getAllByTestId('inquiry-card');
+    expect(inquiryResults.length).to.be.greaterThanOrEqual(1);
+  });
+
+  it('applies and clears a filter', () => {
+    const view = render(
+      <InboxLayout
+        categoryOptions={mockInquiries.uniqueCategories}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    // Confirm filter's starting value and list's variety
+    const statusSelect = view.container.querySelector(
+      'va-select[name="status"]',
+    );
+    expect(statusSelect.getAttribute('value')).to.equal('All');
+
+    const startingResults = view.getAllByTestId('inquiry-card');
+    expect(
+      startingResults.every(a =>
+        a.textContent.includes(`Status ${selectedStatus}`),
+      ),
+    ).to.be.false;
+
+    // Set status filter to "In progress" and apply filters
+    statusSelect.__events.vaSelect({
+      target: { value: selectedStatus },
+    });
+    expect(statusSelect.getAttribute('value')).to.equal(selectedStatus);
+
+    const buttonPair = view.container.querySelector('va-button-pair');
+    buttonPair.__events.primaryClick();
+
+    // Confirm only selected status is present
+    const filteredResults = view.getAllByTestId('inquiry-card');
+    expect(
+      filteredResults.every(a =>
+        a.textContent.includes(`Status ${selectedStatus}`),
+      ),
+    ).to.be.true;
+
+    // Reset filters & list, confirm it matches starting state
+    buttonPair.__events.secondaryClick();
+    const endingResults = view.getAllByTestId('inquiry-card');
+    const endTextContent = endingResults.map(end => end.textContent);
+    const startTextContent = startingResults.map(start => start.textContent);
+    const filteredTextContent = filteredResults.map(
+      filtered => filtered.textContent,
+    );
+
+    expect(statusSelect.getAttribute('value')).to.equal('All');
+
+    expect(endTextContent)
+      .to.eql(startTextContent)
+      .but.not.eql(filteredTextContent);
+  });
+
+  it('shifts focus to search description after a button is clicked', () => {
+    const view = render(
+      <InboxLayout
+        categoryOptions={mockInquiries.uniqueCategories}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    // Apply filters
+    const statusSelect = view.container.querySelector(
+      'va-select[name="status"]',
+    );
+    statusSelect.__events.vaSelect({
+      target: { value: selectedStatus },
+    });
+    const buttonPair = view.container.querySelector('va-button-pair');
+    buttonPair.__events.primaryClick();
+
+    const focusedElement = view.container.ownerDocument.activeElement;
+    const searchDescription = view.getByText(/showing/i);
+
+    expect(focusedElement).to.equal(searchDescription.parentElement);
+  });
+
+  it('searches results based on a query', () => {
+    // Add an inquiry with a reference number guaranteed to be different
+    const inquiriesCopy = [...mockInquiries.personal];
+    const newItem = {
+      ...inquiriesCopy[inquiriesCopy.length - 1],
+      inquiryNumber: 'A-3',
+    };
+    inquiriesCopy.push(newItem);
+
+    const view = render(
+      <InboxLayout
+        categoryOptions={mockInquiries.uniqueCategories}
+        inquiries={{ personal: inquiriesCopy, business: [] }}
+      />,
+    );
+
+    // Confirm starting state
+    const startingResults = view.getAllByTestId('inquiry-card');
+    expect(startingResults.length).to.equal(4);
+    expect(startingResults[0].textContent).to.include('Reference number: A-2');
+
+    const searchBox = view.container.querySelector('va-text-input');
+    expect(searchBox.value).to.equal('');
+
+    // Input a search query and apply
+    searchBox.__events.vaInput({ target: { value: 'A-3' } });
+    expect(searchBox.value).to.equal('A-3');
+    const buttonPair = view.container.querySelector('va-button-pair');
+    buttonPair.__events.primaryClick();
+
+    // Confirm the list is now just one desired result
+    const endingResults = view.getAllByTestId('inquiry-card');
+    expect(endingResults.length).to.equal(1);
+    expect(endingResults[0].textContent).to.include('Reference number: A-3');
+  });
+
+  describe('business and personal tabs', () => {
+    it('hides tabs when there are no business inquiries', () => {
+      const view = render(
+        <InboxLayout
+          categoryOptions={mockInquiries.uniqueCategories}
+          inquiries={{ personal: mockInquiries.personal, business: [] }}
+        />,
+      );
+
+      expect(view.queryByRole('tab')).to.not.exist;
+    });
+
+    it('shows tabs when there are business inquiries', () => {
+      const view = render(
+        <InboxLayout
+          categoryOptions={mockInquiries.uniqueCategories}
+          inquiries={mockInquiries}
+        />,
+      );
+
+      const tabButtons = view.getByRole('tablist');
+      const businessTab = view.getByRole('tab', {
+        name: /business/i,
+      });
+      const personalTab = view.getByRole('tab', {
+        name: /personal/i,
+      });
+
+      expect(tabButtons.childNodes.length).to.equal(2);
+      expect(businessTab).to.exist;
+      expect(personalTab).to.exist;
+    });
+
+    it('switches list content based on the selected tab', () => {
+      const view = render(
+        <InboxLayout
+          categoryOptions={mockInquiries.uniqueCategories}
+          inquiries={mockInquiries}
+        />,
+      );
+
+      // Confirm starting state
+      const businessTab = view.getByRole('tab', {
+        name: /business/i,
+      });
+      const personalTab = view.getByRole('tab', {
+        name: /personal/i,
+      });
+
+      const businessResults = view.getAllByTestId('inquiry-card');
+      expect(businessTab.getAttribute('aria-selected')).to.equal('true');
+      expect(personalTab.getAttribute('aria-selected')).to.equal('false');
+      expect(businessResults[0].textContent).to.include('Category: Education');
+
+      fireEvent.click(personalTab);
+
+      // Confirm content switched with tabs
+      const personalResults = view.getAllByTestId('inquiry-card');
+      expect(businessTab.getAttribute('aria-selected')).to.equal('false');
+      expect(personalTab.getAttribute('aria-selected')).to.equal('true');
+      expect(personalResults[0].textContent).to.not.include(
+        'Category: Education',
+      );
+    });
+  });
+});

--- a/src/applications/ask-va/tests/components/inbox/InboxLayout.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayout.unit.spec.jsx
@@ -18,7 +18,7 @@ describe('<InboxLayout />', () => {
     );
 
     const emptyInboxAlert = view.getByText(
-      "You haven't submitted a question yet.",
+      'You haven’t submitted a question yet.',
     );
     const inquiryResult = view.queryByTestId('inquiry-card');
     expect(emptyInboxAlert).to.exist;

--- a/src/applications/ask-va/tests/constants.unit.spec.jsx
+++ b/src/applications/ask-va/tests/constants.unit.spec.jsx
@@ -18,22 +18,22 @@ describe('Constants', () => {
     sandbox.restore();
   });
 
-  describe('mockTestingFlagforAPI', () => {
+  describe('mockTestingFlagForAPI', () => {
     it('should be true when API_URL is localhost:3000', () => {
       envStub.value({ API_URL: 'http://localhost:3000' });
       constants = require('../constants');
-      expect(constants.mockTestingFlagforAPI).to.be.true;
+      expect(constants.mockTestingFlagForAPI).to.be.true;
     });
 
     it('should be false when API_URL is not localhost:3000', () => {
       envStub.value({ API_URL: 'https://dev-api.va.gov' });
       constants = require('../constants');
-      expect(constants.mockTestingFlagforAPI).to.be.false;
+      expect(constants.mockTestingFlagForAPI).to.be.false;
     });
   });
 
   describe('URL constants', () => {
-    it('should include mock data parameter when mockTestingFlagforAPI is true', () => {
+    it('should include mock data parameter when mockTestingFlagForAPI is true', () => {
       envStub.value({ API_URL: 'http://localhost:3000' });
       constants = require('../constants');
       expect(constants.URL.GET_CATEGORIES).to.include('user_mock_data=true');
@@ -41,7 +41,7 @@ describe('Constants', () => {
       expect(constants.URL.GET_SUBTOPICS).to.include('user_mock_data=true');
     });
 
-    it('should not include mock data parameter when mockTestingFlagforAPI is false', () => {
+    it('should not include mock data parameter when mockTestingFlagForAPI is false', () => {
       envStub.value({ API_URL: 'https://dev-api.va.gov' });
       constants = require('../constants');
       expect(constants.URL.GET_CATEGORIES).to.not.include(

--- a/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
@@ -1,9 +1,4 @@
-import {
-  fireEvent,
-  render,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import {
   createGetHandler,
@@ -16,635 +11,77 @@ import Inbox from '../../containers/Inbox';
 import { ENDPOINTS } from '../../utils/api';
 
 describe('<Inbox />', () => {
-  describe('when the api server succeeds', () => {
-    beforeEach(() => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: [
-                {
-                  id: '1',
-                  attributes: {
-                    inquiryNumber: 'A-1',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Business question',
-                    levelOfAuthentication: 'Business',
-                  },
-                },
-                {
-                  id: '2',
-                  attributes: {
-                    inquiryNumber: 'A-2',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Personal question',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-                {
-                  id: '3',
-                  attributes: {
-                    inquiryNumber: 'A-3',
-                    status: 'Replied',
-                    categoryName: 'Health care',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Another personal question',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-              ],
-            },
-            { status: 200 },
-          );
-        }),
-      );
-    });
-
-    it('should render Your questions and filters', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        // Check for the main heading
-        expect(view.getByText('Your questions')).to.exist;
-
-        // Check for select elements
-        const statusSelect = view.container.querySelector(
-          'va-select[name="status"]',
-        );
-        const categorySelect = view.container.querySelector(
-          'va-select[name="category"]',
-        );
-        expect(statusSelect).to.exist;
-        expect(categorySelect).to.exist;
-
-        // Check that the inquiry content is displayed
-        expect(view.getByText('Business question')).to.exist;
-        expect(view.getByText('A-1')).to.exist;
-      });
-    });
-
-    it('should transform inquiries data correctly', async () => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: [
-                {
-                  id: '1',
-                  attributes: {
-                    inquiryNumber: 'A-1',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Test question 1',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-                {
-                  id: '2',
-                  attributes: {
-                    inquiryNumber: 'A-2',
-                    status: 'Replied',
-                    categoryName: 'Healthcare',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Test question 2',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-                {
-                  id: '3',
-                  attributes: {
-                    inquiryNumber: 'A-3',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Test question 3',
-                    levelOfAuthentication: 'Unauthenticated',
-                  },
-                },
-              ],
-            },
-            { status: 200 },
-          );
-        }),
-      );
-
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        expect(view.container.querySelector('va-loading-indicator')).to.not
-          .exist;
-
-        // Check that categories are correctly extracted (should exclude Unauthenticated)
-        const categorySelect = view.container.querySelector(
-          'va-select[name="category"]',
-        );
-        const options = categorySelect.querySelectorAll('option');
-        expect(options).to.have.lengthOf(3); // All + Benefits + Healthcare
-        expect(options[1].value).to.equal('Benefits');
-        expect(options[2].value).to.equal('Healthcare');
-
-        // Check that statuses are correctly transformed
-        const statusLabels = view.container.querySelectorAll('.usa-label');
-        expect(statusLabels[0].textContent.trim()).to.equal('In progress');
-        expect(statusLabels[1].textContent.trim()).to.equal('Replied');
-
-        // Verify unauthenticated inquiry is not displayed
-        const questions = view.container.querySelectorAll(
-          '.submitter-question',
-        );
-        expect(questions).to.have.lengthOf(2);
-        expect(questions[0].textContent).to.equal('Test question 1');
-        expect(questions[1].textContent).to.equal('Test question 2');
-      });
-    });
-
-    it('should update filter summary when filters applied', async () => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: [
-                {
-                  id: '1',
-                  attributes: {
-                    inquiryNumber: 'A-1',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Test question',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-              ],
-            },
-            { status: 200 },
-          );
-        }),
-      );
-
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        expect(view.container.querySelector('va-loading-indicator')).to.not
-          .exist;
-      });
-
-      // Confirm starting value of status filter
-      const statusSelect = view.container.querySelector(
-        'va-select[name="status"]',
-      );
-      expect(statusSelect.getAttribute('value')).to.equal('All');
-
-      // Set status filter to "In progress"
-      statusSelect.__events.vaSelect({
-        target: { value: 'In progress' },
-      });
-
-      // Wait for pending filter to update
-      await waitFor(() => {
-        expect(statusSelect.getAttribute('value')).to.equal('In progress');
-      });
-
-      // Apply filters
-      const buttonPair = view.container.querySelector('va-button-pair');
-      buttonPair.__events.primaryClick();
-
-      // Wait for the filter summary to update
-      const filterSummary = await view.findByText(/showing/i);
-      expect(filterSummary.textContent).to.include('"In progress"');
-    });
-
-    it('should clear filters when clear button is clicked', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        expect(view.container.querySelector('va-loading-indicator')).to.not
-          .exist;
-      });
-
-      // Set filters to non-default values
-      const statusSelect = view.container.querySelector(
-        'va-select[name="status"]',
-      );
-      statusSelect.__events.vaSelect({ target: { value: 'In progress' } });
-      expect(statusSelect.getAttribute('value')).to.equal('In progress');
-
-      const categorySelect = view.container.querySelector(
-        'va-select[name="category"]',
-      );
-      categorySelect.__events.vaSelect({ target: { value: 'Benefits' } });
-      expect(categorySelect.getAttribute('value')).to.equal('Benefits');
-
-      // Click clear filters button
-      const clearButton = view.container.querySelector('va-button-pair');
-      clearButton.__events.secondaryClick();
-
-      await waitFor(() => {
-        // Verify filters are reset to 'All'
-        expect(statusSelect.getAttribute('value')).to.equal('All');
-        expect(categorySelect.getAttribute('value')).to.equal('All');
-      });
-    });
-
-    it('should sort results based on search query', async () => {
-      const view = render(<Inbox />);
-
-      // Switch to personal tab
-      const personalTab = await view.findByRole('tab', { name: /personal/i });
-      fireEvent.click(personalTab);
-
-      // Confirm correct tab's content is displayed
-      const searchDescription = await view.findByText(/showing/i);
-      expect(searchDescription.textContent).to.include('Personal');
-
-      const resultsBefore = view.getAllByTestId('inquiry-card');
-      expect(resultsBefore.length).to.equal(2);
-      expect(resultsBefore[0].textContent).to.include('Reference number: A-2');
-
-      // Confirm search box starts empty
-      const searchBox = view.container.querySelector('va-text-input');
-      expect(searchBox.value).to.equal('');
-
-      // Input a search query
-      searchBox.__events.vaInput({ target: { value: 'A-3' } });
-      expect(searchBox.value).to.equal('A-3');
-
-      // Apply filters
-      const filterButtons = view.container.querySelector('va-button-pair');
-      filterButtons.__events.primaryClick();
-
-      // Confirrm the list is now just one desired result
-      const resultsAfter = view.getAllByTestId('inquiry-card');
-      expect(resultsAfter.length).to.equal(1);
-      expect(resultsAfter[0].textContent).to.include('Reference number: A-3');
-    });
-  });
-
-  describe('when the api server fails', () => {
-    beforeEach(() => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse({}, { status: 500 });
-        }),
-      );
-    });
-
-    it('should show error alert when API request fails', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        const errorAlert = view.container.querySelector('va-alert');
-        expect(errorAlert).to.exist;
-        expect(errorAlert.getAttribute('status')).to.equal('info');
-      });
-    });
-  });
-
-  describe('pagination functionality', () => {
-    beforeEach(() => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: Array.from({ length: 6 }, (_, i) => ({
-                id: `${i + 1}`,
+  beforeEach(() => {
+    server.use(
+      createGetHandler(ENDPOINTS.inquiries, () => {
+        return jsonResponse(
+          {
+            data: [
+              {
+                id: '1',
                 attributes: {
-                  inquiryNumber: `A-${i + 1}`,
+                  inquiryNumber: 'A-1',
                   status: 'In Progress',
                   categoryName: 'Benefits',
                   createdOn: '01/01/2024 12:00:00 PM',
                   lastUpdate: '01/01/2024 12:00:00 PM',
-                  submitterQuestion: `Test question ${i + 1}`,
+                  submitterQuestion: 'Personal question',
                   levelOfAuthentication: 'Personal',
                 },
-              })),
-            },
-            { status: 200 },
-          );
-        }),
-      );
-    });
-
-    it('should display pagination when there are more than 4 items', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        const pagination = view.container.querySelector('va-pagination');
-        expect(pagination).to.exist;
-        expect(pagination.getAttribute('pages')).to.equal('2');
-      });
-
-      // Verify only 4 items are shown initially
-      const cards = view.container.querySelectorAll('va-card');
-      expect(cards).to.have.lengthOf(4);
-    });
-
-    it('should update displayed items when page changes', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        // Verify first page content
-        expect(view.getByText('Test question 1')).to.exist;
-        expect(view.getByText('Test question 4')).to.exist;
-      });
-
-      // Trigger page change
-      const pagination = view.container.querySelector('va-pagination');
-      pagination.dispatchEvent(
-        new CustomEvent('pageSelect', {
-          detail: { page: 2 },
-          bubbles: true,
-        }),
-      );
-
-      await waitFor(() => {
-        // Verify second page content
-        expect(view.getByText('Test question 5')).to.exist;
-        expect(view.getByText('Test question 6')).to.exist;
-      });
-    });
-
-    it('should update results info text when page changes', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        const filterSummary = view.getByRole('heading', {
-          name: /showing .+ results/i,
-        });
-        expect(filterSummary.textContent).to.include('Showing 1-4 of 6');
-      });
-
-      // Change to page 2
-      const pagination = view.container.querySelector('va-pagination');
-      pagination.dispatchEvent(
-        new CustomEvent('pageSelect', {
-          detail: { page: 2 },
-          bubbles: true,
-        }),
-      );
-
-      await waitFor(() => {
-        const filterSummary = view.getByRole('heading', {
-          name: /showing .+ results/i,
-        });
-        expect(filterSummary.textContent).to.include('Showing 5-6 of 6');
-      });
-    });
-
-    it('should focus on filter summary when page changes', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        const filterSummary = view.getByRole('heading', {
-          level: 3,
-          name: /showing 1-4 of 6 results/i,
-        });
-        expect(filterSummary).to.exist;
-      });
-
-      // Change to page 2
-      const pagination = view.container.querySelector('va-pagination');
-      pagination.dispatchEvent(
-        new CustomEvent('pageSelect', {
-          detail: { page: 2 },
-          bubbles: true,
-        }),
-      );
-
-      await waitFor(() => {
-        const searchDescription = view.getByRole('heading', {
-          level: 3,
-          name: /showing 5-6 of 6 results/i,
-        });
-        expect(document.activeElement).to.equal(
-          searchDescription.parentElement,
+              },
+            ],
+          },
+          { status: 200 },
         );
-      });
+      }),
+    );
+  });
+
+  it('renders InboxLayout when API succeeds', async () => {
+    const view = render(<Inbox />);
+
+    await waitFor(() => {
+      // Check for heading and filters
+      expect(view.getByRole('heading', { name: 'Your questions' })).to.exist;
+      const status = view.container.querySelector('va-select[name="status"]');
+      expect(status).to.exist;
+
+      // Check that the inquiry content is displayed
+      expect(view.getByText('Personal question')).to.exist;
+      expect(view.getByText('A-1')).to.exist;
     });
   });
 
-  describe('loading state', () => {
-    it('should show loading indicator and then content', async () => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: [
-                {
-                  id: '1',
-                  attributes: {
-                    inquiryNumber: 'A-1',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Test question',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-              ],
-            },
-            { status: 200 },
-          );
-        }),
-      );
+  it('shows a loading indicator before content', async () => {
+    const view = render(<Inbox />);
 
-      const view = render(<Inbox />);
+    // Initially should show loading indicator
+    const loadingIndicator = view.getByTestId('loading-indicator');
+    expect(loadingIndicator).to.exist;
+    expect(loadingIndicator.getAttribute('message')).to.equal('Loading...');
 
-      // Initially should show loading indicator
-      const loadingIndicator = view.getByTestId('loading-indicator');
-      expect(loadingIndicator).to.exist;
-      expect(loadingIndicator.getAttribute('message')).to.equal('Loading...');
-
-      await waitForElementToBeRemoved(loadingIndicator);
-
-      await waitFor(() => {
-        // Content should be visible
-        const heading = view.getByRole('heading', {
-          level: 2,
-          name: 'Your questions',
-        });
-        expect(heading).to.exist;
-        expect(view.getByText('Test question')).to.exist;
-      });
+    const heading = await view.findByRole('heading', {
+      level: 2,
+      name: /your questions/i,
     });
+    const loadingGone = view.queryByTestId('loading-indicator');
+
+    expect(heading).to.exist;
+    expect(loadingGone).to.not.exist;
   });
 
-  describe('empty state', () => {
-    beforeEach(() => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: [], // Return empty data array
-            },
-            { status: 200 },
-          );
-        }),
-      );
-    });
+  it('shows an alert when the API request fails', async () => {
+    server.use(
+      createGetHandler(ENDPOINTS.inquiries, () => {
+        return jsonResponse({}, { status: 500 });
+      }),
+    );
+    const view = render(<Inbox />);
 
-    it('should show empty state message when no inquiries exist', async () => {
-      const view = render(<Inbox />);
-
-      await waitFor(() => {
-        // Should show the empty state message
-        const alert = view.container.querySelector('va-alert');
-        expect(alert).to.exist;
-
-        const messageElement = view.container.querySelector(
-          '.vads-u-margin-y--0',
-        );
-        expect(messageElement.textContent).to.include(
-          'submitted a question yet',
-        );
-
-        // Should not show filters
-        expect(view.container.querySelector('.vacardSelectFilters')).to.not
-          .exist;
-        expect(view.container.querySelector('va-select[name="status"]')).to.not
-          .exist;
-        expect(view.container.querySelector('va-select[name="category"]')).to
-          .not.exist;
-
-        // Should not show pagination
-        expect(view.container.querySelector('va-pagination')).to.not.exist;
-      });
-    });
-  });
-
-  describe('business and personal view', () => {
-    beforeEach(() => {
-      server.use(
-        createGetHandler(ENDPOINTS.inquiries, () => {
-          return jsonResponse(
-            {
-              data: [
-                {
-                  id: '1',
-                  attributes: {
-                    inquiryNumber: 'A-1',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Business question',
-                    levelOfAuthentication: 'Business',
-                  },
-                },
-                {
-                  id: '2',
-                  attributes: {
-                    inquiryNumber: 'A-2',
-                    status: 'In Progress',
-                    categoryName: 'Benefits',
-                    createdOn: '01/01/2024 12:00:00 PM',
-                    lastUpdate: '01/01/2024 12:00:00 PM',
-                    submitterQuestion: 'Personal question',
-                    levelOfAuthentication: 'Personal',
-                  },
-                },
-              ],
-            },
-            { status: 200 },
-          );
-        }),
-      );
-    });
-
-    it('should show switchable tabs when both business and personal inquiries exist', async () => {
-      const view = render(<Inbox />);
-
-      const tabButtons = await view.findByRole('tablist');
-      const businessTabBefore = await view.findByRole('tab', {
-        name: /business/i,
-      });
-      const personalTabBefore = await view.findByRole('tab', {
-        name: /personal/i,
-      });
-
-      expect(tabButtons.childNodes.length).to.equal(2);
-      expect(businessTabBefore).to.exist;
-      expect(personalTabBefore).to.exist;
-      expect(businessTabBefore.outerHTML).to.include('aria-selected="true"');
-      expect(personalTabBefore.outerHTML).to.include('aria-selected="false"');
-
-      fireEvent.click(personalTabBefore);
-
-      const businessTabAfter = await view.findByRole('tab', {
-        name: /business/i,
-      });
-      const personalTabAfter = await view.findByRole('tab', {
-        name: /personal/i,
-      });
-
-      expect(businessTabAfter.outerHTML).to.include('aria-selected="false"');
-      expect(personalTabAfter.outerHTML).to.include('aria-selected="true"');
-    });
-
-    it('should apply filters correctly in business view', async () => {
-      const view = render(<Inbox />);
-
-      // Wait for initial load and content
-      await waitFor(() => {
-        expect(view.container.querySelector('va-loading-indicator')).to.not
-          .exist;
-        expect(view.getByText('Business question')).to.exist;
-      });
-
-      // Set status filter to In progress
-      const statusSelect = view.container.querySelector(
-        'va-select[name="status"]',
-      );
-      fireEvent(
-        statusSelect,
-        new CustomEvent('vaSelect', {
-          detail: { value: 'In progress' },
-          bubbles: true,
-        }),
-      );
-
-      // Wait for filter to be applied and check status label
-      await waitFor(() => {
-        const statusLabel = view.container.querySelector('.usa-label');
-        expect(statusLabel.textContent.trim()).to.equal('In progress');
-      });
-    });
-
-    it('should show correct content in personal view', async () => {
-      const view = render(<Inbox />);
-
-      // Wait for initial load
-      await waitFor(() => {
-        expect(view.container.querySelector('va-loading-indicator')).to.not
-          .exist;
-        const businessTab = view.getByRole('tab', {
-          name: /business/i,
-        });
-        expect(businessTab.textContent).to.equal('Business');
-      });
-
-      // Switch to personal tab
-      const personalTab = view.getByRole('tab', { name: /personal/i });
-      fireEvent.click(personalTab);
-
-      // Wait for personal content
-      await waitFor(() => {
-        expect(view.getByText('Personal question')).to.exist;
-        expect(view.queryByText('Business question')).to.not.exist;
-      });
+    await waitFor(() => {
+      const errorAlert = view.container.querySelector('va-alert');
+      expect(errorAlert).to.exist;
+      expect(errorAlert.getAttribute('status')).to.equal('info');
     });
   });
 });

--- a/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
@@ -12,11 +12,11 @@ import {
 import { server } from 'platform/testing/unit/mocha-setup';
 import React from 'react';
 
-import { envUrl } from '../../constants';
+import { envApiUrl } from '../../constants';
 import Inbox from '../../containers/Inbox';
 
 describe('<Inbox />', () => {
-  const apiRequestWithUrl = `${envUrl}/ask_va_api/v0/inquiries`;
+  const apiRequestWithUrl = `${envApiUrl}/ask_va_api/v0/inquiries`;
 
   describe('when the api server succeeds', () => {
     beforeEach(() => {

--- a/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
@@ -12,16 +12,14 @@ import {
 import { server } from 'platform/testing/unit/mocha-setup';
 import React from 'react';
 
-import { envApiUrl } from '../../constants';
 import Inbox from '../../containers/Inbox';
+import { ENDPOINTS } from '../../utils/api';
 
 describe('<Inbox />', () => {
-  const apiRequestWithUrl = `${envApiUrl}/ask_va_api/v0/inquiries`;
-
   describe('when the api server succeeds', () => {
     beforeEach(() => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: [
@@ -94,7 +92,7 @@ describe('<Inbox />', () => {
 
     it('should transform inquiries data correctly', async () => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: [
@@ -173,7 +171,7 @@ describe('<Inbox />', () => {
 
     it('should update filter summary when filters applied', async () => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: [
@@ -297,7 +295,7 @@ describe('<Inbox />', () => {
   describe('when the api server fails', () => {
     beforeEach(() => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse({}, { status: 500 });
         }),
       );
@@ -317,7 +315,7 @@ describe('<Inbox />', () => {
   describe('pagination functionality', () => {
     beforeEach(() => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: Array.from({ length: 6 }, (_, i) => ({
@@ -440,7 +438,7 @@ describe('<Inbox />', () => {
   describe('loading state', () => {
     it('should show loading indicator and then content', async () => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: [
@@ -487,7 +485,7 @@ describe('<Inbox />', () => {
   describe('empty state', () => {
     beforeEach(() => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: [], // Return empty data array
@@ -530,7 +528,7 @@ describe('<Inbox />', () => {
   describe('business and personal view', () => {
     beforeEach(() => {
       server.use(
-        createGetHandler(`${apiRequestWithUrl}`, () => {
+        createGetHandler(ENDPOINTS.inquiries, () => {
           return jsonResponse(
             {
               data: [

--- a/src/applications/ask-va/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/IntroductionPage.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('IntroductionPage', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(constants, 'getMockTestingFlagforAPI').returns(true);
+    sandbox.stub(constants, 'getMockTestingFlagForAPI').returns(true);
     apiRequestStub = sandbox
       .stub(apiUtils, 'apiRequest')
       .resolves(mockInquiryStatusResponse);

--- a/src/applications/ask-va/tests/containers/ResponseInboxPage.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/ResponseInboxPage.unit.spec.jsx
@@ -316,7 +316,7 @@ describe('ResponseInboxPage', () => {
 
   it('should render with inquiries using mockTestingFlagForAPI', async () => {
     const mockTestingFlagStub = sinon
-      .stub(constants, 'getMockTestingFlagforAPI')
+      .stub(constants, 'getMockTestingFlagForAPI')
       .returns(true);
     overridePathname('/user/dashboard/A-20241219-308852');
     apiRequestStub.resolves(mockInquiryResponse);
@@ -388,7 +388,7 @@ describe('ResponseInboxPage', () => {
   it('should be able to download an attachment using mockTestingFlagForAPI', async () => {
     overridePathname('/user/dashboard/A-20241219-308852');
     const mockTestingFlagStub = sinon
-      .stub(constants, 'getMockTestingFlagforAPI')
+      .stub(constants, 'getMockTestingFlagForAPI')
       .returns(true);
     const createElementSpy = sinon.spy(document, 'createElement');
 
@@ -468,10 +468,10 @@ describe('ResponseInboxPage', () => {
     createElementSpy.restore();
   });
 
-  it('should be able to type a reply and click send using getMockTestingFlagforAPI', async () => {
+  it('should be able to type a reply and click send using getMockTestingFlagForAPI', async () => {
     overridePathname('/user/dashboard/A-20241219-308852');
     const mockTestingFlagStub = sinon
-      .stub(constants, 'getMockTestingFlagforAPI')
+      .stub(constants, 'getMockTestingFlagForAPI')
       .returns(true);
     const createElementSpy = sinon.spy(document, 'createElement');
 

--- a/src/applications/ask-va/tests/containers/YourVAHealthFacility.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/YourVAHealthFacility.unit.spec.jsx
@@ -221,10 +221,10 @@ describe('YourVAHealthFacilityPage', () => {
     });
   });
 
-  it('should return mock facilities if mockTestingFlagforAPI is enabled', async () => {
+  it('should return mock facilities if mockTestingFlagForAPI is enabled', async () => {
     convertLocationStub.resolves(mockLocationResponse);
     convertToLatLngStub.resolves([0, 0]);
-    sandbox.stub(constants, 'getMockTestingFlagforAPI').returns(true);
+    sandbox.stub(constants, 'getMockTestingFlagForAPI').returns(true);
 
     const { container, getByRole } = renderWithStoreRTL();
     const input = getByRole('searchbox');

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/inbox/include-pages/your-empty-inquiries.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/inbox/include-pages/your-empty-inquiries.yml
@@ -1,4 +1,4 @@
 steps:
   - action: exists
     target: paragraph
-    value: You haven’t submitted a question yet.
+    value: You haven't submitted a question yet.

--- a/src/applications/ask-va/tests/e2e/fixtures/flows/inbox/include-pages/your-empty-inquiries.yml
+++ b/src/applications/ask-va/tests/e2e/fixtures/flows/inbox/include-pages/your-empty-inquiries.yml
@@ -1,4 +1,4 @@
 steps:
   - action: exists
     target: paragraph
-    value: You haven't submitted a question yet.
+    value: You haven’t submitted a question yet.

--- a/src/applications/ask-va/tests/utils/api.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/api.unit.spec.jsx
@@ -1,0 +1,36 @@
+import { server } from 'platform/testing/unit/mocha-setup';
+import {
+  createGetHandler,
+  jsonResponse,
+} from 'platform/testing/unit/msw-adapter';
+import { expect } from 'chai';
+import { ENDPOINTS, getAllInquiries, getInquiry } from '../../utils/api';
+
+describe('getAllInquiries', () => {
+  it('calls the correct endpoint', async () => {
+    server.use(
+      createGetHandler(ENDPOINTS.inquiries, () =>
+        jsonResponse({ key: 'success' }),
+      ),
+    );
+
+    const res = await getAllInquiries();
+    expect(res.key).to.equal('success');
+  });
+});
+
+describe('getInquiry', () => {
+  it('requests correct inquiryId', async () => {
+    server.use(
+      createGetHandler(`${ENDPOINTS.inquiries}/:inquiryId`, ({ params }) => {
+        return jsonResponse({ data: params.inquiryId });
+      }),
+    );
+
+    const resFail = await getInquiry('failure');
+    expect(resFail.data).to.equal('failure');
+
+    const resSucceed = await getInquiry('success');
+    expect(resSucceed.data).to.equal('success');
+  });
+});

--- a/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
@@ -102,7 +102,7 @@ describe('filterAndSort', () => {
   it('filters by category', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      categoryFilter: 'Veteran ID Card (VIC)',
+      filters: { category: 'Veteran ID Card (VIC)' },
     });
     expect(results.length).to.equal(3);
   });
@@ -110,7 +110,7 @@ describe('filterAndSort', () => {
   it('filters by status', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      statusFilter: 'In progress',
+      filters: { status: 'In progress' },
     });
     expect(results.length).to.equal(6);
   });
@@ -118,8 +118,10 @@ describe('filterAndSort', () => {
   it('filters by both category and status', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      categoryFilter: 'Veteran ID Card (VIC)',
-      statusFilter: 'In progress',
+      filters: {
+        category: 'Veteran ID Card (VIC)',
+        status: 'In progress',
+      },
     });
     expect(results.length).to.equal(1);
   });
@@ -161,7 +163,7 @@ describe('filterAndSort', () => {
   it('sorts by query: submitter question', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      query: 'Hemesh',
+      filters: { query: 'Hemesh' },
     });
 
     expect(results.length).to.equal(1);
@@ -172,7 +174,7 @@ describe('filterAndSort', () => {
   it('sorts by query: inquiry number', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      query: '617',
+      filters: { query: '617' },
     });
 
     expect(results.length).to.equal(1);
@@ -182,7 +184,7 @@ describe('filterAndSort', () => {
   it('sorts by query: category name', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      query: 'employment',
+      filters: { query: 'employment' },
     });
 
     expect(results.length).to.equal(2);

--- a/src/applications/ask-va/tests/utils/links.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/links.unit.spec.jsx
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
-
-const { getConversationLink } = require('../../utils/links');
+import { getConversationLink } from '../../utils/links';
 
 describe('getConversationLink', () => {
   it('returns a properly formatted path', () => {

--- a/src/applications/ask-va/tests/utils/mock-inquiries.js
+++ b/src/applications/ask-va/tests/utils/mock-inquiries.js
@@ -1,3 +1,4 @@
+// 7 personal, 2 business, 1 unauthenticated
 export const mockInquiries = [
   {
     id: '251a31bd-24b7-ef11-b8e9-001dd8053a71',

--- a/src/applications/ask-va/tests/utils/reviewPageUtils.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/reviewPageUtils.unit.spec.jsx
@@ -358,7 +358,7 @@ describe('Review Page Utils', () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
-      originalMockFlag = constants.mockTestingFlagforAPI;
+      originalMockFlag = constants.mockTestingFlagForAPI;
       originalEnvUrl = constants.envUrl;
 
       Object.defineProperty(constants, 'envUrl', {
@@ -367,7 +367,7 @@ describe('Review Page Utils', () => {
         writable: true,
       });
 
-      Object.defineProperty(constants, 'mockTestingFlagforAPI', {
+      Object.defineProperty(constants, 'mockTestingFlagForAPI', {
         value: true,
         configurable: true,
         writable: true,
@@ -377,7 +377,7 @@ describe('Review Page Utils', () => {
     afterEach(() => {
       sandbox.restore();
 
-      Object.defineProperty(constants, 'mockTestingFlagforAPI', {
+      Object.defineProperty(constants, 'mockTestingFlagForAPI', {
         value: originalMockFlag,
         configurable: true,
         writable: true,

--- a/src/applications/ask-va/tests/utils/reviewPageUtils.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/reviewPageUtils.unit.spec.jsx
@@ -359,9 +359,9 @@ describe('Review Page Utils', () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       originalMockFlag = constants.mockTestingFlagForAPI;
-      originalEnvUrl = constants.envUrl;
+      originalEnvUrl = constants.envApiUrl;
 
-      Object.defineProperty(constants, 'envUrl', {
+      Object.defineProperty(constants, 'envApiUrl', {
         value: 'http://localhost:3000',
         configurable: true,
         writable: true,
@@ -383,7 +383,7 @@ describe('Review Page Utils', () => {
         writable: true,
       });
 
-      Object.defineProperty(constants, 'envUrl', {
+      Object.defineProperty(constants, 'envApiUrl', {
         value: originalEnvUrl,
         configurable: true,
         writable: true,

--- a/src/applications/ask-va/utils/api.js
+++ b/src/applications/ask-va/utils/api.js
@@ -1,0 +1,18 @@
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+import { envApiUrl } from '../constants';
+
+const baseURL = '/ask_va_api/v0';
+
+export const ENDPOINTS = {
+  inquiries: `${envApiUrl}${baseURL}/inquiries`,
+  inquiriesAuth: `${envApiUrl}${baseURL}/inquiries/auth`,
+};
+
+export async function getAllInquiries() {
+  return apiRequest(ENDPOINTS.inquiries);
+}
+
+/** @param {string} inquiryId Also known as "reference number" or "inquiry number" */
+export async function getInquiry(inquiryId) {
+  return apiRequest(`${ENDPOINTS.inquiries}/${inquiryId}`);
+}

--- a/src/applications/ask-va/utils/inbox.js
+++ b/src/applications/ask-va/utils/inbox.js
@@ -2,8 +2,17 @@ import Fuse from 'fuse.js';
 import { compareDesc } from 'date-fns';
 import { getVAStatusFromCRM } from '../config/helpers';
 
-export function flattenInquiry(inquiry) {
-  const { id, type, attributes } = inquiry;
+/**
+ * @typedef {import('../components/inbox/InquiryCard').Inquiry} Inquiry
+ */
+
+/**
+ *
+ * @param {object} rawInquiry
+ * @returns {Inquiry}
+ */
+export function flattenInquiry(rawInquiry) {
+  const { id, type, attributes } = rawInquiry;
   return {
     id,
     type,
@@ -14,6 +23,11 @@ export function flattenInquiry(inquiry) {
 
 /** Splits inquires into buckets by their Level of Authentication
  *  @param {Array} rawInquiries
+ *  @returns {{
+ *   business: Inquiry[],
+ *   personal: Inquiry[],
+ *   uniqueCategories: string[]
+ * }}
  */
 export function categorizeByLOA(rawInquiries) {
   const buckets = rawInquiries.reduce(
@@ -33,10 +47,6 @@ export function categorizeByLOA(rawInquiries) {
   // Convert the Set into an array
   return { ...buckets, uniqueCategories: [...buckets.uniqueCategories] };
 }
-
-/**
- * @typedef {import('../components/inbox/InquiryCard').Inquiry} Inquiry
- */
 
 /** Splits an array into buckets of limited size
  * @param {Inquiry[]} inquiries The list of items

--- a/src/applications/ask-va/utils/inbox.js
+++ b/src/applications/ask-va/utils/inbox.js
@@ -77,17 +77,19 @@ export function paginateInquiries(inquiries, itemsPerPage) {
 
 export function filterAndSort({
   inquiriesArray,
-  query = '',
-  categoryFilter = 'All',
-  statusFilter = 'All',
+  filters: { category = 'All', status = 'All', query = '' } = {
+    category: 'All',
+    status: 'All',
+    query: '',
+  },
 }) {
   // Since Array.sort() sorts it in place, create a shallow copy first
   const inquiriesCopy = [...inquiriesArray];
   const filteredAndSorted = inquiriesCopy
     .filter(inq => {
       return (
-        [inq.categoryName, 'All'].includes(categoryFilter) &&
-        [inq.status, 'All'].includes(statusFilter)
+        [inq.categoryName, 'All'].includes(category) &&
+        [inq.status, 'All'].includes(status)
       );
     })
     .sort((a, b) =>

--- a/src/applications/ask-va/utils/links.js
+++ b/src/applications/ask-va/utils/links.js
@@ -1,3 +1,2 @@
-/** @param {string} conversationId Also known as "reference number" or "inquiry number" */
-export const getConversationLink = conversationId =>
-  `/user/dashboard/${conversationId}`;
+/** @param {string} inquiryId Also known as "reference number" or "inquiry number" */
+export const getConversationLink = inquiryId => `/user/dashboard/${inquiryId}`;

--- a/src/applications/ask-va/utils/reviewPageUtils.js
+++ b/src/applications/ask-va/utils/reviewPageUtils.js
@@ -1,7 +1,7 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import { formatDate } from '../config/helpers';
 import submitTransformer from '../config/submit-transformer';
-import { URL, envUrl, mockTestingFlagforAPI } from '../constants';
+import { URL, envUrl, mockTestingFlagForAPI } from '../constants';
 import { mockSubmitResponse } from './mockData';
 import { askVAAttachmentStorage } from './StorageAdapter';
 
@@ -207,7 +207,7 @@ export const handleFormSubmission = async ({
         onSuccess?.({ inquiryNumber, contactPreference });
       },
       onError,
-      mockEnabled: mockTestingFlagforAPI,
+      mockEnabled: mockTestingFlagForAPI,
     });
   } catch (error) {
     onError?.(error);

--- a/src/applications/ask-va/utils/reviewPageUtils.js
+++ b/src/applications/ask-va/utils/reviewPageUtils.js
@@ -1,9 +1,10 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import { formatDate } from '../config/helpers';
 import submitTransformer from '../config/submit-transformer';
-import { URL, envApiUrl, mockTestingFlagForAPI } from '../constants';
+import { mockTestingFlagForAPI } from '../constants';
 import { mockSubmitResponse } from './mockData';
 import { askVAAttachmentStorage } from './StorageAdapter';
+import { ENDPOINTS } from './api';
 
 export const getYesOrNoFromBool = answer => (answer ? 'Yes' : 'No');
 
@@ -191,11 +192,10 @@ export const handleFormSubmission = async ({
       });
     const transformedData = submitTransformer(formData, files);
 
-    const url = `${envApiUrl}${
-      (isLoggedIn && isUserLOA3) || transformedData.requireSignIn
-        ? URL.AUTH_INQUIRIES
-        : URL.INQUIRIES
-    }`;
+    const needsAuth =
+      (isLoggedIn && isUserLOA3) || transformedData.requireSignIn;
+
+    const url = needsAuth ? ENDPOINTS.inquiriesAuth : ENDPOINTS.inquiries;
 
     return await submitFormData({
       url,

--- a/src/applications/ask-va/utils/reviewPageUtils.js
+++ b/src/applications/ask-va/utils/reviewPageUtils.js
@@ -1,7 +1,7 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import { formatDate } from '../config/helpers';
 import submitTransformer from '../config/submit-transformer';
-import { URL, envUrl, mockTestingFlagForAPI } from '../constants';
+import { URL, envApiUrl, mockTestingFlagForAPI } from '../constants';
 import { mockSubmitResponse } from './mockData';
 import { askVAAttachmentStorage } from './StorageAdapter';
 
@@ -191,7 +191,7 @@ export const handleFormSubmission = async ({
       });
     const transformedData = submitTransformer(formData, files);
 
-    const url = `${envUrl}${
+    const url = `${envApiUrl}${
       (isLoggedIn && isUserLOA3) || transformedData.requireSignIn
         ? URL.AUTH_INQUIRIES
         : URL.INQUIRIES


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Refactored the Ask VA inbox to separate concerns in preparation for upcoming changes
  - The UI rendering was too tightly coupled to the data-fetching, resulting in overloaded components. This PR fixes that.
- Not a bug
- This was the solution because it allows us to unit test with more confidence, which will be important as we go into Collab Cycle
- Ask VA owns this code

## Related issue(s)

- Closes department-of-veterans-affairs/ask-va/issues/1998

## Testing done

- There are no UI changes in this PR, but the previous behavior was extraneous re-renders, since there were unrelated bits of logic all being called in one place.
- The main changes were in `Inbox`, `InboxLayout`, and `InboxList`, so running their tests will cover most of it. The API utilities in `utils/api.js` are also new, so their test file should cover the rest.
- While breaking out the inbox test suite into proper unit tests of only the things each component is responsible for, I had a chance to streamline quite a few of them so that they test exactly what they say they do and nothing more.

## What areas of the site does it impact?

Only Ask VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
  - [x] Color contrast
  - [x] axe devtools auto check
  - [x] Zoom issues (screen width: 1200px, zoom to 200%, 300%, 400%)
  - [x] Keyboard navigation

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user