### PR TITLE
Add additionalInfoTitle to fileInputUI and fileInputMultipleUI

### DIFF
--- a/.github/prompts/form-pages-guide.prompt.md
+++ b/.github/prompts/form-pages-guide.prompt.md
@@ -401,14 +401,15 @@ yourDocument: fileInputUI({
   additionalInputLabels: {
     documentStatus: { public: 'Public', private: 'Private' },
   },
-  additionalInput: (error, data, labels) => {
+  additionalInputTitle: 'Document status', // Optional title for additional input
+  additionalInput: (error, data, { labels, title }) => {
     const { documentStatus } = data;
     return (
       <VaSelect
         required
         error={error}
         value={documentStatus}
-        label="Document status"
+        label={title}
       >
         {Object.entries(labels.documentStatus).map(([value, label]) => (
           <option key={value} value={value}>{label}</option>
@@ -475,12 +476,13 @@ financialHardshipDocuments: fileInputMultipleUI({
     additionalInput: 'Choose a document status',
   },
   additionalInputRequired: true,
+  additionalInputTitle: 'Document status', // Optional title for additional input
   additionalInputLabels: {
     documentStatus: { public: 'Public', private: 'Private' },
   },
-  additionalInput: ({ labels }) => {
+  additionalInput: ({ labels, title }) => {
     return (
-      <VaSelect required label="Document status">
+      <VaSelect required label={title}>
         {Object.entries(labels.documentStatus).map(([value, label]) => (
           <option key={value} value={value}>{label}</option>
         ))}

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/supportingDocuments.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/supportingDocuments.js
@@ -30,9 +30,10 @@ export default {
           private: 'Private',
         },
       },
-      additionalInput: ({ labels }) => {
+      additionalInfoTitle: 'Document status',
+      additionalInput: ({ labels, title }) => {
         return (
-          <VaSelect required label="Document status">
+          <VaSelect required label={title}>
             {Object.entries(labels.documentStatus).map(([value, label]) => (
               <option key={value} value={value}>
                 {label}

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/supportingDocuments.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/supportingDocuments.js
@@ -30,7 +30,7 @@ export default {
           private: 'Private',
         },
       },
-      additionalInfoTitle: 'Document status',
+      additionalInputTitle: 'Document status',
       additionalInput: ({ labels, title }) => {
         return (
           <VaSelect required label={title}>

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/upload.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/upload.js
@@ -24,7 +24,7 @@ export default {
         additionalInput: 'Choose a document status',
       },
       additionalInputRequired: true,
-      additionalInfoTitle: 'What is the document status?',
+      additionalInputTitle: 'What is the document status?',
       additionalInputLabels: {
         documentStatus: {
           tax: 'Tax form',

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/upload.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/upload.js
@@ -24,6 +24,7 @@ export default {
         additionalInput: 'Choose a document status',
       },
       additionalInputRequired: true,
+      additionalInfoTitle: 'What is the document status?',
       additionalInputLabels: {
         documentStatus: {
           tax: 'Tax form',
@@ -31,15 +32,10 @@ export default {
           service: 'Service form',
         },
       },
-      additionalInput: (error, data, labels) => {
+      additionalInput: (error, data, { labels, title }) => {
         const { documentStatus } = data;
         return (
-          <VaSelect
-            required
-            error={error}
-            value={documentStatus}
-            label="Document status"
-          >
+          <VaSelect required error={error} value={documentStatus} label={title}>
             {Object.entries(labels.documentStatus).map(([value, label]) => (
               <option key={value} value={value}>
                 {label}

--- a/src/platform/forms-system/src/js/review/FileInputMultiple.jsx
+++ b/src/platform/forms-system/src/js/review/FileInputMultiple.jsx
@@ -11,7 +11,7 @@ const ReviewField = data => {
   const title = data.uiSchema?.['ui:title'];
   const uiOptions = data.uiSchema?.['ui:options'];
   const additionalInputLabels = uiOptions?.additionalInputLabels;
-  const additionalInfoTitle = uiOptions?.additionalInfoTitle;
+  const additionalInputTitle = uiOptions?.additionalInputTitle;
   if (files.length === 0) {
     return (
       <div className="review-row">
@@ -43,7 +43,7 @@ const ReviewField = data => {
           {file.additionalData &&
             Object.entries(file.additionalData).map(([key, value]) => (
               <div className="review-row" key={key}>
-                <dt>{additionalInfoTitle || formatLabel(key)}</dt>
+                <dt>{additionalInputTitle || formatLabel(key)}</dt>
                 <dd>{additionalInputLabels?.[key]?.[value] || value}</dd>
               </div>
             ))}

--- a/src/platform/forms-system/src/js/review/FileInputMultiple.jsx
+++ b/src/platform/forms-system/src/js/review/FileInputMultiple.jsx
@@ -9,8 +9,9 @@ const formatLabel = key =>
 const ReviewField = data => {
   const { formData: files = [] } = data.children.props;
   const title = data.uiSchema?.['ui:title'];
-  const additionalInputLabels =
-    data.uiSchema?.['ui:options']?.additionalInputLabels;
+  const uiOptions = data.uiSchema?.['ui:options'];
+  const additionalInputLabels = uiOptions?.additionalInputLabels;
+  const additionalInfoTitle = uiOptions?.additionalInfoTitle;
   if (files.length === 0) {
     return (
       <div className="review-row">
@@ -42,7 +43,7 @@ const ReviewField = data => {
           {file.additionalData &&
             Object.entries(file.additionalData).map(([key, value]) => (
               <div className="review-row" key={key}>
-                <dt>{formatLabel(key)}</dt>
+                <dt>{additionalInfoTitle || formatLabel(key)}</dt>
                 <dd>{additionalInputLabels?.[key]?.[value] || value}</dd>
               </div>
             ))}

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -260,7 +260,7 @@ const VaFileInputField = props => {
                 childrenProps.formData.additionalData || {},
                 {
                   labels: uiOptions.additionalInputLabels,
-                  title: uiOptions.additionalInfoTitle,
+                  title: uiOptions.additionalInputTitle,
                 },
               ),
               {

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -258,7 +258,10 @@ const VaFileInputField = props => {
               mappedProps.additionalInput(
                 additionalInputError,
                 childrenProps.formData.additionalData || {},
-                uiOptions.additionalInputLabels,
+                {
+                  labels: uiOptions.additionalInputLabels,
+                  title: uiOptions.additionalInfoTitle,
+                },
               ),
               {
                 // attach other listeners as needed

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
@@ -396,6 +396,7 @@ const VaFileInputMultipleField = props => {
           <div className="additional-input-container">
             {mappedProps.additionalInput({
               labels: uiOptions.additionalInputLabels,
+              title: uiOptions.additionalInfoTitle,
             })}
           </div>
         )}

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
@@ -396,7 +396,7 @@ const VaFileInputMultipleField = props => {
           <div className="additional-input-container">
             {mappedProps.additionalInput({
               labels: uiOptions.additionalInputLabels,
-              title: uiOptions.additionalInfoTitle,
+              title: uiOptions.additionalInputTitle,
             })}
           </div>
         )}

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputMultiplePattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputMultiplePattern.jsx
@@ -34,7 +34,7 @@ import ReviewField from '../review/FileInputMultiple';
  *   additionalInputLabels: {
  *     documentStatus: { public: 'Public', private: 'Private' },
  *   },
- *   additionalInfoTitle: 'Document status', // title shown above the additional input inside the file card
+ *   additionalInputTitle: 'Document status', // title shown above the additional input inside the file card
  *   additionalInput: ({ labels }) => {
  *     return (
  *       <VaSelect required label="Document status">
@@ -92,11 +92,11 @@ import ReviewField from '../review/FileInputMultiple';
  * @param {number} [options.maxFileSize] - maximum allowed file size in bytes
  * @param {number} [options.minFileSize] - minimum allowed file size in bytes
  * @param {boolean} [options.additionalInputRequired] - is additional information required
- * @param {(options: { labels?: Record<string, Record<string, string>>, title?: string }) => React.ReactNode} [options.additionalInput] - renders the additional information template. Receives an object with `labels` from `additionalInputLabels` and `title` from `additionalInfoTitle`.
+ * @param {(options: { labels?: Record<string, Record<string, string>>, title?: string }) => React.ReactNode} [options.additionalInput] - renders the additional information template. Receives an object with `labels` from `additionalInputLabels` and `title` from `additionalInputTitle`.
  * @param {(instance: any, error: any, data: any) => void} [options.additionalInputUpdate] - function to update additional input instance
  * @param {(e: CustomEvent) => {[key: string]: any}} [options.handleAdditionalInput] - function to handle event payload from additional info
  * @param {Record<string, Record<string, string>>} [options.additionalInputLabels] - explicit value-to-label mapping for additional input fields on the review page, e.g. `{ documentStatus: { public: 'Public', private: 'Private' } }`. Falls back to DOM querying if not provided.
- * @param {string} [options.additionalInfoTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name
+ * @param {string} [options.additionalInputTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name
  * @param {string} [options.fileUploadUrl] - url to which file will be uploaded
  * @param {string} [options.formNumber] - the form's number
  * @param {boolean} [options.skipUpload] - skip attempt to upload in dev when there is no backend
@@ -232,7 +232,7 @@ export const fileInputMultipleUI = options => {
                   {Object.entries(file.additionalData).map(([key, value]) => (
                     <li key={key}>
                       <span className="vads-u-color--gray">
-                        {uiOptions.additionalInfoTitle ||
+                        {uiOptions.additionalInputTitle ||
                           key
                             .replace(/([A-Z])/g, ' $1')
                             .replace(/^./, s => s.toUpperCase())

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputMultiplePattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputMultiplePattern.jsx
@@ -92,7 +92,7 @@ import ReviewField from '../review/FileInputMultiple';
  * @param {number} [options.maxFileSize] - maximum allowed file size in bytes
  * @param {number} [options.minFileSize] - minimum allowed file size in bytes
  * @param {boolean} [options.additionalInputRequired] - is additional information required
- * @param {(options: { labels?: Record<string, Record<string, string>> }) => React.ReactNode} [options.additionalInput] - renders the additional information template. Receives an object with `labels` from `additionalInputLabels`.
+ * @param {(options: { labels?: Record<string, Record<string, string>>, title?: string }) => React.ReactNode} [options.additionalInput] - renders the additional information template. Receives an object with `labels` from `additionalInputLabels` and `title` from `additionalInfoTitle`.
  * @param {(instance: any, error: any, data: any) => void} [options.additionalInputUpdate] - function to update additional input instance
  * @param {(e: CustomEvent) => {[key: string]: any}} [options.handleAdditionalInput] - function to handle event payload from additional info
  * @param {Record<string, Record<string, string>>} [options.additionalInputLabels] - explicit value-to-label mapping for additional input fields on the review page, e.g. `{ documentStatus: { public: 'Public', private: 'Private' } }`. Falls back to DOM querying if not provided.

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputMultiplePattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputMultiplePattern.jsx
@@ -34,6 +34,7 @@ import ReviewField from '../review/FileInputMultiple';
  *   additionalInputLabels: {
  *     documentStatus: { public: 'Public', private: 'Private' },
  *   },
+ *   additionalInfoTitle: 'Document status', // title shown above the additional input inside the file card
  *   additionalInput: ({ labels }) => {
  *     return (
  *       <VaSelect required label="Document status">
@@ -95,6 +96,7 @@ import ReviewField from '../review/FileInputMultiple';
  * @param {(instance: any, error: any, data: any) => void} [options.additionalInputUpdate] - function to update additional input instance
  * @param {(e: CustomEvent) => {[key: string]: any}} [options.handleAdditionalInput] - function to handle event payload from additional info
  * @param {Record<string, Record<string, string>>} [options.additionalInputLabels] - explicit value-to-label mapping for additional input fields on the review page, e.g. `{ documentStatus: { public: 'Public', private: 'Private' } }`. Falls back to DOM querying if not provided.
+ * @param {string} [options.additionalInfoTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name
  * @param {string} [options.fileUploadUrl] - url to which file will be uploaded
  * @param {string} [options.formNumber] - the form's number
  * @param {boolean} [options.skipUpload] - skip attempt to upload in dev when there is no backend
@@ -230,10 +232,11 @@ export const fileInputMultipleUI = options => {
                   {Object.entries(file.additionalData).map(([key, value]) => (
                     <li key={key}>
                       <span className="vads-u-color--gray">
-                        {key
-                          .replace(/([A-Z])/g, ' $1')
-                          .replace(/^./, s => s.toUpperCase())
-                          .trim()}
+                        {uiOptions.additionalInfoTitle ||
+                          key
+                            .replace(/([A-Z])/g, ' $1')
+                            .replace(/^./, s => s.toUpperCase())
+                            .trim()}
                       </span>
                       :{' '}
                       {uiOptions.additionalInputLabels?.[key]?.[value] || value}

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
@@ -38,6 +38,7 @@ import {
  *   additionalInputLabels: {            // explicit labels for review page
  *     documentStatus: { public: 'Public', private: 'Private' },
  *   },
+ *   additionalInfoTitle: 'Document status', // title shown above the additional input inside the file card
  *   additionalInput: (error, data, labels) => {
  *     const { documentStatus } = data;
  *     return (
@@ -98,6 +99,7 @@ import {
  * @param {(error: any, data: any, labels?: Record<string, Record<string, string>>) => React.ReactNode} [options.additionalInput] - renders the additional information. Receives `additionalInputLabels` as an optional 3rd argument.
  * @param {(e: CustomEvent) => {[key: string]: any}} [options.handleAdditionalInput] - function to handle event payload from additional info
  * @param {Record<string, Record<string, string>>} [options.additionalInputLabels] - explicit value-to-label mapping for additional input fields on the review page, e.g. `{ documentStatus: { public: 'Public', private: 'Private' } }`. Falls back to DOM querying if not provided.
+ * @param {string} [options.additionalInfoTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name
  * @param {string} [options.fileUploadUrl] - url to which file will be uploaded
  * @param {string} [options.formNumber] - the form's number
  * @param {boolean} [options.skipUpload] - skip attempt to upload in dev when there is no backend
@@ -190,10 +192,11 @@ export const fileInputUI = options => {
               Object.entries(file.additionalData).map(([key, value]) => (
                 <div className="review-row" key={key}>
                   <dt>
-                    {key
-                      .replace(/([A-Z])/g, ' $1')
-                      .replace(/^./, s => s.toUpperCase())
-                      .trim()}
+                    {uiOptions.additionalInfoTitle ||
+                      key
+                        .replace(/([A-Z])/g, ' $1')
+                        .replace(/^./, s => s.toUpperCase())
+                        .trim()}
                   </dt>
                   <dd>
                     {uiOptions.additionalInputLabels?.[key]?.[value] || value}
@@ -220,10 +223,11 @@ export const fileInputUI = options => {
             {Object.entries(formData.additionalData).map(([key, value]) => (
               <li key={key}>
                 <span className="vads-u-color--gray">
-                  {key
-                    .replace(/([A-Z])/g, ' $1')
-                    .replace(/^./, s => s.toUpperCase())
-                    .trim()}
+                  {uiOptions.additionalInfoTitle ||
+                    key
+                      .replace(/([A-Z])/g, ' $1')
+                      .replace(/^./, s => s.toUpperCase())
+                      .trim()}
                 </span>
                 : {uiOptions.additionalInputLabels?.[key]?.[value] || value}
               </li>

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
@@ -38,7 +38,7 @@ import {
  *   additionalInputLabels: {            // explicit labels for review page
  *     documentStatus: { public: 'Public', private: 'Private' },
  *   },
- *   additionalInfoTitle: 'Document status', // title shown above the additional input inside the file card
+ *   additionalInputTitle: 'Document status', // title shown above the additional input inside the file card
  *   additionalInput: (error, data, { labels, title }) => {
  *     const { documentStatus } = data;
  *     return (
@@ -96,10 +96,10 @@ import {
  * @param {number} [options.maxFileSize] - maximum allowed file size in bytes
  * @param {number} [options.minFileSize] - minimum allowed file size in bytes
  * @param {boolean} [options.additionalInputRequired] - is additional information required
- * @param {(error: any, data: any, options?: { labels?: Record<string, Record<string, string>>, title?: string }) => React.ReactNode} [options.additionalInput] - renders the additional information. Receives an options object with `labels` from `additionalInputLabels` and `title` from `additionalInfoTitle` as an optional 3rd argument.
+ * @param {(error: any, data: any, options?: { labels?: Record<string, Record<string, string>>, title?: string }) => React.ReactNode} [options.additionalInput] - renders the additional information. Receives an options object with `labels` from `additionalInputLabels` and `title` from `additionalInputTitle` as an optional 3rd argument.
  * @param {(e: CustomEvent) => {[key: string]: any}} [options.handleAdditionalInput] - function to handle event payload from additional info
  * @param {Record<string, Record<string, string>>} [options.additionalInputLabels] - explicit value-to-label mapping for additional input fields on the review page, e.g. `{ documentStatus: { public: 'Public', private: 'Private' } }`. Falls back to DOM querying if not provided.
- * @param {string} [options.additionalInfoTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name
+ * @param {string} [options.additionalInputTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name
  * @param {string} [options.fileUploadUrl] - url to which file will be uploaded
  * @param {string} [options.formNumber] - the form's number
  * @param {boolean} [options.skipUpload] - skip attempt to upload in dev when there is no backend
@@ -192,7 +192,7 @@ export const fileInputUI = options => {
               Object.entries(file.additionalData).map(([key, value]) => (
                 <div className="review-row" key={key}>
                   <dt>
-                    {uiOptions.additionalInfoTitle ||
+                    {uiOptions.additionalInputTitle ||
                       key
                         .replace(/([A-Z])/g, ' $1')
                         .replace(/^./, s => s.toUpperCase())
@@ -223,7 +223,7 @@ export const fileInputUI = options => {
             {Object.entries(formData.additionalData).map(([key, value]) => (
               <li key={key}>
                 <span className="vads-u-color--gray">
-                  {uiOptions.additionalInfoTitle ||
+                  {uiOptions.additionalInputTitle ||
                     key
                       .replace(/([A-Z])/g, ' $1')
                       .replace(/^./, s => s.toUpperCase())

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
@@ -39,14 +39,14 @@ import {
  *     documentStatus: { public: 'Public', private: 'Private' },
  *   },
  *   additionalInfoTitle: 'Document status', // title shown above the additional input inside the file card
- *   additionalInput: (error, data, labels) => {
+ *   additionalInput: (error, data, { labels, title }) => {
  *     const { documentStatus } = data;
  *     return (
  *       <VaSelect
  *         required
  *         error={error}
  *         value={documentStatus}
- *         label="Document status"
+ *         label={title}
  *       >
  *         {Object.entries(labels.documentStatus).map(([value, label]) => (
  *           <option key={value} value={value}>{label}</option>
@@ -96,7 +96,7 @@ import {
  * @param {number} [options.maxFileSize] - maximum allowed file size in bytes
  * @param {number} [options.minFileSize] - minimum allowed file size in bytes
  * @param {boolean} [options.additionalInputRequired] - is additional information required
- * @param {(error: any, data: any, labels?: Record<string, Record<string, string>>) => React.ReactNode} [options.additionalInput] - renders the additional information. Receives `additionalInputLabels` as an optional 3rd argument.
+ * @param {(error: any, data: any, options?: { labels?: Record<string, Record<string, string>>, title?: string }) => React.ReactNode} [options.additionalInput] - renders the additional information. Receives an options object with `labels` from `additionalInputLabels` and `title` from `additionalInfoTitle` as an optional 3rd argument.
  * @param {(e: CustomEvent) => {[key: string]: any}} [options.handleAdditionalInput] - function to handle event payload from additional info
  * @param {Record<string, Record<string, string>>} [options.additionalInputLabels] - explicit value-to-label mapping for additional input fields on the review page, e.g. `{ documentStatus: { public: 'Public', private: 'Private' } }`. Falls back to DOM querying if not provided.
  * @param {string} [options.additionalInfoTitle] - explicit label for the additional input field, used as the `<dt>` on the review and confirmation pages instead of the auto-generated camelCase-to-Title-Case key name


### PR DESCRIPTION
## Summary

- Add `additionalInfoTitle` for also displaying the "ui:title" of the select properly.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5549

## Testing done

- unit, browser, e2e

## Screenshots

<img width="672" height="785" alt="image" src="https://github.com/user-attachments/assets/29dbf3b8-1916-4249-8ae1-031d28c2cb69" />

## What areas of the site does it impact?

File input review

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
