### PR TITLE
130771 - Adding additional sidenav tracking metric

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -9,6 +9,7 @@ import { trackFormResumption } from '../utils/tracking/datadogRumTracking';
 import {
   TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS,
   TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
+  TRACKING_526EZ_SIDENAV_CLICKS,
   DISABILITY_526_V2_ROOT_URL,
 } from '../constants';
 
@@ -29,6 +30,7 @@ export class ITFBanner extends React.Component {
         sessionStorage.removeItem(
           TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
         );
+        sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_CLICKS);
       } catch (error) {
         // Storage access blocked - silent fail
       }

--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -24,7 +24,7 @@ export class ITFBanner extends React.Component {
   componentDidUpdate(prevProps) {
     // Track form resumption when ITF banner is dismissed
     if (!prevProps.messageDismissed && this.props.messageDismissed) {
-      trackFormResumption();
+      // Clear old session click counts before tracking resumption
       try {
         sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS);
         sessionStorage.removeItem(
@@ -34,6 +34,7 @@ export class ITFBanner extends React.Component {
       } catch (error) {
         // Storage access blocked - silent fail
       }
+      trackFormResumption();
     }
   }
 

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -351,6 +351,7 @@ export const TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS =
   '21-526EZ_backButtonClickCount';
 export const TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS =
   '21-526EZ_continueButtonClickCount';
+export const TRACKING_526EZ_SIDENAV_CLICKS = '21-526EZ_sideNavClickCount';
 export const TRACKING_526EZ_SIDENAV_FORM_START = '21-526EZ_formStartTracked';
 export const TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE = '21-526EZ_sidenavEnabled';
 

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -11,6 +11,7 @@ import {
   SAVED_SEPARATION_DATE,
   TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS,
   TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
+  TRACKING_526EZ_SIDENAV_CLICKS,
   TRACKING_526EZ_SIDENAV_FORM_START,
   TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE,
 } from '../constants';
@@ -95,6 +96,7 @@ export default class ConfirmationPage extends React.Component {
     // Clear tracking session storage
     sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS);
     sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS);
+    sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_CLICKS);
     sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_FORM_START);
     sessionStorage.removeItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE);
 

--- a/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
@@ -1,55 +1,339 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as datadogBrowserRum from '@datadog/browser-rum';
+import { VA_FORM_IDS } from '@department-of-veterans-affairs/platform-forms/constants';
 import {
   trackBackButtonClick,
+  trackContinueButtonClick,
   trackFormStarted,
+  trackFormResumption,
+  trackSideNavChapterClick,
+  trackFormSubmitted,
+  trackMobileAccordionClick,
 } from '../../utils/tracking/datadogRumTracking';
 import {
   TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS,
+  TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
   TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE,
+  TRACKING_526EZ_SIDENAV_CLICKS,
 } from '../../constants';
 
 describe('datadogRumTracking', () => {
   let addActionStub;
-  let consoleErrorStub;
+  let consoleLogStub;
 
   beforeEach(() => {
     addActionStub = sinon.stub(datadogBrowserRum.datadogRum, 'addAction');
-    consoleErrorStub = sinon.stub(console, 'error');
+    consoleLogStub = sinon.stub(console, 'log');
     sessionStorage.clear();
   });
 
   afterEach(() => {
     addActionStub.restore();
-    consoleErrorStub.restore();
+    consoleLogStub.restore();
   });
 
-  it('tracks back button clicks and increments the counter', () => {
-    sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'true');
+  describe('trackBackButtonClick', () => {
+    it('tracks back button clicks and increments the counter', () => {
+      sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'true');
 
-    trackBackButtonClick();
+      trackBackButtonClick();
 
-    expect(
-      sessionStorage.getItem(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS),
-    ).to.equal('1');
-    expect(addActionStub.calledOnce).to.be.true;
+      expect(
+        sessionStorage.getItem(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS),
+      ).to.equal('1');
+      expect(addActionStub.calledOnce).to.be.true;
 
-    const [actionName, properties] = addActionStub.firstCall.args;
-    expect(actionName).to.equal('Form navigation - Back button clicked');
-    expect(properties).to.include({
-      clickCount: 1,
-      sidenav526ezEnabled: true,
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal('Form navigation - Back button clicked');
+      expect(properties).to.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        clickCount: 1,
+        sidenav526ezEnabled: true,
+      });
+      expect(properties.sourcePath).to.be.a('string');
     });
-    expect(properties.sourcePath).to.be.a('string');
+
+    it('increments counter on multiple clicks', () => {
+      sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'true');
+
+      trackBackButtonClick();
+      trackBackButtonClick();
+      trackBackButtonClick();
+
+      expect(
+        sessionStorage.getItem(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS),
+      ).to.equal('3');
+      expect(addActionStub.callCount).to.equal(3);
+
+      const thirdCallProps = addActionStub.thirdCall.args[1];
+      expect(thirdCallProps.clickCount).to.equal(3);
+    });
+
+    it('works when sidenav toggle is not set', () => {
+      trackBackButtonClick();
+
+      expect(addActionStub.calledOnce).to.be.true;
+      const [, properties] = addActionStub.firstCall.args;
+      expect(properties).to.not.have.property('sidenav526ezEnabled');
+    });
+
+    it('does not throw when sessionStorage is blocked', () => {
+      const setItemStub = sinon
+        .stub(Storage.prototype, 'setItem')
+        .throws(new Error('QuotaExceededError'));
+      const getItemStub = sinon
+        .stub(Storage.prototype, 'getItem')
+        .throws(new Error('SecurityError'));
+
+      expect(() => trackBackButtonClick()).to.not.throw();
+
+      setItemStub.restore();
+      getItemStub.restore();
+    });
   });
 
-  it('does not throw when datadogRum.addAction fails', () => {
-    addActionStub.restore();
-    addActionStub = sinon
-      .stub(datadogBrowserRum.datadogRum, 'addAction')
-      .throws(new Error('fail'));
+  describe('trackContinueButtonClick', () => {
+    it('tracks continue button clicks and increments the counter', () => {
+      sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'false');
 
-    expect(() => trackFormStarted()).to.not.throw();
+      trackContinueButtonClick();
+
+      expect(
+        sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS),
+      ).to.equal('1');
+      expect(addActionStub.calledOnce).to.be.true;
+
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal('Form navigation - Continue button clicked');
+      expect(properties).to.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        clickCount: 1,
+        sidenav526ezEnabled: false,
+      });
+      expect(properties.sourcePath).to.be.a('string');
+    });
+
+    it('increments counter on multiple clicks', () => {
+      trackContinueButtonClick();
+      trackContinueButtonClick();
+
+      expect(
+        sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS),
+      ).to.equal('2');
+
+      const secondCallProps = addActionStub.secondCall.args[1];
+      expect(secondCallProps.clickCount).to.equal(2);
+    });
+  });
+
+  describe('trackFormStarted', () => {
+    it('tracks when form is started from introduction page', () => {
+      sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'true');
+
+      trackFormStarted();
+
+      expect(addActionStub.calledOnce).to.be.true;
+
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal(
+        'Form started - User began form from introduction page',
+      );
+      expect(properties).to.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        sidenav526ezEnabled: true,
+      });
+      expect(properties.sourcePath).to.be.a('string');
+    });
+
+    it('does not throw when datadogRum.addAction fails', () => {
+      addActionStub.restore();
+      addActionStub = sinon
+        .stub(datadogBrowserRum.datadogRum, 'addAction')
+        .throws(new Error('fail'));
+
+      expect(() => trackFormStarted()).to.not.throw();
+    });
+  });
+
+  describe('trackFormResumption', () => {
+    it('tracks when form is resumed', () => {
+      sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'true');
+
+      trackFormResumption();
+
+      expect(addActionStub.calledOnce).to.be.true;
+
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal('Form resumption - Saved form loaded');
+      expect(properties).to.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        sidenav526ezEnabled: true,
+      });
+      expect(properties.returnUrl).to.be.a('string');
+    });
+
+    it('works without sidenav toggle set', () => {
+      trackFormResumption();
+
+      const [, properties] = addActionStub.firstCall.args;
+      expect(properties).to.not.have.property('sidenav526ezEnabled');
+    });
+  });
+
+  describe('trackSideNavChapterClick', () => {
+    it('tracks side nav chapter clicks', () => {
+      const pageData = {
+        label: 'Veteran details',
+        key: 'veteran-info',
+        path: '/veteran-information',
+      };
+      const pathname = '/disabilities/conditions';
+
+      trackSideNavChapterClick({ pageData, pathname });
+
+      expect(addActionStub.calledOnce).to.be.true;
+      expect(sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CLICKS)).to.equal(
+        '1',
+      );
+
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal('Side navigation - Chapter clicked');
+      expect(properties).to.deep.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        chapterTitle: 'Veteran details',
+        sourcePath: '/disabilities/conditions',
+        sideNavClickCount: 1,
+      });
+    });
+
+    it('increments click counter across multiple chapter clicks', () => {
+      const pageData1 = { label: 'Chapter 1' };
+      const pageData2 = { label: 'Chapter 2' };
+      const pathname = '/test-path';
+
+      trackSideNavChapterClick({ pageData: pageData1, pathname });
+      trackSideNavChapterClick({ pageData: pageData2, pathname });
+
+      expect(sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CLICKS)).to.equal(
+        '2',
+      );
+
+      const secondCallProps = addActionStub.secondCall.args[1];
+      expect(secondCallProps.sideNavClickCount).to.equal(2);
+      expect(secondCallProps.chapterTitle).to.equal('Chapter 2');
+    });
+  });
+
+  describe('trackFormSubmitted', () => {
+    it('tracks form submission', () => {
+      sessionStorage.setItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE, 'true');
+
+      trackFormSubmitted();
+
+      expect(addActionStub.calledOnce).to.be.true;
+
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal('Form submission - Submit button clicked');
+      expect(properties).to.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        sidenav526ezEnabled: true,
+      });
+      expect(properties.sourcePath).to.be.a('string');
+    });
+
+    it('works without sidenav toggle', () => {
+      trackFormSubmitted();
+
+      const [, properties] = addActionStub.firstCall.args;
+      expect(properties).to.not.have.property('sidenav526ezEnabled');
+    });
+  });
+
+  describe('trackMobileAccordionClick', () => {
+    it('tracks mobile accordion expand', () => {
+      const params = {
+        pathname: '/veteran-information',
+        state: 'expanded',
+        accordionTitle: 'Form steps',
+      };
+
+      trackMobileAccordionClick(params);
+
+      expect(addActionStub.calledOnce).to.be.true;
+      expect(sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CLICKS)).to.equal(
+        '1',
+      );
+
+      const [actionName, properties] = addActionStub.firstCall.args;
+      expect(actionName).to.equal('Side navigation - Mobile accordion clicked');
+      expect(properties).to.deep.include({
+        formId: VA_FORM_IDS.FORM_21_526EZ,
+        state: 'expanded',
+        accordionTitle: 'Form steps',
+        sourcePath: '/veteran-information',
+        sideNavClickCount: 1,
+      });
+    });
+
+    it('tracks mobile accordion collapse', () => {
+      const params = {
+        pathname: '/disabilities/conditions',
+        state: 'collapsed',
+        accordionTitle: 'Form steps',
+      };
+
+      trackMobileAccordionClick(params);
+
+      const [, properties] = addActionStub.firstCall.args;
+      expect(properties.state).to.equal('collapsed');
+    });
+
+    it('shares click counter with chapter clicks', () => {
+      const pageData = { label: 'Test Chapter' };
+      const pathname = '/test';
+
+      trackSideNavChapterClick({ pageData, pathname });
+      trackMobileAccordionClick({
+        pathname,
+        state: 'expanded',
+        accordionTitle: 'Steps',
+      });
+
+      expect(sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CLICKS)).to.equal(
+        '2',
+      );
+
+      const secondCallProps = addActionStub.secondCall.args[1];
+      expect(secondCallProps.sideNavClickCount).to.equal(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('continues silently when tracking fails', () => {
+      addActionStub.restore();
+      addActionStub = sinon
+        .stub(datadogBrowserRum.datadogRum, 'addAction')
+        .throws(new Error('Tracking service unavailable'));
+
+      expect(() => trackBackButtonClick()).to.not.throw();
+      expect(() => trackContinueButtonClick()).to.not.throw();
+      expect(() => trackFormStarted()).to.not.throw();
+      expect(() => trackFormResumption()).to.not.throw();
+      expect(() => trackFormSubmitted()).to.not.throw();
+      expect(() =>
+        trackSideNavChapterClick({
+          pageData: { label: 'Test' },
+          pathname: '/test',
+        }),
+      ).to.not.throw();
+      expect(() =>
+        trackMobileAccordionClick({
+          pathname: '/test',
+          state: 'expanded',
+          accordionTitle: 'Test',
+        }),
+      ).to.not.throw();
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
@@ -86,10 +86,12 @@ describe('datadogRumTracking', () => {
         .stub(Storage.prototype, 'getItem')
         .throws(new Error('SecurityError'));
 
-      expect(() => trackBackButtonClick()).to.not.throw();
-
-      setItemStub.restore();
-      getItemStub.restore();
+      try {
+        expect(() => trackBackButtonClick()).to.not.throw();
+      } finally {
+        setItemStub.restore();
+        getItemStub.restore();
+      }
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('datadogRumTracking', () => {
       expect(actionName).to.equal('Form navigation - Back button clicked');
       expect(properties).to.include({
         formId: VA_FORM_IDS.FORM_21_526EZ,
-        clickCount: 1,
+        backButtonClickCount: 1,
         sidenav526ezEnabled: true,
       });
       expect(properties.sourcePath).to.be.a('string');
@@ -67,7 +67,7 @@ describe('datadogRumTracking', () => {
       expect(addActionStub.callCount).to.equal(3);
 
       const thirdCallProps = addActionStub.thirdCall.args[1];
-      expect(thirdCallProps.clickCount).to.equal(3);
+      expect(thirdCallProps.backButtonClickCount).to.equal(3);
     });
 
     it('works when sidenav toggle is not set', () => {
@@ -110,7 +110,7 @@ describe('datadogRumTracking', () => {
       expect(actionName).to.equal('Form navigation - Continue button clicked');
       expect(properties).to.include({
         formId: VA_FORM_IDS.FORM_21_526EZ,
-        clickCount: 1,
+        continueButtonClickCount: 1,
         sidenav526ezEnabled: false,
       });
       expect(properties.sourcePath).to.be.a('string');
@@ -125,7 +125,7 @@ describe('datadogRumTracking', () => {
       ).to.equal('2');
 
       const secondCallProps = addActionStub.secondCall.args[1];
-      expect(secondCallProps.clickCount).to.equal(2);
+      expect(secondCallProps.continueButtonClickCount).to.equal(2);
     });
   });
 
@@ -146,6 +146,10 @@ describe('datadogRumTracking', () => {
         sidenav526ezEnabled: true,
       });
       expect(properties.sourcePath).to.be.a('string');
+      // Should not have click counts on first form start
+      expect(properties).to.not.have.property('backButtonClickCount');
+      expect(properties).to.not.have.property('continueButtonClickCount');
+      expect(properties).to.not.have.property('sideNavClickCount');
     });
 
     it('does not throw when datadogRum.addAction fails', () => {
@@ -242,6 +246,10 @@ describe('datadogRumTracking', () => {
         sidenav526ezEnabled: true,
       });
       expect(properties.sourcePath).to.be.a('string');
+      // Should not have click counts if user hasn't clicked anything
+      expect(properties).to.not.have.property('backButtonClickCount');
+      expect(properties).to.not.have.property('continueButtonClickCount');
+      expect(properties).to.not.have.property('sideNavClickCount');
     });
 
     it('works without sidenav toggle', () => {

--- a/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx
@@ -20,17 +20,14 @@ import {
 
 describe('datadogRumTracking', () => {
   let addActionStub;
-  let consoleLogStub;
 
   beforeEach(() => {
     addActionStub = sinon.stub(datadogBrowserRum.datadogRum, 'addAction');
-    consoleLogStub = sinon.stub(console, 'log');
     sessionStorage.clear();
   });
 
   afterEach(() => {
     addActionStub.restore();
-    consoleLogStub.restore();
   });
 
   describe('trackBackButtonClick', () => {
@@ -79,15 +76,21 @@ describe('datadogRumTracking', () => {
     });
 
     it('does not throw when sessionStorage is blocked', () => {
+      const storageProto = Object.getPrototypeOf(sessionStorage);
       const setItemStub = sinon
-        .stub(Storage.prototype, 'setItem')
+        .stub(storageProto, 'setItem')
         .throws(new Error('QuotaExceededError'));
       const getItemStub = sinon
-        .stub(Storage.prototype, 'getItem')
+        .stub(storageProto, 'getItem')
         .throws(new Error('SecurityError'));
 
       try {
         expect(() => trackBackButtonClick()).to.not.throw();
+        expect(addActionStub.calledOnce).to.be.true;
+
+        const [, properties] = addActionStub.firstCall.args;
+        expect(properties.formId).to.equal(VA_FORM_IDS.FORM_21_526EZ);
+        expect(properties).to.not.have.property('backButtonClickCount');
       } finally {
         setItemStub.restore();
         getItemStub.restore();
@@ -176,7 +179,7 @@ describe('datadogRumTracking', () => {
         formId: VA_FORM_IDS.FORM_21_526EZ,
         sidenav526ezEnabled: true,
       });
-      expect(properties.returnUrl).to.be.a('string');
+      expect(properties.sourcePath).to.be.a('string');
     });
 
     it('works without sidenav toggle set', () => {
@@ -228,6 +231,15 @@ describe('datadogRumTracking', () => {
       const secondCallProps = addActionStub.secondCall.args[1];
       expect(secondCallProps.sideNavClickCount).to.equal(2);
       expect(secondCallProps.chapterTitle).to.equal('Chapter 2');
+    });
+
+    it('does not throw with missing params and tracks with defaults', () => {
+      expect(() => trackSideNavChapterClick()).to.not.throw();
+
+      expect(addActionStub.calledOnce).to.be.true;
+      const [, properties] = addActionStub.firstCall.args;
+      expect(properties.chapterTitle).to.equal('');
+      expect(properties.sourcePath).to.equal('');
     });
   });
 
@@ -316,6 +328,16 @@ describe('datadogRumTracking', () => {
 
       const secondCallProps = addActionStub.secondCall.args[1];
       expect(secondCallProps.sideNavClickCount).to.equal(2);
+    });
+
+    it('does not throw with missing params and tracks with defaults', () => {
+      expect(() => trackMobileAccordionClick()).to.not.throw();
+
+      expect(addActionStub.calledOnce).to.be.true;
+      const [, properties] = addActionStub.firstCall.args;
+      expect(properties.sourcePath).to.equal('');
+      expect(properties.state).to.equal('');
+      expect(properties.accordionTitle).to.equal('');
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
+++ b/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
@@ -33,11 +33,12 @@ const trackAction = (actionName, properties) => {
 const incrementClickCounter = storageKey => {
   let count = 1;
   try {
-    const currentCount = parseInt(
+    const parsedCount = parseInt(
       sessionStorage.getItem(storageKey) || '0',
       10,
     );
-    count = currentCount + 1;
+    const safeCurrentCount = Number.isFinite(parsedCount) ? parsedCount : 0;
+    count = safeCurrentCount + 1;
     sessionStorage.setItem(storageKey, count.toString());
   } catch (error) {
     // Storage access blocked - continue with default count

--- a/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
+++ b/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
@@ -18,8 +18,6 @@ import {
 const trackAction = (actionName, properties) => {
   try {
     datadogRum.addAction(actionName, properties);
-    // eslint-disable-next-line no-console
-    console.log(`Tracked action: ${actionName}`, properties); // Debug log for tracking
   } catch (error) {
     // Silent fail - tracking should never break the form
   }

--- a/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
+++ b/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
@@ -4,6 +4,7 @@ import {
   TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS,
   TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
   TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE,
+  TRACKING_526EZ_SIDENAV_CLICKS,
 } from '../../constants';
 
 /**
@@ -17,11 +18,33 @@ import {
 const trackAction = (actionName, properties) => {
   try {
     datadogRum.addAction(actionName, properties);
+    // eslint-disable-next-line no-console
+    console.log(`Tracked action: ${actionName}`, properties); // Debug log for tracking
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
+};
+
+/**
+ * Increments a click counter in sessionStorage
+ * Returns the new count value, defaulting to 1 if storage is blocked
+ *
+ * @param {string} storageKey - The sessionStorage key to increment
+ * @returns {number} The new click count
+ */
+const incrementClickCounter = storageKey => {
+  let count = 1;
+  try {
+    const currentCount = parseInt(
+      sessionStorage.getItem(storageKey) || '0',
+      10,
+    );
+    count = currentCount + 1;
+    sessionStorage.setItem(storageKey, count.toString());
+  } catch (error) {
+    // Storage access blocked - continue with default count
+  }
+  return count;
 };
 
 /**
@@ -57,23 +80,9 @@ const getSideNavTrackingDefaults = () => {
 export const trackBackButtonClick = () => {
   try {
     const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
-
-    let newCount = 1;
-
-    try {
-      const currentCount = parseInt(
-        sessionStorage.getItem(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS) ||
-          '0',
-        10,
-      );
-      newCount = currentCount + 1;
-      sessionStorage.setItem(
-        TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS,
-        newCount.toString(),
-      );
-    } catch (error) {
-      // Storage access blocked - continue with default count
-    }
+    const newCount = incrementClickCounter(
+      TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS,
+    );
 
     const properties = {
       formId: VA_FORM_IDS.FORM_21_526EZ,
@@ -88,8 +97,6 @@ export const trackBackButtonClick = () => {
     trackAction('Form navigation - Back button clicked', properties);
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };
 
@@ -101,23 +108,9 @@ export const trackBackButtonClick = () => {
 export const trackContinueButtonClick = () => {
   try {
     const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
-
-    let newCount = 1;
-
-    try {
-      const currentCount = parseInt(
-        sessionStorage.getItem(TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS) ||
-          '0',
-        10,
-      );
-      newCount = currentCount + 1;
-      sessionStorage.setItem(
-        TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
-        newCount.toString(),
-      );
-    } catch (error) {
-      // Storage access blocked - continue with default count
-    }
+    const newCount = incrementClickCounter(
+      TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS,
+    );
 
     const properties = {
       formId: VA_FORM_IDS.FORM_21_526EZ,
@@ -132,8 +125,6 @@ export const trackContinueButtonClick = () => {
     trackAction('Form navigation - Continue button clicked', properties);
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };
 
@@ -160,8 +151,6 @@ export const trackFormStarted = () => {
     );
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };
 
@@ -185,8 +174,6 @@ export const trackFormResumption = () => {
     trackAction('Form resumption - Saved form loaded', properties);
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };
 
@@ -200,17 +187,18 @@ export const trackFormResumption = () => {
  */
 export const trackSideNavChapterClick = ({ pageData, pathname }) => {
   try {
+    const clickCount = incrementClickCounter(TRACKING_526EZ_SIDENAV_CLICKS);
+
     const properties = {
       formId: VA_FORM_IDS.FORM_21_526EZ,
       chapterTitle: pageData.label,
       sourcePath: pathname,
+      sideNavClickCount: clickCount,
     };
 
     trackAction('Side navigation - Chapter clicked', properties);
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };
 
@@ -234,8 +222,6 @@ export const trackFormSubmitted = () => {
     trackAction('Form submission - Submit button clicked', properties);
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };
 
@@ -254,17 +240,18 @@ export const trackMobileAccordionClick = ({
   accordionTitle,
 }) => {
   try {
+    const clickCount = incrementClickCounter(TRACKING_526EZ_SIDENAV_CLICKS);
+
     const properties = {
       formId: VA_FORM_IDS.FORM_21_526EZ,
       state,
       accordionTitle,
       sourcePath: pathname,
+      sideNavClickCount: clickCount,
     };
 
     trackAction('Side navigation - Mobile accordion clicked', properties);
   } catch (error) {
     // Silent fail - tracking should never break the form
-    // eslint-disable-next-line no-console
-    console.error('[DataDog Tracking Error]', error);
   }
 };

--- a/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
+++ b/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
@@ -33,10 +33,7 @@ const trackAction = (actionName, properties) => {
 const incrementClickCounter = storageKey => {
   let count = 1;
   try {
-    const parsedCount = parseInt(
-      sessionStorage.getItem(storageKey) || '0',
-      10,
-    );
+    const parsedCount = parseInt(sessionStorage.getItem(storageKey) || '0', 10);
     const safeCurrentCount = Number.isFinite(parsedCount) ? parsedCount : 0;
     count = safeCurrentCount + 1;
     sessionStorage.setItem(storageKey, count.toString());

--- a/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
+++ b/src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js
@@ -89,6 +89,13 @@ const getClickCounts = () => {
  */
 const getSideNavTrackingDefaults = () => {
   let sidenav526ezEnabled;
+  let sourcePath = '';
+
+  try {
+    sourcePath = window?.location?.pathname || '';
+  } catch (error) {
+    sourcePath = '';
+  }
 
   try {
     const raw = sessionStorage.getItem(TRACKING_526EZ_SIDENAV_FEATURE_TOGGLE);
@@ -99,7 +106,7 @@ const getSideNavTrackingDefaults = () => {
   }
 
   return {
-    sourcePath: window.location.pathname,
+    sourcePath,
     sidenav526ezEnabled,
   };
 };
@@ -110,24 +117,20 @@ const getSideNavTrackingDefaults = () => {
  * from sessionStorage / window.location for DataDog RUM tracking
  */
 export const trackBackButtonClick = () => {
-  try {
-    const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
-    incrementClickCounter(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS);
+  const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
+  incrementClickCounter(TRACKING_526EZ_SIDENAV_BACK_BUTTON_CLICKS);
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      sourcePath,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    sourcePath,
+    ...getClickCounts(),
+  };
 
-    if (sidenav526ezEnabled !== undefined) {
-      properties.sidenav526ezEnabled = sidenav526ezEnabled;
-    }
-
-    trackAction('Form navigation - Back button clicked', properties);
-  } catch (error) {
-    // Silent fail - tracking should never break the form
+  if (sidenav526ezEnabled !== undefined) {
+    properties.sidenav526ezEnabled = sidenav526ezEnabled;
   }
+
+  trackAction('Form navigation - Back button clicked', properties);
 };
 
 /**
@@ -136,24 +139,20 @@ export const trackBackButtonClick = () => {
  * from sessionStorage / window.location for DataDog RUM tracking
  */
 export const trackContinueButtonClick = () => {
-  try {
-    const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
-    incrementClickCounter(TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS);
+  const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
+  incrementClickCounter(TRACKING_526EZ_SIDENAV_CONTINUE_BUTTON_CLICKS);
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      sourcePath,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    sourcePath,
+    ...getClickCounts(),
+  };
 
-    if (sidenav526ezEnabled !== undefined) {
-      properties.sidenav526ezEnabled = sidenav526ezEnabled;
-    }
-
-    trackAction('Form navigation - Continue button clicked', properties);
-  } catch (error) {
-    // Silent fail - tracking should never break the form
+  if (sidenav526ezEnabled !== undefined) {
+    properties.sidenav526ezEnabled = sidenav526ezEnabled;
   }
+
+  trackAction('Form navigation - Continue button clicked', properties);
 };
 
 /**
@@ -161,26 +160,22 @@ export const trackContinueButtonClick = () => {
  * This tracks the initial form start event (not resumption)
  */
 export const trackFormStarted = () => {
-  try {
-    const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
+  const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      sourcePath,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    sourcePath,
+    ...getClickCounts(),
+  };
 
-    if (sidenav526ezEnabled !== undefined) {
-      properties.sidenav526ezEnabled = sidenav526ezEnabled;
-    }
-
-    trackAction(
-      'Form started - User began form from introduction page',
-      properties,
-    );
-  } catch (error) {
-    // Silent fail - tracking should never break the form
+  if (sidenav526ezEnabled !== undefined) {
+    properties.sidenav526ezEnabled = sidenav526ezEnabled;
   }
+
+  trackAction(
+    'Form started - User began form from introduction page',
+    properties,
+  );
 };
 
 /**
@@ -188,23 +183,19 @@ export const trackFormStarted = () => {
  * This tracks form resumption (not initial start)
  */
 export const trackFormResumption = () => {
-  try {
-    const { sidenav526ezEnabled } = getSideNavTrackingDefaults();
+  const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      returnUrl: window.location.pathname,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    sourcePath,
+    ...getClickCounts(),
+  };
 
-    if (sidenav526ezEnabled !== undefined) {
-      properties.sidenav526ezEnabled = sidenav526ezEnabled;
-    }
-
-    trackAction('Form resumption - Saved form loaded', properties);
-  } catch (error) {
-    // Silent fail - tracking should never break the form
+  if (sidenav526ezEnabled !== undefined) {
+    properties.sidenav526ezEnabled = sidenav526ezEnabled;
   }
+
+  trackAction('Form resumption - Saved form loaded', properties);
 };
 
 /**
@@ -216,21 +207,18 @@ export const trackFormResumption = () => {
  * @param {object} params.pageData - Page data including key, label, and path
  * @param {string} params.pathname - Current page pathname before navigation
  */
-export const trackSideNavChapterClick = ({ pageData, pathname }) => {
-  try {
-    incrementClickCounter(TRACKING_526EZ_SIDENAV_CLICKS);
+export const trackSideNavChapterClick = (params = {}) => {
+  const { pageData = {}, pathname = '' } = params;
+  incrementClickCounter(TRACKING_526EZ_SIDENAV_CLICKS);
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      chapterTitle: pageData.label,
-      sourcePath: pathname,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    chapterTitle: pageData?.label || '',
+    sourcePath: pathname,
+    ...getClickCounts(),
+  };
 
-    trackAction('Side navigation - Chapter clicked', properties);
-  } catch (error) {
-    // Silent fail - tracking should never break the form
-  }
+  trackAction('Side navigation - Chapter clicked', properties);
 };
 
 /**
@@ -238,23 +226,19 @@ export const trackSideNavChapterClick = ({ pageData, pathname }) => {
  * This tracks when the user clicks the submit button on the 526EZ form
  */
 export const trackFormSubmitted = () => {
-  try {
-    const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
+  const { sourcePath, sidenav526ezEnabled } = getSideNavTrackingDefaults();
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      sourcePath,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    sourcePath,
+    ...getClickCounts(),
+  };
 
-    if (sidenav526ezEnabled !== undefined) {
-      properties.sidenav526ezEnabled = sidenav526ezEnabled;
-    }
-
-    trackAction('Form submission - Submit button clicked', properties);
-  } catch (error) {
-    // Silent fail - tracking should never break the form
+  if (sidenav526ezEnabled !== undefined) {
+    properties.sidenav526ezEnabled = sidenav526ezEnabled;
   }
+
+  trackAction('Form submission - Submit button clicked', properties);
 };
 
 /**
@@ -268,23 +252,19 @@ export const trackFormSubmitted = () => {
  * @param {string} params.accordionTitle - Title of the accordion (e.g., "Form steps")
  */
 export const trackMobileAccordionClick = ({
-  pathname,
-  state,
-  accordionTitle,
-}) => {
-  try {
-    incrementClickCounter(TRACKING_526EZ_SIDENAV_CLICKS);
+  pathname = '',
+  state = '',
+  accordionTitle = '',
+} = {}) => {
+  incrementClickCounter(TRACKING_526EZ_SIDENAV_CLICKS);
 
-    const properties = {
-      formId: VA_FORM_IDS.FORM_21_526EZ,
-      state,
-      accordionTitle,
-      sourcePath: pathname,
-      ...getClickCounts(),
-    };
+  const properties = {
+    formId: VA_FORM_IDS.FORM_21_526EZ,
+    state,
+    accordionTitle,
+    sourcePath: pathname,
+    ...getClickCounts(),
+  };
 
-    trackAction('Side navigation - Mobile accordion clicked', properties);
-  } catch (error) {
-    // Silent fail - tracking should never break the form
-  }
+  trackAction('Side navigation - Mobile accordion clicked', properties);
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added side navigation click counter tracking to the 526EZ disability benefits form
- Implemented shared click counter between `trackSideNavChapterClick` and `trackMobileAccordionClick` functions using `TRACKING_526EZ_SIDENAV_CLICKS` sessionStorage key
- Removed console.error statements and eslint-disable comments
- Extended unit test coverage for all DataDog RUM tracking functions
- No flipper required - tracking enhancement only
- DBC Team 5

## Related issue(s)

- Relates to department-of-veterans-affairs/va.gov-team/issues/130771

## Testing done

- **Old behavior**: 
  - Side nav chapter clicks and mobile accordion clicks were not tracked with a counter
- **New behavior**: 
  - Side nav interactions now maintain a session-based click counter
  - Comprehensive test coverage for all tracking functions
- **Steps to verify**:
  1. Run `yarn test:unit src/applications/disability-benefits/all-claims/tests/utils/datadogRumTracking.unit.spec.jsx`
  2. Verify all 18 tests pass
  3. Run full test suite: `yarn test:unit src/applications/disability-benefits/all-claims/tests/**/*.unit.spec.jsx*`
  4. Verify all 2,766 tests pass with no regressions
  5. Manually test in browser: click side nav items and check sessionStorage for `TRACKING_526EZ_SIDENAV_CLICKS` counter incrementing
- **Test results**: ✅ All 18 unit tests passing. Full test suite passes with 2,766 tests.

# Manual Testing - Enable Console Tracking

To verify DataDog tracking events are firing correctly:

1. **Temporarily add console logging** to `src/applications/disability-benefits/all-claims/utils/tracking/datadogRumTracking.js` to mirror what is sent to datadogRum. (datadogRum does not send data in the local environment):

   In the `trackAction` function's try block, add:
   `console.log(`[DataDog Tracking] ${actionName}:`, properties);`

2. **Test the following actions** and verify each produces a console log with DataDog action data:
  
   - **Side nav chapter clicked**: Click any chapter in the side navigation (desktop or mobile)
   
   - **Side nav mobile accordion clicked**: On mobile viewport, click to expand/collapse the "Form steps" accordion

3. **Verify each console log includes**:
   - Action name
   - `formId: "21-526EZ"`
   - `sourcePath` (current pathname)
   - `sidenav526ezEnabled` (feature toggle state) [unnecessary for sidenav chapter clicks, sidenav mobile accordion clicks]
   - `sideNavClickCount` (Count of sidenav interactions)

## Screenshots

_N/A - No UI changes (tracking enhancement only)_

## What areas of the site does it impact?

526EZ disability benefits application (`src/applications/disability-benefits/all-claims`) - specifically the DataDog RUM tracking for side navigation interactions.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A - internal tracking utility)
- [x] Screenshot of the developed feature is added (N/A - no UI changes)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - no UI changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A - tracking only)

## Requested Feedback

This PR enhances DataDog RUM tracking for side navigation interactions by adding click counters, removes console.error logging (switched to silent try/catch failures on tracking that do not block the form), and extends test coverage for all tracking utilities.