### PR TITLE
MHV / Remove isAcceleratingVaccines toggle from BB report

### DIFF
--- a/src/applications/mhv-medical-records/actions/blueButtonReport.js
+++ b/src/applications/mhv-medical-records/actions/blueButtonReport.js
@@ -3,7 +3,6 @@ import {
   getLabsAndTests,
   getNotes,
   getVaccineList,
-  getAcceleratedImmunizations,
   getAllergies,
   getConditions,
   getVitalsList,
@@ -25,18 +24,10 @@ export const getBlueButtonReportData = (
   options = {},
   dateFilter,
 ) => async dispatch => {
-  const { isAcceleratingVaccines = false } = options;
-
-  const vaccinesActionType = isAcceleratingVaccines
-    ? Actions.Vaccines.GET_UNIFIED_LIST
-    : Actions.Vaccines.GET_LIST;
-
   const fetchMap = {
     labsAndTests: getLabsAndTests,
     notes: getNotes,
-    vaccines: isAcceleratingVaccines
-      ? getAcceleratedImmunizations
-      : getVaccineList,
+    vaccines: getVaccineList,
     allergies: getAllergies,
     conditions: getConditions,
     vitals: getVitalsList,
@@ -115,7 +106,7 @@ export const getBlueButtonReportData = (
           break;
         case 'vaccines':
           dispatch({
-            type: vaccinesActionType,
+            type: Actions.Vaccines.GET_LIST,
             response,
           });
           break;

--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -16,7 +16,6 @@ import {
   makePdf,
   formatUserDob,
   formatNameFirstLast,
-  useAcceleratedData,
 } from '@department-of-veterans-affairs/mhv/exports';
 import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { isBefore, isAfter } from 'date-fns';
@@ -57,7 +56,6 @@ const DownloadFileType = props => {
   const [fileTypeError, setFileTypeError] = useState('');
 
   const dispatch = useDispatch();
-  const { isAcceleratingVaccines } = useAcceleratedData();
 
   const fileTypeFilter = useSelector(
     state => state.mr.downloads?.fileTypeFilter,
@@ -235,14 +233,13 @@ const DownloadFileType = props => {
         demographics: recordFilter?.includes('demographics'),
         militaryService: recordFilter?.includes('militaryService'),
         patient: true,
-        isAcceleratingVaccines,
       };
 
       if (!isDataFetched) {
         dispatch(getBlueButtonReportData(options, dateFilter));
       }
     },
-    [isDataFetched, recordFilter, dispatch, dateFilter, isAcceleratingVaccines],
+    [isDataFetched, recordFilter, dispatch, dateFilter],
   );
 
   const recordData = useMemo(

--- a/src/applications/mhv-medical-records/tests/actions/blueButtonReport.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/blueButtonReport.unit.spec.jsx
@@ -93,67 +93,6 @@ describe('Blue Button Actions', () => {
         );
       });
 
-      describe('vaccines with accelerating toggle', () => {
-        let getVaccineListStub;
-        let getAcceleratedImmunizationsStub;
-
-        beforeEach(() => {
-          getVaccineListStub = sinon
-            .stub(MrApi, 'getVaccineList')
-            .resolves({ mockData: 'v1VaccinesData' });
-          getAcceleratedImmunizationsStub = sinon
-            .stub(MrApi, 'getAcceleratedImmunizations')
-            .resolves({ mockData: 'v2ImmunizationsData' });
-        });
-
-        afterEach(() => {
-          getVaccineListStub.restore();
-          getAcceleratedImmunizationsStub.restore();
-        });
-
-        it('should call v1 getVaccineList and dispatch GET_LIST when isAcceleratingVaccines is false', async () => {
-          const dispatch = sinon.spy();
-          const action = getBlueButtonReportData(
-            { vaccines: true, isAcceleratingVaccines: false },
-            {},
-          );
-          await action(dispatch);
-
-          expect(getVaccineListStub.calledOnce).to.be.true;
-          expect(getAcceleratedImmunizationsStub.called).to.be.false;
-          expect(dispatch.firstCall.args[0].type).to.equal(
-            Actions.Vaccines.GET_LIST,
-          );
-        });
-
-        it('should call v2 getAcceleratedImmunizations and dispatch GET_UNIFIED_LIST when isAcceleratingVaccines is true', async () => {
-          const dispatch = sinon.spy();
-          const action = getBlueButtonReportData(
-            { vaccines: true, isAcceleratingVaccines: true },
-            {},
-          );
-          await action(dispatch);
-
-          expect(getAcceleratedImmunizationsStub.calledOnce).to.be.true;
-          expect(getVaccineListStub.called).to.be.false;
-          expect(dispatch.firstCall.args[0].type).to.equal(
-            Actions.Vaccines.GET_UNIFIED_LIST,
-          );
-        });
-
-        it('should call v1 getVaccineList and dispatch GET_LIST when isAcceleratingVaccines is not provided (default)', async () => {
-          const dispatch = sinon.spy();
-          const action = getBlueButtonReportData({ vaccines: true }, {});
-          await action(dispatch);
-
-          expect(getVaccineListStub.calledOnce).to.be.true;
-          expect(getAcceleratedImmunizationsStub.called).to.be.false;
-          expect(dispatch.firstCall.args[0].type).to.equal(
-            Actions.Vaccines.GET_LIST,
-          );
-        });
-      });
-
       it('should get conditions', async () => {
         const mockData = { mockData: 'mockData' };
         mockApiRequest(mockData);

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/blue-button-download-vaccines.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vaccines/blue-button-download-vaccines.cypress.spec.js
@@ -4,116 +4,58 @@ import DownloadAllPage from '../../pages/DownloadAllPage';
 import oracleHealthUser from '../fixtures/user/oracle-health.json';
 import vaccinesData from '../fixtures/vaccines/sample-lighthouse.json';
 
-describe('Medical Records - Blue Button Download with Accelerated Vaccines', () => {
+describe('Medical Records - Blue Button Download Vaccines', () => {
   const site = new MedicalRecordsSite();
 
-  describe('when accelerating vaccines is enabled', () => {
-    beforeEach(() => {
-      site.login(oracleHealthUser, false);
-      site.mockFeatureToggles({
-        isAcceleratingEnabled: true,
-        isAcceleratingVaccines: true,
-      });
-    });
-
-    it('calls v2 immunizations endpoint when downloading vaccines in Blue Button report', () => {
-      // Intercept v2 endpoint - this SHOULD be called
-      cy.intercept('GET', '/my_health/v2/medical_records/immunizations*', {
-        statusCode: 200,
-        body: vaccinesData,
-      }).as('v2Immunizations');
-
-      // Track v1 endpoint - this should NOT be called
-      let v1Called = false;
-      cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', req => {
-        v1Called = true;
-        req.reply({ statusCode: 200, body: vaccinesData });
-      }).as('v1Vaccines');
-
-      // Intercept patient endpoint (required for Blue Button)
-      cy.intercept('GET', '/my_health/v1/medical_records/patient*', {
-        statusCode: 200,
-        body: { data: { attributes: {} } },
-      }).as('patient');
-
-      site.loadPage();
-      DownloadReportsPage.goToReportsPage();
-      DownloadReportsPage.goToDownloadAllPage();
-
-      // Select date range
-      DownloadAllPage.selectDateRangeDropdown('any');
-      DownloadAllPage.clickContinueOnDownloadAllPage();
-
-      // Select vaccines checkbox on page 2
-      DownloadAllPage.selectVaccinesCheckbox();
-      DownloadAllPage.clickContinueOnDownloadAllPage();
-
-      // Wait for the v2 endpoint to be called
-      cy.wait('@v2Immunizations').then(interception => {
-        expect(interception.response.statusCode).to.equal(200);
-      });
-
-      // Verify v1 was not called
-      cy.wrap(null).then(() => {
-        expect(v1Called).to.equal(false);
-      });
-
-      cy.injectAxeThenAxeCheck();
+  beforeEach(() => {
+    site.login(oracleHealthUser, false);
+    site.mockFeatureToggles({
+      isAcceleratingEnabled: true,
     });
   });
 
-  describe('when accelerating vaccines is disabled', () => {
-    beforeEach(() => {
-      site.login();
-      // Default feature toggles have acceleration disabled
+  it('always calls v1 vaccines endpoint when downloading vaccines in Blue Button report', () => {
+    // Intercept v1 endpoint - this SHOULD be called
+    cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', {
+      statusCode: 200,
+      body: vaccinesData,
+    }).as('v1Vaccines');
+
+    // Track v2 endpoint - this should NOT be called
+    let v2Called = false;
+    cy.intercept('GET', '/my_health/v2/medical_records/immunizations*', req => {
+      v2Called = true;
+      req.reply({ statusCode: 200, body: vaccinesData });
+    }).as('v2Immunizations');
+
+    // Intercept patient endpoint (required for Blue Button)
+    cy.intercept('GET', '/my_health/v1/medical_records/patient*', {
+      statusCode: 200,
+      body: { data: { attributes: {} } },
+    }).as('patient');
+
+    site.loadPage();
+    DownloadReportsPage.goToReportsPage();
+    DownloadReportsPage.goToDownloadAllPage();
+
+    // Select date range
+    DownloadAllPage.selectDateRangeDropdown('any');
+    DownloadAllPage.clickContinueOnDownloadAllPage();
+
+    // Select vaccines checkbox on page 2
+    DownloadAllPage.selectVaccinesCheckbox();
+    DownloadAllPage.clickContinueOnDownloadAllPage();
+
+    // Wait for the v1 endpoint to be called
+    cy.wait('@v1Vaccines').then(interception => {
+      expect(interception.response.statusCode).to.equal(200);
     });
 
-    it('calls v1 vaccines endpoint when downloading vaccines in Blue Button report', () => {
-      // Intercept v1 endpoint - this SHOULD be called
-      cy.intercept('GET', '/my_health/v1/medical_records/vaccines*', {
-        statusCode: 200,
-        body: vaccinesData,
-      }).as('v1Vaccines');
-
-      // Track v2 endpoint - this should NOT be called
-      let v2Called = false;
-      cy.intercept(
-        'GET',
-        '/my_health/v2/medical_records/immunizations*',
-        req => {
-          v2Called = true;
-          req.reply({ statusCode: 200, body: vaccinesData });
-        },
-      ).as('v2Immunizations');
-
-      // Intercept patient endpoint (required for Blue Button)
-      cy.intercept('GET', '/my_health/v1/medical_records/patient*', {
-        statusCode: 200,
-        body: { data: { attributes: {} } },
-      }).as('patient');
-
-      cy.visit('my-health/medical-records/download');
-      DownloadReportsPage.goToDownloadAllPage();
-
-      // Select date range
-      DownloadAllPage.selectDateRangeDropdown('any');
-      DownloadAllPage.clickContinueOnDownloadAllPage();
-
-      // Select vaccines checkbox on page 2
-      DownloadAllPage.selectVaccinesCheckbox();
-      DownloadAllPage.clickContinueOnDownloadAllPage();
-
-      // Wait for the v1 endpoint to be called
-      cy.wait('@v1Vaccines').then(interception => {
-        expect(interception.response.statusCode).to.equal(200);
-      });
-
-      // Verify v2 was not called
-      cy.wrap(null).then(() => {
-        expect(v2Called).to.equal(false);
-      });
-
-      cy.injectAxeThenAxeCheck();
+    // Verify v2 was not called
+    cy.wrap(null).then(() => {
+      expect(v2Called).to.equal(false);
     });
+
+    cy.injectAxeThenAxeCheck();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Removed the accelerated vaccines toggle from the blue button report download to align with all other BB domains pulling from V1
  - Updated related tests
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
  - If the accelerated vaccines toggle was enabled it would pull vaccine data from V2
- _Describe the steps required to verify your changes are working as expected_
  - When downloading records verify that the endpoint is v1 in the network tab
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

N/A - data change only

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
MHV medical records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
