### PR TITLE
Fix for conditions redirect loop issue / ALL forms being affected, not just new ones

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -231,7 +231,6 @@ export const Form526Entry = ({
     'disability526Enable2024Form4142',
     'disability526ToxicExposureOptOutDataPurge',
     'disability526SupportingEvidenceEnhancement',
-    'disabilityCompNewConditionsWorkflow',
     'disability526ExtraBDDPagesEnabled',
   ]);
 

--- a/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
@@ -539,21 +539,45 @@ describe('utils', () => {
       expect(router.push.calledWith('/veteran-information')).to.be.true;
     });
 
-    it('old-flow redirect takes priority over other redirect branches', () => {
+    it('other redirects take priority over old-flow redirect', () => {
       const router = { push: sinon.spy() };
-      // Set up formData that would also trigger the evidence enhancement redirect
+      // Set up formData that triggers the 4142 redirect
       const formData = {
-        ...baseFormData,
         disabilityCompNewConditionsWorkflow: true,
-        disability526SupportingEvidenceEnhancement: true,
+        disability526Enable2024Form4142: true,
+        'view:hasEvidence': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
+        'view:patientAcknowledgement': { 'view:acknowledgement': true },
+        'view:uploadPrivateRecordsQualifier': {
+          'view:hasPrivateRecordsToUpload': false,
+        },
+        patient4142Acknowledgement: false,
       };
-      // Use a returnUrl that matches old-flow (not evidence)
+      // Use a returnUrl that matches old-flow
       onFormLoaded({
         returnUrl: '/new-disabilities/add',
         formData,
         router,
       });
-      // Should redirect to /contact-information, not evidence-request
+      // 4142 redirect should take priority — it sends to a valid page
+      expect(
+        router.push.calledWith('/supporting-evidence/private-medical-records'),
+      ).to.be.true;
+    });
+
+    it('old-flow redirect fires when no other redirect applies', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/new-disabilities/add',
+        formData,
+        router,
+      });
       expect(router.push.calledWith('/contact-information')).to.be.true;
     });
   });

--- a/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
@@ -6,6 +6,9 @@ import {
   onFormLoaded,
   redirectLegacyToEnhancement,
   redirectEnhancementToLegacy,
+  redirectOldFlowToNewFlow,
+  isNewConditionsOn,
+  isNewConditionsOff,
   hasEvidenceChoice,
 } from '../../utils';
 
@@ -162,6 +165,396 @@ describe('utils', () => {
 
     it('returns false when no selection or uploads exist', () => {
       expect(hasEvidenceChoice({})).to.be.false;
+    });
+  });
+
+  describe('isNewConditionsOn', () => {
+    it('returns true when disabilityCompNewConditionsWorkflow is true', () => {
+      expect(isNewConditionsOn({ disabilityCompNewConditionsWorkflow: true }))
+        .to.be.true;
+    });
+
+    it('returns false when disabilityCompNewConditionsWorkflow is false', () => {
+      expect(isNewConditionsOn({ disabilityCompNewConditionsWorkflow: false }))
+        .to.be.false;
+    });
+
+    it('returns false when disabilityCompNewConditionsWorkflow is undefined', () => {
+      expect(isNewConditionsOn({})).to.be.false;
+    });
+
+    it('returns false when formData is undefined', () => {
+      expect(isNewConditionsOn(undefined)).to.be.false;
+    });
+
+    it('returns false when formData is null', () => {
+      expect(isNewConditionsOn(null)).to.be.false;
+    });
+  });
+
+  describe('isNewConditionsOff', () => {
+    it('returns true when disabilityCompNewConditionsWorkflow is false', () => {
+      expect(isNewConditionsOff({ disabilityCompNewConditionsWorkflow: false }))
+        .to.be.true;
+    });
+
+    it('returns true when disabilityCompNewConditionsWorkflow is absent', () => {
+      expect(isNewConditionsOff({})).to.be.true;
+    });
+
+    it('returns false when disabilityCompNewConditionsWorkflow is true', () => {
+      expect(isNewConditionsOff({ disabilityCompNewConditionsWorkflow: true }))
+        .to.be.false;
+    });
+  });
+
+  describe('redirectOldFlowToNewFlow', () => {
+    const newFlowFormData = { disabilityCompNewConditionsWorkflow: true };
+    const oldFlowFormData = { disabilityCompNewConditionsWorkflow: false };
+    const noFlagFormData = {};
+
+    describe('when new conditions workflow is ON', () => {
+      it('returns true for /claim-type', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/claim-type',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for /disabilities/orientation', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/disabilities/orientation',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for /disabilities/rated-disabilities', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/disabilities/rated-disabilities',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for /disabilities/summary', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/disabilities/summary',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for /new-disabilities/add', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/new-disabilities/add',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for /new-disabilities/follow-up', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/new-disabilities/follow-up',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for parameterized old-flow paths like /new-disabilities/follow-up/0', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/new-disabilities/follow-up/0',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns true for parameterized old-flow paths like /new-disabilities/follow-up/3', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/new-disabilities/follow-up/3',
+            formData: newFlowFormData,
+          }),
+        ).to.be.true;
+      });
+
+      it('returns false for new-flow paths like /conditions/summary', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/conditions/summary',
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false for unrelated paths like /veteran-information', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/veteran-information',
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false for /contact-information', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/contact-information',
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false for evidence paths', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/supporting-evidence/evidence-types',
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+    });
+
+    describe('when new conditions workflow is OFF', () => {
+      it('returns false for old-flow paths when flag is false', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/claim-type',
+            formData: oldFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false for old-flow paths when flag is absent', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/new-disabilities/add',
+            formData: noFlagFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false for /disabilities/rated-disabilities when flag is off', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/disabilities/rated-disabilities',
+            formData: oldFlowFormData,
+          }),
+        ).to.be.false;
+      });
+    });
+
+    describe('edge cases', () => {
+      it('returns false when returnUrl is undefined', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: undefined,
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false when returnUrl is null', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: null,
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('returns false when returnUrl is empty string', () => {
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '',
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+
+      it('does not match partial path prefixes (e.g. /claim-type-something)', () => {
+        // /claim-type-something should not match /claim-type because
+        // the check is exact match OR startsWith('/claim-type/')
+        expect(
+          redirectOldFlowToNewFlow({
+            returnUrl: '/claim-type-something',
+            formData: newFlowFormData,
+          }),
+        ).to.be.false;
+      });
+    });
+  });
+
+  describe('onFormLoaded — old-flow redirect', () => {
+    // Minimal formData that won't trigger other redirect branches
+    const baseFormData = {
+      disability526Enable2024Form4142: false,
+    };
+
+    it('redirects to /contact-information when new conditions is ON and returnUrl is an old-flow path', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/new-disabilities/add',
+        formData,
+        router,
+      });
+      expect(router.push.calledOnce).to.be.true;
+      expect(router.push.calledWith('/contact-information')).to.be.true;
+    });
+
+    it('redirects to /contact-information for /claim-type when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/claim-type',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/contact-information')).to.be.true;
+    });
+
+    it('redirects to /contact-information for /disabilities/rated-disabilities when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/disabilities/rated-disabilities',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/contact-information')).to.be.true;
+    });
+
+    it('redirects to /contact-information for /disabilities/orientation when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/disabilities/orientation',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/contact-information')).to.be.true;
+    });
+
+    it('redirects to /contact-information for /disabilities/summary when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/disabilities/summary',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/contact-information')).to.be.true;
+    });
+
+    it('redirects to /contact-information for /new-disabilities/follow-up/0 when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/new-disabilities/follow-up/0',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/contact-information')).to.be.true;
+    });
+
+    it('does NOT redirect to /contact-information when new conditions is OFF', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: false,
+      };
+      onFormLoaded({
+        returnUrl: '/new-disabilities/add',
+        formData,
+        router,
+      });
+      // Should fall through to the default branch and push returnUrl
+      expect(router.push.calledWith('/new-disabilities/add')).to.be.true;
+    });
+
+    it('does NOT redirect to /contact-information when flag is absent', () => {
+      const router = { push: sinon.spy() };
+      const formData = { ...baseFormData };
+      onFormLoaded({
+        returnUrl: '/claim-type',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/claim-type')).to.be.true;
+    });
+
+    it('does NOT redirect for new-flow paths even when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/conditions/summary',
+        formData,
+        router,
+      });
+      // Should fall through to the default and push returnUrl
+      expect(router.push.calledWith('/conditions/summary')).to.be.true;
+    });
+
+    it('does NOT redirect for unrelated paths when new conditions is ON', () => {
+      const router = { push: sinon.spy() };
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+      };
+      onFormLoaded({
+        returnUrl: '/veteran-information',
+        formData,
+        router,
+      });
+      expect(router.push.calledWith('/veteran-information')).to.be.true;
+    });
+
+    it('old-flow redirect takes priority over other redirect branches', () => {
+      const router = { push: sinon.spy() };
+      // Set up formData that would also trigger the evidence enhancement redirect
+      const formData = {
+        ...baseFormData,
+        disabilityCompNewConditionsWorkflow: true,
+        disability526SupportingEvidenceEnhancement: true,
+      };
+      // Use a returnUrl that matches old-flow (not evidence)
+      onFormLoaded({
+        returnUrl: '/new-disabilities/add',
+        formData,
+        router,
+      });
+      // Should redirect to /contact-information, not evidence-request
+      expect(router.push.calledWith('/contact-information')).to.be.true;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
@@ -6,7 +6,7 @@ import {
   onFormLoaded,
   redirectLegacyToEnhancement,
   redirectEnhancementToLegacy,
-  redirectOldFlowToNewFlow,
+  redirectOldConditionsFlowToNew,
   isNewConditionsOn,
   isNewConditionsOff,
   hasEvidenceChoice,
@@ -208,7 +208,7 @@ describe('utils', () => {
     });
   });
 
-  describe('redirectOldFlowToNewFlow', () => {
+  describe('redirectOldConditionsFlowToNew', () => {
     const newFlowFormData = { disabilityCompNewConditionsWorkflow: true };
     const oldFlowFormData = { disabilityCompNewConditionsWorkflow: false };
     const noFlagFormData = {};
@@ -216,7 +216,7 @@ describe('utils', () => {
     describe('when new conditions workflow is ON', () => {
       it('returns true for /claim-type', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/claim-type',
             formData: newFlowFormData,
           }),
@@ -225,7 +225,7 @@ describe('utils', () => {
 
       it('returns true for /disabilities/orientation', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/disabilities/orientation',
             formData: newFlowFormData,
           }),
@@ -234,7 +234,7 @@ describe('utils', () => {
 
       it('returns true for /disabilities/rated-disabilities', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/disabilities/rated-disabilities',
             formData: newFlowFormData,
           }),
@@ -243,7 +243,7 @@ describe('utils', () => {
 
       it('returns true for /disabilities/summary', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/disabilities/summary',
             formData: newFlowFormData,
           }),
@@ -252,7 +252,7 @@ describe('utils', () => {
 
       it('returns true for /new-disabilities/add', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/new-disabilities/add',
             formData: newFlowFormData,
           }),
@@ -261,7 +261,7 @@ describe('utils', () => {
 
       it('returns true for /new-disabilities/follow-up', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/new-disabilities/follow-up',
             formData: newFlowFormData,
           }),
@@ -270,7 +270,7 @@ describe('utils', () => {
 
       it('returns true for parameterized old-flow paths like /new-disabilities/follow-up/0', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/new-disabilities/follow-up/0',
             formData: newFlowFormData,
           }),
@@ -279,7 +279,7 @@ describe('utils', () => {
 
       it('returns true for parameterized old-flow paths like /new-disabilities/follow-up/3', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/new-disabilities/follow-up/3',
             formData: newFlowFormData,
           }),
@@ -288,7 +288,7 @@ describe('utils', () => {
 
       it('returns false for new-flow paths like /conditions/summary', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/conditions/summary',
             formData: newFlowFormData,
           }),
@@ -297,7 +297,7 @@ describe('utils', () => {
 
       it('returns false for unrelated paths like /veteran-information', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/veteran-information',
             formData: newFlowFormData,
           }),
@@ -306,7 +306,7 @@ describe('utils', () => {
 
       it('returns false for /contact-information', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/contact-information',
             formData: newFlowFormData,
           }),
@@ -315,7 +315,7 @@ describe('utils', () => {
 
       it('returns false for evidence paths', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/supporting-evidence/evidence-types',
             formData: newFlowFormData,
           }),
@@ -326,7 +326,7 @@ describe('utils', () => {
     describe('when new conditions workflow is OFF', () => {
       it('returns false for old-flow paths when flag is false', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/claim-type',
             formData: oldFlowFormData,
           }),
@@ -335,7 +335,7 @@ describe('utils', () => {
 
       it('returns false for old-flow paths when flag is absent', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/new-disabilities/add',
             formData: noFlagFormData,
           }),
@@ -344,7 +344,7 @@ describe('utils', () => {
 
       it('returns false for /disabilities/rated-disabilities when flag is off', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/disabilities/rated-disabilities',
             formData: oldFlowFormData,
           }),
@@ -355,7 +355,7 @@ describe('utils', () => {
     describe('edge cases', () => {
       it('returns false when returnUrl is undefined', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: undefined,
             formData: newFlowFormData,
           }),
@@ -364,7 +364,7 @@ describe('utils', () => {
 
       it('returns false when returnUrl is null', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: null,
             formData: newFlowFormData,
           }),
@@ -373,7 +373,7 @@ describe('utils', () => {
 
       it('returns false when returnUrl is empty string', () => {
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '',
             formData: newFlowFormData,
           }),
@@ -384,7 +384,7 @@ describe('utils', () => {
         // /claim-type-something should not match /claim-type because
         // the check is exact match OR startsWith('/claim-type/')
         expect(
-          redirectOldFlowToNewFlow({
+          redirectOldConditionsFlowToNew({
             returnUrl: '/claim-type-something',
             formData: newFlowFormData,
           }),

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -1065,7 +1065,7 @@ const isOldFlowReturnUrl = returnUrl =>
  * When the new conditions workflow is ON but the returnUrl points to an
  * old-flow page, redirect to the new-flow conditions summary instead.
  */
-export const redirectOldFlowToNewFlow = ({ returnUrl, formData }) =>
+export const redirectOldConditionsFlowToNew = ({ returnUrl, formData }) =>
   isNewConditionsOn(formData) && isOldFlowReturnUrl(returnUrl);
 
 export const onFormLoaded = props => {
@@ -1075,7 +1075,7 @@ export const onFormLoaded = props => {
   const shouldRevertWhenNoEvidence = redirectWhenNoEvidence(props);
   const shouldRedirectLegacyToEnhancement = redirectLegacyToEnhancement(props);
   const shouldRedirectEnhancementToLegacy = redirectEnhancementToLegacy(props);
-  const shouldRedirectOldFlowToNewFlow = redirectOldFlowToNewFlow(props);
+  const shouldRedirectOldFlowToNewFlow = redirectOldConditionsFlowToNew(props);
   const redirectUrl = legacy4142AuthURL;
 
   if (shouldRedirectOldFlowToNewFlow) {

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -1078,11 +1078,7 @@ export const onFormLoaded = props => {
   const shouldRedirectOldFlowToNewFlow = redirectOldConditionsFlowToNew(props);
   const redirectUrl = legacy4142AuthURL;
 
-  if (shouldRedirectOldFlowToNewFlow) {
-    // returnUrl points to a page hidden by the new conditions workflow —
-    // redirect to a safe page that is always available regardless of flipper
-    router.push('/contact-information');
-  } else if (shouldRedirectToModern4142Choice === true) {
+  if (shouldRedirectToModern4142Choice === true) {
     // if we should redirect to the modern 4142 choice page, we set the shared variable
     // and redirect to the redirectUrl (the modern 4142 choice page)
     setSharedVariable('alertNeedsShown4142', shouldRedirectToModern4142Choice);
@@ -1107,6 +1103,12 @@ export const onFormLoaded = props => {
   } else if (shouldRedirectEnhancementToLegacy === true) {
     // Handle evidence enhancement flow transition: enhancement → legacy
     router.push('/supporting-evidence/evidence-types');
+  } else if (shouldRedirectOldFlowToNewFlow) {
+    // Last resort: returnUrl points to a page hidden by the new conditions
+    // workflow. Redirect to a safe, always-accessible page to avoid a loop.
+    // This is checked last so other redirects (4142, evidence enhancement)
+    // can take priority — they all send to valid, non-old-flow pages.
+    router.push('/contact-information');
   } else {
     // otherwise, we just redirect to the returnUrl as usual when resuming a form
     router.push(returnUrl);


### PR DESCRIPTION
## Summary

- **Bug fix**: Users with existing InProgressForm (IPF) records for the 526EZ form were getting stuck in redirect loops when resuming their saved application after the `disabilityCompNewConditionsWorkflow` Flipper toggle was enabled.
- **Root cause**: The `useFormFeatureToggleSync` hook was injecting `disabilityCompNewConditionsWorkflow: true|false` into old forms that never had the key. This caused old-flow pages (e.g. `/claim-type`, `/new-disabilities/add`, `/disabilities/rated-disabilities`) to become hidden via `gatePages(..., isNewConditionsOff)`. When the user resumed the form, `onFormLoaded` blindly pushed to the saved `returnUrl` — which now pointed to a hidden page — causing an infinite redirect loop.
- **Fix (two parts)**:
  1. Removed `disabilityCompNewConditionsWorkflow` from the `useFormFeatureToggleSync` array in `Form526EZApp.jsx` to prevent future contamination of old IPFs.
  2. Added a guard in `onFormLoaded` (`redirectOldConditionsFlowToNew`) that detects when the new conditions workflow is ON but the `returnUrl` points to an old-flow page, and redirects the user to `/contact-information` (a safe, always-accessible page) instead.
- **Team**: Disability Benefits Experience - Core team, we own this code
- **Flipper**: `disability_compensation_new_conditions_workflow` — no end date change; this fix ensures existing IPFs interact correctly with the toggle regardless of state.

## Related issue(s)
https://dsva.slack.com/archives/C04KW0B46N5/p1771428175921629
Ticket TBD

## Testing done

- **Old behavior**: Users with a saved 526EZ form (created before the `disabilityCompNewConditionsWorkflow` flipper was enabled) would get stuck in a redirect loop when resuming their form. The `useFormFeatureToggleSync` hook would inject `disabilityCompNewConditionsWorkflow: true` into old form data, hiding old-flow pages. The saved `returnUrl` (e.g. `/new-disabilities/add`) pointed to a now-hidden page, causing an infinite redirect.
- **Steps to verify**:
  1. Create a saved 526EZ form with the `disabilityCompNewConditionsWorkflow` flipper OFF (so the form uses the old flow and saves a `returnUrl` like `/new-disabilities/add`).
  2. Edit the IPF data via popup dev_on thing, and add `disabilityCompNewConditionsWorkflow: true`
  3. Enable the `disabilityCompNewConditionsWorkflow` flipper.
  4. Resume the saved form — user should be redirected to `/contact-information` instead of getting stuck in a loop.
  5. Verify that users with the flipper OFF still resume to their saved `returnUrl` normally.
  6. Verify that users with the flipper ON and a new-flow `returnUrl` (e.g. `/conditions/summary`) resume normally without being redirected.
- **Unit tests added** (42 new tests, 51 total in file):
  - `isNewConditionsOn` — true, false, undefined, null, missing formData
  - `isNewConditionsOff` — inverse cases
  - `redirectOldFlowToNewFlow` — all 6 old-flow paths, parameterized paths (`/follow-up/0`, `/follow-up/3`), new-flow paths, unrelated paths, edge cases (undefined/null/empty `returnUrl`, partial prefix matching)
  - `onFormLoaded` old-flow redirect — each old-flow path triggers `/contact-information`, flag-off falls through, flag-absent falls through, new-flow/unrelated paths pass through, priority over other redirect branches
- All 51 unit tests passing.

## Screenshots

N/A — No UI changes. This is a redirect logic fix; affected users will now land on the contact information page instead of being stuck in a loop.

## What areas of the site does it impact?

- **526EZ Disability Compensation form** — specifically the save-in-progress resume flow for users with existing saved forms when the `disabilityCompNewConditionsWorkflow` flipper is enabled.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
