### PR TITLE
534ez validate marriage dates

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/01-veteran-information/veteranAdditional.js
+++ b/src/applications/survivors-benefits/config/chapters/01-veteran-information/veteranAdditional.js
@@ -5,6 +5,7 @@ import {
   dateOfDeathUI,
   dateOfDeathSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { validations } from '../../validations';
 
 /** @type {PageSchema} */
 export default {
@@ -17,9 +18,12 @@ export default {
     diedOnDuty: yesNoUI({
       title: 'Did the Veteran die while on active duty?',
     }),
-    veteranDateOfDeath: dateOfDeathUI({
-      monthSelect: false,
-    }),
+    veteranDateOfDeath: {
+      ...dateOfDeathUI({
+        monthSelect: false,
+      }),
+      'ui:validations': [validations.isAfterVeteranBirthDate],
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/survivors-benefits/config/chapters/03-military-history/powPeriodOfTime.js
+++ b/src/applications/survivors-benefits/config/chapters/03-military-history/powPeriodOfTime.js
@@ -17,6 +17,7 @@ const powPeriodOfTimePage = {
         title: 'End date',
         monthSelect: false,
       },
+      'End date must be after the start date.',
     ),
   },
   schema: {

--- a/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
+++ b/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
@@ -33,7 +33,7 @@ export default {
         title: 'Final release date from active duty',
         monthSelect: false,
       },
-      'Final release date must be after the initially entered date.',
+      'Final release date must be after date initially entered into active duty.',
     ),
     placeOfSeparation: textUI({
       title: 'Place of Veteran’s last separation',

--- a/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
+++ b/src/applications/survivors-benefits/config/chapters/03-military-history/servicePeriod.js
@@ -33,6 +33,7 @@ export default {
         title: 'Final release date from active duty',
         monthSelect: false,
       },
+      'Final release date must be after the initially entered date.',
     ),
     placeOfSeparation: textUI({
       title: 'Place of Veteran’s last separation',

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranEndInfo.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranEndInfo.js
@@ -16,6 +16,25 @@ import {
 } from '../../../utils/labels';
 import { customAddressSchema } from '../../definitions';
 
+const validation = {
+  pattern: (errors, values, formData) => {
+    if (formData?.marriageToVeteranStartDate) {
+      const endDate = new Date(values);
+      const startDate = new Date(formData.marriageToVeteranStartDate);
+      if (endDate.getTime() < startDate.getTime()) {
+        errors.addError(
+          'The date marriage ended must be after the date marriage started',
+        );
+      }
+    }
+  },
+  widget: (errors, value) => {
+    if ((value || '').trim() === '') {
+      errors.addError('Check at least one!');
+    }
+  },
+};
+
 /** @type {PageSchema} */
 export default {
   uiSchema: {
@@ -23,10 +42,13 @@ export default {
       'When and where did your marriage end?',
       'If you were married at the time of their death, this will be their date and place of death.',
     ),
-    marriageToVeteranEndDate: currentOrPastDateUI({
-      title: 'Date marriage ended',
-      monthSelect: false,
-    }),
+    marriageToVeteranEndDate: {
+      ...currentOrPastDateUI({
+        title: 'Date marriage ended',
+        monthSelect: false,
+      }),
+      'ui:validations': [validation.pattern],
+    },
     marriageToVeteranEndOutsideUs: checkboxUI({
       title: 'My marriage ended outside the U.S.',
     }),

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranEndInfo.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/marriageToVeteranEndInfo.js
@@ -15,25 +15,7 @@ import {
   COUNTRY_NAMES,
 } from '../../../utils/labels';
 import { customAddressSchema } from '../../definitions';
-
-const validation = {
-  pattern: (errors, values, formData) => {
-    if (formData?.marriageToVeteranStartDate) {
-      const endDate = new Date(values);
-      const startDate = new Date(formData.marriageToVeteranStartDate);
-      if (endDate.getTime() < startDate.getTime()) {
-        errors.addError(
-          'The date marriage ended must be after the date marriage started',
-        );
-      }
-    }
-  },
-  widget: (errors, value) => {
-    if ((value || '').trim() === '') {
-      errors.addError('Check at least one!');
-    }
-  },
-};
+import { validations } from '../../validations';
 
 /** @type {PageSchema} */
 export default {
@@ -47,7 +29,7 @@ export default {
         title: 'Date marriage ended',
         monthSelect: false,
       }),
-      'ui:validations': [validation.pattern],
+      'ui:validations': [validations.isAfterMarriageStartDate],
     },
     marriageToVeteranEndOutsideUs: checkboxUI({
       title: 'My marriage ended outside the U.S.',

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/previousMarriagesPages.js
@@ -27,6 +27,7 @@ import {
   previousMarriageEndOptions,
 } from '../../../utils/labels';
 import { customAddressSchema } from '../../definitions';
+import { validations } from '../../validations';
 
 // Show previous marriages pages ONLY if user answered YES to hadPreviousMarriages
 // Ansering NO skips all previous marriage flows and jumps to Dependents
@@ -249,10 +250,13 @@ const marriageEndDateAndLocationPage = {
     ...arrayBuilderItemSubsequentPageTitleUI(
       'When and where did your marriage end?',
     ),
-    dateOfSeparation: currentOrPastDateUI({
-      title: 'Date marriage ended',
-      monthSelect: false,
-    }),
+    dateOfSeparation: {
+      ...currentOrPastDateUI({
+        title: 'Date marriage ended',
+        monthSelect: false,
+      }),
+      'ui:validations': [validations.isAfterPreviousMarriageStartDate],
+    },
     marriageEndedOutsideUS: checkboxUI({
       title: 'My marriage ended outside the U.S.',
     }),

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/remarriageDetails.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/remarriageDetails.js
@@ -40,6 +40,7 @@ export default {
         hint: 'Leave blank if you are still married',
         monthSelect: false,
       },
+      'End date must be after the start date.',
     ),
   },
   schema: {

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/separationDetails.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/separationDetails.js
@@ -9,6 +9,7 @@ import {
 import { isYes } from '../../../utils/helpers';
 import { customTextSchema } from '../../definitions';
 import { CourtOrderSeparationAlert } from '../../../components/FormAlerts';
+import { validations } from '../../validations';
 
 /** @type {PageSchema} */
 export default {
@@ -23,10 +24,13 @@ export default {
       title: 'Start date of separation',
       monthSelect: false,
     }),
-    separationEndDate: currentOrPastDateUI({
-      title: 'End date of separation',
-      monthSelect: false,
-    }),
+    separationEndDate: {
+      ...currentOrPastDateUI({
+        title: 'End date of separation',
+        monthSelect: false,
+      }),
+      'ui:validations': [validations.isAfterSeparationStartDate],
+    },
     courtOrderedSeparation: yesNoUI({
       title: 'Was the separation due to a court order?',
     }),

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/veteranMarriagesPages.js
@@ -28,6 +28,7 @@ import {
 } from '../../../utils/labels';
 import { handleVeteranMaxMarriagesAlert } from '../../../components/FormAlerts';
 import { customAddressSchema, customTextSchema } from '../../definitions';
+import { validations } from '../../validations';
 
 /**
  * Pages for Veteran's previous marriages (array-builder)
@@ -256,13 +257,16 @@ const marriageEndDateLocationPage = {
     ...arrayBuilderItemSubsequentPageTitleUI(
       'When and where did their marriage end?',
     ),
-    dateOfSeparation: currentOrPastDateUI({
-      title: 'Date marriage ended',
-      monthSelect: false,
-      'ui:description':
-        'Enter 1 or 2 digits for the month and day and 4 digits for the year.',
-      required: formData => !formData['view:dateOfSeparation'],
-    }),
+    dateOfSeparation: {
+      ...currentOrPastDateUI({
+        title: 'Date marriage ended',
+        monthSelect: false,
+        'ui:description':
+          'Enter 1 or 2 digits for the month and day and 4 digits for the year.',
+        required: formData => !formData['view:dateOfSeparation'],
+      }),
+      'ui:validations': [validations.isAfterPreviousMarriageStartDate],
+    },
     marriageEndedOutsideUS: checkboxUI({
       title: 'Their marriage ended outside the U.S.',
     }),

--- a/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
+++ b/src/applications/survivors-benefits/config/chapters/05-claim-information/treatmentPages.js
@@ -9,6 +9,7 @@ import {
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import { transformDate } from './helpers';
 import { customTextSchema } from '../../definitions';
+import { validations } from '../../validations';
 
 /** @type {ArrayBuilderOptions} */
 export const options = {
@@ -101,10 +102,13 @@ const treatmentDatePage = {
       title: 'Start date of treatment',
       monthSelect: false,
     }),
-    endDate: currentOrPastDateUI({
-      title: 'End date of treatment',
-      monthSelect: false,
-    }),
+    endDate: {
+      ...currentOrPastDateUI({
+        title: 'End date of treatment',
+        monthSelect: false,
+      }),
+      'ui:validations': [validations.isAfterTreatmentStartDate],
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/survivors-benefits/config/validations.js
+++ b/src/applications/survivors-benefits/config/validations.js
@@ -1,0 +1,40 @@
+const beforeStartDateErrorMsg = startDate => {
+  const dateArray = startDate.split('-');
+  // Show date string in MM/DD/YYYY format instead of YYYY-MM-DD
+  const dateString = `${dateArray[1]}/${dateArray[2]}/${dateArray[0]}`;
+  return `End date must be after the start date. Enter a date later than [${dateString}].`;
+};
+const checkIfEndDateAfterStartDate = (endDate, startDate) => {
+  const end = new Date(endDate);
+  const start = new Date(startDate);
+  return end.getTime() >= start.getTime();
+};
+
+export const validations = {
+  isAfterMarriageStartDate: (errors, values, formData) => {
+    if (
+      formData?.marriageToVeteranStartDate &&
+      !checkIfEndDateAfterStartDate(values, formData.marriageToVeteranStartDate)
+    ) {
+      errors.addError(
+        beforeStartDateErrorMsg(formData.marriageToVeteranStartDate),
+      );
+    }
+  },
+  isAfterPreviousMarriageStartDate: (errors, values, formData) => {
+    if (
+      formData?.dateOfMarriage &&
+      !checkIfEndDateAfterStartDate(values, formData.dateOfMarriage)
+    ) {
+      errors.addError(beforeStartDateErrorMsg(formData.dateOfMarriage));
+    }
+  },
+  isAfterSeparationStartDate: (errors, values, formData) => {
+    if (
+      formData?.separationStartDate &&
+      !checkIfEndDateAfterStartDate(values, formData.separationStartDate)
+    ) {
+      errors.addError(beforeStartDateErrorMsg(formData.separationStartDate));
+    }
+  },
+};

--- a/src/applications/survivors-benefits/config/validations.js
+++ b/src/applications/survivors-benefits/config/validations.js
@@ -1,8 +1,9 @@
-const beforeStartDateErrorMsg = startDate => {
+const beforeStartDateErrorMsg = (startDate, customMessage) => {
   const dateArray = startDate.split('-');
   // Show date string in MM/DD/YYYY format instead of YYYY-MM-DD
   const dateString = `${dateArray[1]}/${dateArray[2]}/${dateArray[0]}`;
-  return `End date must be after the start date. Enter a date later than ${dateString}.`;
+  const message = customMessage || 'End date must be after the start date.';
+  return `${message} Enter a date later than ${dateString}.`;
 };
 const checkIfEndDateAfterStartDate = (endDate, startDate) => {
   const end = new Date(endDate);
@@ -42,7 +43,12 @@ export const validations = {
       formData?.veteranDateOfBirth &&
       !checkIfEndDateAfterStartDate(values, formData.veteranDateOfBirth)
     ) {
-      errors.addError(beforeStartDateErrorMsg(formData.veteranDateOfBirth));
+      errors.addError(
+        beforeStartDateErrorMsg(
+          formData.veteranDateOfBirth,
+          'Date of death must be after the date of birth.',
+        ),
+      );
     }
   },
   isAfterTreatmentStartDate: (errors, values, formData) => {

--- a/src/applications/survivors-benefits/config/validations.js
+++ b/src/applications/survivors-benefits/config/validations.js
@@ -2,7 +2,7 @@ const beforeStartDateErrorMsg = startDate => {
   const dateArray = startDate.split('-');
   // Show date string in MM/DD/YYYY format instead of YYYY-MM-DD
   const dateString = `${dateArray[1]}/${dateArray[2]}/${dateArray[0]}`;
-  return `End date must be after the start date. Enter a date later than [${dateString}].`;
+  return `End date must be after the start date. Enter a date later than ${dateString}.`;
 };
 const checkIfEndDateAfterStartDate = (endDate, startDate) => {
   const end = new Date(endDate);

--- a/src/applications/survivors-benefits/config/validations.js
+++ b/src/applications/survivors-benefits/config/validations.js
@@ -37,4 +37,20 @@ export const validations = {
       errors.addError(beforeStartDateErrorMsg(formData.separationStartDate));
     }
   },
+  isAfterVeteranBirthDate: (errors, values, formData) => {
+    if (
+      formData?.veteranDateOfBirth &&
+      !checkIfEndDateAfterStartDate(values, formData.veteranDateOfBirth)
+    ) {
+      errors.addError(beforeStartDateErrorMsg(formData.veteranDateOfBirth));
+    }
+  },
+  isAfterTreatmentStartDate: (errors, values, formData) => {
+    if (
+      formData?.startDate &&
+      !checkIfEndDateAfterStartDate(values, formData.startDate)
+    ) {
+      errors.addError(beforeStartDateErrorMsg(formData.startDate));
+    }
+  },
 };

--- a/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import { validations } from '../../config/validations';
+
+describe('Custom form validations', () => {
+  let errorMessage = [];
+  const errors = {
+    addError: msg => errorMessage.push(msg),
+  };
+  const formData = {
+    marriageToVeteranStartDate: '2021-01-01',
+    separationStartDate: '2000-03-05',
+    dateOfMarriage: '1990-02-02',
+  };
+  beforeEach(() => {
+    errorMessage = [];
+  });
+  it('should validate that the marriage end date is after the marriage start date', () => {
+    validations.isAfterMarriageStartDate(errors, '2020-01-01', formData);
+    expect(errorMessage).to.include(
+      'End date must be after the start date. Enter a date later than [01/01/2021].',
+    );
+  });
+  it('should validate that the separation end date is after the separation start date', () => {
+    validations.isAfterSeparationStartDate(errors, '1999-01-01', formData);
+    expect(errorMessage).to.include(
+      'End date must be after the start date. Enter a date later than [03/05/2000].',
+    );
+  });
+  it('should validate that the previous marriage end date is after the previous marriage start date', () => {
+    validations.isAfterPreviousMarriageStartDate(
+      errors,
+      '1985-01-01',
+      formData,
+    );
+    expect(errorMessage).to.include(
+      'End date must be after the start date. Enter a date later than [02/02/1990].',
+    );
+  });
+  it('should not return an error if the marriage end date is after the marriage start date', () => {
+    validations.isAfterMarriageStartDate(errors, '2022-01-01', formData);
+    expect(errorMessage).to.be.empty;
+  });
+  it('should not return an error if the marriage end date is the same as the marriage start date', () => {
+    validations.isAfterMarriageStartDate(errors, '2021-01-01', formData);
+    expect(errorMessage).to.be.empty;
+  });
+  it('should return an error if value does not exist', () => {
+    validations.isAfterMarriageStartDate(errors, '2021-01-01', {});
+    expect(errorMessage).to.be.empty;
+    validations.isAfterSeparationStartDate(errors, '2021-01-01', {});
+    expect(errorMessage).to.be.empty;
+    validations.isAfterPreviousMarriageStartDate(errors, '2021-01-01', {});
+    expect(errorMessage).to.be.empty;
+  });
+});

--- a/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
@@ -10,6 +10,7 @@ describe('Custom form validations', () => {
     marriageToVeteranStartDate: '2021-01-01',
     separationStartDate: '2000-03-05',
     dateOfMarriage: '1990-02-02',
+    veteranDateOfBirth: '1970-04-15',
   };
   beforeEach(() => {
     errorMessage = [];
@@ -36,6 +37,20 @@ describe('Custom form validations', () => {
       'End date must be after the start date. Enter a date later than [02/02/1990].',
     );
   });
+  it('should validate that a treatment end date is after its start date', () => {
+    validations.isAfterTreatmentStartDate(errors, '1985-01-01', {
+      startDate: '1990-02-02',
+    });
+    expect(errorMessage).to.include(
+      'End date must be after the start date. Enter a date later than [02/02/1990].',
+    );
+  });
+  it('should validate that the veteran date of death is after the the date of birth', () => {
+    validations.isAfterVeteranBirthDate(errors, '1965-01-01', formData);
+    expect(errorMessage).to.include(
+      'End date must be after the start date. Enter a date later than [04/15/1970].',
+    );
+  });
   it('should not return an error if the marriage end date is after the marriage start date', () => {
     validations.isAfterMarriageStartDate(errors, '2022-01-01', formData);
     expect(errorMessage).to.be.empty;
@@ -44,12 +59,18 @@ describe('Custom form validations', () => {
     validations.isAfterMarriageStartDate(errors, '2021-01-01', formData);
     expect(errorMessage).to.be.empty;
   });
+  it('should not return an error if the date of death is after the veteran birth date', () => {
+    validations.isAfterVeteranBirthDate(errors, '2021-01-01', formData);
+    expect(errorMessage).to.be.empty;
+  });
   it('should return an error if value does not exist', () => {
     validations.isAfterMarriageStartDate(errors, '2021-01-01', {});
     expect(errorMessage).to.be.empty;
     validations.isAfterSeparationStartDate(errors, '2021-01-01', {});
     expect(errorMessage).to.be.empty;
     validations.isAfterPreviousMarriageStartDate(errors, '2021-01-01', {});
+    expect(errorMessage).to.be.empty;
+    validations.isAfterVeteranBirthDate(errors, '2021-01-01', {});
     expect(errorMessage).to.be.empty;
   });
 });

--- a/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
@@ -18,13 +18,13 @@ describe('Custom form validations', () => {
   it('should validate that the marriage end date is after the marriage start date', () => {
     validations.isAfterMarriageStartDate(errors, '2020-01-01', formData);
     expect(errorMessage).to.include(
-      'End date must be after the start date. Enter a date later than [01/01/2021].',
+      'End date must be after the start date. Enter a date later than 01/01/2021.',
     );
   });
   it('should validate that the separation end date is after the separation start date', () => {
     validations.isAfterSeparationStartDate(errors, '1999-01-01', formData);
     expect(errorMessage).to.include(
-      'End date must be after the start date. Enter a date later than [03/05/2000].',
+      'End date must be after the start date. Enter a date later than 03/05/2000.',
     );
   });
   it('should validate that the previous marriage end date is after the previous marriage start date', () => {
@@ -34,7 +34,7 @@ describe('Custom form validations', () => {
       formData,
     );
     expect(errorMessage).to.include(
-      'End date must be after the start date. Enter a date later than [02/02/1990].',
+      'End date must be after the start date. Enter a date later than 02/02/1990.',
     );
   });
   it('should validate that a treatment end date is after its start date', () => {
@@ -42,13 +42,13 @@ describe('Custom form validations', () => {
       startDate: '1990-02-02',
     });
     expect(errorMessage).to.include(
-      'End date must be after the start date. Enter a date later than [02/02/1990].',
+      'End date must be after the start date. Enter a date later than 02/02/1990.',
     );
   });
   it('should validate that the veteran date of death is after the the date of birth', () => {
     validations.isAfterVeteranBirthDate(errors, '1965-01-01', formData);
     expect(errorMessage).to.include(
-      'End date must be after the start date. Enter a date later than [04/15/1970].',
+      'End date must be after the start date. Enter a date later than 04/15/1970.',
     );
   });
   it('should not return an error if the marriage end date is after the marriage start date', () => {

--- a/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/validations.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('Custom form validations', () => {
   it('should validate that the veteran date of death is after the the date of birth', () => {
     validations.isAfterVeteranBirthDate(errors, '1965-01-01', formData);
     expect(errorMessage).to.include(
-      'End date must be after the start date. Enter a date later than 04/15/1970.',
+      'Date of death must be after the date of birth. Enter a date later than 04/15/1970.',
     );
   });
   it('should not return an error if the marriage end date is after the marriage start date', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add custom validation to check if one date is after another and return a custom message
- For fields on different pages or that didn't use the date range fields, use custom validation
- For fields using the date range fields, update error to use language from the question instead of generic `To` message
- Add unit tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126476

## Testing done

- Manual testing
- Add new unit tests

## Screenshots

| Field | New Error |
| ------ | ----- |
| Veteran date of death  | <img width="387" height="248" alt="Screenshot 2026-02-23 at 11 03 38 AM" src="https://github.com/user-attachments/assets/24c6bca2-f291-4d56-b0ef-80c19b2f6fc5" /> |
| VAMC treatment dates | <img width="464" height="357" alt="Screenshot 2026-02-23 at 10 25 17 AM" src="https://github.com/user-attachments/assets/bca5bdab-8676-452e-a18e-8effcb4ef387" /> |
| Date marriage ended (previous and main question) | <img width="479" height="307" alt="Screenshot 2026-02-23 at 10 24 44 AM" src="https://github.com/user-attachments/assets/c7790cf5-9370-49a3-b47f-655a44626b10" /> |
| Remarriage (already a range, so couldn't easily add extra date to message) | <img width="544" height="794" alt="Screenshot 2026-02-23 at 8 49 04 AM" src="https://github.com/user-attachments/assets/ee967616-bf43-4dce-9bde-8c56e4f21374" /> |
| Separation details | <img width="556" height="322" alt="Screenshot 2026-02-23 at 10 24 26 AM" src="https://github.com/user-attachments/assets/6832e526-072d-47d1-970b-ae94f4f86add" /> |
| POW period (already a range, so couldn't easily add extra date to message) |  <img width="375" height="485" alt="Screenshot 2026-02-23 at 8 47 56 AM" src="https://github.com/user-attachments/assets/396d0f6c-6e4e-4530-805e-1bc6a17b63af" /> |
| Service period (already a range, so couldn't easily add extra date to message) | <img width="411" height="475" alt="Screenshot 2026-02-23 at 10 59 07 AM" src="https://github.com/user-attachments/assets/e221e7e8-06f7-482b-9b1c-f1d0680a5f51" /> |

## What areas of the site does it impact?

Marriage date fields on 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
