### PR TITLE
fix(mhv-medications): V2 filter count undefined and renewal filter mismatch

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -48,19 +48,19 @@ const MedicationsListFilter = ({ updateFilter, filterCount, isLoading }) => {
         return filterCount.active;
       }
       case currentFilterOptions.RECENTLY_REQUESTED?.label: {
-        return filterCount.recentlyRequested;
+        return filterCount.recentlyRequested ?? filterCount.inProgress;
       }
       case currentFilterOptions.IN_PROGRESS?.label: {
         return filterCount.inProgress;
       }
       case currentFilterOptions.RENEWAL?.label: {
-        return filterCount.renewal;
+        return filterCount.renewal ?? filterCount.renewable;
       }
       case currentFilterOptions.RENEWABLE?.label: {
         return filterCount.renewable;
       }
       case currentFilterOptions.NON_ACTIVE?.label: {
-        return filterCount.nonActive;
+        return filterCount.nonActive ?? filterCount.inactive;
       }
       case currentFilterOptions.INACTIVE?.label: {
         return filterCount.inactive;
@@ -165,7 +165,7 @@ const MedicationsListFilter = ({ updateFilter, filterCount, isLoading }) => {
                 filterCount &&
                 mapFilterCountToFilterLabels(
                   currentFilterOptions[option].label,
-                ) !== null
+                ) != null
                   ? ` (${mapFilterCountToFilterLabels(
                       currentFilterOptions[option].label,
                     )})`

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListFilter.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListFilter.unit.spec.jsx
@@ -256,6 +256,36 @@ describe('Medications List Filter component', () => {
       expect(screen.getByTestId('filter-option-SHIPPED')).to.exist;
       expect(screen.getByTestId('filter-option-INACTIVE')).to.exist;
     });
+
+    it('falls back to V2 count keys when only cernerPilot is enabled', () => {
+      const v2OnlyFilterCount = {
+        allMedications: 100,
+        active: 20,
+        inProgress: 15,
+        shipped: 10,
+        renewable: 12,
+        inactive: 45,
+        transferred: 5,
+        statusNotAvailable: 5,
+      };
+      const screen = setup({}, () => {}, v2OnlyFilterCount, true, false, false);
+      const renewalOption = screen.getByTestId('filter-option-RENEWAL');
+      expect(renewalOption).to.exist;
+      expect(renewalOption.label).to.contain('(12)');
+    });
+
+    it('does not show undefined count when V2 API returns renewable instead of renewal', () => {
+      const v2OnlyFilterCount = {
+        allMedications: 100,
+        active: 20,
+        inProgress: 15,
+        renewable: 12,
+        inactive: 45,
+      };
+      const screen = setup({}, () => {}, v2OnlyFilterCount, true, false, false);
+      const renewalOption = screen.getByTestId('filter-option-RENEWAL');
+      expect(renewalOption.label).to.not.contain('undefined');
+    });
   });
 
   describe('Button loading states', () => {

--- a/src/applications/mhv-medications/tests/util/helpers/getRxStatus.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/helpers/getRxStatus.unit.spec.jsx
@@ -244,15 +244,24 @@ describe('getRxStatus helper functions', () => {
       const cernerPilotFlag = true;
       const v2StatusMappingFlag = false;
 
-      it('returns V1 filter options', () => {
+      it('returns V1 filter options with V2-compatible renewal URL', () => {
         const result = getFilterOptions(cernerPilotFlag, v2StatusMappingFlag);
-        expect(result).to.deep.equal(filterOptions);
+        expect(result).to.have.property('RENEWAL');
+        expect(result.RENEWAL.label).to.equal(filterOptions.RENEWAL.label);
+        expect(result.RENEWAL.url).to.equal(filterOptionsV2.RENEWABLE.url);
       });
 
       it('includes V1-specific filter keys', () => {
         const result = getFilterOptions(cernerPilotFlag, v2StatusMappingFlag);
         expect(result).to.have.property('ACTIVE');
         expect(result).to.have.property('RECENTLY_REQUESTED');
+        expect(result).to.have.property('NON_ACTIVE');
+      });
+
+      it('preserves V1 labels and descriptions for non-renewal filters', () => {
+        const result = getFilterOptions(cernerPilotFlag, v2StatusMappingFlag);
+        expect(result.ACTIVE).to.deep.equal(filterOptions.ACTIVE);
+        expect(result.NON_ACTIVE).to.deep.equal(filterOptions.NON_ACTIVE);
       });
     });
 

--- a/src/applications/mhv-medications/util/helpers/getRxStatus.js
+++ b/src/applications/mhv-medications/util/helpers/getRxStatus.js
@@ -2,6 +2,8 @@ import { rxSourceIsNonVA } from './rxSourceIsNonVA';
 import {
   ACTIVE_NON_VA,
   FIELD_NONE_NOTED,
+  RENEWAL_FILTER_KEY,
+  RENEWABLE_FILTER_KEY,
   pdfStatusDefinitions,
   pdfStatusDefinitionsV2,
   filterOptions,
@@ -50,5 +52,15 @@ export const getPdfStatusDefinitionKey = (dispStatus, refillStatus) => {
  * @returns {Object} Filter options object
  */
 export const getFilterOptions = (isCernerPilot, isV2StatusMapping) => {
-  return isCernerPilot && isV2StatusMapping ? filterOptionsV2 : filterOptions;
+  if (isCernerPilot && isV2StatusMapping) return filterOptionsV2;
+  if (isCernerPilot) {
+    return {
+      ...filterOptions,
+      [RENEWAL_FILTER_KEY]: {
+        ...filterOptions[RENEWAL_FILTER_KEY],
+        url: filterOptionsV2[RENEWABLE_FILTER_KEY].url,
+      },
+    };
+  }
+  return filterOptions;
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug**: When `mhv_medications_cerner_pilot` is enabled but `mhv_medications_v2_status_mapping` is disabled, filter counts show `(undefined)` for "Recently requested," "Renewal needed before refill," and "Non-active" filters. Additionally, the renewal filter returns ~19 prescriptions instead of only the 1 that is actually renewable.
- **Root cause**: The V2 API returns `filterCount` with keys `renewable`, `inProgress`, `inactive`, but the V1 filter code reads `renewal`, `recentlyRequested`, `nonActive` — all undefined on the V2 response. The `!== null` check does not catch `undefined`, so `(undefined)` renders in the label. The V1 renewal filter URL uses `disp_status=Active,Expired` which is too broad for V2 — it should use `is_renewable=true`.
- **Fix**: Added `??` fallback keys in `MedicationsListFilter.jsx`, changed `!== null` to `!= null`, and added hybrid filter options in `getFilterOptions()` that use V1 labels with the V2 `is_renewable=true` renewal filter URL when only cernerPilot is enabled. Also aligned the (currently inactive) `prescriptionsLoader.js` to use the same feature-flag-aware filter options.
- **Team**: MHV Medications
- **Flipper**: `mhv_medications_cerner_pilot` (existing toggle)

### Details on filtering

<details>

## How Renewal Filtering Works End-to-End

### 1. Frontend: Choosing the API Version

When the prescriptions list is fetched, the frontend selects V1 or V2 based on the `mhv_medications_cerner_pilot` feature toggle:

- `prescriptionsApi.js` — `getApiBasePath()` returns `/my_health/v2` when cernerPilot is true, `/my_health/v1` otherwise.

### 2. Frontend: Constructing the Filter Query

Filter options are defined in `filters.js`:

| Config | Key | Filter URL sent to API |
|--------|-----|----------------------|
| **V1** (`filterOptions`) | `RENEWAL` | `&filter[[disp_status][eq]]=Active,Expired` |
| **V2** (`filterOptionsV2`) | `RENEWABLE` | `&filter[[is_renewable][eq]]=true` |

When a user selects a filter, `buildPrescriptionsListQuery()` appends the filter's `.url` string directly to the query params, producing a request like:

```
GET /my_health/v2/prescriptions?page=1&per_page=10&filter[[is_renewable][eq]]=true
```

The function `getFilterOptions()` in `getRxStatus.js` decides **which filter set** to use based on feature flags. The critical case our fix handles — cernerPilot=true, v2StatusMapping=false — returns a **hybrid**: V1 labels (so the UI text stays the same) but swaps the renewal filter URL to V2's `is_renewable=true`.

### 3. vets-api Routing

Both API versions route to their own prescriptions controller:

- `v2/prescriptions` → `MyHealth::V2::PrescriptionsController`
- `v1/prescriptions` → `MyHealth::V1::PrescriptionsController`

### 4. V1 Controller: `disp_status` Filtering (Legacy)

In the V1 `PrescriptionsController`, `apply_filters()` checks the `filter[disp_status][eq]` param:

```ruby
if disp_status[:eq]&.downcase == 'active,expired'.downcase
  filter_renewals(resource)
else
  # plain disp_status matching
end
```

When it detects `Active,Expired`, it calls `filter_renewals()` which uses `resource.data.select(&method(:renewable))` — filtering via the `renewable` helper rather than simple status matching.

The V1 `renewable()` method (in `prescription_helper.rb`) uses a **heuristic** based on `disp_status`, `refill_remaining`, `is_refillable`, and `expiration_date`:

- **Active + zero refills + not refillable** → renewable
- **Active: Parked + has refill records + zero refills + not refillable** → renewable
- **Expired + expired within 120 days + not refillable** → renewable

The V1 controller returns `filter_count` with key **`renewal`** in `set_filter_metadata()`:

```ruby
filter_count: {
  renewal: list.select(&method(:renewable)).length,
  recently_requested: ...,
  non_active: ...
}
```

### 5. V2 Controller: `is_renewable` Filtering (Cerner/Oracle Health)

The V2 `PrescriptionsController` supports an additional filter type — `is_renewable`:

```ruby
filter_params = params.require(:filter).permit(
  disp_status: [:eq], is_trackable: [:eq], is_renewable: [:eq]
)
```

`apply_renewable_filter()` simply checks the `is_renewable` boolean property on each prescription object:

```ruby
prescriptions.select { |item| item.respond_to?(:is_renewable) && item.is_renewable == true }
```

This is a **model-level property** — UHD/Cerner prescriptions arrive with `is_renewable` already computed by the upstream service, rather than calculated via heuristic.

The V2 `renewable()` helper (in `prescription_helper_v2.rb`) prefers `is_renewable` when available, falling back to the heuristic for legacy data:

```ruby
def renewable(item)
  return item.is_renewable if item.respond_to?(:is_renewable) && !item.is_renewable.nil?
  # ... fallback heuristic for UHD prescriptions without is_renewable
end
```

The V2 controller returns `filter_count` with key **`renewable`** in `set_filter_metadata()`:

```ruby
filter_count: {
  renewable: count_renewable_medications(list),
  in_progress: ...,
  inactive: ...
}
```

### 6. The Mismatch (The Bug)

When **cernerPilot=true, v2StatusMapping=false**:

| Layer | What happens |
|-------|-------------|
| API URL | Frontend hits `/my_health/v2` (correct — cernerPilot is on) |
| Filter URL | V1's `&filter[[disp_status][eq]]=Active,Expired` gets sent to V2 controller |
| V2 filtering | V2 does a **plain disp_status match** — returns all Active + Expired prescriptions (~19), not just renewable ones |
| Response keys | V2 returns `{ renewable: 1, inProgress: 3, inactive: 5 }` |
| Frontend reads | V1 code reads `filterCount.renewal` → **undefined** |
| Display | Shows `"Renewal needed before refill (undefined)"` |

### 7. The Fix

- **Frontend filter URL**: `getFilterOptions()` now returns a **hybrid** when cernerPilot-only: spreads V1 options but overrides the `RENEWAL` entry's `.url` with V2's `&filter[[is_renewable][eq]]=true` — so the V2 controller uses `apply_renewable_filter()` instead of plain disp_status matching.
- **Frontend count keys**: `MedicationsListFilter.jsx` uses `filterCount.renewal ?? filterCount.renewable` (and similarly for the other renamed keys) so it reads whichever key the API returns.
- **Null guard**: Changed `!== null` to `!= null` to catch both `null` and `undefined`.

</details>

## Testing done

- Verified the bug with cernerPilot=true, v2StatusMapping=false on local build with mock API
- Verified fix resolves both issues: filter counts display correctly, renewal filter returns only 1 renewable prescription
- All 1355 unit tests passing (3 pending)

### Before fix

| Issue | Screenshot |
| ----- | ---------- |
| Filter counts show `(undefined)` | <img width="1265" height="6316" alt="before-filter" src="https://github.com/user-attachments/assets/b15caca5-c486-4c95-b3f3-b6e60dfc016f" />  |
| Renewal filter returns 19 results (most not renewable) | <img width="1265" height="6340" alt="before-renewal" src="https://github.com/user-attachments/assets/1aff2108-03c7-48e0-b3d4-bc50446ed67c" /> |

### After fix

| Issue | Screenshot |
| ----- | ---------- |
| Filter counts display correctly | <img width="1265" height="6316" alt="after-filter" src="https://github.com/user-attachments/assets/64a65811-5b84-4101-88d4-4a1f8ec9347b" /> |
| Renewal filter returns only 1 renewable prescription | <img width="1265" height="3593" alt="after-renewal" src="https://github.com/user-attachments/assets/b63049ee-7480-4b9a-8e09-f4f1970b1457" /> |

### Test output

```
  1355 passing (12s)
  3 pending
```

## What areas of the site does it impact?

MHV Medications list page — specifically the filter sidebar and its counts/results when using the V2 (Cerner/Oracle Health) API path.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

The `prescriptionsLoader.js` changes align the loader with the feature-flag-aware `getFilterOptions()` function, but the loader is **not currently active** — the prescriptions list is fetched by the `useFetchPrescriptionsList` hook. The loader fix is included for correctness if/when route-based loading is activated.
