### PR TITLE
DR 133459: Add user identifier to RUM sessions

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { isLoggedIn } from 'platform/user/selectors';
 import { setData } from 'platform/forms-system/src/js/actions';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import {
   getContestableIssues as getContestableIssuesAction,
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
@@ -33,6 +34,10 @@ export const FormApp = ({
   contestableIssues = {},
 }) => {
   const { pathname } = location || {};
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const addUserUuidToRUM = useToggleValue(
+    TOGGLE_NAMES.decisionReviewAddUserUuidToRUM,
+  );
 
   useEffect(
     () => {
@@ -122,6 +127,7 @@ export const FormApp = ({
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
     userUuid: accountUuid,
+    addUserUuid: addUserUuidToRUM,
   });
 
   return wrapWithBreadcrumb(

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -22,6 +22,7 @@ import {
 import { isOutsideForm } from '../../shared/utils/helpers';
 
 export const FormApp = ({
+  accountUuid,
   isLoading,
   loggedIn,
   location,
@@ -120,6 +121,7 @@ export const FormApp = ({
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
+    userUuid: accountUuid,
   });
 
   return wrapWithBreadcrumb(
@@ -131,6 +133,7 @@ export const FormApp = ({
 };
 
 FormApp.propTypes = {
+  accountUuid: PropTypes.string,
   children: PropTypes.object,
   contestableIssues: PropTypes.shape({
     issues: PropTypes.array,
@@ -156,6 +159,7 @@ FormApp.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  accountUuid: state?.user?.profile?.accountUuid,
   formData: state.form?.data || {},
   contestableIssues: state.contestableIssues,
   isLoading: state.featureToggles?.loading,

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -35,8 +35,8 @@ export const FormApp = ({
 }) => {
   const { pathname } = location || {};
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
-  const addUserUuidToRUM = useToggleValue(
-    TOGGLE_NAMES.decisionReviewAddUserUuidToRUM,
+  const addUserAccountIdToRUM = useToggleValue(
+    TOGGLE_NAMES.decisionReviewAddUserAccountIdToRUM,
   );
 
   useEffect(
@@ -126,8 +126,8 @@ export const FormApp = ({
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
-    userUuid: accountUuid,
-    addUserUuid: addUserUuidToRUM,
+    accountUuid,
+    addUserAccountId: addUserAccountIdToRUM,
   });
 
   return wrapWithBreadcrumb(

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -51,7 +51,15 @@ export const App = ({
 }) => {
   // ------- REMOVE when new design toggle is removed
   const TOGGLE_KEY = 'decisionReviewsScRedesign';
-  const { useFormFeatureToggleSync } = useFeatureToggle();
+  const {
+    TOGGLE_NAMES,
+    useFormFeatureToggleSync,
+    useToggleValue,
+  } = useFeatureToggle();
+
+  const addUserUuidToRUM = useToggleValue(
+    TOGGLE_NAMES.decisionReviewAddUserUuidToRUM,
+  );
 
   useFormFeatureToggleSync([
     {
@@ -178,6 +186,7 @@ export const App = ({
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
     userUuid: accountUuid,
+    addUserUuid: addUserUuidToRUM,
   });
 
   return wrapWithBreadcrumb(

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -177,6 +177,7 @@ export const App = ({
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
+    userUuid: accountUuid,
   });
 
   return wrapWithBreadcrumb(

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -57,8 +57,8 @@ export const App = ({
     useToggleValue,
   } = useFeatureToggle();
 
-  const addUserUuidToRUM = useToggleValue(
-    TOGGLE_NAMES.decisionReviewAddUserUuidToRUM,
+  const addUserAccountIdToRUM = useToggleValue(
+    TOGGLE_NAMES.decisionReviewAddUserAccountIdToRUM,
   );
 
   useFormFeatureToggleSync([
@@ -185,8 +185,8 @@ export const App = ({
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
-    userUuid: accountUuid,
-    addUserUuid: addUserUuidToRUM,
+    accountUuid,
+    addUserAccountId: addUserAccountIdToRUM,
   });
 
   return wrapWithBreadcrumb(

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -30,6 +30,7 @@ import { isOutsideForm } from '../../shared/utils/helpers';
 import { data996 } from '../../shared/props';
 
 export const Form0996App = ({
+  accountUuid,
   loggedIn,
   location,
   children,
@@ -156,6 +157,7 @@ export const Form0996App = ({
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
+    userUuid: accountUuid,
   });
 
   // Add data-location attribute to allow styling specific pages
@@ -170,6 +172,7 @@ export const Form0996App = ({
 Form0996App.propTypes = {
   getContestableIssues: PropTypes.func.isRequired,
   setFormData: PropTypes.func.isRequired,
+  accountUuid: PropTypes.string,
   children: PropTypes.any,
   contestableIssues: PropTypes.shape({
     status: PropTypes.string,
@@ -190,6 +193,7 @@ Form0996App.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  accountUuid: state?.user?.profile?.accountUuid,
   loggedIn: isLoggedIn(state),
   formData: state.form?.data || {},
   profile: selectProfile(state),

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -43,8 +43,8 @@ export const Form0996App = ({
 }) => {
   const { pathname } = location || {};
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
-  const addUserUuidToRUM = useToggleValue(
-    TOGGLE_NAMES.decisionReviewAddUserUuidToRUM,
+  const addUserAccountIdToRUM = useToggleValue(
+    TOGGLE_NAMES.decisionReviewAddUserAccountIdToRUM,
   );
 
   // Make sure we're only loading issues once - see
@@ -162,8 +162,8 @@ export const Form0996App = ({
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
-    userUuid: accountUuid,
-    addUserUuid: addUserUuidToRUM,
+    accountUuid,
+    addUserAccountId: addUserAccountIdToRUM,
   });
 
   // Add data-location attribute to allow styling specific pages

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -5,6 +5,7 @@ import { getStoredSubTask } from '@department-of-veterans-affairs/platform-forms
 import { selectProfile, isLoggedIn } from 'platform/user/selectors';
 import RoutedSavableApp from '~/platform/forms/save-in-progress/RoutedSavableApp';
 import { setData } from '~/platform/forms-system/src/js/actions';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import formConfig from '../config/form';
 import {
   DATA_DOG_ID,
@@ -41,6 +42,10 @@ export const Form0996App = ({
   contestableIssues,
 }) => {
   const { pathname } = location || {};
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const addUserUuidToRUM = useToggleValue(
+    TOGGLE_NAMES.decisionReviewAddUserUuidToRUM,
+  );
 
   // Make sure we're only loading issues once - see
   // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
@@ -158,6 +163,7 @@ export const Form0996App = ({
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,
     userUuid: accountUuid,
+    addUserUuid: addUserUuidToRUM,
   });
 
   // Add data-location attribute to allow styling specific pages

--- a/src/applications/appeals/shared/utils/useBrowserMonitoring.js
+++ b/src/applications/appeals/shared/utils/useBrowserMonitoring.js
@@ -42,6 +42,10 @@ const initializeRealUserMonitoring = customRumSettings => {
 
     // If sessionReplaySampleRate > 0, we need to manually start the recording
     datadogRum.startSessionReplayRecording();
+
+    datadogRum.setUserProperty({
+      userUuid: customRumSettings?.userUuid || null,
+    });
   }
 };
 

--- a/src/applications/appeals/shared/utils/useBrowserMonitoring.js
+++ b/src/applications/appeals/shared/utils/useBrowserMonitoring.js
@@ -43,9 +43,11 @@ const initializeRealUserMonitoring = customRumSettings => {
     // If sessionReplaySampleRate > 0, we need to manually start the recording
     datadogRum.startSessionReplayRecording();
 
-    datadogRum.setUserProperty({
-      userUuid: customRumSettings?.userUuid || null,
-    });
+    if (customRumSettings?.addUserUuid) {
+      datadogRum.setUserProperty({
+        userUuid: customRumSettings?.userUuid || null,
+      });
+    }
   }
 };
 

--- a/src/applications/appeals/shared/utils/useBrowserMonitoring.js
+++ b/src/applications/appeals/shared/utils/useBrowserMonitoring.js
@@ -43,9 +43,9 @@ const initializeRealUserMonitoring = customRumSettings => {
     // If sessionReplaySampleRate > 0, we need to manually start the recording
     datadogRum.startSessionReplayRecording();
 
-    if (customRumSettings?.addUserUuid) {
+    if (customRumSettings?.addUserAccountId) {
       datadogRum.setUserProperty({
-        userUuid: customRumSettings?.userUuid || null,
+        userAccountId: customRumSettings?.accountUuid || null,
       });
     }
   }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -63,6 +63,7 @@
   "cstTimezoneDateDiscrepancyMitigation": "cst_timezone_discrepancy_mitigation",
   "cstUseDataDogRUM": "cst_use_dd_rum",
   "debtLettersShowLettersVBMS": "debt_letters_show_letters_vbms",
+  "decisionReviewAddUserUuidToRUM": "decision_review_add_user_uuid_to_rum",
   "decisionReviewNodFeb2025PdfEnabled": "decision_review_nod_feb2025_pdf_enabled",
   "decisionReviewsMyVADisplay": "my_va_display_decision_reviews_forms",
   "decisionReviewsScRedesign": "decision_review_sc_redesign_nov2025",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -63,7 +63,7 @@
   "cstTimezoneDateDiscrepancyMitigation": "cst_timezone_discrepancy_mitigation",
   "cstUseDataDogRUM": "cst_use_dd_rum",
   "debtLettersShowLettersVBMS": "debt_letters_show_letters_vbms",
-  "decisionReviewAddUserUuidToRUM": "decision_review_add_user_uuid_to_rum",
+  "decisionReviewAddUserAccountIdToRUM": "decision_review_add_user_account_id_to_rum",
   "decisionReviewNodFeb2025PdfEnabled": "decision_review_nod_feb2025_pdf_enabled",
   "decisionReviewsMyVADisplay": "my_va_display_decision_reviews_forms",
   "decisionReviewsScRedesign": "decision_review_sc_redesign_nov2025",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

During our [production incident investigation](https://github.com/department-of-veterans-affairs/va.gov-team/issues/133280), we discovered that we do not have any user identifiers tied to Datadog RUM sessions.

We got [the approval from Cory](https://dsva.slack.com/archives/C5AGLBNRK/p1771355127864879?thread_ts=1771016980.329019&cid=C5AGLBNRK) to add a `user_account_id` to each session for future troubleshooting help.

I looked through [the Datadog docs](https://docs.datadoghq.com/logs/log_collection/javascript/?tab=npm#user-context) and found that we can set user properties via the `datadogRum.setUserProperty` method.

I found that the `src/applications/hca` team (10-10EZ) uses this property in their code [here](https://github.com/department-of-veterans-affairs/vets-website/blob/d129793567dba2370b401e4e3c450df3bd1d3fd6/src/applications/hca/hooks/useBrowserMonitoring.jsx#L52). I also inspected [one of their RUM sessions](https://vagov.ddog-gov.com/rum/sessions?query=%40type%3Asession%20%40application.id%3A9d5155fd-8623-4bc9-8580-ad8ec2cdd7fa%20%40session.id%3A39e15dc6-1799-4ff8-bc0d-eb4465431927&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZx8xtK3j7_wewAAABhBWng4eHRLM0FBQU0xdDlvV2VGdFF4aEoAAAAkMDE5YzdjY2UtNGUwMC00MGUxLThmYjUtYTVjNDRhY2Y3YWJlAAAHxQ&fromUser=false&refresh_mode=sliding&viz=stream&from_ts=1771605540487&to_ts=1771620759247&live=true) to discover that they have a `User` section under the Attributes tab and can set values in there. This is what our sessions will look like once we add the property for `userUuid`. I also followed their convention of setting the user property after the `setSessionReplayRecording` call. I did not find specific examples in the Datadog documentation about where this call should go specifically.

The `accountUuid` is mapped to our forms via some Forms Library magic in app setup. We already had it in use in the Supplemental Claims `App` file, but it needed to be added to HLR & NOD. Here's what it looks like in the `/v0/user` call (in the Network tab):

<img width="600" alt="Screenshot 2026-02-18 at 3 36 44 PM" src="https://github.com/user-attachments/assets/af32d674-91a0-4fb3-aa48-c9aa7b76187e" />

Here's where it's stored in the Redux store:

<img width="600" alt="Screenshot 2026-02-20 at 2 47 48 PM" src="https://github.com/user-attachments/assets/060025cb-09ae-42ce-b51d-5e6119b2bd9f" />

This matches the `user_uuid` used as a reference in the back end. I checked this particular UUID (for user 0, Hector Allen) against his IPFs locally.

<img width="1382" height="74" alt="Screenshot 2026-02-20 at 2 50 10 PM" src="https://github.com/user-attachments/assets/38150fb7-00ac-4158-b8eb-bc352c07051c" />

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/133459

## Testing done

I don't think there's much we can do to test this locally because RUM isn't enabled in that environment. I can  test this when it makes it to staging.