### PR TITLE
[Bugfix] Prefill Contact Card text not changing when there's no details

### DIFF
--- a/src/applications/simple-forms/mock-form-prefill/config/form.js
+++ b/src/applications/simple-forms/mock-form-prefill/config/form.js
@@ -82,9 +82,7 @@ const formConfig = {
       title: 'Veteran information',
       pages: {
         ...profilePersonalInfoPage(),
-        ...profileContactInfoPages({
-          contactInfoRequiredKeys: ['mailingAddress'],
-        }),
+        ...profileContactInfoPages(),
       },
     },
   },

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -362,11 +362,10 @@ export const ContactInfoBase = ({
       contactFieldName === FIELD_NAMES.HOME_PHONE ||
       contactFieldName === FIELD_NAMES.MOBILE_PHONE
     ) {
-      const { areaCode, countryCode, phoneNumber } = contactField;
+      const { areaCode, phoneNumber } = contactField;
       // Return true if ALL phone fields are falsy
       return (
         isFieldEmpty(areaCode, contactFieldName) &&
-        isFieldEmpty(countryCode, contactFieldName) &&
         isFieldEmpty(phoneNumber, contactFieldName)
       );
     }

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -319,21 +319,75 @@ export const ContactInfoBase = ({
     ) : null;
   };
 
-  // return boolean flag if a required field is among the missing info fields
-  function hasMissingInfo(key) {
+  // Return boolean flag if a required field is among the missing info fields
+  const hasMissingRequiredInfo = key => {
     // get config for a field
     const config = Object.values(fieldConfig).find(field => field.key === key);
     // check if a field in missing info matches a field's config
     return missingInfo.some(field =>
       config.text.toLowerCase().startsWith(field),
     );
-  }
+  };
+
+  // Return true if a field object is missing relevant properties
+  const isContactFieldEmpty = (contactField, contactFieldName) => {
+    // If no data object exists, it's empty
+    if (!contactField || typeof contactField !== 'object') {
+      return true;
+    }
+
+    if (contactFieldName === FIELD_NAMES.MAILING_ADDRESS) {
+      const {
+        addressLine1,
+        city,
+        countryName,
+        stateCode,
+        zipCode,
+      } = contactField;
+      // Return true if ALL required address fields are falsy
+      return (
+        isFieldEmpty(addressLine1, contactFieldName) &&
+        isFieldEmpty(city, contactFieldName) &&
+        isFieldEmpty(countryName, contactFieldName) &&
+        isFieldEmpty(stateCode, contactFieldName) &&
+        isFieldEmpty(zipCode, contactFieldName)
+      );
+    }
+
+    if (contactFieldName === FIELD_NAMES.EMAIL) {
+      return isFieldEmpty(contactField.emailAddress, contactFieldName);
+    }
+
+    if (
+      contactFieldName === FIELD_NAMES.HOME_PHONE ||
+      contactFieldName === FIELD_NAMES.MOBILE_PHONE
+    ) {
+      const { areaCode, countryCode, phoneNumber } = contactField;
+      // Return true if ALL phone fields are falsy
+      return (
+        isFieldEmpty(areaCode, contactFieldName) &&
+        isFieldEmpty(countryCode, contactFieldName) &&
+        isFieldEmpty(phoneNumber, contactFieldName)
+      );
+    }
+
+    // Default: if we don't recognize the field, consider it empty
+    return true;
+  };
 
   // Extract contact section rendering
   const renderAddressSection = () => {
     if (!keys.address) return null;
-    const missingAddress = hasMissingInfo(FIELD_NAMES.MAILING_ADDRESS);
-    const cardContent = missingAddress ? (
+    const missingRequiredAddress = hasMissingRequiredInfo(
+      FIELD_NAMES.MAILING_ADDRESS,
+    );
+    const linkText = isContactFieldEmpty(
+      dataWrap[keys.address],
+      FIELD_NAMES.MAILING_ADDRESS,
+    )
+      ? `${content.add} mailing address`
+      : `${content.edit} mailing address`;
+    const cardContent = missingRequiredAddress ? (
       'None provided'
     ) : (
       <AddressView data={dataWrap[keys.address]} />
@@ -342,7 +396,7 @@ export const ContactInfoBase = ({
     return (
       <ContactInfoCard
         key={FIELD_NAMES.MAILING_ADDRESS}
-        error={missingAddress ? 'You must add your adress' : ''}
+        error={missingRequiredAddress ? 'You must add your address' : ''}
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.MAILING_ADDRESS)}
         formKey={keys.address}
@@ -350,13 +404,9 @@ export const ContactInfoBase = ({
         editPath={`${baseEditPath}/edit-mailing-address`}
         headerLevel={headerLevel}
         headerText={content.mailingAddress}
-        tagText={missingAddress ? MISSING_ALERT_TEXT : ''}
-        tagStatus={missingAddress ? 'error' : 'info'}
-        linkText={
-          isFieldEmpty(dataWrap[keys.address], FIELD_NAMES.MAILING_ADDRESS)
-            ? `${content.add} mailing address`
-            : `${content.edit} mailing address`
-        }
+        tagText={missingRequiredAddress ? MISSING_ALERT_TEXT : ''}
+        tagStatus={missingRequiredAddress ? 'error' : 'info'}
+        linkText={linkText}
       >
         {cardContent}
       </ContactInfoCard>
@@ -365,8 +415,16 @@ export const ContactInfoBase = ({
 
   const renderHomePhoneSection = () => {
     if (!keys.homePhone) return null;
-    const missingHomePhone = hasMissingInfo(FIELD_NAMES.HOME_PHONE);
-    const cardContent = missingHomePhone ? (
+    const missingRequiredHomePhone = hasMissingRequiredInfo(
+      FIELD_NAMES.HOME_PHONE,
+    );
+    const linkText = isContactFieldEmpty(
+      dataWrap[keys.homePhone],
+      FIELD_NAMES.HOME_PHONE,
+    )
+      ? `${content.add} home phone number`
+      : `${content.edit} home phone number`;
+    const cardContent = missingRequiredHomePhone ? (
       'None provided'
     ) : (
       <div className="dd-privacy-hidden" data-dd-action-name="home phone">
@@ -376,7 +434,9 @@ export const ContactInfoBase = ({
     return (
       <ContactInfoCard
         key={FIELD_NAMES.HOME_PHONE}
-        error={missingHomePhone ? 'You must add your home phone number' : ''}
+        error={
+          missingRequiredHomePhone ? 'You must add your home phone number' : ''
+        }
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.HOME_PHONE)}
         formKey={keys.homePhone}
@@ -384,13 +444,9 @@ export const ContactInfoBase = ({
         editPath={`${baseEditPath}/edit-home-phone`}
         headerLevel={headerLevel}
         headerText={content.homePhone}
-        tagText={missingHomePhone ? MISSING_ALERT_TEXT : ''}
-        tagStatus={missingHomePhone ? 'error' : 'info'}
-        linkText={
-          isFieldEmpty(dataWrap[keys.homePhone], FIELD_NAMES.HOME_PHONE)
-            ? `${content.add} home phone number`
-            : `${content.edit} home phone number`
-        }
+        tagText={missingRequiredHomePhone ? MISSING_ALERT_TEXT : ''}
+        tagStatus={missingRequiredHomePhone ? 'error' : 'info'}
+        linkText={linkText}
       >
         {cardContent}
       </ContactInfoCard>
@@ -399,8 +455,16 @@ export const ContactInfoBase = ({
 
   const renderMobilePhoneSection = () => {
     if (!keys.mobilePhone) return null;
-    const missingMobilePhone = hasMissingInfo(FIELD_NAMES.MOBILE_PHONE);
-    const cardContent = missingMobilePhone ? (
+    const missingRequiredMobilePhone = hasMissingRequiredInfo(
+      FIELD_NAMES.MOBILE_PHONE,
+    );
+    const linkText = isContactFieldEmpty(
+      dataWrap[keys.mobilePhone],
+      FIELD_NAMES.MOBILE_PHONE,
+    )
+      ? `${content.add} mobile phone number`
+      : `${content.edit} mobile phone number`;
+    const cardContent = missingRequiredMobilePhone ? (
       'None provided'
     ) : (
       <div className="dd-privacy-hidden" data-dd-action-name="mobile phone">
@@ -412,7 +476,9 @@ export const ContactInfoBase = ({
       <ContactInfoCard
         key={FIELD_NAMES.MOBILE_PHONE}
         error={
-          missingMobilePhone ? 'You must add your mobile phone number' : ''
+          missingRequiredMobilePhone
+            ? 'You must add your mobile phone number'
+            : ''
         }
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.MOBILE_PHONE)}
@@ -420,14 +486,10 @@ export const ContactInfoBase = ({
         wrapper={keys.wrapper}
         editPath={`${baseEditPath}/edit-mobile-phone`}
         headerLevel={headerLevel}
-        headerText={content.editMobilePhone}
-        tagText={missingMobilePhone ? MISSING_ALERT_TEXT : ''}
-        tagStatus={missingMobilePhone ? 'error' : 'info'}
-        linkText={
-          isFieldEmpty(dataWrap[keys.mobilePhone], FIELD_NAMES.MOBILE_PHONE)
-            ? `${content.add} mobile phone number`
-            : `${content.edit} mobile phone number`
-        }
+        headerText={content.mobilePhone}
+        tagText={missingRequiredMobilePhone ? MISSING_ALERT_TEXT : ''}
+        tagStatus={missingRequiredMobilePhone ? 'error' : 'info'}
+        linkText={linkText}
       >
         {cardContent}
       </ContactInfoCard>
@@ -436,8 +498,14 @@ export const ContactInfoBase = ({
 
   const renderEmailSection = () => {
     if (!keys.email) return null;
-    const missingEmail = hasMissingInfo(FIELD_NAMES.EMAIL);
-    const cardContent = missingEmail ? (
+    const missingRequiredEmail = hasMissingRequiredInfo(FIELD_NAMES.EMAIL);
+    const linkText = isContactFieldEmpty(
+      dataWrap[keys.email],
+      FIELD_NAMES.EMAIL,
+    )
+      ? `${content.add} email address`
+      : `${content.edit} email address`;
+    const cardContent = missingRequiredEmail ? (
       'None provided'
     ) : (
       <div className="dd-privacy-hidden" data-dd-action-name="email">
@@ -448,21 +516,17 @@ export const ContactInfoBase = ({
     return (
       <ContactInfoCard
         key={FIELD_NAMES.EMAIL}
-        error={missingEmail ? 'You must add your email address' : ''}
+        error={missingRequiredEmail ? 'You must add your email address' : ''}
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.EMAIL)}
         formKey={keys.email}
         wrapper={keys.wrapper}
         editPath={`${baseEditPath}/edit-email-address`}
         headerLevel={headerLevel}
-        headerText={content.editEmail}
-        tagText={missingEmail ? MISSING_ALERT_TEXT : ''}
-        tagStatus={missingEmail ? 'error' : 'info'}
-        linkText={
-          isFieldEmpty(dataWrap[keys.email], FIELD_NAMES.EMAIL)
-            ? `${content.add} email address`
-            : `${content.edit} email address`
-        }
+        headerText={content.email}
+        tagText={missingRequiredEmail ? MISSING_ALERT_TEXT : ''}
+        tagStatus={missingRequiredEmail ? 'error' : 'info'}
+        linkText={linkText}
       >
         {cardContent}
       </ContactInfoCard>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

The links on the Contact Info Cards are supposed to say "Add" if there is no data and "Edit" if there is data.  There's a bug in which the link text does not change to "Add" even when there is no data, and this PR introduces a fix.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5763

## Testing done

Local tests
Unit tests
E2e tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|<img width="419" height="343" alt="image" src="https://github.com/user-attachments/assets/e800acaa-a461-4e9f-ba70-0a50b2c16a3b" />|<img width="409" height="347" alt="image" src="https://github.com/user-attachments/assets/4c79245c-4d5d-4956-8db8-8d681d2bf0ff" />|

## What areas of the site does it impact?

Prefill pattern

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
