### PR TITLE
[Find a Rep v3] 132321: Combine Rep Name and Distance for Accessibility and Swap Their Order

### DIFF
--- a/src/applications/representative-search/components/results/SearchResult.jsx
+++ b/src/applications/representative-search/components/results/SearchResult.jsx
@@ -203,36 +203,31 @@ const SearchResult = ({
           cancelRepresentativeReport={cancelRepresentativeReport}
         />
       )}
-      <va-card class="representative-result-card vads-u-padding--4">
+      <va-card
+        id={`representative-${representativeId}`}
+        class="representative-result-card vads-u-padding--4"
+      >
         <div className="representative-result-card-content">
           <div className="representative-info-heading">
-            {hasDistance && (
-              <div
-                id={`representative-${representativeId}`}
-                className="vads-u-font-weight--bold vads-u-font-family--serif"
-              >
-                {parseFloat(JSON.parse(distance).toFixed(2))} miles
-                {isEstimatedAddress ? ' (estimated)' : ''}
-              </div>
-            )}
-            {officer && (
-              <>
-                <div
-                  className="vads-u-font-family--serif vads-u-margin-top--2p5"
-                  id={`result-${representativeId}`}
-                >
-                  <h3 aria-describedby={`representative-${representativeId}`}>
-                    {officer}
-                  </h3>
-                </div>
-                {associatedOrgs?.length === 1 && (
-                  <p style={{ marginTop: 0 }}>{associatedOrgs[0]}</p>
-                )}
-              </>
-            )}
+            <h3
+              className="vads-u-margin-top--0"
+              aria-describedby={`representative-${representativeId}`}
+            >
+              {officer && <span className="officer">{officer}</span>}
+              {hasDistance && (
+                <span className="distance vads-u-margin-top--1 vads-u-display--block vads-u-font-size--h4">
+                  {parseFloat(JSON.parse(distance).toFixed(2))} miles
+                  {isEstimatedAddress ? ' (estimated)' : ''}
+                </span>
+              )}
+            </h3>
           </div>
-          {associatedOrgs?.length > 1 && (
-            <div className="associated-organizations-info vads-u-margin-top--1p5">
+
+          <div className="associated-organizations-info vads-u-margin-top--1p5">
+            {associatedOrgs?.length === 1 && (
+              <span className="vads-u-font-size--md">{associatedOrgs[0]}</span>
+            )}
+            {associatedOrgs?.length > 1 && (
               <va-additional-info
                 trigger="See associated organizations"
                 disable-border
@@ -240,8 +235,8 @@ const SearchResult = ({
               >
                 {associatedOrgs?.map(org => <div key={org}>{org}</div>)}
               </va-additional-info>
-            </div>
-          )}
+            )}
+          </div>
 
           <div className="representative-contact-section vads-u-margin-top--3">
             {addressExists && (

--- a/src/applications/representative-search/sass/find-a-representative.scss
+++ b/src/applications/representative-search/sass/find-a-representative.scss
@@ -97,10 +97,6 @@
       margin-bottom: 3.2rem;
     }
 
-    h3 {
-      margin: 0.8rem 0 0.8rem 0;
-    }
-
     .sort-select {
       width: 18.8rem;
       display: flex;

--- a/src/applications/representative-search/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchResult.unit.spec.jsx
@@ -243,9 +243,7 @@ describe('SearchResults', () => {
         </Provider>,
       );
 
-      const distanceElement = container.querySelector(
-        '.vads-u-font-weight--bold.vads-u-font-family--serif',
-      );
+      const distanceElement = container.querySelector('h3 span.distance');
       expect(distanceElement).to.exist;
       expect(distanceElement.textContent).to.contain('miles');
       expect(distanceElement.textContent).to.not.contain('(estimated)');
@@ -258,9 +256,7 @@ describe('SearchResults', () => {
         </Provider>,
       );
 
-      const distanceElement = container.querySelector(
-        '.vads-u-font-weight--bold.vads-u-font-family--serif',
-      );
+      const distanceElement = container.querySelector('h3 span.distance');
 
       expect(distanceElement).to.exist;
       expect(distanceElement.textContent).to.contain('0 miles');
@@ -281,9 +277,7 @@ describe('SearchResults', () => {
         </Provider>,
       );
 
-      const distanceElement = container.querySelector(
-        '.vads-u-font-weight--bold.vads-u-font-family--serif',
-      );
+      const distanceElement = container.querySelector('h3 span.distance');
       expect(distanceElement).to.exist;
       expect(distanceElement.textContent).to.contain('(estimated)');
     });
@@ -303,9 +297,7 @@ describe('SearchResults', () => {
         </Provider>,
       );
 
-      const distanceElement = container.querySelector(
-        '.vads-u-font-weight--bold.vads-u-font-family--serif',
-      );
+      const distanceElement = container.querySelector('h3 span.distance');
       expect(distanceElement).to.exist;
       expect(distanceElement.textContent).to.contain('(estimated)');
     });
@@ -397,15 +389,11 @@ describe('SearchResults', () => {
       </Provider>,
     );
 
-    const distanceElement = container.querySelector(
-      '.vads-u-font-weight--bold.vads-u-font-family--serif',
-    );
-    expect(distanceElement).to.exist;
-
-    const officerElement = container.querySelector(
-      '.vads-u-font-family--serif.vads-u-margin-top--2p5 h3',
-    );
+    const officerElement = container.querySelector('h3 span.officer');
     expect(officerElement).to.exist;
+
+    const distanceElement = container.querySelector('h3 span.distance');
+    expect(distanceElement).to.exist;
   });
 
   it('renders modal when appropriate', () => {


### PR DESCRIPTION
## Summary

This PR makes the following updates to the Find a Rep experience:
1. Swaps the order of the distance and representative name in the results cards for improved user experience. (Representative name now comes first.)
2. Combines the representative name and distance into a single `h3` for improved accessibility.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132321

## Testing done

Tested layout/style updates in Chrome, Safari, and Firefox, in all common viewports.

Tested the accessibility of the updated `h3` using VoiceOver.

Ensured that all unit tests pass after the change (`yarn test:unit --app-folder representative-search`).

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="401" height="602" alt="Before" src="https://github.com/user-attachments/assets/9c8cddda-f5dd-41c9-931d-4e83f32c428d" /> | <img width="417" height="593" alt="Screenshot 2026-02-20 at 11 18 32 AM" src="https://github.com/user-attachments/assets/ef868dc0-502c-4ad0-83e9-1558dcf6a6ce" /> |
| Desktop | <img width="733" height="736" alt="Before" src="https://github.com/user-attachments/assets/86234c85-75dd-4205-8bfa-53c622a2efe4" /> | <img width="754" height="716" alt="After" src="https://github.com/user-attachments/assets/e0f8458b-2be6-43f1-b3f8-fb7b91fc2680" /> |

**VoiceOver Header List:**
<img width="1905" height="1638" alt="VoiceOver Screenshot Headings List" src="https://github.com/user-attachments/assets/5061b20b-9ac0-478a-8131-dd1a86437940" />

**VoiceOver Focus After Hitting 'Enter':**
<img width="2335" height="1465" alt="VoiceOver Screenshot Header Focus" src="https://github.com/user-attachments/assets/dd8ce7df-14fb-4ffa-9012-302d198e864d" />

## What areas of the site does it impact?

Find a Rep: `/get-help-from-accredited-representative/find-rep/`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).