### PR TITLE
VACMS-23508: Removes buffalo rbo cross domain redirect

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -2205,17 +2205,5 @@
   "src": "/romanila",
   "dest": "/va-regional-benefit-office-at-us-embassy-in-manila/",
   "catchAll": true
-},
-{
-  "domain": "www.benefits.va.gov",
-  "src": "/buffalo",
-  "dest": "/buffalo-va-regional-benefit-office/",
-  "catchAll": true
-},
-{
-  "domain": "www.benefits.va.gov",
-  "src": "/robuffalo",
-  "dest": "/buffalo-va-regional-benefit-office/",
-  "catchAll": true
 }
 ]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request removes two redirect rules from the cross-domain redirect configuration. These rules previously redirected requests for `/buffalo` and `/robuffalo` on the `www.benefits.va.gov` domain to the Buffalo VA Regional Benefit Office page. These redirects are instead going to be handled by the WebOps team.

Redirect rule removals:

* Removed redirect from `/buffalo` on `www.benefits.va.gov` to `/buffalo-va-regional-benefit-office/`.
* Removed redirect from `/robuffalo` on `www.benefits.va.gov` to `/buffalo-va-regional-benefit-office/`.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23508