### PR TITLE
perf: Cypress video A/B test — BASELINE (video ON)

### DIFF
--- a/src/applications/check-in/api/index.js
+++ b/src/applications/check-in/api/index.js
@@ -1,3 +1,4 @@
+// perf: baseline trigger for Cypress video A/B test
 import { v2 } from './versions/v2';
 
 const api = {

--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -1,3 +1,4 @@
+// perf: baseline trigger for Cypress video A/B test
 import '@department-of-veterans-affairs/platform-polyfills';
 import {
   applyPolyfills,


### PR DESCRIPTION
## Baseline for Cypress video A/B test

This branch triggers Cypress tests for `check-in` (30 specs) and `facility-locator` (20 specs) with **video recording ON** (the current default behavior).

Compare the **Cypress E2E Tests** job duration against the treatment branch: `perf/cypress-video-off`.

### What changed
- Trivial no-op comments added to trigger CI for the two apps
- No functional changes — this is the control group