### PR TITLE
Spacing fix for vaFileNumber field

### DIFF
--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -40,7 +40,8 @@
 .form-21-686c,
 .form-21-526EZ {
   -webkit-font-smoothing: antialiased;
-  [for="root_vaFileNumber"] {
+  [for="root_vaFileNumber"],
+  [for="root_veteranSubPage_vaFileNumber"] {
     margin-top: 1.5rem;
   }
   .usa-width-two-thirds {


### PR DESCRIPTION
## Summary

- Fix spacing between the date of birth and VA file number fields.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131012

## Testing done

- Tested locally on MacOS/Google Chrome
- Confirmed spacing on ITF and 526EZ

## Screenshots
Before:
<img width="340" height="201" alt="Screenshot 2026-02-20 at 4 54 15 PM" src="https://github.com/user-attachments/assets/3fb0385c-2897-4e9f-8089-cc6cdf1dd210" />

After:
<img width="447" height="278" alt="Screenshot 2026-02-20 at 4 55 09 PM" src="https://github.com/user-attachments/assets/7245904c-8648-4d8c-b402-7ddc677b7bf5" />

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
