### PR TITLE
VASS Error Path Cypress Tests

### DIFF
--- a/src/applications/vass/pages/CancelAppointment.jsx
+++ b/src/applications/vass/pages/CancelAppointment.jsx
@@ -14,6 +14,7 @@ import {
   isCancellationFailedError,
   isMissingParameterError,
   isServerError,
+  isAppointmentNotFoundError,
 } from '../utils/errors';
 
 const getLoadingMessage = isCanceling => {
@@ -73,7 +74,8 @@ const CancelAppointment = () => {
         isCancellationFailedError(cancelAppointmentError) ||
         isMissingParameterError(cancelAppointmentError) ||
         isServerError(cancelAppointmentError) ||
-        isServerError(appointmentError)
+        isServerError(appointmentError) ||
+        isAppointmentNotFoundError(appointmentError)
       }
       testID="cancel-appointment-page"
       pageTitle="Would you like to cancel this appointment?"

--- a/src/applications/vass/pages/EnterOTP.jsx
+++ b/src/applications/vass/pages/EnterOTP.jsx
@@ -88,7 +88,6 @@ const EnterOTP = () => {
 
     if (response.error) {
       setApiError('API Error');
-      setCode('');
       return;
     }
 

--- a/src/applications/vass/pages/EnterOTP.jsx
+++ b/src/applications/vass/pages/EnterOTP.jsx
@@ -88,6 +88,7 @@ const EnterOTP = () => {
 
     if (response.error) {
       setApiError('API Error');
+      setCode('');
       return;
     }
 

--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -1,0 +1,727 @@
+import VerifyPageObject from './page-objects/VerifyPageObject';
+import EnterOTPPageObject from './page-objects/EnterOTPPageObject';
+import DateTimeSelectionPageObject from './page-objects/DateTimeSelectionPageObject';
+import TopicSelectionPageObject from './page-objects/TopicSelectionPageObject';
+import ReviewPageObject from './page-objects/ReviewPageObject';
+import CancelAppointmentPageObject from './page-objects/CancelAppointmentPageObject';
+import {
+  mockRequestOtpApi,
+  mockAuthenticateOtpApi,
+  mockAppointmentAvailabilityApi,
+  mockTopicsApi,
+  mockCreateAppointmentApi,
+  mockAppointmentDetailsApi,
+  mockCancelAppointmentApi,
+  patchCookiesForCI,
+} from './vass-e2e-helpers';
+import MockRequestOtpResponse from '../fixtures/MockRequestOtpResponse';
+import MockAuthenticateOtpResponse from '../fixtures/MockAuthenticateOtpResponse';
+import MockAppointmentAvailabilityResponse from '../fixtures/MockAppointmentAvailabilityResponse';
+import MockTopicsResponse from '../fixtures/MockTopicsResponse';
+import MockCreateAppointmentResponse from '../fixtures/MockCreateAppointmentResponse';
+import MockAppointmentDetailsResponse from '../fixtures/MockAppointmentDetailsResponse';
+import MockCancelAppointmentResponse from '../fixtures/MockCancelAppointmentResponse';
+import { createMockJwt } from '../../utils/mock-helpers';
+import { FLOW_TYPES } from '../../utils/constants';
+
+const uuid = 'c0ffee-1234-beef-5678';
+const expiresIn = 3600;
+
+describe('VASS Error Paths', () => {
+  beforeEach(() => {
+    // Patch document.cookie so the VASS JWT cookie can be stored
+    // in CI where the test server runs on http://127.0.0.1 (not HTTPS/va.gov)
+    patchCookiesForCI();
+  });
+
+  describe('Verify Identity', () => {
+    describe('API Errors', () => {
+      describe('when the user submits invalid credentials', () => {
+        beforeEach(() => {
+          mockRequestOtpApi({
+            response: MockRequestOtpResponse.createInvalidCredentialsError(),
+            responseCode: 401,
+          });
+          cy.visit(
+            `/service-member/benefits/solid-start/schedule?uuid=${uuid}`,
+          );
+        });
+
+        it('should display an error when identity verification fails for the first time', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.enterLastName('WrongName');
+          VerifyPageObject.enterDateOfBirth('1990-01-01');
+          VerifyPageObject.clickSubmit();
+
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.assertInvalidCredentialsErrorAlert();
+        });
+
+        it('should display a verification error alert after 3 failed attempts', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.fillAndSubmitDefaultForm();
+
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.clickSubmit();
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.clickSubmit();
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.assertInvalidVerificationErrorAlert({
+            exist: true,
+          });
+        });
+      });
+
+      describe('when the user is rate limited', () => {
+        beforeEach(() => {
+          mockRequestOtpApi({
+            response: MockRequestOtpResponse.createRateLimitExceededError(),
+            responseCode: 429,
+          });
+          cy.visit(
+            `/service-member/benefits/solid-start/schedule?uuid=${uuid}`,
+          );
+        });
+
+        it('should display a verification error alert', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.fillAndSubmitDefaultForm();
+
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.assertInvalidVerificationErrorAlert({
+            exist: true,
+          });
+        });
+      });
+
+      describe('when the API returns a server error', () => {
+        beforeEach(() => {
+          mockRequestOtpApi({
+            response: MockRequestOtpResponse.createVassApiError(),
+            responseCode: 500,
+          });
+          cy.visit(
+            `/service-member/benefits/solid-start/schedule?uuid=${uuid}`,
+          );
+        });
+
+        it('should display a wrapper error alert', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.fillAndSubmitDefaultForm();
+
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+        });
+      });
+
+      describe('when the service is unavailable', () => {
+        beforeEach(() => {
+          mockRequestOtpApi({
+            response: MockRequestOtpResponse.createServiceError(),
+            responseCode: 503,
+          });
+          cy.visit(
+            `/service-member/benefits/solid-start/schedule?uuid=${uuid}`,
+          );
+        });
+
+        it('should display a wrapper error alert', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.fillAndSubmitDefaultForm();
+
+          cy.wait('@vass:post:request-otp');
+
+          VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+        });
+      });
+    });
+
+    describe('UI Errors', () => {
+      beforeEach(() => {
+        cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+      });
+      describe('when the user leaves the last name input empty', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.enterLastName('');
+          VerifyPageObject.enterDateOfBirth('1990-01-01');
+          VerifyPageObject.clickSubmit();
+
+          VerifyPageObject.assertLastNameError('Please enter your last name');
+        });
+      });
+
+      describe('when the user leaves the date of birth input empty', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          VerifyPageObject.assertVerifyPage();
+          cy.injectAxeThenAxeCheck();
+
+          VerifyPageObject.enterLastName('Smith');
+          VerifyPageObject.clickSubmit();
+
+          VerifyPageObject.assertDateOfBirthError(
+            'Please enter your date of birth',
+          );
+        });
+      });
+    });
+  });
+
+  describe('OTP Verification Errors', () => {
+    beforeEach(() => {
+      mockRequestOtpApi();
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+      VerifyPageObject.fillAndSubmitDefaultForm();
+      cy.wait('@vass:post:request-otp');
+    });
+
+    describe('API Errors', () => {
+      describe('when the user enters an invalid OTP', () => {
+        beforeEach(() => {
+          mockAuthenticateOtpApi({
+            response: MockAuthenticateOtpResponse.createInvalidOtpError(3),
+            responseCode: 401,
+          });
+        });
+
+        it('should display an invalid OTP error', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
+          cy.injectAxeThenAxeCheck();
+
+          EnterOTPPageObject.enterOTP('123456');
+          EnterOTPPageObject.clickContinue();
+
+          cy.wait('@vass:post:authenticate-otp');
+
+          EnterOTPPageObject.assertOTPErrorAlert({
+            exist: true,
+            contain: /The one-time verification code you entered doesn’t match the one we sent you. Check your email and try again./i,
+          });
+        });
+
+        it('should display an invalid OTP error when the user has 1 remaining attempt', () => {
+          mockAuthenticateOtpApi({
+            response: MockAuthenticateOtpResponse.createInvalidOtpError(1),
+            responseCode: 401,
+          });
+
+          EnterOTPPageObject.assertEnterOTPPage();
+          cy.injectAxeThenAxeCheck();
+
+          EnterOTPPageObject.enterOTP('123456');
+          EnterOTPPageObject.clickContinue();
+
+          cy.wait('@vass:post:authenticate-otp');
+
+          EnterOTPPageObject.assertOTPErrorAlert({
+            exist: true,
+            contain: /The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again./i,
+          });
+        });
+      });
+
+      describe('when the user account is locked', () => {
+        beforeEach(() => {
+          mockAuthenticateOtpApi({
+            response: MockAuthenticateOtpResponse.createAccountLockedError(),
+            responseCode: 401,
+          });
+        });
+
+        it('should display a verification error alert', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
+          cy.injectAxeThenAxeCheck();
+
+          EnterOTPPageObject.enterOTP('123456');
+          EnterOTPPageObject.clickContinue();
+
+          cy.wait('@vass:post:authenticate-otp');
+
+          EnterOTPPageObject.assertVerificationErrorPage();
+        });
+      });
+
+      describe('when the API returns a server error', () => {
+        beforeEach(() => {
+          mockAuthenticateOtpApi({
+            response: MockAuthenticateOtpResponse.createVassApiError(),
+            responseCode: 500,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
+          cy.injectAxeThenAxeCheck();
+
+          EnterOTPPageObject.enterOTP('123456');
+          EnterOTPPageObject.clickContinue();
+
+          cy.wait('@vass:post:authenticate-otp');
+
+          EnterOTPPageObject.assertWrapperErrorAlert({ exist: true });
+        });
+      });
+
+      describe('when the service is unavailable', () => {
+        beforeEach(() => {
+          mockAuthenticateOtpApi({
+            response: MockAuthenticateOtpResponse.createServiceError(),
+            responseCode: 503,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
+          cy.injectAxeThenAxeCheck();
+
+          EnterOTPPageObject.enterOTP('123456');
+          EnterOTPPageObject.clickContinue();
+
+          cy.wait('@vass:post:authenticate-otp');
+
+          EnterOTPPageObject.assertWrapperErrorAlert({ exist: true });
+        });
+      });
+    });
+
+    describe('UI Errors', () => {
+      describe('when the user leaves the OTP input empty', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
+          cy.injectAxeThenAxeCheck();
+
+          EnterOTPPageObject.submitEmptyForm();
+
+          EnterOTPPageObject.assertOTPError(
+            'Please enter your one-time verification code',
+          );
+        });
+      });
+
+      describe('when the user enters an invalid OTP', () => {
+        describe('when the user enters a non-numeric OTP', () => {
+          it('should not submit the form and display an error when the user submits the form', () => {
+            EnterOTPPageObject.assertEnterOTPPage();
+            cy.injectAxeThenAxeCheck();
+
+            EnterOTPPageObject.enterOTP('aaaaaa');
+            EnterOTPPageObject.clickContinue();
+
+            EnterOTPPageObject.assertOTPError(
+              'Your verification code should only contain numbers',
+            );
+          });
+        });
+
+        describe('when the user enters a less than 6 digits OTP', () => {
+          it('should not submit the form and display an error when the user submits the form', () => {
+            EnterOTPPageObject.assertEnterOTPPage();
+            cy.injectAxeThenAxeCheck();
+
+            EnterOTPPageObject.enterOTP('12345');
+            EnterOTPPageObject.clickContinue();
+
+            EnterOTPPageObject.assertOTPError(
+              'Your verification code should be 6 digits',
+            );
+          });
+        });
+      });
+    });
+  });
+
+  describe('Appointment Availability Errors', () => {
+    beforeEach(() => {
+      mockRequestOtpApi();
+      const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+        token: createMockJwt(uuid, expiresIn),
+        expiresIn,
+      }).toJSON();
+      mockAuthenticateOtpApi({
+        response: authenticateOtpResponse,
+        responseCode: 200,
+      });
+
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+      VerifyPageObject.fillAndSubmitDefaultForm();
+      cy.wait('@vass:post:request-otp');
+    });
+    describe('when the user is not within the cohort window', () => {
+      beforeEach(() => {
+        mockAppointmentAvailabilityApi({
+          response: MockAppointmentAvailabilityResponse.createNotWithinCohortError(),
+          responseCode: 403,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        cy.wait('@vass:get:appointment-availability');
+        cy.injectAxeThenAxeCheck();
+
+        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+
+    // TODO: implement this case
+    // describe('when no slots are available', () => {
+    //   beforeEach(() => {
+    //     mockAppointmentAvailabilityApi({
+    //       response: MockAppointmentAvailabilityResponse.createNoSlotsAvailableError(),
+    //       responseCode: 404,
+    //     });
+    //   });
+
+    //   it('should display a no slots available error', () => {
+    //     // TODO: implement
+    //   });
+    // });
+
+    describe('when the API returns a server error', () => {
+      beforeEach(() => {
+        mockAppointmentAvailabilityApi({
+          response: MockAppointmentAvailabilityResponse.createVassApiError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        cy.wait('@vass:get:appointment-availability');
+        cy.injectAxeThenAxeCheck();
+
+        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+
+    describe('when the service is unavailable', () => {
+      beforeEach(() => {
+        mockAppointmentAvailabilityApi({
+          response: MockAppointmentAvailabilityResponse.createServiceError(),
+          responseCode: 503,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        cy.wait('@vass:get:appointment-availability');
+        cy.injectAxeThenAxeCheck();
+
+        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+  });
+
+  describe('Topics Errors', () => {
+    beforeEach(() => {
+      mockRequestOtpApi();
+
+      const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+        token: createMockJwt(uuid, expiresIn),
+        expiresIn,
+      }).toJSON();
+      mockAuthenticateOtpApi({
+        response: authenticateOtpResponse,
+        responseCode: 200,
+      });
+
+      mockAppointmentAvailabilityApi();
+
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+      VerifyPageObject.fillAndSubmitDefaultForm();
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+    });
+
+    describe('when the API returns a server error', () => {
+      beforeEach(() => {
+        mockTopicsApi({
+          response: MockTopicsResponse.createVassApiError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+        cy.wait('@vass:get:topics');
+        cy.injectAxeThenAxeCheck();
+
+        TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+
+    describe('when the service is unavailable', () => {
+      beforeEach(() => {
+        mockTopicsApi({
+          response: MockTopicsResponse.createServiceError(),
+          responseCode: 503,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+        cy.wait('@vass:get:topics');
+        cy.injectAxeThenAxeCheck();
+
+        TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+  });
+
+  describe('Create Appointment Errors', () => {
+    beforeEach(() => {
+      mockRequestOtpApi();
+
+      const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+        token: createMockJwt(uuid, expiresIn),
+        expiresIn,
+      }).toJSON();
+      mockAuthenticateOtpApi({
+        response: authenticateOtpResponse,
+        responseCode: 200,
+      });
+
+      mockAppointmentAvailabilityApi();
+      mockTopicsApi();
+
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+      VerifyPageObject.fillAndSubmitDefaultForm();
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+      TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
+    });
+
+    describe('when the appointment fails to save', () => {
+      beforeEach(() => {
+        mockCreateAppointmentApi({
+          response: MockCreateAppointmentResponse.createAppointmentSaveFailedError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        ReviewPageObject.clickConfirmAppointment();
+        cy.wait('@vass:post:appointment');
+        cy.injectAxeThenAxeCheck();
+
+        ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+
+    describe('when the API returns a server error', () => {
+      beforeEach(() => {
+        mockCreateAppointmentApi({
+          response: MockCreateAppointmentResponse.createVassApiError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        ReviewPageObject.clickConfirmAppointment();
+        cy.wait('@vass:post:appointment');
+        cy.injectAxeThenAxeCheck();
+
+        ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+
+    describe('when the service is unavailable', () => {
+      beforeEach(() => {
+        mockCreateAppointmentApi({
+          response: MockCreateAppointmentResponse.createServiceError(),
+          responseCode: 503,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        ReviewPageObject.clickConfirmAppointment();
+        cy.wait('@vass:post:appointment');
+        cy.injectAxeThenAxeCheck();
+
+        ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+  });
+
+  describe('Appointment Details Errors', () => {
+    beforeEach(() => {
+      mockRequestOtpApi();
+
+      const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+        token: createMockJwt(uuid, expiresIn),
+        expiresIn,
+      }).toJSON();
+      mockAuthenticateOtpApi({
+        response: authenticateOtpResponse,
+        responseCode: 200,
+      });
+
+      mockAppointmentAvailabilityApi();
+      mockTopicsApi();
+      mockCreateAppointmentApi();
+
+      cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
+      VerifyPageObject.fillAndSubmitDefaultForm();
+      cy.wait('@vass:post:request-otp');
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+      TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
+    });
+
+    describe('when the appointment is not found', () => {
+      beforeEach(() => {
+        mockAppointmentDetailsApi({
+          response: MockAppointmentDetailsResponse.createAppointmentNotFoundError(),
+          responseCode: 404,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        ReviewPageObject.clickConfirmAppointment();
+        cy.wait('@vass:post:appointment');
+        cy.injectAxeThenAxeCheck();
+
+        ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+
+    describe('when the API returns a server error', () => {
+      beforeEach(() => {
+        mockAppointmentDetailsApi({
+          response: MockAppointmentDetailsResponse.createVassApiError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        ReviewPageObject.clickConfirmAppointment();
+        cy.wait('@vass:post:appointment');
+        cy.injectAxeThenAxeCheck();
+
+        ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+      });
+    });
+  });
+
+  describe('Cancel Appointment Errors', () => {
+    beforeEach(() => {
+      mockRequestOtpApi();
+
+      const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+        token: createMockJwt(uuid, expiresIn),
+        expiresIn,
+      }).toJSON();
+      mockAuthenticateOtpApi({
+        response: authenticateOtpResponse,
+        responseCode: 200,
+      });
+
+      const appointmentId = 'abcdef123456';
+      mockAppointmentAvailabilityApi({
+        response: new MockAppointmentAvailabilityResponse({
+          appointmentId,
+          availableSlots: MockAppointmentAvailabilityResponse.createSlots(),
+        }).toJSON(),
+        responseCode: 200,
+      });
+      mockTopicsApi();
+      mockCreateAppointmentApi();
+      mockAppointmentDetailsApi({
+        response: new MockAppointmentDetailsResponse({
+          appointmentId,
+        }).toJSON(),
+        responseCode: 200,
+      });
+
+      cy.visit(
+        `/service-member/benefits/solid-start/schedule?uuid=${uuid}&cancel=true`,
+      );
+      VerifyPageObject.fillAndSubmitDefaultForm();
+      cy.wait('@vass:post:request-otp');
+    });
+
+    describe('when cancellation fails', () => {
+      beforeEach(() => {
+        mockCancelAppointmentApi({
+          response: MockCancelAppointmentResponse.createCancellationFailedError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        cy.wait('@vass:post:authenticate-otp');
+        CancelAppointmentPageObject.clickYesCancelAppointment();
+        cy.wait('@vass:post:cancel-appointment');
+        cy.injectAxeThenAxeCheck();
+
+        CancelAppointmentPageObject.assertWrapperErrorAlert({
+          exist: true,
+          flowType: FLOW_TYPES.CANCEL,
+        });
+      });
+    });
+
+    describe('when the appointment to cancel is not found', () => {
+      beforeEach(() => {
+        mockAppointmentDetailsApi({
+          response: MockAppointmentDetailsResponse.createAppointmentNotFoundError(),
+          responseCode: 404,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        cy.wait('@vass:post:authenticate-otp');
+        cy.wait('@vass:get:appointment-details');
+        cy.injectAxeThenAxeCheck();
+
+        CancelAppointmentPageObject.assertWrapperErrorAlert({
+          exist: true,
+          flowType: FLOW_TYPES.CANCEL,
+        });
+      });
+    });
+
+    describe('when the API returns a server error', () => {
+      beforeEach(() => {
+        mockCancelAppointmentApi({
+          response: MockCancelAppointmentResponse.createVassApiError(),
+          responseCode: 500,
+        });
+      });
+
+      it('should display a wrapper error alert', () => {
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        cy.wait('@vass:post:authenticate-otp');
+        CancelAppointmentPageObject.clickYesCancelAppointment();
+        cy.wait('@vass:post:cancel-appointment');
+        cy.injectAxeThenAxeCheck();
+
+        CancelAppointmentPageObject.assertWrapperErrorAlert({
+          exist: true,
+          flowType: FLOW_TYPES.CANCEL,
+        });
+      });
+    });
+  });
+});

--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -213,7 +213,8 @@ describe('VASS Error Paths', () => {
 
           EnterOTPPageObject.assertOTPErrorAlert({
             exist: true,
-            contain: /The one-time verification code you entered doesn’t match the one we sent you. Check your email and try again./i,
+            containsText:
+              'The one-time verification code you entered doesn’t match the one we sent you. Check your email and try again.',
           });
         });
 
@@ -233,7 +234,8 @@ describe('VASS Error Paths', () => {
 
           EnterOTPPageObject.assertOTPErrorAlert({
             exist: true,
-            contain: /The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again./i,
+            containsText:
+              'The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again.',
           });
         });
       });

--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -64,7 +64,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertVerifyPage();
           cy.injectAxeThenAxeCheck();
 
-          VerifyPageObject.fillAndSubmitDefaultForm();
+          VerifyPageObject.fillAndSubmitForm();
 
           cy.wait('@vass:post:request-otp');
 
@@ -95,7 +95,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertVerifyPage();
           cy.injectAxeThenAxeCheck();
 
-          VerifyPageObject.fillAndSubmitDefaultForm();
+          VerifyPageObject.fillAndSubmitForm();
 
           cy.wait('@vass:post:request-otp');
 
@@ -120,7 +120,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertVerifyPage();
           cy.injectAxeThenAxeCheck();
 
-          VerifyPageObject.fillAndSubmitDefaultForm();
+          VerifyPageObject.fillAndSubmitForm();
 
           cy.wait('@vass:post:request-otp');
 
@@ -143,7 +143,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertVerifyPage();
           cy.injectAxeThenAxeCheck();
 
-          VerifyPageObject.fillAndSubmitDefaultForm();
+          VerifyPageObject.fillAndSubmitForm();
 
           cy.wait('@vass:post:request-otp');
 
@@ -189,7 +189,7 @@ describe('VASS Error Paths', () => {
     beforeEach(() => {
       mockRequestOtpApi();
       cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
     });
 
@@ -363,7 +363,7 @@ describe('VASS Error Paths', () => {
       });
 
       cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
     });
     describe('when the user is not within the cohort window', () => {
@@ -375,7 +375,7 @@ describe('VASS Error Paths', () => {
       });
 
       it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
         cy.injectAxeThenAxeCheck();
 
@@ -406,7 +406,7 @@ describe('VASS Error Paths', () => {
       });
 
       it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
         cy.injectAxeThenAxeCheck();
 
@@ -423,7 +423,7 @@ describe('VASS Error Paths', () => {
       });
 
       it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
         cy.injectAxeThenAxeCheck();
 
@@ -448,9 +448,9 @@ describe('VASS Error Paths', () => {
       mockAppointmentAvailabilityApi();
 
       cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
     });
 
     describe('when the API returns a server error', () => {
@@ -505,9 +505,9 @@ describe('VASS Error Paths', () => {
       mockTopicsApi();
 
       cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
       DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
       TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
     });
@@ -582,9 +582,9 @@ describe('VASS Error Paths', () => {
       mockCreateAppointmentApi();
 
       cy.visit(`/service-member/benefits/solid-start/schedule?uuid=${uuid}`);
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
       DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
       TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
     });
@@ -657,7 +657,7 @@ describe('VASS Error Paths', () => {
       cy.visit(
         `/service-member/benefits/solid-start/schedule?uuid=${uuid}&cancel=true`,
       );
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
     });
 
@@ -670,7 +670,7 @@ describe('VASS Error Paths', () => {
       });
 
       it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:post:authenticate-otp');
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');
@@ -692,7 +692,7 @@ describe('VASS Error Paths', () => {
       });
 
       it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:post:authenticate-otp');
         cy.wait('@vass:get:appointment-details');
         cy.injectAxeThenAxeCheck();
@@ -713,7 +713,7 @@ describe('VASS Error Paths', () => {
       });
 
       it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:post:authenticate-otp');
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');

--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -727,7 +727,7 @@ describe('VASS Error Paths', () => {
     });
   });
 
-  describe.only('Navigation', () => {
+  describe('Navigation', () => {
     describe('when the user attempt to navigate back from the Date/Time Selection page', () => {
       beforeEach(() => {
         mockAppointmentAvailabilityApi();

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -67,13 +67,13 @@ describe('VASS Schedule Appointment', () => {
 
       cy.injectAxeThenAxeCheck();
 
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
 
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -148,12 +148,12 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -208,12 +208,12 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -284,13 +284,13 @@ describe('VASS Schedule Appointment', () => {
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
 
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
 
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -334,13 +334,13 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage({ cancellationFlow: true });
       cy.injectAxeThenAxeCheck();
-      VerifyPageObject.fillAndSubmitDefaultForm();
+      VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       cy.injectAxeThenAxeCheck();
       EnterOTPPageObject.assertEnterOTPPage({ cancellationFlow: true });
       EnterOTPPageObject.assertSuccessAlertContainsEmail('s****@email.com');
-      EnterOTPPageObject.fillAndSubmitDefaultOTP();
+      EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-details');
 
@@ -397,11 +397,11 @@ describe('VASS Schedule Appointment', () => {
 
         VerifyPageObject.assertVerifyPage();
         cy.injectAxeThenAxeCheck();
-        VerifyPageObject.fillAndSubmitDefaultForm();
+        VerifyPageObject.fillAndSubmitForm();
 
         cy.wait('@vass:post:request-otp');
         cy.injectAxeThenAxeCheck();
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
 
         cy.wait('@vass:get:appointment-availability');
         cy.wait('@vass:get:appointment-details');
@@ -415,12 +415,12 @@ describe('VASS Schedule Appointment', () => {
 
         VerifyPageObject.assertVerifyPage();
         cy.injectAxeThenAxeCheck();
-        VerifyPageObject.fillAndSubmitDefaultForm();
+        VerifyPageObject.fillAndSubmitForm();
 
         cy.wait('@vass:post:request-otp');
         EnterOTPPageObject.assertEnterOTPPage();
         cy.injectAxeThenAxeCheck();
-        EnterOTPPageObject.fillAndSubmitDefaultOTP();
+        EnterOTPPageObject.fillAndSubmitOTP();
 
         cy.wait('@vass:get:appointment-availability');
         cy.wait('@vass:get:appointment-details');

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -67,13 +67,13 @@ describe('VASS Schedule Appointment', () => {
 
       cy.injectAxeThenAxeCheck();
 
-      VerifyPageObject.fillAndSubmitValidForm();
+      VerifyPageObject.fillAndSubmitDefaultForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
 
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitValidOTP();
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -121,6 +121,7 @@ describe('VASS Schedule Appointment', () => {
         response: new MockAppointmentAvailabilityResponse({
           availableSlots: [firstSlot, secondSlot],
         }).toJSON(),
+        responseCode: 200,
       });
 
       mockAppointmentDetailsApi({
@@ -129,6 +130,7 @@ describe('VASS Schedule Appointment', () => {
           startUTC: secondSlotStart,
           endUTC: '2025-06-03T14:00:00.000Z',
         }).toJSON(),
+        responseCode: 200,
       });
 
       // Format expected date/time in the same timezone as the app (works in UTC or any server TZ)
@@ -146,12 +148,12 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
-      VerifyPageObject.fillAndSubmitValidForm();
+      VerifyPageObject.fillAndSubmitDefaultForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitValidOTP();
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -206,12 +208,12 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
-      VerifyPageObject.fillAndSubmitValidForm();
+      VerifyPageObject.fillAndSubmitDefaultForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitValidOTP();
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -282,7 +284,7 @@ describe('VASS Schedule Appointment', () => {
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
 
-      VerifyPageObject.fillAndSubmitForm({
+      VerifyPageObject.fillAndSubmitDefaultForm({
         lastName: 'Smith',
         dateOfBirth: '1935-04-07',
       });
@@ -291,7 +293,7 @@ describe('VASS Schedule Appointment', () => {
       EnterOTPPageObject.assertEnterOTPPage();
 
       cy.injectAxeThenAxeCheck();
-      EnterOTPPageObject.fillAndSubmitValidOTP();
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
@@ -335,13 +337,13 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage({ cancellationFlow: true });
       cy.injectAxeThenAxeCheck();
-      VerifyPageObject.fillAndSubmitValidForm();
+      VerifyPageObject.fillAndSubmitDefaultForm();
 
       cy.wait('@vass:post:request-otp');
       cy.injectAxeThenAxeCheck();
       EnterOTPPageObject.assertEnterOTPPage({ cancellationFlow: true });
       EnterOTPPageObject.assertSuccessAlertContainsEmail('s****@email.com');
-      EnterOTPPageObject.fillAndSubmitValidOTP();
+      EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
       cy.wait('@vass:get:appointment-details');
 
@@ -398,11 +400,11 @@ describe('VASS Schedule Appointment', () => {
 
         VerifyPageObject.assertVerifyPage();
         cy.injectAxeThenAxeCheck();
-        VerifyPageObject.fillAndSubmitValidForm();
+        VerifyPageObject.fillAndSubmitDefaultForm();
 
         cy.wait('@vass:post:request-otp');
         cy.injectAxeThenAxeCheck();
-        EnterOTPPageObject.fillAndSubmitValidOTP();
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
         cy.wait('@vass:get:appointment-availability');
         cy.wait('@vass:get:appointment-details');
@@ -416,12 +418,12 @@ describe('VASS Schedule Appointment', () => {
 
         VerifyPageObject.assertVerifyPage();
         cy.injectAxeThenAxeCheck();
-        VerifyPageObject.fillAndSubmitValidForm();
+        VerifyPageObject.fillAndSubmitDefaultForm();
 
         cy.wait('@vass:post:request-otp');
         EnterOTPPageObject.assertEnterOTPPage();
         cy.injectAxeThenAxeCheck();
-        EnterOTPPageObject.fillAndSubmitValidOTP();
+        EnterOTPPageObject.fillAndSubmitDefaultOTP();
 
         cy.wait('@vass:get:appointment-availability');
         cy.wait('@vass:get:appointment-details');

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -284,10 +284,7 @@ describe('VASS Schedule Appointment', () => {
       VerifyPageObject.assertVerifyPage();
       cy.injectAxeThenAxeCheck();
 
-      VerifyPageObject.fillAndSubmitDefaultForm({
-        lastName: 'Smith',
-        dateOfBirth: '1935-04-07',
-      });
+      VerifyPageObject.fillAndSubmitDefaultForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();

--- a/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
@@ -25,13 +25,11 @@ export class CancelAppointmentPageObject extends PageObject {
     // Appointment card
     this.assertElement('appointment-card');
     this.assertElement('appointment-type', {
-      exist: true,
       containsText: 'Phone appointment',
     });
 
     // How to join section with phone number
     this.assertElement('how-to-join-section', {
-      exist: true,
       containsText: 'Your representative will call you from',
     });
     cy.findByTestId('how-to-join-section').within(() => {
@@ -45,13 +43,11 @@ export class CancelAppointmentPageObject extends PageObject {
 
     // What section
     this.assertElement('what-section', {
-      exist: true,
       containsText: 'VA Solid Start',
     });
 
     // Who section with agent name
     this.assertElement('who-section', {
-      exist: true,
       containsText: agentName,
     });
 

--- a/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/CancelAppointmentPageObject.js
@@ -25,11 +25,13 @@ export class CancelAppointmentPageObject extends PageObject {
     // Appointment card
     this.assertElement('appointment-card');
     this.assertElement('appointment-type', {
+      exist: true,
       containsText: 'Phone appointment',
     });
 
     // How to join section with phone number
     this.assertElement('how-to-join-section', {
+      exist: true,
       containsText: 'Your representative will call you from',
     });
     cy.findByTestId('how-to-join-section').within(() => {
@@ -42,10 +44,16 @@ export class CancelAppointmentPageObject extends PageObject {
     this.assertElement('when-section');
 
     // What section
-    this.assertElement('what-section', { containsText: 'VA Solid Start' });
+    this.assertElement('what-section', {
+      exist: true,
+      containsText: 'VA Solid Start',
+    });
 
     // Who section with agent name
-    this.assertElement('who-section', { containsText: agentName });
+    this.assertElement('who-section', {
+      exist: true,
+      containsText: agentName,
+    });
 
     // Cancel/print buttons should NOT be present on this page (different from Confirmation)
     this.assertElement('print-button', { exist: false });

--- a/src/applications/vass/tests/e2e/page-objects/DateTimeSelectionPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/DateTimeSelectionPageObject.js
@@ -211,9 +211,9 @@ export class DateTimeSelectionPageObject extends PageObject {
    * @returns {DateTimeSelectionPageObject}
    */
   assertTimezoneText(timezone) {
-    cy.findByTestId('content')
-      .should('exist')
-      .and('contain.text', timezone);
+    this.assertElement('content', {
+      containsText: timezone,
+    });
     return this;
   }
 

--- a/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
@@ -41,7 +41,7 @@ export class EnterOTPPageObject extends PageObject {
   assertVerificationErrorPage({ exist = true } = {}) {
     if (exist) {
       this.assertVerificationErrorAlert({
-        headingText: /We couldn.t verify your information/i,
+        headingText: 'We couldn’t verify your information',
         containsText:
           'The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes. Check your email and select the link to schedule a call.',
       });

--- a/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
@@ -53,20 +53,12 @@ export class EnterOTPPageObject extends PageObject {
 
   /**
    * Enter an OTP code value
-   * @param {string} code - The OTP code to enter
+   * @param {string} code - The OTP code to enter. If no value is provided, the default value of '123456' will be used.
    * @returns {EnterOTPPageObject}
    */
-  enterOTP(code) {
+  enterOTP(code = '123456') {
     cy.fillVaTextInput('otp', code);
     return this;
-  }
-
-  /**
-   * Enter a default OTP code for testing
-   * @returns {EnterOTPPageObject}
-   */
-  enterDefaultOTP() {
-    return this.enterOTP('123456');
   }
 
   /**
@@ -140,21 +132,11 @@ export class EnterOTPPageObject extends PageObject {
   }
 
   /**
-   * Fill the form with default OTP and submit
-   * @returns {EnterOTPPageObject}
-   */
-  fillAndSubmitDefaultOTP() {
-    this.enterDefaultOTP();
-    this.clickContinue();
-    return this;
-  }
-
-  /**
    * Fill the form with custom OTP and submit
-   * @param {string} code - The OTP code to enter
+   * @param {string} code - The OTP code to enter. If no value is provided, the default value of '123456' will be used.
    * @returns {EnterOTPPageObject}
    */
-  fillAndSubmitOTP(code) {
+  fillAndSubmitOTP(code = '123456') {
     this.enterOTP(code);
     this.clickContinue();
     return this;

--- a/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
@@ -26,6 +26,7 @@ export class EnterOTPPageObject extends PageObject {
 
     // Assert no error states on initial load
     this.assertOTPErrorAlert({ exist: false });
+    this.assertVerificationErrorAlert({ exist: false });
 
     // Assert need help footer
     this.assertNeedHelpFooter();
@@ -37,12 +38,15 @@ export class EnterOTPPageObject extends PageObject {
    * Assert the verification error page is displayed (account locked)
    * @returns {EnterOTPPageObject}
    */
-  assertVerificationErrorPage() {
-    this.assertHeading({
-      name: /We couldn.t verify your information/i,
-      level: 1,
-      exist: true,
-    });
+  assertVerificationErrorPage({ exist = true } = {}) {
+    if (exist) {
+      this.assertVerificationErrorAlert({
+        headingText: /We couldn.t verify your information/i,
+        contain: /The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes. Check your email and select the link to schedule a call./i,
+      });
+    } else {
+      this.assertVerificationErrorAlert({ exist: false });
+    }
     return this;
   }
 
@@ -57,10 +61,10 @@ export class EnterOTPPageObject extends PageObject {
   }
 
   /**
-   * Enter a valid OTP code for testing
+   * Enter a default OTP code for testing
    * @returns {EnterOTPPageObject}
    */
-  enterValidOTP() {
+  enterDefaultOTP() {
     return this.enterOTP('123456');
   }
 
@@ -90,28 +94,11 @@ export class EnterOTPPageObject extends PageObject {
    * Assert the error alert is displayed or not
    * @param {Object} props - Options
    * @param {boolean} props.exist - Whether the alert should exist
+   * @param {string|RegExp} props.contain - The text of the alert to assert
    * @returns {EnterOTPPageObject}
    */
-  assertOTPErrorAlert({ exist = true } = {}) {
-    this.assertElement('enter-otp-error-alert', { exist });
-    return this;
-  }
-
-  /**
-   * Assert the continue button is in loading state
-   * @returns {EnterOTPPageObject}
-   */
-  assertContinueLoading() {
-    cy.findByTestId('continue-button').should('have.attr', 'loading', 'true');
-    return this;
-  }
-
-  /**
-   * Assert the continue button is not in loading state
-   * @returns {EnterOTPPageObject}
-   */
-  assertContinueNotLoading() {
-    cy.findByTestId('continue-button').should('not.have.attr', 'loading');
+  assertOTPErrorAlert({ exist = true, contain } = {}) {
+    this.assertElement('enter-otp-error-alert', { exist, contain });
     return this;
   }
 
@@ -147,11 +134,11 @@ export class EnterOTPPageObject extends PageObject {
   }
 
   /**
-   * Fill the form with valid OTP and submit
+   * Fill the form with default OTP and submit
    * @returns {EnterOTPPageObject}
    */
-  fillAndSubmitValidOTP() {
-    this.enterValidOTP();
+  fillAndSubmitDefaultOTP() {
+    this.enterDefaultOTP();
     this.clickContinue();
     return this;
   }

--- a/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/EnterOTPPageObject.js
@@ -42,7 +42,8 @@ export class EnterOTPPageObject extends PageObject {
     if (exist) {
       this.assertVerificationErrorAlert({
         headingText: /We couldn.t verify your information/i,
-        contain: /The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes. Check your email and select the link to schedule a call./i,
+        containsText:
+          'The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes. Check your email and select the link to schedule a call.',
       });
     } else {
       this.assertVerificationErrorAlert({ exist: false });
@@ -94,11 +95,16 @@ export class EnterOTPPageObject extends PageObject {
    * Assert the error alert is displayed or not
    * @param {Object} props - Options
    * @param {boolean} props.exist - Whether the alert should exist
-   * @param {string|RegExp} props.contain - The text of the alert to assert
+   * @param {string} props.containsText - The text of the alert to contain
+   * @param {RegExp} props.matchText - The text of the alert to match
    * @returns {EnterOTPPageObject}
    */
-  assertOTPErrorAlert({ exist = true, contain } = {}) {
-    this.assertElement('enter-otp-error-alert', { exist, contain });
+  assertOTPErrorAlert({ exist = true, containsText, matchText } = {}) {
+    this.assertElement('enter-otp-error-alert', {
+      exist,
+      containsText,
+      matchText,
+    });
     return this;
   }
 

--- a/src/applications/vass/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/PageObject.js
@@ -87,8 +87,8 @@ export default class PageObject {
       this.assertHeading({
         name:
           flowType === FLOW_TYPES.SCHEDULE
-            ? /Error Alert We can’t schedule your appointment right now/i
-            : /Error Alert We can’t cancel your appointment right now/i,
+            ? 'Error Alert We can’t schedule your appointment right now'
+            : 'Error Alert We can’t cancel your appointment right now',
         level: 2,
         exist: true,
       });

--- a/src/applications/vass/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/PageObject.js
@@ -4,7 +4,9 @@ export default class PageObject {
   rootUrl = '/service-member/benefits/solid-start/schedule';
 
   /**
-   * Assert an element exists and optionally contains text
+   * Assert an element exists and optionally contains text or matches a regex pattern.
+   * If no options are provided, the element will be asserted to exist. If both
+   * containsText and matchText are provided, containsText will be used and matchText will be ignored.
    * @param {string} testId - The data-testid to find
    * @param {Object} options - Options
    * @param {boolean} options.exist - Whether the element should exist
@@ -13,17 +15,22 @@ export default class PageObject {
    * @returns {PageObject}
    */
   assertElement(testId, { exist = true, containsText, matchText } = {}) {
-    if (exist && containsText) {
+    if (!exist) {
+      cy.findByTestId(testId).should('not.exist');
+      return this;
+    }
+
+    if (containsText) {
       cy.findByTestId(testId)
         .should('exist')
         .and('contain.text', containsText);
-    } else if (exist && matchText) {
+    } else if (matchText) {
       cy.findByTestId(testId)
         .should('exist')
         .invoke('text')
         .and('match', matchText);
     } else {
-      cy.findByTestId(testId).should(exist ? 'exist' : 'not.exist');
+      cy.findByTestId(testId).should('exist');
     }
     return this;
   }

--- a/src/applications/vass/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/PageObject.js
@@ -9,13 +9,19 @@ export default class PageObject {
    * @param {Object} options - Options
    * @param {boolean} options.exist - Whether the element should exist
    * @param {string} options.containsText - Text the element should contain
+   * @param {RegExp} options.matchText - Text the element should match
    * @returns {PageObject}
    */
-  assertElement(testId, { exist = true, containsText } = {}) {
+  assertElement(testId, { exist = true, containsText, matchText } = {}) {
     if (exist && containsText) {
       cy.findByTestId(testId)
         .should('exist')
         .and('contain.text', containsText);
+    } else if (exist && matchText) {
+      cy.findByTestId(testId)
+        .should('exist')
+        .invoke('text')
+        .and('match', matchText);
     } else {
       cy.findByTestId(testId).should(exist ? 'exist' : 'not.exist');
     }
@@ -49,7 +55,8 @@ export default class PageObject {
   } = {}) {
     this.assertElement('api-error-alert', {
       exist,
-      contain: /We’re sorry. There’s a problem with our system. Refresh this page to start over or try again later./i,
+      containsText:
+        'We’re sorry. There’s a problem with our system. Refresh this page to start over or try again later',
     });
 
     if (!exist) {
@@ -89,10 +96,14 @@ export default class PageObject {
    * @param {Object} options - Options
    * @param {boolean} options.exist - Whether the alert should exist
    * @param {string|RegExp} options.headingText - The text of the heading to assert
-   * @param {string} options.contain - The text of the alert to assert
+   * @param {string} options.containsText - The text of the alert to assert
    * @returns {PageObject}
    */
-  assertVerificationErrorAlert({ exist = true, headingText, contain } = {}) {
+  assertVerificationErrorAlert({
+    exist = true,
+    headingText,
+    containsText,
+  } = {}) {
     if (headingText) {
       this.assertHeading({
         name: headingText,
@@ -100,7 +111,7 @@ export default class PageObject {
         exist: true,
       });
     }
-    this.assertElement('verification-error-alert', { exist, contain });
+    this.assertElement('verification-error-alert', { exist, containsText });
     return this;
   }
 

--- a/src/applications/vass/tests/e2e/page-objects/ReviewPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/ReviewPageObject.js
@@ -134,28 +134,6 @@ export class ReviewPageObject extends PageObject {
   }
 
   /**
-   * Assert the confirm button is in loading state
-   * @returns {ReviewPageObject}
-   */
-  assertConfirmLoading() {
-    cy.findByTestId('confirm-call-button').should(
-      'have.attr',
-      'loading',
-      'true',
-    );
-    return this;
-  }
-
-  /**
-   * Assert the confirm button is not in loading state
-   * @returns {ReviewPageObject}
-   */
-  assertConfirmNotLoading() {
-    cy.findByTestId('confirm-call-button').should('not.have.attr', 'loading');
-    return this;
-  }
-
-  /**
    * Confirm the appointment by clicking the confirm button
    * @returns {ReviewPageObject}
    */

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -105,21 +105,13 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Enter a last name value
-   * @param {string} lastName - The last name to enter
+   * Enter a last name value. If no value is provided, the default value of 'Smith' will be used.
+   * @param {string} [lastName='Smith'] - The last name to enter
    * @returns {VerifyPageObject}
    */
-  enterLastName(lastName) {
+  enterLastName(lastName = 'Smith') {
     cy.fillVaTextInput('last-name', lastName);
     return this;
-  }
-
-  /**
-   * Enter a default last name for testing
-   * @returns {VerifyPageObject}
-   */
-  enterDefaultLastName() {
-    return this.enterLastName('Smith');
   }
 
   /**
@@ -127,10 +119,10 @@ export class VerifyPageObject extends PageObject {
    * Uses standard Cypress .type() instead of cy.fillVaMemorableDate() because
    * the platform command uses cy.realType() (from cypress-real-events) in Chrome,
    * which hangs indefinitely in headless Chrome inside Docker CI containers.
-   * @param {string} dateString - Date in YYYY-MM-DD format (e.g., '1990-01-15')
+   * @param {string} [dateString='1935-04-07'] - Date in YYYY-MM-DD format (e.g., '1935-04-07')
    * @returns {VerifyPageObject}
    */
-  enterDateOfBirth(dateString) {
+  enterDateOfBirth(dateString = '1935-04-07') {
     const [year, month, day] = dateString
       .split('-')
       .map(
@@ -169,14 +161,6 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Enter a default date of birth for testing
-   * @returns {VerifyPageObject}
-   */
-  enterDefaultDateOfBirth() {
-    return this.enterDateOfBirth('1935-04-07');
-  }
-
-  /**
    * Click the submit button
    * @returns {VerifyPageObject}
    */
@@ -188,24 +172,13 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Fill the form with default data and submit
-   * @returns {VerifyPageObject}
-   */
-  fillAndSubmitDefaultForm() {
-    this.enterDefaultLastName();
-    this.enterDefaultDateOfBirth();
-    this.clickSubmit();
-    return this;
-  }
-
-  /**
    * Fill the form with custom data and submit
    * @param {Object} props - Form data
-   * @param {string} props.lastName - Last name to enter
-   * @param {string} props.dateOfBirth - Date of birth in YYYY-MM-DD format
+   * @param {string} props.lastName - Last name to enter. If no value is provided, the default value of 'Smith' will be used.
+   * @param {string} props.dateOfBirth - Date of birth in YYYY-MM-DD format. If no value is provided, the default value of '1935-04-07' will be used.
    * @returns {VerifyPageObject}
    */
-  fillAndSubmitForm({ lastName, dateOfBirth }) {
+  fillAndSubmitForm({ lastName = 'Smith', dateOfBirth = '1935-04-07' }) {
     this.enterLastName(lastName);
     this.enterDateOfBirth(dateOfBirth);
     this.clickSubmit();

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -178,7 +178,7 @@ export class VerifyPageObject extends PageObject {
    * @param {string} props.dateOfBirth - Date of birth in YYYY-MM-DD format. If no value is provided, the default value of '1935-04-07' will be used.
    * @returns {VerifyPageObject}
    */
-  fillAndSubmitForm({ lastName = 'Smith', dateOfBirth = '1935-04-07' }) {
+  fillAndSubmitForm({ lastName = 'Smith', dateOfBirth = '1935-04-07' } = {}) {
     this.enterLastName(lastName);
     this.enterDateOfBirth(dateOfBirth);
     this.clickSubmit();

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -38,7 +38,8 @@ export class VerifyPageObject extends PageObject {
       .and('not.have.attr', 'disabled');
 
     // Assert no error states on initial load
-    this.assertVerifyErrorAlert({ exist: false });
+    this.assertInvalidCredentialsErrorAlert({ exist: false });
+    this.assertInvalidVerificationErrorAlert({ exist: false });
 
     // Assert need help footer
     this.assertNeedHelpFooter();
@@ -47,24 +48,36 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Assert the verification error page is displayed
+   * Assert the invalid credentials error alert is displayed
+   * @param {Object} options - Options
+   * @param {boolean} options.exist - Whether the alert should exist
    * @returns {VerifyPageObject}
    */
-  assertVerificationErrorPage() {
-    this.assertHeading({
-      name: /We couldn.t verify your information/i,
-      level: 1,
-      exist: true,
+  assertInvalidCredentialsErrorAlert({ exist = true } = {}) {
+    this.assertElement('verify-error-alert', {
+      exist,
+      contain: exist
+        ? 'We’re sorry. We couldn’t find a record that matches that last name or date of birth. Please try again.'
+        : undefined,
     });
     return this;
   }
 
   /**
-   * Assert the error alert is displayed
+   * Assert the verification error alert is displayed
+   * @param {Object} options - Options
+   * @param {boolean} options.exist - Whether the alert should exist
    * @returns {VerifyPageObject}
    */
-  assertVerifyErrorAlert({ exist = true } = {}) {
-    this.assertElement('verify-error-alert', { exist });
+  assertInvalidVerificationErrorAlert({ exist = true } = {}) {
+    if (exist) {
+      this.assertVerificationErrorAlert({
+        headingText: /We couldn.t verify your information/i,
+        contain: /We’re sorry. We couldn’t match your information to your records. Please call us for help./i,
+      });
+    } else {
+      this.assertVerificationErrorAlert({ exist: false });
+    }
     return this;
   }
 
@@ -103,10 +116,10 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Enter a valid last name for testing
+   * Enter a default last name for testing
    * @returns {VerifyPageObject}
    */
-  enterValidLastName() {
+  enterDefaultLastName() {
     return this.enterLastName('Smith');
   }
 
@@ -157,11 +170,11 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Enter a valid date of birth for testing
+   * Enter a default date of birth for testing
    * @returns {VerifyPageObject}
    */
-  enterValidDateOfBirth() {
-    return this.enterDateOfBirth('1990-01-15');
+  enterDefaultDateOfBirth() {
+    return this.enterDateOfBirth('1935-04-07');
   }
 
   /**
@@ -176,12 +189,12 @@ export class VerifyPageObject extends PageObject {
   }
 
   /**
-   * Fill the form with valid data and submit
+   * Fill the form with default data and submit
    * @returns {VerifyPageObject}
    */
-  fillAndSubmitValidForm() {
-    this.enterValidLastName();
-    this.enterValidDateOfBirth();
+  fillAndSubmitDefaultForm() {
+    this.enterDefaultLastName();
+    this.enterDefaultDateOfBirth();
     this.clickSubmit();
     return this;
   }

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -20,12 +20,11 @@ export class VerifyPageObject extends PageObject {
     });
 
     // Assert intro text is displayed with correct content
-    cy.findByTestId('verify-intro-text')
-      .should('exist')
-      .and(
-        'contain.text',
+    this.assertElement('verify-intro-text', {
+      exist: true,
+      containsText:
         'we’ll need your information so we can send you a one-time verification code',
-      );
+    });
 
     // Assert form inputs exist
     this.assertElement('last-name-input', { exist: true });

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -21,7 +21,6 @@ export class VerifyPageObject extends PageObject {
 
     // Assert intro text is displayed with correct content
     this.assertElement('verify-intro-text', {
-      exist: true,
       containsText:
         'we’ll need your information so we can send you a one-time verification code',
     });

--- a/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/VerifyPageObject.js
@@ -56,7 +56,7 @@ export class VerifyPageObject extends PageObject {
   assertInvalidCredentialsErrorAlert({ exist = true } = {}) {
     this.assertElement('verify-error-alert', {
       exist,
-      contain: exist
+      containsText: exist
         ? 'We’re sorry. We couldn’t find a record that matches that last name or date of birth. Please try again.'
         : undefined,
     });
@@ -72,8 +72,9 @@ export class VerifyPageObject extends PageObject {
   assertInvalidVerificationErrorAlert({ exist = true } = {}) {
     if (exist) {
       this.assertVerificationErrorAlert({
-        headingText: /We couldn.t verify your information/i,
-        contain: /We’re sorry. We couldn’t match your information to your records. Please call us for help./i,
+        headingText: 'We couldn’t verify your information',
+        containsText:
+          'We’re sorry. We couldn’t match your information to your records. Please call us for help.',
       });
     } else {
       this.assertVerificationErrorAlert({ exist: false });

--- a/src/applications/vass/tests/e2e/vass-e2e-helpers.js
+++ b/src/applications/vass/tests/e2e/vass-e2e-helpers.js
@@ -230,7 +230,7 @@ export function mockAppointmentDetailsApi({
   response = new MockAppointmentDetailsResponse().toJSON(),
   responseCode = 200,
 } = {}) {
-  const { appointmentId } = response.data;
+  const { appointmentId } = response.data ?? {};
   const pathPattern = appointmentId
     ? `/vass/v0/appointment/${appointmentId}`
     : /\/vass\/v0\/appointment\/[^/]+$/;
@@ -268,7 +268,7 @@ export function mockCancelAppointmentApi({
   response = new MockCancelAppointmentResponse().toJSON(),
   responseCode = 200,
 } = {}) {
-  const { appointmentId } = response.data;
+  const { appointmentId } = response.data ?? {};
   const pathPattern = appointmentId
     ? `/vass/v0/appointment/${appointmentId}/cancel`
     : /\/vass\/v0\/appointment\/[^/]+\/cancel$/;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Added Cypress E2E tests covering error/unhappy paths for the VASS (VA Solid Start) scheduling
  application. This complements the existing happy-path E2E tests merged in
  [#42137](https://github.com/department-of-veterans-affairs/vets-website/pull/42137).
  - Tests cover API error responses and client-side validation errors across all steps of the
  scheduling flow: identity verification, OTP verification, appointment availability, topics,
  appointment creation, appointment details, and appointment cancellation.
  - Refactored page objects (`VerifyPageObject`, `EnterOTPPageObject`, `PageObject`) to support
  error-state assertions (e.g., `assertWrapperErrorAlert`, `assertInvalidCredentialsErrorAlert`,
  `assertVerificationErrorAlert`, `assertOTPErrorAlert`). Renamed
  `fillAndSubmitValidForm`/`fillAndSubmitValidOTP` to
  `fillAndSubmitDefaultForm`/`fillAndSubmitDefaultOTP` for clarity.
  - Fixed a bug in `CancelAppointment.jsx` where an `appointment_not_found` error on the
  appointment details fetch was not surfacing the error alert — added `isAppointmentNotFoundError`
  to the error condition.
  - Fixed `mockAppointmentDetailsApi` and `mockCancelAppointmentApi` helpers to use optional
  chaining (`response.data ?? {}`) so error responses (which lack `data`) don't throw.
  - Team: VASS (VA Solid Start). This team owns the maintenance of this application.

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#128632

  ## Testing done

  - **Before**: Only happy-path E2E tests existed. No error/unhappy-path scenarios were covered by
  Cypress tests.
  - **After**: 22 new E2E test cases validate error handling across the entire VASS scheduling and
  cancellation flow:
    - **Verify Identity (6 tests)**: Invalid credentials (first attempt + after 3 failed attempts),
   rate limiting, VASS API error, service unavailable, empty last name, empty date of birth
    - **OTP Verification (7 tests)**: Invalid OTP (multiple remaining attempts + 1 remaining
  attempt), account locked, VASS API error, service unavailable, empty OTP, non-numeric OTP,
  too-short OTP
    - **Appointment Availability (3 tests)**: Not within cohort, VASS API error, service
  unavailable
    - **Topics (2 tests)**: VASS API error, service unavailable
    - **Create Appointment (3 tests)**: Save failed, VASS API error, service unavailable
    - **Appointment Details (2 tests)**: Not found, VASS API error
    - **Cancel Appointment (3 tests)**: Cancellation failed, appointment not found, VASS API error
  - Each test verifies the correct error alert is displayed and includes
  `cy.injectAxeThenAxeCheck()` accessibility checks.
  - Existing happy-path tests were updated to use the renamed page object methods and continue to
  pass.

  **Known gaps:**
  - The `no_slots_available` availability error scenario is commented out / deferred (TODO in code)
   — the UI handling for this case may not yet be implemented.
  - Error recovery flows (e.g., user retries after seeing an error and succeeds) are not tested.

  ## Screenshots

  N/A — This PR adds only E2E test code and a minor bug fix in error condition logic. No UI changes
   were made.

  ## What areas of the site does it impact?

  This only impacts the VASS scheduling application at
  `/service-member/benefits/solid-start/schedule`. No other areas of the site are affected.

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
  hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [ ] Documentation has been updated — No documentation updates needed; this is a test-only
  change.
  - [ ] Screenshot of the developed feature is added — N/A; no UI changes, only E2E tests and a
  minor error-handling fix.
  - [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-c
  ycle/prepare-for-an-accessibility-staging-review) has been performed — Every test case includes
  `cy.injectAxeThenAxeCheck()` assertions.

  ### Error Handling

  - [x] Browser console contains no warnings or errors.
  - [ ] Events are being sent to the appropriate logging solution — No new logging was added; this
  PR tests existing error handling behavior.
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A; this is a
  testing PR.

  ### Authentication

  - [ ] Did you login to a local build and verify all authenticated routes work as expected with a
  test user — VASS uses its own OTP-based authentication (not VA.gov SSO). The E2E tests mock the
  full auth flow including JWT token creation via `createMockJwt`.

  ## Requested Feedback

  - The `no_slots_available` scenario is commented out — reviewer input on whether this should be
  implemented now or deferred to a follow-up ticket is appreciated.
  - The `CancelAppointment.jsx` bug fix adds `isAppointmentNotFoundError(appointmentError)` to the
  error display condition — please verify this aligns with the intended UX for the cancel flow when
   an appointment is not found.