### PR TITLE
Update Appointment Card to level H3

### DIFF
--- a/src/applications/vass/components/CardSection.jsx
+++ b/src/applications/vass/components/CardSection.jsx
@@ -10,7 +10,7 @@ import AddToCalendarButton from './AddToCalendarButton';
  * @param {import('../utils/appointments').Appointment} props.appointmentData - The appointment data
  * @param {string} props.textContent - The text content
  * @param {string} props.heading - The heading
- * @param {number} props.level - The level
+ * @param {number} props.level - The heading level. Defaults to 3.
  * @param {boolean} props.showAddToCalendarButton - Whether to show the add to calendar button if appointmentData is provided
  * @param {React.ReactNode} props.customBodyElement - The custom body element
  * @returns {JSX.Element}
@@ -19,7 +19,7 @@ export default function CardSection({
   appointmentData,
   textContent,
   heading,
-  level = 2,
+  level = 3,
   customBodyElement,
   showAddToCalendarButton,
   ...props


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Changed the default heading level in the `CardSection` component from `h2` to `h3` to fix a heading hierarchy violation.
- The `AppointmentCard` component renders an `h2` for "Phone appointment", and each nested `CardSection` (e.g., "How to join", "When", "What", "Who", "Topics you'd like to learn more about") was also defaulting to `h2`, creating a flat `h2 > h2` hierarchy instead of the correct `h2 > h3`.
- The fix updates the default value of the `level` prop in `CardSection` from `2` to `3`, so all `CardSection` headings render as `h3` by default, establishing proper parent-child heading semantics without requiring callers to pass `level={3}` explicitly.
- VASS team owns this component.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#133289
- Related epic: department-of-veterans-affairs/va.gov-team#116989

## Testing done

- **Old behavior:** All headings inside `AppointmentCard` ("Phone appointment", "How to join", "When", "What", "Who", "Topics you'd like to learn more about") rendered at `h2` level, creating a flat heading hierarchy that screen reader users could not distinguish between parent and sub-sections.
- **New behavior:** "Phone appointment" remains `h2`; all `CardSection` headings now render as `h3`, producing a correct `h2 > h3` hierarchy.
- **Steps to verify:**
  1. Navigate to the Confirmation page after scheduling an appointment.
  2. Inspect the heading hierarchy using the browser's accessibility tree, an axe DevTools audit, or a screen reader heading navigation (e.g., NVDA: `H` key).
  3. Confirm "Phone appointment" is `h2` and "How to join", "When", "What", "Who", and "Topics you'd like to learn more about" are all `h3`.
  4. Verify the same correct hierarchy on the CancelAppointment and CancelConfirmation pages.
- Existing `CardSection` unit tests pass (no tests were explicitly passing `level={2}`; the default change is transparent).

## Screenshots

_Not applicable — this is a semantic HTML/accessibility fix with no visual change. The headings retain the same visual styling via `vads-u-font-size--h4`; only the underlying heading level element changed from `<h2>` to `<h3>`._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A    | N/A   |
| Desktop | N/A    | N/A   |

## What areas of the site does it impact?

This change impacts the VASS (VA Solid Start) application, specifically any page that renders the `AppointmentCard` component:
- Confirmation page
- CancelAppointment page
- CancelConfirmation page

No other areas of the site are affected since `CardSection` is only used within the VASS application.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (JSDoc comment for the `level` prop updated in `CardSection.jsx`)
- [ ] Screenshot of the developed feature is added — N/A, no visual change (semantic HTML fix only)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, no new feature or runtime behavior change

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a one-line default value change (`level = 2` → `level = 3`) in `CardSection.jsx`. Please confirm that no other consumers of `CardSection` outside of `AppointmentCard` rely on the `h2` default. A codebase search shows `CardSection` is only used within `AppointmentCard.jsx`, so the change is safe.