### PR TITLE
perf: Cypress video A/B test — TREATMENT (video OFF)

### DIFF
--- a/config/cypress.config.js
+++ b/config/cypress.config.js
@@ -8,7 +8,7 @@ const cypressConfig = {
   fixturesFolder: 'src',
   waitForAnimations: false,
   chromeWebSecurity: false,
-  video: true,
+  video: false,
   videoCompression: false,
   retries: {
     runMode: 2,

--- a/script/github-actions/run-cypress-stress-tests.js
+++ b/script/github-actions/run-cypress-stress-tests.js
@@ -7,7 +7,7 @@ const tests = fs.existsSync(path.resolve(`e2e_tests_to_stress_test.json`))
   : null;
 
 const status = runCommandSync(
-  `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --quiet --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec '${tests}'`,
+  `yarn cy:run --quiet --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec '${tests}'`,
 );
 
 process.exit(status);

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -18,12 +18,20 @@ const batch = tests
   .slice(step * divider, (step + 1) * divider)
   .join(',');
 
+const baseCmd = `yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec '${batch}' --env app_url=${appUrl}`;
+
 let status = null;
 
 if (batch !== '') {
-  status = runCommandSync(
-    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec '${batch}' --env app_url=${appUrl}`,
-  );
+  // First run: video disabled (default config) for speed.
+  status = runCommandSync(baseCmd);
+
+  // Re-run with video on failure to capture debugging artifacts.
+  if (status !== 0) {
+    // eslint-disable-next-line no-console
+    console.log('Re-running failed specs with video enabled...');
+    status = runCommandSync(`${baseCmd} --config video=true`);
+  }
 } else {
   process.exit(0);
 }

--- a/src/applications/check-in/api/index.js
+++ b/src/applications/check-in/api/index.js
@@ -1,3 +1,4 @@
+// perf: baseline trigger for Cypress video A/B test
 import { v2 } from './versions/v2';
 
 const api = {

--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -1,3 +1,4 @@
+// perf: trigger for Cypress video A/B test
 import '@department-of-veterans-affairs/platform-polyfills';
 import {
   applyPolyfills,

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -1,4 +1,3 @@
-// perf: baseline trigger for Cypress video A/B test
 import environment from 'platform/utilities/environment';
 import compact from 'lodash/compact';
 import {

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -1,3 +1,4 @@
+// perf: baseline trigger for Cypress video A/B test
 import environment from 'platform/utilities/environment';
 import compact from 'lodash/compact';
 import {


### PR DESCRIPTION
## Treatment for Cypress video A/B test

This branch disables Cypress video recording by default and re-enables it only on failure retries, to measure the performance impact.

Compare the **Cypress E2E Tests** job duration against the baseline branch: `perf/cypress-video-baseline` ([PR #42535](https://github.com/department-of-veterans-affairs/vets-website/pull/42535)).

### Changes
- `config/cypress.config.js`: Set `video: false` (was `true`)
- `script/github-actions/run-cypress-tests.js`: Remove `CYPRESS_EVERY_NTH_FRAME=1`, re-run failed batches with `--config video=true` for debugging artifacts
- `script/github-actions/run-cypress-stress-tests.js`: Remove `CYPRESS_EVERY_NTH_FRAME=1`
- Same app triggers as baseline (`check-in` + `facility-locator`)