### PR TITLE
Fix nested Spans

### DIFF
--- a/src/applications/vass/components/NeedHelp.jsx
+++ b/src/applications/vass/components/NeedHelp.jsx
@@ -14,50 +14,43 @@ export default function NeedHelp() {
         aria-hidden="true"
         className="vads-u-margin-y--1p5 vads-u-border-color--primary"
       />
-      <p>
-        <span className="vads-u-margin-top--0 vads-u-font-weight--bold">
-          If you need to get in touch with VA Solid Start,{' '}
-          <span className="vads-u-font-weight--normal">
-            give us a call at{' '}
-            <va-telephone
-              contact={VASS_PHONE_NUMBER}
-              data-testid="solid-start-telephone"
-            />
-            or visit{' '}
-            <a href="https://benefits.va.gov/benefits/solid-start.asp?trk=public_post_comment-text">
-              VA Solid Start
-            </a>{' '}
-            for more information.
-          </span>
+      <p className="vads-u-margin-top--0">
+        <strong>If you need to get in touch with VA Solid Start,</strong>{' '}
+        <span className="vads-u-font-weight--normal">
+          give us a call at{' '}
+          <va-telephone
+            contact={VASS_PHONE_NUMBER}
+            data-testid="solid-start-telephone"
+          />
+          or visit{' '}
+          <a href="https://benefits.va.gov/benefits/solid-start.asp?trk=public_post_comment-text">
+            VA Solid Start
+          </a>{' '}
+          for more information.
         </span>
       </p>
-      <p>
-        <span className="vads-u-margin-top--0 vads-u-font-weight--bold">
-          If you’re in crisis or having thoughts of suicide,{' '}
-          <span className="vads-u-font-weight--normal">
-            call the Veterans Crisis Line at{' '}
-            <va-telephone
-              contact="988"
-              data-testid="veterans-crisis-line-telephone"
-            />
-            {'. '}
-            Then select 1. Or text{' '}
-            <va-telephone
-              contact="838255"
-              data-testid="veterans-crisis-line-text-telephone"
-            />
-            . We offer confidential support anytime, day or night.
-          </span>
+      <p className="vads-u-margin-top--0">
+        <strong>If you’re in crisis or having thoughts of suicide,</strong>{' '}
+        <span className="vads-u-font-weight--normal">
+          call the Veterans Crisis Line at{' '}
+          <va-telephone
+            contact="988"
+            data-testid="veterans-crisis-line-telephone"
+          />
+          {'. '}
+          Then select 1. Or text{' '}
+          <va-telephone
+            contact="838255"
+            data-testid="veterans-crisis-line-text-telephone"
+          />
+          . We offer confidential support anytime, day or night.
         </span>
       </p>
-      <p>
-        <span className="vads-u-margin-top--0 vads-u-font-weight--bold">
-          If you think your life or health is in danger,{' '}
-          <span className="vads-u-font-weight--normal">
-            call{' '}
-            <va-telephone contact="911" data-testid="emergency-telephone" /> or
-            go to the nearest emergency room.
-          </span>
+      <p className="vads-u-margin-top--0">
+        <strong>If you think your life or health is in danger,</strong>{' '}
+        <span className="vads-u-font-weight--normal">
+          call <va-telephone contact="911" data-testid="emergency-telephone" />{' '}
+          or go to the nearest emergency room.
         </span>
       </p>
     </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Refactored the `NeedHelp` component (`src/applications/vass/components/NeedHelp.jsx`) to replace deeply nested `<span>` elements with semantic HTML.
- The original markup used `<span className="vads-u-font-weight--bold">` wrapping another `<span className="vads-u-font-weight--normal">` for each paragraph, creating three levels of nesting (`<p>` > `<span>` > `<span>`) that caused unexpected reading behavior in some screen readers.
- Replaced the outer bold `<span>` with `<strong>` for semantic emphasis, removed one nesting level, and moved the `vads-u-margin-top--0` class from the `<span>` (where it had no effect on an inline element) to the `<p>` element.
- The VASS (VA Solid Start) team owns this component. This is a non-visual accessibility fix — no UI changes.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#133297
- Related epic: department-of-veterans-affairs/va.gov-team#116989

## Testing done

- **Before:** Each paragraph in the "Need help?" section used `<span class="vads-u-font-weight--bold">` wrapping a nested `<span class="vads-u-font-weight--normal">`, producing three levels of inline nesting. `vads-u-margin-top--0` was applied to a `<span>` (inline element) where it had no effect. Screen readers could announce inline element boundaries, causing unexpected reading pauses.
- **After:** Bold lead-in text now uses `<strong>`, only one `<span>` remains for the normal-weight continuation text, and `vads-u-margin-top--0` is on the `<p>`. The DOM is flatter and semantically correct.
- **Steps to verify:**
  1. Start the local dev server and navigate to any VASS page where the "Need help?" section appears.
  2. Inspect the DOM of the "Need help?" section — confirm `<strong>` is used for bold lead-in text and there is no `<span>` > `<span>` nesting.
  3. Confirm the `vads-u-margin-top--0` class is on the `<p>` elements, not on a `<span>`.
  4. Visually confirm the component looks identical to before (no styling regressions).
  5. Use a screen reader (e.g., VoiceOver) to read through the "Need help?" section — confirm there are no unexpected pauses or boundary announcements between the bold and normal text.
- Ran axe accessibility checks on the component with no violations.

## Screenshots

_Not applicable — this is a semantic HTML refactor with no visual changes. The rendered output is identical before and after._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A — no visual change | N/A — no visual change |
| Desktop | N/A — no visual change | N/A — no visual change |

## What areas of the site does it impact?

This change only impacts the `NeedHelp` component used across VASS (VA Solid Start) pages. No other applications or shared components are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#)) — N/A, no documentation changes needed for this semantic HTML fix
- [x] Screenshot of the developed feature is added — N/A, no visual change (justified above)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, this is a markup-only accessibility fix with no new features or error paths

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a straightforward semantic HTML cleanup. Reviewers may want to confirm with a screen reader that the reading flow through the "Need help?" section is smooth and there are no unexpected pauses at element boundaries.
