### PR TITLE
Changed facility to White City for first nudge

### DIFF
--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -132,12 +132,12 @@ export const checkPortalRequirements = ({
   const redirectElligible =
     isPortalNoticeInterstitialEnabled && provisioned && vaPatient;
 
-  const activeFacilities = ['757'];
+  const activeFacilities = ['692'];
   const approvedFacilities = [
     ...activeFacilities,
     '653',
     '687',
-    '692',
+    '757',
     '668',
     '556',
   ];

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -421,7 +421,7 @@ describe('AuthApp', () => {
                   vaPatient: true,
                   facilities: [
                     {
-                      facilityId: '757',
+                      facilityId: '692',
                       isCerner: true,
                     },
                   ],


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- This work is behind a flipper: `portal_notice_interstitial_enabled`
- Switches the Oracle Health transition nudge interstitial from targeting Columbus, OH (facility 757) to **White City VA Medical Center (facility 692)** — a lower-traffic facility for safer 100% rollout testing.
- In `src/applications/auth/helpers.js`, `activeFacilities` controls which facility IDs trigger the `/sign-in-health-portal` interstitial redirect after sign-in. Changed from `['757']` to `['692']`. Moved `757` into `approvedFacilities` (replacing where `692` was, since `692` now spreads in via `activeFacilities`).
- Team: MHV on VA.gov — My Health / MHV Horizon team owns this component.
- Flipper end date: TBD based on White City rollout success. Success criteria: White City users see the interstitial redirect with no errors; non-White City users are unaffected.

## Related issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/133789

## Testing done

- **Old behavior:** Users at facility 757 (Columbus) would see the portal notice interstitial redirect when `portalNoticeInterstitialEnabled` toggle was enabled.
- **New behavior:** Users at facility 692 (White City) now see the interstitial redirect instead. Users at 757 no longer see the interstitial but are still in `approvedFacilities` (so they get routed to My Health correctly).
- **Steps to verify:**
  1. With `portalNoticeInterstitialEnabled` toggle enabled, sign in as a user with facility 692 → should redirect to `/sign-in-health-portal`.
  2. Sign in as a user with facility 757 → should NOT redirect to `/sign-in-health-portal`, but should NOT redirect to `/my-health` either (757 is still in `approvedFacilities`).
  3. Sign in as a user with no OH facilities → no interstitial, normal redirect.
- Unit test updated: `AuthApp.unit.spec.jsx` fixture changed from `facilityId: '757'` to `'692'`.

## Screenshots

_N/A — no UI changes. The interstitial page itself is unchanged; only which users are redirected to it changed._

## What areas of the site does it impact?

The auth callback flow (`src/applications/auth/`). Specifically, which facility IDs trigger the portal notice interstitial redirect after sign-in. No other areas of the site are impacted.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.

## Requested Feedback

This is a coordinated change. The backend also needs `facilities_ready_for_info_alert` updated in Parameter Store to include `692`, and the `portal_notice_interstitial_enabled` Flipper flag enabled at 100%. This frontend PR alone will not activate the nudge — all three pieces (this PR + Parameter Store + Flipper) need to land together.