### PR TITLE
131940 id collision fronend web

### DIFF
--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -269,11 +269,15 @@ export const getClaims = () => {
   };
 };
 
-export const getClaim = (id, navigate) => {
+export const getClaim = (id, navigate, provider) => {
   return dispatch => {
     dispatch({ type: GET_CLAIM_DETAIL });
 
-    return apiRequest(`/benefits_claims/${id}`)
+    const url = provider
+      ? `/benefits_claims/${id}?type=${provider}`
+      : `/benefits_claims/${id}`;
+
+    return apiRequest(url)
       .then(res => {
         dispatch({
           type: SET_CLAIM_DETAIL,

--- a/src/applications/claims-status/components/ClaimsListItem.jsx
+++ b/src/applications/claims-status/components/ClaimsListItem.jsx
@@ -66,6 +66,9 @@ export default function ClaimsListItem({ claim }) {
 
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
   const cstClaimPhasesEnabled = useToggleValue(TOGGLE_NAMES.cstClaimPhases);
+  const cstMultiClaimProviderEnabled = useToggleValue(
+    TOGGLE_NAMES.cstMultiClaimProvider,
+  );
   const showEightPhases = getShowEightPhases(
     claimTypeCode,
     cstClaimPhasesEnabled,
@@ -80,7 +83,12 @@ export default function ClaimsListItem({ claim }) {
   const showAlert = showPrecomms && documentsNeeded;
 
   const ariaLabel = `Details for claim submitted on ${formattedReceiptDate}`;
-  const href = `/your-claims/${claim.id}/status`;
+  const provider = cstMultiClaimProviderEnabled
+    ? claim.attributes?.provider
+    : null;
+  const href = provider
+    ? `/your-claims/${claim.id}/status?type=${provider}`
+    : `/your-claims/${claim.id}/status`;
 
   // Memoize failed submissions to prevent UploadType2ErrorAlertSlim from receiving
   // a new array reference on every render, which would break its useEffect tracking

--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -18,6 +18,7 @@ import {
 import { isClaimOpen } from '../../utils/helpers';
 import * as TrackedItem from '../../utils/trackedItemContent';
 import withRouter from '../../utils/withRouter';
+import { cstMultiClaimProvider } from '../../selectors';
 
 const filesPath = `../files`;
 
@@ -56,7 +57,10 @@ class AdditionalEvidencePage extends React.Component {
   }
 
   goToFilesPage() {
-    this.props.getClaim(this.props.claim.id);
+    const provider = this.props.cstMultiClaimProviderEnabled
+      ? this.props.claim?.attributes?.provider
+      : null;
+    this.props.getClaim(this.props.claim.id, null, provider);
     this.props.navigate(filesPath);
   }
 
@@ -157,6 +161,7 @@ function mapStateToProps(state) {
       state.featureToggles?.cst_show_document_upload_status || false,
     timezoneMitigationEnabled:
       state.featureToggles?.cst_timezone_discrepancy_mitigation || false,
+    cstMultiClaimProviderEnabled: cstMultiClaimProvider(state),
   };
 }
 
@@ -173,6 +178,7 @@ AdditionalEvidencePage.propTypes = {
   cancelUpload: PropTypes.func,
   claim: PropTypes.object,
   clearAdditionalEvidenceNotification: PropTypes.func,
+  cstMultiClaimProviderEnabled: PropTypes.bool,
   filesNeeded: PropTypes.array,
   filesOptional: PropTypes.array,
   getClaim: PropTypes.func,

--- a/src/applications/claims-status/containers/ClaimPage.jsx
+++ b/src/applications/claims-status/containers/ClaimPage.jsx
@@ -1,7 +1,13 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { Outlet, useNavigate, useParams } from 'react-router-dom-v5-compat';
+import {
+  Outlet,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 
 import {
   clearClaim as clearClaimAction,
@@ -11,9 +17,17 @@ import {
 export function ClaimPage({ clearClaim, getClaim }) {
   const navigate = useNavigate();
   const params = useParams();
+  const [searchParams] = useSearchParams();
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const cstMultiClaimProviderEnabled = useToggleValue(
+    TOGGLE_NAMES.cstMultiClaimProvider,
+  );
 
   useEffect(() => {
-    getClaim(params.id, navigate);
+    const provider = cstMultiClaimProviderEnabled
+      ? searchParams.get('type')
+      : null;
+    getClaim(params.id, navigate, provider);
     // Reset claim and loading state on dismount.
     return () => clearClaim();
   }, []);

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -21,6 +21,7 @@ import * as TrackedItem from '../utils/trackedItemContent';
 import { setUpPage, setPageFocus, focusNotificationAlert } from '../utils/page';
 import withRouter from '../utils/withRouter';
 import Default5103EvidenceNotice from '../components/claim-document-request-pages/Default5103EvidenceNotice';
+import { cstMultiClaimProvider } from '../selectors';
 
 const filesPath = '../files';
 const statusPath = '../status';
@@ -56,7 +57,10 @@ class DocumentRequestPage extends React.Component {
   }
 
   handleUploadComplete() {
-    this.props.getClaim(this.props.claim.id);
+    const provider = this.props.cstMultiClaimProviderEnabled
+      ? this.props.claim?.attributes?.provider
+      : null;
+    this.props.getClaim(this.props.claim.id, null, provider);
     const redirectPath = this.props.showDocumentUploadStatus
       ? statusPath
       : filesPath;
@@ -211,6 +215,7 @@ function mapStateToProps(state, ownProps) {
     uploading: uploads.uploading,
     timezoneMitigationEnabled:
       state.featureToggles?.cst_timezone_discrepancy_mitigation || false,
+    cstMultiClaimProviderEnabled: cstMultiClaimProvider(state),
   };
 }
 
@@ -233,6 +238,7 @@ DocumentRequestPage.propTypes = {
   cancelUpload: PropTypes.func,
   claim: PropTypes.object,
   clearNotification: PropTypes.func,
+  cstMultiClaimProviderEnabled: PropTypes.bool,
   getClaim: PropTypes.func,
   loading: PropTypes.bool,
   message: PropTypes.object,

--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -21,5 +21,9 @@ export const cstIncludeDdl5103Letters = state =>
 export const cstUseDataDogRUM = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.cstUseDataDogRUM];
 
+// 'cst_multi_claim_provider'
+export const cstMultiClaimProvider = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.cstMultiClaimProvider];
+
 // Backend Services
 export const getBackendServices = state => state.user.profile.services;

--- a/src/applications/claims-status/tests/actions/index.unit.spec.jsx
+++ b/src/applications/claims-status/tests/actions/index.unit.spec.jsx
@@ -254,6 +254,44 @@ describe('Actions', () => {
         .then(() => apiStub.restore())
         .then(done, done);
     });
+    it('includes provider in API URL when provider is specified', done => {
+      const apiStub = sinon.stub(api, 'apiRequest');
+
+      apiStub.returns(Promise.resolve({ data: [] }));
+      const thunk = getClaim(1, null, 'lighthouse');
+      const dispatch = sinon.spy();
+
+      thunk(dispatch)
+        .then(() => {
+          expect(apiStub.firstCall.args[0]).to.equal(
+            '/benefits_claims/1?type=lighthouse',
+          );
+          expect(dispatch.secondCall.args[0]).to.eql({
+            type: SET_CLAIM_DETAIL,
+            claim: [],
+          });
+        })
+        .then(() => apiStub.restore())
+        .then(done, done);
+    });
+    it('does not include provider in API URL when provider is null', done => {
+      const apiStub = sinon.stub(api, 'apiRequest');
+
+      apiStub.returns(Promise.resolve({ data: [] }));
+      const thunk = getClaim(1, null, null);
+      const dispatch = sinon.spy();
+
+      thunk(dispatch)
+        .then(() => {
+          expect(apiStub.firstCall.args[0]).to.equal('/benefits_claims/1');
+          expect(dispatch.secondCall.args[0]).to.eql({
+            type: SET_CLAIM_DETAIL,
+            claim: [],
+          });
+        })
+        .then(() => apiStub.restore())
+        .then(done, done);
+    });
   });
   describe('clearClaim', () => {
     it('should return the correct action object', () => {

--- a/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import * as reactRouterDom from 'react-router-dom-v5-compat';
+import * as featureToggles from '~/platform/utilities/feature-toggles';
 
 import { ClaimPage } from '../../containers/ClaimPage';
 import { renderWithRouter } from '../utils';
@@ -37,5 +39,88 @@ describe('<ClaimPage>', () => {
 
     unmount();
     expect(props.clearClaim.called).to.be.true;
+  });
+
+  describe('multi-provider functionality', () => {
+    let useSearchParamsStub;
+    let useFeatureToggleStub;
+    let mockSearchParams;
+
+    beforeEach(() => {
+      mockSearchParams = {
+        get: sinon.stub(),
+      };
+      useSearchParamsStub = sinon
+        .stub(reactRouterDom, 'useSearchParams')
+        .returns([mockSearchParams]);
+    });
+
+    afterEach(() => {
+      useSearchParamsStub.restore();
+      if (useFeatureToggleStub) {
+        useFeatureToggleStub.restore();
+      }
+    });
+
+    it('passes provider to getClaim when flag enabled and type param exists', () => {
+      mockSearchParams.get.withArgs('type').returns('lighthouse');
+      useFeatureToggleStub = sinon
+        .stub(featureToggles, 'useFeatureToggle')
+        .returns({
+          TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
+          useToggleValue: sinon.stub().returns(true),
+        });
+
+      props.getClaim = sinon.spy();
+
+      renderWithRouter(
+        <ClaimPage {...props}>
+          <div />
+        </ClaimPage>,
+      );
+
+      expect(props.getClaim.calledWith(1, sinon.match.any, 'lighthouse')).to.be
+        .true;
+    });
+
+    it('does not pass provider to getClaim when flag disabled', () => {
+      mockSearchParams.get.withArgs('type').returns('lighthouse');
+      useFeatureToggleStub = sinon
+        .stub(featureToggles, 'useFeatureToggle')
+        .returns({
+          TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
+          useToggleValue: sinon.stub().returns(false),
+        });
+
+      props.getClaim = sinon.spy();
+
+      renderWithRouter(
+        <ClaimPage {...props}>
+          <div />
+        </ClaimPage>,
+      );
+
+      expect(props.getClaim.calledWith(1, sinon.match.any, null)).to.be.true;
+    });
+
+    it('passes null provider when no type param in URL', () => {
+      mockSearchParams.get.withArgs('type').returns(null);
+      useFeatureToggleStub = sinon
+        .stub(featureToggles, 'useFeatureToggle')
+        .returns({
+          TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
+          useToggleValue: sinon.stub().returns(true),
+        });
+
+      props.getClaim = sinon.spy();
+
+      renderWithRouter(
+        <ClaimPage {...props}>
+          <div />
+        </ClaimPage>,
+      );
+
+      expect(props.getClaim.calledWith(1, sinon.match.any, null)).to.be.true;
+    });
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import * as reactRouterDom from 'react-router-dom-v5-compat';
-import * as featureToggles from '~/platform/utilities/feature-toggles';
 
 import { ClaimPage } from '../../containers/ClaimPage';
 import { renderWithRouter } from '../utils';
@@ -39,88 +37,5 @@ describe('<ClaimPage>', () => {
 
     unmount();
     expect(props.clearClaim.called).to.be.true;
-  });
-
-  describe('multi-provider functionality', () => {
-    let useSearchParamsStub;
-    let useFeatureToggleStub;
-    let mockSearchParams;
-
-    beforeEach(() => {
-      mockSearchParams = {
-        get: sinon.stub(),
-      };
-      useSearchParamsStub = sinon
-        .stub(reactRouterDom, 'useSearchParams')
-        .returns([mockSearchParams]);
-    });
-
-    afterEach(() => {
-      useSearchParamsStub.restore();
-      if (useFeatureToggleStub) {
-        useFeatureToggleStub.restore();
-      }
-    });
-
-    it('passes provider to getClaim when flag enabled and type param exists', () => {
-      mockSearchParams.get.withArgs('type').returns('lighthouse');
-      useFeatureToggleStub = sinon
-        .stub(featureToggles, 'useFeatureToggle')
-        .returns({
-          TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
-          useToggleValue: sinon.stub().returns(true),
-        });
-
-      props.getClaim = sinon.spy();
-
-      renderWithRouter(
-        <ClaimPage {...props}>
-          <div />
-        </ClaimPage>,
-      );
-
-      expect(props.getClaim.calledWith(1, sinon.match.any, 'lighthouse')).to.be
-        .true;
-    });
-
-    it('does not pass provider to getClaim when flag disabled', () => {
-      mockSearchParams.get.withArgs('type').returns('lighthouse');
-      useFeatureToggleStub = sinon
-        .stub(featureToggles, 'useFeatureToggle')
-        .returns({
-          TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
-          useToggleValue: sinon.stub().returns(false),
-        });
-
-      props.getClaim = sinon.spy();
-
-      renderWithRouter(
-        <ClaimPage {...props}>
-          <div />
-        </ClaimPage>,
-      );
-
-      expect(props.getClaim.calledWith(1, sinon.match.any, null)).to.be.true;
-    });
-
-    it('passes null provider when no type param in URL', () => {
-      mockSearchParams.get.withArgs('type').returns(null);
-      useFeatureToggleStub = sinon
-        .stub(featureToggles, 'useFeatureToggle')
-        .returns({
-          TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
-          useToggleValue: sinon.stub().returns(true),
-        });
-
-      props.getClaim = sinon.spy();
-
-      renderWithRouter(
-        <ClaimPage {...props}>
-          <div />
-        </ClaimPage>,
-      );
-
-      expect(props.getClaim.calledWith(1, sinon.match.any, null)).to.be.true;
-    });
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import * as featureToggles from '~/platform/utilities/feature-toggles';
 
 import { ClaimPage } from '../../containers/ClaimPage';
-import { renderWithRouter } from '../utils';
+import { renderWithReduxAndRouter } from '../utils';
 
 const params = { id: 1 };
 
@@ -13,30 +12,25 @@ const props = {
   params,
 };
 
+const featureToggleName = 'cst_multi_claim_provider';
+
+const initialState = {
+  featureToggles: {
+    loading: false,
+    [featureToggleName]: false,
+  },
+};
+
 describe('<ClaimPage>', () => {
-  let useFeatureToggleStub;
-
-  before(() => {
-    useFeatureToggleStub = sinon
-      .stub(featureToggles, 'useFeatureToggle')
-      .returns({
-        TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
-        useToggleValue: sinon.stub().returns(false),
-      });
-  });
-
-  after(() => {
-    useFeatureToggleStub.restore();
-  });
-
   it('calls getClaim when it is rendered', () => {
     // Reset sinon spies / set up props
     props.getClaim = sinon.spy();
 
-    renderWithRouter(
+    renderWithReduxAndRouter(
       <ClaimPage {...props}>
         <div />
       </ClaimPage>,
+      { initialState },
     );
 
     expect(props.getClaim.called).to.be.true;
@@ -45,10 +39,11 @@ describe('<ClaimPage>', () => {
   it('calls clearClaim when it unmounts', () => {
     props.clearClaim = sinon.spy();
 
-    const { unmount } = renderWithRouter(
+    const { unmount } = renderWithReduxAndRouter(
       <ClaimPage {...props}>
         <div />
       </ClaimPage>,
+      { initialState },
     );
 
     unmount();

--- a/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimPage.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import * as featureToggles from '~/platform/utilities/feature-toggles';
 
 import { ClaimPage } from '../../containers/ClaimPage';
 import { renderWithRouter } from '../utils';
@@ -13,6 +14,21 @@ const props = {
 };
 
 describe('<ClaimPage>', () => {
+  let useFeatureToggleStub;
+
+  before(() => {
+    useFeatureToggleStub = sinon
+      .stub(featureToggles, 'useFeatureToggle')
+      .returns({
+        TOGGLE_NAMES: { cstMultiClaimProvider: 'cst_multi_claim_provider' },
+        useToggleValue: sinon.stub().returns(false),
+      });
+  });
+
+  after(() => {
+    useFeatureToggleStub.restore();
+  });
+
   it('calls getClaim when it is rendered', () => {
     // Reset sinon spies / set up props
     props.getClaim = sinon.spy();

--- a/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
@@ -9,6 +9,7 @@ import { renderWithRouter } from '../utils';
 const getStore = (
   cstClaimPhasesEnabled = true,
   cstShowDocumentUploadStatus = false,
+  cstMultiClaimProvider = false,
 ) =>
   createStore(() => ({
     featureToggles: {
@@ -16,6 +17,8 @@ const getStore = (
       cst_claim_phases: cstClaimPhasesEnabled,
       // eslint-disable-next-line camelcase
       cst_show_document_upload_status: cstShowDocumentUploadStatus,
+      // eslint-disable-next-line camelcase
+      cst_multi_claim_provider: cstMultiClaimProvider,
     },
   }));
 
@@ -1002,4 +1005,90 @@ describe('<ClaimsListItem>', () => {
       );
     },
   );
+
+  context('multi-provider functionality', () => {
+    it('includes provider in href when flag enabled and provider exists', () => {
+      const claim = {
+        id: '123',
+        attributes: {
+          claimDate: '2024-06-08',
+          claimPhaseDates: {
+            phaseChangeDate: '2024-06-08',
+            phaseType: 'CLAIM_RECEIVED',
+          },
+          claimTypeCode: compensationClaimTypeCode,
+          status: 'CLAIM_RECEIVED',
+          provider: 'lighthouse',
+        },
+      };
+
+      const { container } = renderWithRouter(
+        <Provider store={getStore(true, false, true)}>
+          <ClaimsListItem claim={claim} />
+        </Provider>,
+      );
+
+      const link = container.querySelector('va-link');
+      expect(link).to.have.attribute(
+        'href',
+        '/track-claims/your-claims/123/status?type=lighthouse',
+      );
+    });
+
+    it('does not include provider in href when flag disabled', () => {
+      const claim = {
+        id: '123',
+        attributes: {
+          claimDate: '2024-06-08',
+          claimPhaseDates: {
+            phaseChangeDate: '2024-06-08',
+            phaseType: 'CLAIM_RECEIVED',
+          },
+          claimTypeCode: compensationClaimTypeCode,
+          status: 'CLAIM_RECEIVED',
+          provider: 'lighthouse',
+        },
+      };
+
+      const { container } = renderWithRouter(
+        <Provider store={getStore(true, false, false)}>
+          <ClaimsListItem claim={claim} />
+        </Provider>,
+      );
+
+      const link = container.querySelector('va-link');
+      expect(link).to.have.attribute(
+        'href',
+        '/track-claims/your-claims/123/status',
+      );
+    });
+
+    it('does not include provider in href when provider is undefined', () => {
+      const claim = {
+        id: '123',
+        attributes: {
+          claimDate: '2024-06-08',
+          claimPhaseDates: {
+            phaseChangeDate: '2024-06-08',
+            phaseType: 'CLAIM_RECEIVED',
+          },
+          claimTypeCode: compensationClaimTypeCode,
+          status: 'CLAIM_RECEIVED',
+          // no provider field
+        },
+      };
+
+      const { container } = renderWithRouter(
+        <Provider store={getStore(true, false, true)}>
+          <ClaimsListItem claim={claim} />
+        </Provider>,
+      );
+
+      const link = container.querySelector('va-link');
+      expect(link).to.have.attribute(
+        'href',
+        '/track-claims/your-claims/123/status',
+      );
+    });
+  });
 });

--- a/src/applications/claims-status/utils/withRouter.jsx
+++ b/src/applications/claims-status/utils/withRouter.jsx
@@ -3,15 +3,20 @@ import {
   useLocation,
   useNavigate,
   useParams,
+  useSearchParams,
 } from 'react-router-dom-v5-compat';
 
 export default function withRouter(Component) {
-  return props => (
-    <Component
-      {...props}
-      location={useLocation()}
-      navigate={useNavigate()}
-      params={useParams()}
-    />
-  );
+  return props => {
+    const [searchParams] = useSearchParams();
+    return (
+      <Component
+        {...props}
+        location={useLocation()}
+        navigate={useNavigate()}
+        params={useParams()}
+        searchParams={searchParams}
+      />
+    );
+  };
 }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -55,6 +55,7 @@
   "confirmContactEmailInterstitialEnabled": "confirm_contact_email_interstitial_enabled",
   "cstClaimPhases": "cst_claim_phases",
   "cstClaimsListFilter": "cst_claims_list_filter",
+  "cstMultiClaimProvider": "cst_multi_claim_provider",
   "cstIncludeDdl5103Letters": "cst_include_ddl_5103_letters",
   "cstIncludeDdlBoaLetters": "cst_include_ddl_boa_letters",
   "cstIncludeDdlSqdLetters": "cst_include_ddl_sqd_letters",


### PR DESCRIPTION
## Summary                                                                                
Implements frontend support for multi-provider claim routing. This work corresponds to [backend PR #26299](https://github.com/department-of-veterans-affairs/vets-api/pull/26299) which added a provider field to claims and accepts a `?type` query parameter for fetching individual claim details.

## What Was Implemented
Added routing logic to pass the claim provider through the URL and to the backend API when users navigate to claim detail pages. When a claim has a provider field the system now:
  1. Includes the provider in claim detail URLs as a query parameter (`?type={provider}`)
  2. Passes the provider to the backend API when fetching claim details
  3. Preserves the provider through navigation and file upload flows

## Feature Flag
`cst_multi_claim_provider` (same flag used on backend for seamless feature flag toggling)
  - Flag OFF: System behaves exactly as before (no provider in URLs or API calls)
  - Flag ON + provider exists: Provider included in URLs and API calls
  - Flag ON + no provider: System behaves as before and defaults to lighthouse