### PR TITLE
[Find a Rep v3] 132320: Update Sort UI and Behavior

### DIFF
--- a/src/applications/representative-search/components/results/ResultsList.jsx
+++ b/src/applications/representative-search/components/results/ResultsList.jsx
@@ -31,7 +31,6 @@ const ResultsList = props => {
               <SearchResult
                 officer={result.attributes.fullName || result.attributes.name}
                 reports={result.reports}
-                key={index}
                 type={result.type}
                 addressLine1={result.attributes.addressLine1}
                 addressLine2={result.attributes.addressLine2}

--- a/src/applications/representative-search/components/results/SearchResult.jsx
+++ b/src/applications/representative-search/components/results/SearchResult.jsx
@@ -322,7 +322,7 @@ SearchResult.propTypes = {
   addressLine3: PropTypes.string,
   associatedOrgs: PropTypes.array,
   city: PropTypes.string,
-  distance: PropTypes.string,
+  distance: PropTypes.number,
   email: PropTypes.string,
   initializeRepresentativeReport: PropTypes.func,
   key: PropTypes.number,
@@ -345,15 +345,17 @@ SearchResult.propTypes = {
     other: PropTypes.string,
   }),
   representativeId: PropTypes.string,
-  searchResults: PropTypes.shape({
-    meta: PropTypes.shape({
-      pagination: PropTypes.shape({
-        totalEntries: PropTypes.number,
-        totalPages: PropTypes.number,
-        currentPage: PropTypes.number,
+  searchResults: PropTypes.arrayOf(
+    PropTypes.shape({
+      meta: PropTypes.shape({
+        pagination: PropTypes.shape({
+          totalEntries: PropTypes.number,
+          totalPages: PropTypes.number,
+          currentPage: PropTypes.number,
+        }),
       }),
     }),
-  }),
+  ),
   setReportModalTester: PropTypes.func,
   stateCode: PropTypes.string,
   submitRepresentativeReport: PropTypes.func,

--- a/src/applications/representative-search/components/results/SearchResultsHeader.jsx
+++ b/src/applications/representative-search/components/results/SearchResultsHeader.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
@@ -24,8 +24,6 @@ export const SearchResultsHeader = props => {
   );
   const { totalEntries, currentPage, totalPages } = pagination;
   const noResultsFound = !searchResults || !searchResults?.length;
-
-  const [selectedSortType, setSelectedSortType] = useState(sortType);
 
   if (inProgress || !context) {
     return <div style={{ height: '38px' }} />;
@@ -67,7 +65,8 @@ export const SearchResultsHeader = props => {
   ));
 
   // selection is updated in redux
-  const onClickApplyButton = () => {
+  const handleSortChange = event => {
+    const selectedSortType = event.target.value || sortType;
     const queryUpdateCommitPayload = {
       id: Date.now(),
       page: 1,
@@ -79,17 +78,7 @@ export const SearchResultsHeader = props => {
   };
 
   return (
-    <div className="search-results-header vads-u-margin-bottom--5 vads-u-margin-padding-x--5">
-      {/* Trigger methods for unit testing - temporary workaround for shadow root issues */}
-      {props.onClickApplyButtonTester ? (
-        <button
-          id="test-button"
-          label="test-button"
-          type="button"
-          text-label="button"
-          onClick={onClickApplyButton}
-        />
-      ) : null}
+    <div className="search-results-header">
       <h2 className="vads-u-margin-y--1">Your search results</h2>
       <div className="vads-u-margin-top--3">
         {searchResults?.length ? (
@@ -162,27 +151,16 @@ export const SearchResultsHeader = props => {
             For better results, try increasing your <b>search area</b>.
           </p>
         ) : (
-          <div className="sort-dropdown">
-            <div className="sort-select-and-apply">
-              <div className="sort-select">
-                <VaSelect
-                  name="sort"
-                  value={selectedSortType}
-                  label="Sort by"
-                  onVaSelect={e => {
-                    setSelectedSortType(e.target.value || options[0].key);
-                  }}
-                  uswds
-                >
-                  {options}
-                </VaSelect>
-              </div>
-
-              <div className="sort-apply-button">
-                <va-button onClick={onClickApplyButton} text="Sort" secondary />
-              </div>
-            </div>
-          </div>
+          <VaSelect
+            className="sort-select vads-u-margin-top--3"
+            name="sort"
+            value={sortType}
+            label="Sort by"
+            onVaSelect={handleSortChange}
+            uswds
+          >
+            {options}
+          </VaSelect>
         )}
       </div>
     </div>
@@ -204,7 +182,6 @@ SearchResultsHeader.propTypes = {
   searchResults: PropTypes.array,
   updateSearchQuery: PropTypes.func,
   commitSearchQuery: PropTypes.func,
-  onClickApplyButtonTester: PropTypes.func,
 };
 
 // Only re-render if results or inProgress props have changed

--- a/src/applications/representative-search/sass/find-a-representative.scss
+++ b/src/applications/representative-search/sass/find-a-representative.scss
@@ -101,32 +101,11 @@
       margin: 0.8rem 0 0.8rem 0;
     }
 
-    .sort-dropdown {
-      .sort-select-and-apply {
-        display: flex;
-        align-items: flex-end;
-
-        .sort-select {
-          min-width: 15.625rem;
-          margin-left: 0;
-        }
-
-        .sort-apply-button {
-          margin-left: 1.25rem;
-        }
-      }
-
-
-      @media (max-width: 16.25rem) {
-        .sort-select-and-apply {
-          flex-direction: column;
-          align-items: flex-start;
-
-          .sort-apply-button {
-            margin: 1.5rem 0 0 0;
-          }
-        }
-      }
+    .sort-select {
+      width: 18.8rem;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
     }
 
     .representative-results-list {

--- a/src/applications/representative-search/tests/components/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchResultsHeader.unit.spec.jsx
@@ -379,15 +379,15 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
-  it('calls updateSearchQuerySpy and commitSearchQuerySpy when sort is selected', () => {
+  it('calls updateSearchQuerySpy and commitSearchQuerySpy when sort changes', () => {
     const updateSearchQuerySpy = sinon.spy();
     const commitSearchQuerySpy = sinon.spy();
 
     const query = {
       inProgress: false,
-      context: {},
+      context: { location: 'new york' },
       representativeType: 'attorney',
-      sortType: 'name',
+      sortType: 'distance_asc',
       searchArea: '50',
     };
 
@@ -396,19 +396,18 @@ describe('SearchResultsHeader', () => {
         <SearchResultsHeader
           updateSearchQuery={updateSearchQuerySpy}
           commitSearchQuery={commitSearchQuerySpy}
-          searchResults={[]}
-          pagination={{ currentPage: 1, totalPages: 1, totalEntries: 0 }}
+          searchResults={[testDataRepresentative]}
+          pagination={{ totalEntries: 1 }}
           query={{
             ...query,
             committedSearchQuery: query,
           }}
-          onClickApplyButtonTester
         />
       </Provider>,
     );
 
-    wrapper.find('#test-button').simulate('click');
-
+    const select = wrapper.find('VaSelect.sort-select');
+    select.prop('onVaSelect')({ target: { value: 'first_name_asc' } });
     wrapper.update();
 
     sinon.assert.calledOnce(updateSearchQuerySpy);
@@ -418,7 +417,7 @@ describe('SearchResultsHeader', () => {
       updateSearchQuerySpy,
       sinon.match({
         page: 1,
-        sortType: 'name',
+        sortType: 'first_name_asc',
       }),
     );
 
@@ -426,7 +425,7 @@ describe('SearchResultsHeader', () => {
       commitSearchQuerySpy,
       sinon.match({
         page: 1,
-        sortType: 'name',
+        sortType: 'first_name_asc',
       }),
     );
 

--- a/src/applications/representative-search/tests/components/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchResultsHeader.unit.spec.jsx
@@ -408,6 +408,7 @@ describe('SearchResultsHeader', () => {
 
     const select = wrapper.find('VaSelect.sort-select');
     select.prop('onVaSelect')({ target: { value: 'first_name_asc' } });
+
     wrapper.update();
 
     sinon.assert.calledOnce(updateSearchQuerySpy);

--- a/src/applications/representative-search/tests/components/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchResultsHeader.unit.spec.jsx
@@ -379,7 +379,7 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
-  it('calls updateSearchQuerySpy and commitSearchQuerySpy when sort changes', () => {
+  it('calls updateSearchQuerySpy and commitSearchQuerySpy when sort option changes', () => {
     const updateSearchQuerySpy = sinon.spy();
     const commitSearchQuerySpy = sinon.spy();
 


### PR DESCRIPTION
## Summary

This PR makes the following updates to the Find a Rep experience:
1. Removes the "Sort" button next to the sort select box and fires a new search on select change rather than button click.
2. Moves the "Sort by" select label from on top of the select box to directly next to (to the left of) it.
3. Fixes a few React console warnings.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132320

## Testing done

Tested all search functionality after updates, paying special attention to the sort behavior.

Tested layout/style updates in Chrome, Safari, and Firefox, in all common viewports.

Ensured that all unit tests pass after the change (`yarn test:unit --app-folder representative-search`).

## Screenshots
Before:
<img width="756" height="662" alt="Before Screenshot" src="https://github.com/user-attachments/assets/e685548a-d521-4fd0-bcf1-44f20d67454c" />

After:
<img width="761" height="654" alt="After Screenshot" src="https://github.com/user-attachments/assets/e9e85701-fb27-40d9-99c4-3e281f81919f" />

## What areas of the site does it impact?

Find a Rep: `/get-help-from-accredited-representative/find-rep/`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).