### PR TITLE
fix(claims-status): replace deprecated require.ensure with dynamic import()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,12 @@ module.exports = {
         message:
           'require.ensure is deprecated. Use dynamic import() instead. See https://webpack.js.org/guides/code-splitting/#dynamic-imports',
       },
+      {
+        selector:
+          'CallExpression[callee.object.type="ImportExpression"][callee.property.name="then"] > :matches(ArrowFunctionExpression, FunctionExpression) > ObjectPattern.params',
+        message:
+          'Do not destructure the parameter in import().then(). Use `module =>` and access `module.default` instead. Example: import("./foo").then(module => { const { Bar } = module.default; })',
+      },
     ],
     camelcase: [2, { properties: 'always' }], // Override airbnb style.
     'react/jsx-wrap-multilines': 'off', // Conflicts with Prettier

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,15 @@ module.exports = {
   },
   rules: {
     /* || Eslint main rules || */
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector:
+          'CallExpression[callee.object.name="require"][callee.property.name="ensure"]',
+        message:
+          'require.ensure is deprecated. Use dynamic import() instead. See https://webpack.js.org/guides/code-splitting/#dynamic-imports',
+      },
+    ],
     camelcase: [2, { properties: 'always' }], // Override airbnb style.
     'react/jsx-wrap-multilines': 'off', // Conflicts with Prettier
     '@department-of-veterans-affairs/no-cross-app-imports': [

--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -460,7 +460,8 @@ export function submitFiles(
       progress: 0,
     });
     import(/* webpackChunkName: "claims-uploader" */ 'fine-uploader/lib/core').then(
-      ({ FineUploaderBasic }) => {
+      module => {
+        const { FineUploaderBasic } = module.default;
         const csrfTokenStored = localStorage.getItem('csrfToken');
         const uploader = new FineUploaderBasic({
           request: {

--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -459,11 +459,9 @@ export function submitFiles(
       type: SET_PROGRESS,
       progress: 0,
     });
-    require.ensure(
-      [],
-      require => {
+    import(/* webpackChunkName: "claims-uploader" */ 'fine-uploader/lib/core').then(
+      ({ FineUploaderBasic }) => {
         const csrfTokenStored = localStorage.getItem('csrfToken');
-        const { FineUploaderBasic } = require('fine-uploader/lib/core');
         const uploader = new FineUploaderBasic({
           request: {
             endpoint: `${
@@ -609,7 +607,6 @@ export function submitFiles(
         });
         /* eslint-enable camelcase */
       },
-      'claims-uploader',
     );
   };
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders

### :warning: TeamSites :warning:
- [x] No

## Summary

- Replaced the deprecated `require.ensure` code-splitting call in claims-status file upload with standard dynamic `import()`.
- `require.ensure` has been deprecated since webpack 4 in favor of `import()`. This is the only usage in the codebase.
- Fixed CJS-to-ESM interop: the `fine-uploader` library uses `module.exports = qq` (CommonJS), so when loaded via dynamic `import()`, webpack places the export under `module.default`. The `.then()` callback now correctly accesses `module.default` to destructure `FineUploaderBasic`, matching the established codebase pattern.
- Added two eslint `no-restricted-syntax` rules:
  1. Ban `require.ensure` calls with a message directing developers to use `import()` instead.
  2. Ban destructuring the parameter in `import().then()` (e.g., `({ Foo }) =>`) — developers must use `module =>` and access `module.default` to avoid CJS interop issues.
- Platform Infrastructure team.

## Related issue(s)

- department-of-veterans-affairs/vets-website#42397

## Testing done

- **Red/green on lint rules**: Verified both `no-restricted-syntax` rules work correctly — the `require.ensure` rule catches legacy calls, and the `import().then()` destructuring rule catches `({ Foo }) =>` while allowing `module =>`.
- **No existing violations**: Linted all 40 files in the codebase that use `import().then()` — zero violations of the new destructuring rule.
- **No other `require.ensure` usage**: Confirmed via grep that this was the only instance in the codebase.
- **Build verified**: Built claims-status and confirmed the compiled output produces a proper async chunk (`claims-uploader.entry.js`) with correct dynamic loading.
- **E2E coverage**: The `submitFiles` function (which contains the changed code) is exercised by these existing Cypress tests that upload files and assert on the upload POST request:
  - `src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js`
  - `src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js`
  - `src/applications/claims-status/tests/e2e/10.va-file-input-multiple.cypress.spec.js`
  - `src/applications/claims-status/tests/e2e/11.date-discrepancy-mitigation.cypress.spec.js`

## Screenshots

N/A — no UI changes.

## What areas of the site does it impact?

Claims status file upload functionality (`src/applications/claims-status/actions/index.js`). The runtime behavior is unchanged — files are still loaded asynchronously via a separate chunk.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A — no UI changes)
- [x] Accessibility testing has been performed (N/A — no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — no auth changes)

## Requested Feedback

None — straightforward deprecated API replacement with lint guards.