### PR TITLE
Fix back link anti-pattern

### DIFF
--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -108,13 +108,11 @@ const Wrapper = props => {
       {!errorAlert &&
         showBackLink && (
           <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
-            <nav aria-label="backlink">
+            <nav aria-label="Back">
               <va-link
                 back
-                aria-label="Back link"
                 data-testid="back-link"
                 text="Back"
-                href="#"
                 onClick={e => {
                   e.preventDefault();
                   navigate(-1);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixes an accessibility defect in the VASS back navigation link inside `Wrapper.jsx`. The `va-link` component previously used `href="#"`, which is an anti-pattern that causes the page to scroll to the top if JavaScript fails. It also had a redundant `aria-label="Back link"` that violated WCAG 2.5.3 (Label in Name) and the `<nav>` element used the concatenated label `"backlink"` instead of a natural phrase.
- The fix removes `href="#"`, removes the redundant `aria-label` from the `<va-link>`, and updates the `<nav>` element's `aria-label` from `"backlink"` to `"Back"`.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#133296
- Related epic: department-of-veterans-affairs/va.gov-team#116989

## Testing done

- **Old behavior:** The back link rendered with `href="#"`, so if JavaScript failed to load or `preventDefault` didn't fire, clicking the link scrolled the user to the top of the page. Screen readers could announce the link as "Back link, link to hash" due to the redundant `aria-label` and `href="#"`. The `<nav>` element had `aria-label="backlink"` (a single concatenated word).
- **Steps to verify:**
  1. Navigate to any page with the back link (e.g., the Review page in the VASS flow).
  2. Inspect the DOM and confirm `href="#"` is no longer present on the `va-link`.
  3. Confirm the `<nav>` element now has `aria-label="Back"`.
  4. Confirm the `<va-link>` no longer has an `aria-label` attribute — the visible `text="Back"` prop provides the accessible name.
  5. Use a screen reader (e.g., VoiceOver) to navigate to the back link and confirm it announces "Back" without extra "link to hash" or "Back link" overrides.
  6. Click the back link and confirm it navigates to the previous page as expected.
- **Tests completed:** Existing unit tests in `Wrapper.unit.spec.jsx` continue to pass. The back link is identified by `data-testid="back-link"` which remains unchanged. No new unit tests were needed as the change is a removal of attributes, and the existing tests validate the back link renders correctly.

## Screenshots

_N/A — This is an attribute-level change with no visual difference. The back link renders identically before and after the fix._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A    | N/A   |
| Desktop | N/A    | N/A   |

## What areas of the site does it impact?

This change impacts the VASS (VA Solid Start) application only, specifically any page that renders the `Wrapper` component with `showBackLink` enabled (e.g., Review, DateTimeSelection, TopicSelection, CancelAppointment pages).

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) *if necessary) — No documentation update needed; this is a bug fix removing invalid attributes.
- [x] Screenshot of the developed feature is added — N/A, no visual change. The fix is attribute-level only.
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, this is a minor a11y attribute fix.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a straightforward a11y fix that removes three problematic attributes. Reviewers should confirm that removing `href="#"` does not affect the `va-link` web component's rendering or click behavior, since `onClick` with `navigate(-1)` handles the navigation.
