### PR TITLE
fix: replace vagov-dependency-check with local bulk advisory API script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prebuild": "node script/prebuild.js",
     "proxy-rewrite:verify-targets": "node src/applications/proxy-rewrite/scripts/verify-injection-targets.js",
     "reset:env": "./script/reset-environment.sh",
-    "security-check": "yarn vagov-dependency-check",
+    "security-check": "node script/security-audit.js",
     "test": "npm run test:unit",
     "test:coverage": "npm run test:unit -- --coverage --log-level debug",
     "test:coverage-app": "node script/run-app-coverage.js",

--- a/script/security-audit.js
+++ b/script/security-audit.js
@@ -1,0 +1,205 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const semver = require('semver');
+const lockfile = require('@yarnpkg/lockfile');
+
+const REGISTRY_HOST = 'registry.npmjs.org';
+const BULK_ADVISORY_PATH = '/-/npm/v1/security/advisories/bulk';
+
+const SEVERITY_FILTER = new Set(['low', 'moderate', 'high', 'critical']);
+
+const EXCEPTION_SET = new Set([
+  'https://npmjs.com/advisories/996',
+  'https://npmjs.com/advisories/1488',
+  'https://github.com/advisories/GHSA-r683-j2x4-v87g',
+  'https://github.com/advisories/GHSA-8hfj-j24r-96c4',
+]);
+
+/**
+ * Parse yarn.lock and return a map of package name -> { version, dependencies }.
+ */
+function parseYarnLock(lockPath) {
+  const raw = fs.readFileSync(lockPath, 'utf8');
+  const parsed = lockfile.parse(raw);
+
+  if (parsed.type !== 'success') {
+    throw new Error(`Failed to parse yarn.lock: ${parsed.type}`);
+  }
+
+  // Build a map of packageName -> { version, dependencies }
+  const packages = {};
+  for (const [key, entry] of Object.entries(parsed.object)) {
+    // Key format: "package-name@^1.0.0" or "@scope/name@^1.0.0"
+    const atIndex = key.lastIndexOf('@');
+    const name = key.substring(0, atIndex);
+
+    if (!packages[name]) {
+      packages[name] = {
+        version: entry.version,
+        dependencies: entry.dependencies || {},
+      };
+    }
+  }
+
+  return packages;
+}
+
+/**
+ * Build a set of all package names reachable from production dependencies.
+ */
+function getProductionReachable(productionDeps, allPackages) {
+  const reachable = new Set();
+  const queue = [...productionDeps];
+
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (reachable.has(name)) continue;
+    reachable.add(name);
+
+    const pkg = allPackages[name];
+    if (pkg && pkg.dependencies) {
+      for (const dep of Object.keys(pkg.dependencies)) {
+        if (!reachable.has(dep)) {
+          queue.push(dep);
+        }
+      }
+    }
+  }
+
+  return reachable;
+}
+
+/**
+ * Query the npm bulk advisory API.
+ */
+function fetchAdvisories(packageVersions) {
+  return new Promise((resolve, reject) => {
+    const body = Buffer.from(JSON.stringify(packageVersions));
+
+    const req = https.request(
+      {
+        hostname: REGISTRY_HOST,
+        path: BULK_ADVISORY_PATH,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'Content-Length': body.length,
+        },
+      },
+      res => {
+        let data = [];
+        res.on('data', chunk => data.push(chunk));
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(
+              new Error(
+                `Advisory API returned ${res.statusCode}: ${Buffer.concat(
+                  data,
+                ).toString()}`,
+              ),
+            );
+            return;
+          }
+          try {
+            resolve(JSON.parse(Buffer.concat(data).toString()));
+          } catch (e) {
+            reject(new Error(`Failed to parse advisory response: ${e.message}`));
+          }
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+async function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const packageJsonPath = path.join(rootDir, 'package.json');
+  const yarnLockPath = path.join(rootDir, 'yarn.lock');
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const productionDeps = Object.keys(packageJson.dependencies || {});
+
+  const allPackages = parseYarnLock(yarnLockPath);
+  const productionReachable = getProductionReachable(
+    productionDeps,
+    allPackages,
+  );
+
+  // Build the bulk request payload: { packageName: [version] }
+  const packageVersions = {};
+  for (const [name, pkg] of Object.entries(allPackages)) {
+    if (productionReachable.has(name)) {
+      packageVersions[name] = [pkg.version];
+    }
+  }
+
+  console.log(
+    `Auditing ${Object.keys(packageVersions).length} production packages...`,
+  );
+
+  const advisories = await fetchAdvisories(packageVersions);
+  const vulnerabilities = [];
+
+  for (const [packageName, advisoryList] of Object.entries(advisories)) {
+    const pkg = allPackages[packageName];
+    if (!pkg) continue;
+
+    for (const advisory of advisoryList) {
+      if (EXCEPTION_SET.has(advisory.url)) continue;
+      if (!SEVERITY_FILTER.has(advisory.severity)) continue;
+
+      if (semver.satisfies(pkg.version, advisory.vulnerable_versions)) {
+        vulnerabilities.push({
+          packageName,
+          installedVersion: pkg.version,
+          severity: advisory.severity,
+          title: advisory.title,
+          url: advisory.url,
+          vulnerableRange: advisory.vulnerable_versions,
+        });
+      }
+    }
+  }
+
+  if (vulnerabilities.length === 0) {
+    console.log(
+      'No security advisories rated moderate or higher found for production dependencies.',
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `\nFound ${vulnerabilities.length} security ${
+      vulnerabilities.length === 1 ? 'advisory' : 'advisories'
+    }:\n`,
+  );
+
+  for (const vuln of vulnerabilities) {
+    const output = [
+      `Security advisory:`,
+      `  Title: ${vuln.title}`,
+      `  Package: ${vuln.packageName}@${vuln.installedVersion}`,
+      `  Severity: ${vuln.severity}`,
+      `  Vulnerable range: ${vuln.vulnerableRange}`,
+      `  Details: ${vuln.url}`,
+    ].join('\n');
+
+    if (process.env.CI) {
+      console.log(`::warning::${output.replace(/\n/g, '%0A')}`);
+    } else {
+      console.log(`${output}\n`);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(`Security audit failed: ${err.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The `yarn security-check` CI step has been failing with a 500 Internal Server Error from the npm registry's legacy `/-/npm/v1/security/audits` endpoint. This endpoint is used by Yarn 1.x's `yarn audit` command, which is called by the `@department-of-veterans-affairs/vagov-platform` package's `vagov-dependency-check` script.
- The legacy audit endpoint is returning 500 for this repository's dependency tree (1.4MB payload with 5,791 dependency nodes). The newer bulk advisory API (`/-/npm/v1/security/advisories/bulk`) works correctly.
- This PR replaces the external `vagov-dependency-check` dependency with a local script (`script/security-audit.js`) that queries the working bulk advisory API directly. The new script reads `yarn.lock` to collect package versions, identifies production dependency chains, and reports advisories matching the same filtering criteria as the old script (production deps, configurable severity, exception list).
- The old script was informational only (printed advisories but did not block CI). This behavior is preserved.
- Platform SRE team owns this change.

## Related issue(s)

- No associated issue — this is an emergency fix for a broken CI check caused by an upstream npm registry API failure.

## Testing done

- Verified the legacy `/-/npm/v1/security/audits` endpoint returns 500 for this repo's dependency tree
- Verified the bulk advisory API (`/-/npm/v1/security/advisories/bulk`) returns 200 with correct advisory data
- Ran `yarn security-check` locally — script exits 0, correctly identifies 37 advisories across production dependency chains
- Confirmed the script matches the old behavior: prints warnings but does not block CI

## Screenshots

Not applicable — no UI changes. This is a CI infrastructure fix.

## What areas of the site does it impact?

CI pipeline only — the `security-audit` job in the `continuous-integration` workflow.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). — Not applicable; this is a standalone CI script replacing an external package dependency. The script is validated by running it locally and in CI.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#)) — Not applicable; no external documentation exists for the previous script.
- [ ] Screenshot of the developed feature is added — Not applicable; no UI changes.
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed — Not applicable; no UI changes.

### Error Handling

- [ ] Browser console contains no warnings or errors. — Not applicable; CI-only change.
- [x] Events are being sent to the appropriate logging solution — Advisories are logged as `::warning::` annotations in GitHub Actions.
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — Not applicable.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user — Not applicable; CI-only change.