### PR TITLE
Add supporting documents features from option A and C per #133587

### DIFF
--- a/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
+++ b/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
@@ -1,4 +1,6 @@
+import React from 'react';
 import environment from 'platform/utilities/environment';
+import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   titleUI,
   fileInputMultipleUI,
@@ -7,21 +9,122 @@ import {
 
 export default {
   uiSchema: {
-    ...titleUI(
-      'Submit supporting documents',
-      'This may include legal documents, bills, or other documentation of expenses',
-    ),
+    ...titleUI('Submit supporting documents', ({ formData }) => {
+      const expenses = formData?.expenses || [];
+      const debts = formData?.otherDebts || [];
+      const uploadedFiles = formData?.veteranSupportingDocuments || [];
+      const hasExpenses = expenses.length > 0;
+      const hasDebts = debts.length > 0;
+
+      if (!hasExpenses && !hasDebts) {
+        return 'This may include legal documents, bills, or other documentation of expenses.';
+      }
+
+      const totalExpected = expenses.length + debts.length;
+      const totalUploaded = uploadedFiles.length;
+
+      if (totalUploaded >= totalExpected) {
+        return 'This may include legal documents, bills, or other documentation of expenses.';
+      }
+
+      const capitalize = str =>
+        str ? str.charAt(0).toUpperCase() + str.slice(1) : str;
+
+      return (
+        <div>
+          <p>
+            Based on what you've reported, please upload the following
+            supporting documents:
+          </p>
+          <va-alert status="info" uswds closeable>
+            {hasExpenses && (
+              <>
+                <p className="vads-u-margin-top--0">
+                  <strong>Expenses ({expenses.length} reported):</strong>
+                </p>
+                <ul>
+                  {expenses.map((expense, i) => {
+                    const provider = expense?.provider || 'Unknown provider';
+                    const type = capitalize(expense?.expenseType) || 'Expense';
+                    const amount = expense?.amount
+                      ? `$${parseFloat(expense.amount).toFixed(2)}`
+                      : '';
+                    return (
+                      <li key={`exp-msg-${i}`}>
+                        {type} from {provider}
+                        {amount && ` — ${amount}`}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
+            {hasDebts && (
+              <>
+                <p className="vads-u-margin-top--0">
+                  <strong>Debts ({debts.length} reported):</strong>
+                </p>
+                <ul className="vads-u-margin-bottom--0">
+                  {debts.map((debt, i) => {
+                    const type = debt?.debtType || 'Debt';
+                    const amount = debt?.debtAmount
+                      ? `$${parseFloat(debt.debtAmount).toFixed(2)}`
+                      : '';
+                    const creditor = debt?.creditorName;
+                    return (
+                      <li key={`debt-msg-${i}`}>
+                        {type}
+                        {creditor && ` owed to ${creditor}`}
+                        {amount && ` — ${amount}`}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
+          </va-alert>
+        </div>
+      );
+    }),
     veteranSupportingDocuments: fileInputMultipleUI({
       title: 'Supporting documents',
       required: false,
       hint: 'Upload a file that is between 1KB and 5MB.',
       formNumber: '21P-601',
       disallowEncryptedPdfs: true,
-      fileUploadUrl: `${
-        environment.API_URL
-      }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
+      fileUploadUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
       maxFileSize: 1024 * 1024 * 5,
       minFileSize: 1,
+      additionalInputRequired: true,
+      additionalInput: (error, data) => {
+        const { documentCategory } = data || {};
+        return (
+          <VaSelect
+            required
+            error={error}
+            value={documentCategory}
+            label="What type of document is this?"
+          >
+            <option value="funeral">Funeral service receipt</option>
+            <option value="burial">Burial expense receipt</option>
+            <option value="hospital">Hospital bill</option>
+            <option value="doctor">Doctor bill</option>
+            <option value="other_medical">Other medical expense</option>
+            <option value="debt">Debt documentation</option>
+            <option value="other">Other supporting document</option>
+          </VaSelect>
+        );
+      },
+      // eslint-disable-next-line no-param-reassign
+      additionalInputUpdate: (instance, error, data) => {
+        instance.setAttribute('error', error || '');
+        if (data) {
+          instance.value = data.documentCategory || ''; // eslint-disable-line no-param-reassign
+        }
+      },
+      handleAdditionalInput: e => {
+        return { documentCategory: e.detail.value };
+      },
     }),
   },
   schema: {

--- a/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
+++ b/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
@@ -105,6 +105,9 @@ export default {
             value={documentCategory}
             label="What type of document is this?"
           >
+            <option value="" disabled>
+              Select a document type
+            </option>
             <option value="funeral">Funeral service receipt</option>
             <option value="burial">Burial expense receipt</option>
             <option value="hospital">Hospital bill</option>

--- a/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
+++ b/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
@@ -92,7 +92,9 @@ export default {
       hint: 'Upload a file that is between 1KB and 5MB.',
       formNumber: '21P-601',
       disallowEncryptedPdfs: true,
-      fileUploadUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
+      fileUploadUrl: `${
+        environment.API_URL
+      }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
       maxFileSize: 1024 * 1024 * 5,
       minFileSize: 1,
       additionalInputRequired: true,

--- a/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
+++ b/src/applications/simple-forms/21P-601/pages/supportingDocuments.js
@@ -29,6 +29,26 @@ export default {
 
       const capitalize = str =>
         str ? str.charAt(0).toUpperCase() + str.slice(1) : str;
+      const buildExpenseKey = (expense, index) => {
+        const provider = expense?.provider;
+        const type = expense?.expenseType;
+        const amount = expense?.amount;
+        const parts = [provider, type, amount].filter(Boolean);
+        if (parts.length) {
+          return `exp-${parts.join('-')}`;
+        }
+        return `exp-idx-${index}`;
+      };
+      const buildDebtKey = (debt, index) => {
+        const type = debt?.debtType;
+        const amount = debt?.debtAmount;
+        const creditor = debt?.creditorName;
+        const parts = [type, amount, creditor].filter(Boolean);
+        if (parts.length) {
+          return `debt-${parts.join('-')}`;
+        }
+        return `debt-idx-${index}`;
+      };
 
       return (
         <div>
@@ -50,7 +70,7 @@ export default {
                       ? `$${parseFloat(expense.amount).toFixed(2)}`
                       : '';
                     return (
-                      <li key={`exp-msg-${i}`}>
+                      <li key={buildExpenseKey(expense, i)}>
                         {type} from {provider}
                         {amount && ` — ${amount}`}
                       </li>
@@ -72,7 +92,7 @@ export default {
                       : '';
                     const creditor = debt?.creditorName;
                     return (
-                      <li key={`debt-msg-${i}`}>
+                      <li key={buildDebtKey(debt, i)}>
                         {type}
                         {creditor && ` owed to ${creditor}`}
                         {amount && ` — ${amount}`}


### PR DESCRIPTION
### Summary
User testing for the 21P-601 (Apply for Accrued Benefits) form revealed that by the time users reach the document upload step (Step 7: "Additional remarks"), they have forgotten which documents they need to upload based on the expense and debt questions they answered earlier (Step 6: "Expenses and debts").

Currently, the upload page shows a generic "Supporting documents" label with the hint "This may include legal documents, bills, or other documentation of expenses" - providing no connection to the specific expenses the user entered (e.g., funeral home costs, hospital bills, burial expenses).

### Tasks
- Adding meaningful labels/categories to uploaded files
- Providing better context on what documents are needed based on user answers


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#133587


## Testing done

- manual verification


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Info | Labels |
| ------- | ------ | ----- |
| Desktop |  <img width="1812" height="1622" alt="image" src="https://github.com/user-attachments/assets/afe7f421-1adc-4b36-962e-9f799d3cae41" />   |   <img width="1132" height="987" alt="image" src="https://github.com/user-attachments/assets/555d2104-191e-44d6-a74d-5859a40cd49e" />  |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
