### PR TITLE
destructive modal on additional evidence intro page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/AdditionalEvidenceIntroPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/AdditionalEvidenceIntroPage.jsx
@@ -9,24 +9,18 @@ import _ from 'platform/utilities/data';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { scrollToFirstError } from 'platform/utilities/scroll';
 import { checkValidations } from '../utils/submit';
+import { getAdditionalDocuments } from '../utils';
+import { renderFileList } from '../content/evidenceRequest';
 import {
-  getVaEvidence,
-  getPrivateFacilities,
-  getPrivateEvidenceUploads,
-} from '../utils';
-import {
-  evidenceRequestAdditionalInfo,
-  evidenceRequestQuestion,
-  privateEvidenceContent,
-  vaEvidenceContent,
-  privateFacilityContent,
-  alertMessage,
-  renderFacilityList,
-  renderFileList,
-  missingSelectionErrorMessageEvidenceRequestPage,
-} from '../content/evidenceRequest';
+  evidenceChoiceIntroDescriptionContent,
+  evidenceChoiceIntroQuestion,
+  evidenceChoiceIntroTitle,
+  additionalEvidenceModalContent,
+  missingSelectionErrorMessage,
+} from '../content/form0781/supportingEvidenceEnhancement/evidenceChoiceIntroPage';
+import { mentalHealthSupportAlert } from '../content/form0781';
 
-export const EvidenceRequestPage = ({
+export const AdditionalEvidenceIntroPage = ({
   data,
   setFormData,
   onReviewPage,
@@ -36,24 +30,19 @@ export const EvidenceRequestPage = ({
   goForward,
   updatePage,
 }) => {
-  const selectionField = 'view:hasMedicalRecords';
-  const hasMedicalRecords = _.get('view:hasMedicalRecords', data, null);
+  const selectionField = 'view:hasEvidenceChoice';
+  const hasEvidenceChoice = _.get('view:hasEvidenceChoice', data, null);
   const [hasError, setHasError] = useState(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [alertVisible, setAlertVisible] = useState(false);
-  const [alertType, setAlertType] = useState([]);
 
   const hasEvidenceToRemove = () => {
-    return (
-      getVaEvidence(data).length > 0 ||
-      getPrivateEvidenceUploads(data).length > 0 ||
-      getPrivateFacilities(data).length > 0
-    );
+    return getAdditionalDocuments(data).length > 0;
   };
   const missingSelection = (error, _fieldData, formData) => {
     const value = formData?.[selectionField];
     if (value !== true && value !== false) {
-      error.addError?.(missingSelectionErrorMessageEvidenceRequestPage);
+      error.addError?.(missingSelectionErrorMessage);
     }
   };
 
@@ -73,26 +62,7 @@ export const EvidenceRequestPage = ({
   const handlers = {
     onChangeAndRemove: () => {
       const updatedFormData = { ...data };
-      const selectableEvidenceTypes = {
-        ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
-      };
-
-      if (getVaEvidence(data).length > 0) {
-        delete updatedFormData.vaTreatmentFacilities;
-        selectableEvidenceTypes['view:hasVaMedicalRecords'] = false;
-        setAlertType(prevState => [...prevState, 'va']);
-      }
-      if (getPrivateEvidenceUploads(data).length > 0) {
-        delete updatedFormData.privateMedicalRecordAttachments;
-        selectableEvidenceTypes['view:hasPrivateMedicalRecords'] = false;
-        setAlertType(prevState => [...prevState, 'privateMedicalRecords']);
-      }
-      if (getPrivateFacilities(data).length > 0) {
-        delete updatedFormData.providerFacility;
-        selectableEvidenceTypes['view:hasPrivateMedicalRecords'] = false;
-        setAlertType(prevState => [...prevState, 'privateFacility']);
-      }
-      updatedFormData['view:selectableEvidenceTypes'] = selectableEvidenceTypes;
+      delete updatedFormData.evidenceChoiceAdditionalDocuments;
       setFormData(updatedFormData);
       setModalVisible(false);
       setAlertVisible(true);
@@ -119,19 +89,8 @@ export const EvidenceRequestPage = ({
       event.preventDefault();
       if (checkErrors()) {
         scrollToFirstError();
-      } else if (hasMedicalRecords === false && hasEvidenceToRemove()) {
+      } else if (hasEvidenceChoice === false && hasEvidenceToRemove()) {
         setModalVisible(true);
-      } else if (hasMedicalRecords === false) {
-        const updatedFormData = { ...data };
-        updatedFormData['view:selectableEvidenceTypes'] = {
-          ...(updatedFormData['view:selectableEvidenceTypes'] || {}),
-          'view:hasVaMedicalRecords': false,
-          'view:hasPrivateMedicalRecords': false,
-        };
-        updatedFormData.patient4142Acknowledgement = false;
-        setFormData(updatedFormData);
-        setAlertVisible(false);
-        goForward(updatedFormData);
       } else {
         setAlertVisible(false);
         goForward(data);
@@ -141,7 +100,7 @@ export const EvidenceRequestPage = ({
       event.preventDefault();
       if (checkErrors()) {
         scrollToFirstError();
-      } else if (hasMedicalRecords === false && hasEvidenceToRemove()) {
+      } else if (hasEvidenceChoice === false && hasEvidenceToRemove()) {
         setModalVisible(true);
       } else {
         setAlertVisible(false);
@@ -152,7 +111,8 @@ export const EvidenceRequestPage = ({
 
   return (
     <>
-      <h3>Medical records that support your disability claim</h3>
+      <h3>{evidenceChoiceIntroTitle}</h3>
+      {evidenceChoiceIntroDescriptionContent}
       <div className="vads-u-margin-bottom--1">
         <VaAlert
           closeBtnAriaLabel="Close notification"
@@ -165,46 +125,32 @@ export const EvidenceRequestPage = ({
           uswds
           tabIndex="-1"
         >
-          <p className="vads-u-margin-y--0">{alertMessage(alertType)}</p>
+          <p className="vads-u-margin-y--0">
+            We’ve deleted the documents you uploaded supporting your claim.
+          </p>
         </VaAlert>
       </div>
       <VaModal
         clickToClose
-        modalTitle="Change your medical records?"
+        modalTitle="Cancel uploading files?"
         onCloseEvent={handlers.onCancelChange}
         onPrimaryButtonClick={handlers.onChangeAndRemove}
         onSecondaryButtonClick={handlers.onCancelChange}
         visible={modalVisible}
         status="warning"
-        primaryButtonText="Change and remove"
-        secondaryButtonText="Cancel change"
+        primaryButtonText="Change and delete"
+        secondaryButtonText="Keep files"
       >
-        {getVaEvidence(data).length > 0 && (
+        {getAdditionalDocuments(data).length > 0 && (
           <>
-            {vaEvidenceContent}
-            {renderFacilityList(getVaEvidence(data), 'treatmentCenterName')}
-          </>
-        )}
-        {getPrivateFacilities(data).length > 0 && (
-          <>
-            {privateFacilityContent}
-            {renderFacilityList(
-              getPrivateFacilities(data),
-              'providerFacilityName',
-            )}
-          </>
-        )}
-        {getPrivateEvidenceUploads.length > 0 && (
-          <>
-            {privateEvidenceContent}
-            {renderFileList(getPrivateEvidenceUploads(data))}
+            {additionalEvidenceModalContent}
+            {renderFileList(getAdditionalDocuments(data))}
           </>
         )}
       </VaModal>
       <form onSubmit={handlers.onSubmit}>
         <VaRadio
-          label={evidenceRequestQuestion.label}
-          hint={evidenceRequestQuestion.hint}
+          label={evidenceChoiceIntroQuestion}
           required
           uswds="true"
           class="rjsf-web-component-field hydrated"
@@ -215,18 +161,17 @@ export const EvidenceRequestPage = ({
           <va-radio-option
             label="Yes"
             name="private"
-            checked={hasMedicalRecords === true}
+            checked={hasEvidenceChoice === true}
             value="true"
           />
           <va-radio-option
             label="No"
             name="private"
-            checked={hasMedicalRecords === false}
+            checked={hasEvidenceChoice === false}
             value="false"
           />
         </VaRadio>
-        {!onReviewPage && evidenceRequestAdditionalInfo}
-
+        {!onReviewPage && mentalHealthSupportAlert()}
         {onReviewPage ? (
           /**
            * Does not use web component for design consistency on all pages.
@@ -256,7 +201,7 @@ export const EvidenceRequestPage = ({
   );
 };
 
-EvidenceRequestPage.propTypes = {
+AdditionalEvidenceIntroPage.propTypes = {
   contentAfterButtons: PropTypes.element,
   contentBeforeButtons: PropTypes.element,
   data: PropTypes.object,

--- a/src/applications/disability-benefits/all-claims/components/AdditionalEvidenceIntroPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/AdditionalEvidenceIntroPage.jsx
@@ -144,7 +144,7 @@ export const AdditionalEvidenceIntroPage = ({
         {getAdditionalDocuments(data).length > 0 && (
           <>
             {additionalEvidenceModalContent}
-            {renderFileList(getAdditionalDocuments(data))}
+            {renderFileList(getAdditionalDocuments(data), true)}
           </>
         )}
       </VaModal>

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -151,6 +151,7 @@ import getPreSubmitInfo from '../content/preSubmitInfo';
 import ConfirmationAncillaryFormsWizard from '../components/confirmationFields/ConfirmationAncillaryFormsWizard';
 import { EvidenceRequestPage } from '../components/EvidenceRequestPage';
 import { MedicalRecordsPage } from '../components/MedicalRecordsPage';
+import { AdditionalEvidenceIntroPage } from '../components/AdditionalEvidenceIntroPage';
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -727,6 +728,8 @@ const formConfig = {
             formData.disability526SupportingEvidenceEnhancement,
           // TODO: update this path to `'supporting-evidence/additional-evidence', once we can get rid of `additionalDocuments` page
           path: 'supporting-evidence/additional-evidence-intro',
+          CustomPage: AdditionalEvidenceIntroPage,
+          CustomPageReview: null,
           uiSchema: evidenceChoiceIntro.uiSchema,
           schema: evidenceChoiceIntro.schema,
         },

--- a/src/applications/disability-benefits/all-claims/content/evidenceRequest.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceRequest.jsx
@@ -95,7 +95,7 @@ export const renderFacilityList = (facilities, nameKey) => {
   );
 };
 
-export const renderFileList = files => {
+export const renderFileList = (files, additionalEvidencePage = false) => {
   const showAll = files.length <= maxDisplayedItems + 1;
   const displayList = showAll ? files : files.slice(0, maxDisplayedItems);
   return (
@@ -105,7 +105,10 @@ export const renderFileList = files => {
       ))}
 
       {!showAll && (
-        <li>{files.length - maxDisplayedItems} other medical records</li>
+        <li>
+          {files.length - maxDisplayedItems} other{' '}
+          {additionalEvidencePage ? 'files' : 'medical records'}
+        </li>
       )}
     </ul>
   );

--- a/src/applications/disability-benefits/all-claims/content/form0781/supportingEvidenceEnhancement/evidenceChoiceIntroPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/supportingEvidenceEnhancement/evidenceChoiceIntroPage.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 export const evidenceChoiceIntroTitle =
   'Supporting documents and additional forms for your disability claim';
 
+export const evidenceChoiceIntroQuestion =
+  'Are there any supporting documents or additional forms that you want us to review with your claim?';
+
 const evidenceChoiceIntroDescription = (
   <p>Support your claim by providing documents from any of these sources</p>
 );
@@ -90,3 +93,8 @@ export const evidenceChoiceIntroDescriptionContent = (
     {additionalFormsLinkAndNote}
   </>
 );
+
+export const additionalEvidenceModalContent =
+  'You can choose not to include supporting documents and additional forms. If you do so, we’ll delete these files you uploaded:';
+
+export const missingSelectionErrorMessage = 'You must provide a response';

--- a/src/applications/disability-benefits/all-claims/pages/form0781/supportingEvidenceEnhancement/evidenceChoiceIntroPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/supportingEvidenceEnhancement/evidenceChoiceIntroPage.js
@@ -9,14 +9,14 @@ import {
 import {
   evidenceChoiceIntroTitle,
   evidenceChoiceIntroDescriptionContent,
+  evidenceChoiceIntroQuestion,
 } from '../../../content/form0781/supportingEvidenceEnhancement/evidenceChoiceIntroPage';
 
 export const uiSchema = {
   'ui:title': standardTitle(evidenceChoiceIntroTitle),
   'ui:description': evidenceChoiceIntroDescriptionContent,
   'view:hasEvidenceChoice': yesNoUI({
-    title:
-      'Are there any supporting documents or additional forms that you want us to review with your claim?',
+    title: evidenceChoiceIntroQuestion,
   }),
   'view:mentalHealthSupportAlert': {
     'ui:description': mentalHealthSupportAlert,

--- a/src/applications/disability-benefits/all-claims/tests/components/AdditionalEvidenceIntroPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/AdditionalEvidenceIntroPage.unit.spec.jsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import {
+  $$,
+  $,
+} from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { AdditionalEvidenceIntroPage } from '../../components/AdditionalEvidenceIntroPage';
+
+describe('AdditionalEvidenceIntroPage', () => {
+  const page = ({
+    data = {},
+    goBack = () => {},
+    goForward = () => {},
+    setFormData = () => {},
+    updatePage = () => {},
+    onReviewPage = false,
+  } = {}) => {
+    return (
+      <div>
+        <AdditionalEvidenceIntroPage
+          setFormData={setFormData}
+          data={data}
+          goBack={goBack}
+          goForward={goForward}
+          onReviewPage={onReviewPage}
+          updatePage={updatePage}
+        />
+      </div>
+    );
+  };
+
+  it('should render', () => {
+    const { container } = render(page());
+
+    expect($$('va-radio-option').length).to.equal(2);
+
+    const question = container.querySelector('va-radio');
+    expect(question).to.have.attribute(
+      'label',
+      'Are there any supporting documents or additional forms that you want us to review with your claim?',
+    );
+
+    expect(container.querySelector('va-radio-option[label="Yes"]')).to.exist;
+    expect(container.querySelector('va-radio-option[label="No"]')).to.exist;
+    expect(container.querySelector('va-alert-expandable')).to.exist;
+  });
+  it('should display additional documents in modal when the user choose No but provided additional documents and clicks continue', async () => {
+    const data = {
+      'view:hasEvidenceChoice': false,
+      evidenceChoiceAdditionalDocuments: [
+        {
+          name: 'supportingDoc.pdf',
+        },
+      ],
+    };
+
+    const { container } = render(page({ data }));
+
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+      expect(modal.textContent).to.include('supportingDoc.pdf');
+    });
+  });
+
+  it('should limit displayed files to maxDisplayedItems', async () => {
+    const data = {
+      'view:hasEvidenceChoice': false,
+      evidenceChoiceAdditionalDocuments: [
+        {
+          name: 'supportingDoc1.pdf',
+        },
+        {
+          name: 'supportingDoc2.pdf',
+        },
+        {
+          name: 'supportingDoc3.pdf',
+        },
+        {
+          name: 'supportingDoc4.pdf',
+        },
+        {
+          name: 'supportingDoc5.pdf',
+        },
+      ],
+    };
+
+    const { container } = render(page({ data }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal.textContent).to.include('supportingDoc1.pdf');
+      expect(modal.textContent).to.include('supportingDoc2.pdf');
+      expect(modal.textContent).to.include('supportingDoc3.pdf');
+      expect(modal.textContent).to.include('2 other medical records');
+      expect(modal.textContent).to.not.include('supportingDoc4.pdf');
+    });
+  });
+
+  it('should remove additional documents when confirming modal', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasEvidenceChoice': false,
+      evidenceChoiceAdditionalDocuments: [
+        {
+          name: 'supportingDoc1.pdf',
+        },
+        {
+          name: 'supportingDoc2.pdf',
+        },
+      ],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.firstCall.args[0];
+      expect(updatedData).to.not.have.property(
+        'evidenceChoiceAdditionalDocuments',
+      );
+    });
+  });
+
+  it('should show success alert after removing evidence', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasEvidenceChoice': false,
+      evidenceChoiceAdditionalDocuments: [
+        {
+          name: 'supportingDoc1.pdf',
+        },
+        {
+          name: 'supportingDoc2.pdf',
+        },
+      ],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const primaryButton = container.querySelector('va-modal');
+    fireEvent(primaryButton, new CustomEvent('primaryButtonClick'));
+
+    await waitFor(() => {
+      const alert = container.querySelector('va-alert');
+      expect(alert).to.have.attribute('visible', 'true');
+      expect(alert.textContent).to.include(
+        'We’ve deleted the documents you uploaded supporting your claim.',
+      );
+    });
+  });
+
+  it('should cancel modal and reset selection to Yes after user click cancel change', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasEvidenceChoice': false,
+      evidenceChoiceAdditionalDocuments: [
+        {
+          name: 'supportingDoc1.pdf',
+        },
+        {
+          name: 'supportingDoc2.pdf',
+        },
+      ],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const modal = container.querySelector('va-modal');
+    fireEvent(modal, new CustomEvent('secondaryButtonClick'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.lastCall.args[0];
+      expect(updatedData['view:hasEvidenceChoice']).to.be.true;
+      expect(modal).to.have.attribute('visible', 'false');
+    });
+  });
+
+  it('should cancel modal and reset selection to Yes after user click x on the modal', async () => {
+    const setFormData = sinon.spy();
+    const data = {
+      'view:hasEvidenceChoice': false,
+      evidenceChoiceAdditionalDocuments: [
+        {
+          name: 'supportingDoc1.pdf',
+        },
+        {
+          name: 'supportingDoc2.pdf',
+        },
+      ],
+    };
+
+    const { container } = render(page({ data, setFormData }));
+    fireEvent.click($('button[type="submit"]', container));
+
+    await waitFor(() => {
+      const modal = container.querySelector('va-modal');
+      expect(modal).to.have.attribute('visible', 'true');
+    });
+
+    const modal = container.querySelector('va-modal');
+    fireEvent(modal, new CustomEvent('closeEvent'));
+
+    await waitFor(() => {
+      expect(setFormData.called).to.be.true;
+      const updatedData = setFormData.lastCall.args[0];
+      expect(updatedData['view:hasEvidenceChoice']).to.be.true;
+      expect(modal).to.have.attribute('visible', 'false');
+    });
+  });
+
+  it('should render update button on review page', () => {
+    const { container } = render(page({ onReviewPage: true }));
+
+    const updateButton = container.querySelector('button.usa-button-primary');
+    expect(updateButton).to.exist;
+    expect(updateButton.textContent).to.equal('Update page');
+  });
+
+  it('should not render mental health alert on review page', () => {
+    const { container } = render(page({ onReviewPage: true }));
+
+    const additionalInfo = container.querySelector('va-alert-expandable');
+    expect(additionalInfo).to.not.exist;
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/components/AdditionalEvidenceIntroPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/AdditionalEvidenceIntroPage.unit.spec.jsx
@@ -97,7 +97,7 @@ describe('AdditionalEvidenceIntroPage', () => {
       expect(modal.textContent).to.include('supportingDoc1.pdf');
       expect(modal.textContent).to.include('supportingDoc2.pdf');
       expect(modal.textContent).to.include('supportingDoc3.pdf');
-      expect(modal.textContent).to.include('2 other medical records');
+      expect(modal.textContent).to.include('2 other files');
       expect(modal.textContent).to.not.include('supportingDoc4.pdf');
     });
   });

--- a/src/applications/disability-benefits/all-claims/tests/side-nav-mvp.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/side-nav-mvp.cypress.spec.js
@@ -150,7 +150,14 @@ const testConfig = createTestConfig(
       },
 
       'supporting-evidence/additional-evidence-intro': () => {
-        cy.fillPage();
+        cy.get('@testData').then(data => {
+          const hasEvidenceChoice = data['view:hasEvidenceChoice'];
+
+          cy.get(
+            `va-radio-option[label="${hasEvidenceChoice ? 'Yes' : 'No'}"]`,
+          ).click();
+          cy.findByText(/continue/i, { selector: 'button' }).click();
+        });
       },
 
       'supporting-evidence/evidence-request': () => {

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -274,6 +274,8 @@ export const getPrivateFacilities = formData =>
   _.get('providerFacility', formData, []);
 export const getPrivateEvidenceUploads = formData =>
   _.get('privateMedicalRecordAttachments', formData, []);
+export const getAdditionalDocuments = formData =>
+  _.get('evidenceChoiceAdditionalDocuments', formData, []);
 
 export const hasMedicalRecords = formData => {
   if (isEvidenceEnhancement(formData)) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Add destructive modal on evidence choice page when user click no but provided additional evidences
- _(If bug, how to reproduce)_
N/A
- _(What is the solution, why is this the solution)_
Add destructive modal to clarify user's action to choice no after provide additional evidences
- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Benefits Pathways team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
disability526SupportingEvidenceEnhancement
## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/129735

## Testing done

Tested locally 
Ran unit tests that includes this new behavior

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
Mod| Mobile  |        |       |
| Desktop |        |   


https://github.com/user-attachments/assets/ee6359e6-b2c5-4c33-aef3-1352146bc2f6



 |

## What areas of the site does it impact?

Evidence choice page on 0781 form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
