### PR TITLE
Copy update for search.gov being down

### DIFF
--- a/src/applications/search/components/SearchMaintenance.jsx
+++ b/src/applications/search/components/SearchMaintenance.jsx
@@ -28,11 +28,11 @@ const SearchMaintenance = ({ unexpectedMaintenance }) => {
     <div className="vads-u-margin-bottom--1p5">
       <va-banner
         data-label="Error banner"
-        headline="Search Maintenance"
+        headline="We couldn’t complete your search"
         type="warning"
       >
-        We’re working on Search VA.gov right now. If you have trouble using the
-        search tool, check back later. Thank you for your patience.
+        We’re sorry. Something went wrong in our system. Try again later. Or use
+        one of the other VA search tools on this page.
       </va-banner>
     </div>
   );

--- a/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
+++ b/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
@@ -57,7 +57,7 @@ describe('Unexpected outage from Search.gov', () => {
     cy.get(s.APP).within(() => {
       cy.get(s.OUTAGE_BOX)
         .should('exist')
-        .and('contain', 'We’re working on Search VA.gov right now.');
+        .and('contain', 'We couldn’t complete your search');
     });
   };
 

--- a/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
+++ b/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
@@ -57,7 +57,7 @@ describe('Unexpected outage from Search.gov', () => {
     cy.get(s.APP).within(() => {
       cy.get(s.OUTAGE_BOX)
         .should('exist')
-        .and('contain', 'We couldn’t complete your search');
+        .and('contain', 'Something went wrong in our system');
     });
   };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


## Summary

CAIA recommendations for alert copy when search.gov is down. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133302
