### PR TITLE
Feature/canada mexico state mapping

### DIFF
--- a/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
+++ b/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
@@ -19,6 +19,11 @@ function isOnlyWhitespace(str) {
 
 const stateRequiredCountries = new Set(['USA', 'CAN', 'MEX']);
 const MILITARY_STATE_CODES = ['AE', 'AA', 'AP'];
+const MILITARY_ZIP_HINTS = {
+  AE: 'Must start with 09',
+  AA: 'Must start with 340',
+  AP: 'Must be in range 962xx\u2013966xx',
+};
 
 function validateMilitaryZipCode(errors, addressData) {
   if (
@@ -35,8 +40,9 @@ function validateMilitaryZipCode(errors, addressData) {
     (state === 'AP' && /^96[2-6]\d*/.test(postalCode));
 
   if (!isValidMilitaryZip) {
+    const hint = MILITARY_ZIP_HINTS[state];
     errors.postalCode.addError(
-      'Please enter a valid zip code for the selected military state',
+      `Please enter a valid zip code for ${state}. ${hint}`,
     );
   }
 }

--- a/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
+++ b/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
@@ -17,7 +17,30 @@ function isOnlyWhitespace(str) {
   return str && !str.trim().length;
 }
 
-const stateRequiredCountries = new Set(['USA']);
+const stateRequiredCountries = new Set(['USA', 'CAN', 'MEX']);
+const MILITARY_STATE_CODES = ['AE', 'AA', 'AP'];
+
+function validateMilitaryZipCode(errors, addressData) {
+  if (
+    !MILITARY_STATE_CODES.includes(addressData.state) ||
+    !addressData.postalCode
+  ) {
+    return;
+  }
+
+  const { state, postalCode } = addressData;
+  const isValidMilitaryZip =
+    (state === 'AA' && /^340\d*/.test(postalCode)) ||
+    (state === 'AE' && /^09[0-9]\d*/.test(postalCode)) ||
+    (state === 'AP' && /^96[2-6]\d*/.test(postalCode));
+
+  if (!isValidMilitaryZip) {
+    errors.postalCode.addError(
+      'Please enter a valid zip code for the selected military state',
+    );
+  }
+}
+
 function customValidateAddress(errors, addressData, formData, currentSchema) {
   if (
     stateRequiredCountries.has(addressData.country) &&
@@ -37,6 +60,8 @@ function customValidateAddress(errors, addressData, formData, currentSchema) {
   if (addressData.postalCode && !isValidPostalCode) {
     errors.postalCode.addError('Please provide a valid postal code');
   }
+
+  validateMilitaryZipCode(errors, addressData);
 }
 
 const mailingAddress33 = {
@@ -103,8 +128,11 @@ const mailingAddress33 = {
               field => field !== 'state',
             );
 
-            // Only add state as required for USA or military base
-            if (livesOnMilitaryBase || country === 'USA') {
+            // Only add state as required for USA, Canada, Mexico, or military base
+            if (
+              livesOnMilitaryBase ||
+              ['USA', 'CAN', 'MEX'].includes(country)
+            ) {
               required.push('state');
             }
             if (livesOnMilitaryBase) {
@@ -135,6 +163,20 @@ const mailingAddress33 = {
                 ...stateSchema,
                 enum: constants.states.USA.map(state => state.value),
                 enumNames: constants.states.USA.map(state => state.label),
+              };
+            } else if (country === 'CAN') {
+              stateSchema = {
+                ...stateSchema,
+                title: 'Province',
+                enum: constants.states.CAN.map(state => state.value),
+                enumNames: constants.states.CAN.map(state => state.label),
+              };
+            } else if (country === 'MEX') {
+              stateSchema = {
+                ...stateSchema,
+                title: 'State',
+                enum: constants.states.MEX.map(state => state.value),
+                enumNames: constants.states.MEX.map(state => state.label),
               };
             }
             return {

--- a/src/applications/my-education-benefits/tests/units/mailingAddress.unit.spec.jsx
+++ b/src/applications/my-education-benefits/tests/units/mailingAddress.unit.spec.jsx
@@ -163,7 +163,7 @@ describe('my-education-benefits customValidateAddress', () => {
       customValidateAddress(errors, addressData, {}, { required: [] });
       expect(errors.postalCode.addError.calledOnce).to.be.true;
       expect(errors.postalCode.addError.firstCall.args[0]).to.contain(
-        'valid zip code for the selected military state',
+        'valid zip code for AE',
       );
     });
 

--- a/src/applications/my-education-benefits/tests/units/mailingAddress.unit.spec.jsx
+++ b/src/applications/my-education-benefits/tests/units/mailingAddress.unit.spec.jsx
@@ -1,0 +1,222 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import mailingAddress33 from '../../config/chapters/33/contactInfo/mailingAddress';
+
+const getUpdateSchema = () =>
+  mailingAddress33.uiSchema['view:mailingAddress'].address['ui:options']
+    .updateSchema;
+
+const getCustomValidateAddress = () =>
+  mailingAddress33.uiSchema['view:mailingAddress'].address['ui:validations'][0];
+
+const baseAddressSchema = {
+  required: ['street', 'city', 'postalCode'],
+  properties: {
+    country: { type: 'string' },
+    street: { type: 'string' },
+    city: { type: 'string' },
+    state: { type: 'string' },
+    postalCode: { type: 'string' },
+  },
+};
+
+describe('my-education-benefits mailingAddress updateSchema', () => {
+  const updateSchema = getUpdateSchema();
+
+  it('should include state as required for USA', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'USA' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.include('state');
+  });
+
+  it('should include state as required for CAN', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'CAN' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.include('state');
+  });
+
+  it('should include state as required for MEX', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'MEX' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.include('state');
+  });
+
+  it('should not include state as required for other countries', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'GBR' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.not.include('state');
+  });
+
+  it('should return Province title for CAN', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'CAN' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.title).to.equal('Province');
+    expect(result.properties.state.enum).to.be.an('array').that.is.not.empty;
+  });
+
+  it('should return State title for MEX', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'MEX' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.title).to.equal('State');
+    expect(result.properties.state.enum).to.be.an('array').that.is.not.empty;
+  });
+
+  it('should return USA state enum for USA', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'USA' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.enum).to.include('CA');
+    expect(result.properties.state.enum).to.include('NY');
+  });
+
+  it('should return AE/AA/AP for military base', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: true,
+        address: { country: 'USA' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.enum).to.deep.equal(['AE', 'AA', 'AP']);
+    expect(result.properties.state.title).to.equal('AE/AA/AP');
+  });
+
+  it('should return generic State/County/Province title for other countries', () => {
+    const formData = {
+      'view:mailingAddress': {
+        livesOnMilitaryBase: false,
+        address: { country: 'GBR' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.title).to.equal('State/County/Province');
+    expect(result.properties.state.enum).to.be.undefined;
+  });
+});
+
+describe('my-education-benefits customValidateAddress', () => {
+  const customValidateAddress = getCustomValidateAddress();
+  let errors;
+
+  beforeEach(() => {
+    errors = {
+      state: { addError: sinon.spy() },
+      postalCode: { addError: sinon.spy() },
+    };
+  });
+
+  describe('military zip code validation', () => {
+    it('should accept valid AE zip code (09xxx)', () => {
+      const addressData = { state: 'AE', postalCode: '09123', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should accept valid AA zip code (340xx)', () => {
+      const addressData = { state: 'AA', postalCode: '34012', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should accept valid AP zip code (96[2-6]xx)', () => {
+      const addressData = { state: 'AP', postalCode: '96234', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should reject invalid AE zip code', () => {
+      const addressData = { state: 'AE', postalCode: '12345', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+      expect(errors.postalCode.addError.firstCall.args[0]).to.contain(
+        'valid zip code for the selected military state',
+      );
+    });
+
+    it('should reject invalid AA zip code', () => {
+      const addressData = { state: 'AA', postalCode: '12345', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+    });
+
+    it('should reject invalid AP zip code', () => {
+      const addressData = { state: 'AP', postalCode: '12345', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+    });
+
+    it('should reject AP zip code outside 962-966 range', () => {
+      const addressData = { state: 'AP', postalCode: '96700', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+    });
+
+    it('should not validate military zip when state is not military', () => {
+      const addressData = { state: 'CA', postalCode: '90210', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should not validate military zip when postalCode is empty', () => {
+      const addressData = { state: 'AE', postalCode: '', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+  });
+
+  describe('state required for CAN and MEX', () => {
+    it('should require state for CAN', () => {
+      const addressData = {
+        country: 'CAN',
+        state: undefined,
+        postalCode: 'K1A0B1',
+      };
+      customValidateAddress(errors, addressData, {}, { required: ['state'] });
+      expect(errors.state.addError.calledOnce).to.be.true;
+    });
+
+    it('should require state for MEX', () => {
+      const addressData = {
+        country: 'MEX',
+        state: undefined,
+        postalCode: '01000',
+      };
+      customValidateAddress(errors, addressData, {}, { required: ['state'] });
+      expect(errors.state.addError.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -117,6 +117,11 @@ function phoneUISchema(category) {
 
 const stateRequiredCountries = new Set(['USA', 'CAN', 'MEX']);
 const MILITARY_STATE_CODES = ['AE', 'AA', 'AP'];
+const MILITARY_ZIP_HINTS = {
+  AE: 'Must start with 09',
+  AA: 'Must start with 340',
+  AP: 'Must be in range 962xx\u2013966xx',
+};
 
 function validateMilitaryZipCode(errors, addressData) {
   if (
@@ -133,8 +138,9 @@ function validateMilitaryZipCode(errors, addressData) {
     (state === 'AP' && /^96[2-6]\d*/.test(postalCode));
 
   if (!isValidMilitaryZip) {
+    const hint = MILITARY_ZIP_HINTS[state];
     errors.postalCode.addError(
-      'Please enter a valid zip code for the selected military state',
+      `Please enter a valid zip code for ${state}. ${hint}`,
     );
   }
 }

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -115,7 +115,30 @@ function phoneUISchema(category) {
   return schema;
 }
 
-const stateRequiredCountries = new Set(['USA']);
+const stateRequiredCountries = new Set(['USA', 'CAN', 'MEX']);
+const MILITARY_STATE_CODES = ['AE', 'AA', 'AP'];
+
+function validateMilitaryZipCode(errors, addressData) {
+  if (
+    !MILITARY_STATE_CODES.includes(addressData.state) ||
+    !addressData.postalCode
+  ) {
+    return;
+  }
+
+  const { state, postalCode } = addressData;
+  const isValidMilitaryZip =
+    (state === 'AA' && /^340\d*/.test(postalCode)) ||
+    (state === 'AE' && /^09[0-9]\d*/.test(postalCode)) ||
+    (state === 'AP' && /^96[2-6]\d*/.test(postalCode));
+
+  if (!isValidMilitaryZip) {
+    errors.postalCode.addError(
+      'Please enter a valid zip code for the selected military state',
+    );
+  }
+}
+
 function customValidateAddress(errors, addressData, formData, currentSchema) {
   if (
     stateRequiredCountries.has(addressData.country) &&
@@ -135,6 +158,8 @@ function customValidateAddress(errors, addressData, formData, currentSchema) {
   if (addressData.postalCode && !isValidPostalCode) {
     errors.postalCode.addError('Please provide a valid postal code');
   }
+
+  validateMilitaryZipCode(errors, addressData);
 }
 
 function phoneSchema() {
@@ -642,8 +667,11 @@ const formConfig = {
                       field => field !== 'state',
                     );
 
-                    // Only add state as required for USA or military base
-                    if (livesOnMilitaryBase || country === 'USA') {
+                    // Only add state as required for USA, Canada, Mexico, or military base
+                    if (
+                      livesOnMilitaryBase ||
+                      ['USA', 'CAN', 'MEX'].includes(country)
+                    ) {
                       required.push('state');
                     }
 
@@ -676,6 +704,24 @@ const formConfig = {
                         ...stateSchema,
                         enum: constants.states.USA.map(state => state.value),
                         enumNames: constants.states.USA.map(
+                          state => state.label,
+                        ),
+                      };
+                    } else if (country === 'CAN') {
+                      stateSchema = {
+                        ...stateSchema,
+                        title: 'Province',
+                        enum: constants.states.CAN.map(state => state.value),
+                        enumNames: constants.states.CAN.map(
+                          state => state.label,
+                        ),
+                      };
+                    } else if (country === 'MEX') {
+                      stateSchema = {
+                        ...stateSchema,
+                        title: 'State',
+                        enum: constants.states.MEX.map(state => state.value),
+                        enumNames: constants.states.MEX.map(
                           state => state.label,
                         ),
                       };

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/mailingAddress.unit.spec.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/mailingAddress.unit.spec.jsx
@@ -166,7 +166,7 @@ describe('22-5490 customValidateAddress', () => {
       customValidateAddress(errors, addressData, {}, { required: [] });
       expect(errors.postalCode.addError.calledOnce).to.be.true;
       expect(errors.postalCode.addError.firstCall.args[0]).to.contain(
-        'valid zip code for the selected military state',
+        'valid zip code for AE',
       );
     });
 

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/mailingAddress.unit.spec.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/mailingAddress.unit.spec.jsx
@@ -1,0 +1,225 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import formConfig from '../../../config/form';
+
+const mailingAddressPage =
+  formConfig.chapters.contactInformationChapter.pages.mailingAddress;
+
+const getUpdateSchema = () =>
+  mailingAddressPage.uiSchema.mailingAddressInput.address['ui:options']
+    .updateSchema;
+
+const getCustomValidateAddress = () =>
+  mailingAddressPage.uiSchema.mailingAddressInput.address['ui:validations'][0];
+
+const baseAddressSchema = {
+  required: ['street', 'city', 'postalCode'],
+  properties: {
+    country: { type: 'string' },
+    street: { type: 'string' },
+    city: { type: 'string' },
+    state: { type: 'string' },
+    postalCode: { type: 'string' },
+  },
+};
+
+describe('22-5490 mailingAddress updateSchema', () => {
+  const updateSchema = getUpdateSchema();
+
+  it('should include state as required for USA', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'USA' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.include('state');
+  });
+
+  it('should include state as required for CAN', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'CAN' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.include('state');
+  });
+
+  it('should include state as required for MEX', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'MEX' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.include('state');
+  });
+
+  it('should not include state as required for other countries', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'GBR' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.required).to.not.include('state');
+  });
+
+  it('should return Province title for CAN', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'CAN' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.title).to.equal('Province');
+    expect(result.properties.state.enum).to.be.an('array').that.is.not.empty;
+  });
+
+  it('should return State title for MEX', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'MEX' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.title).to.equal('State');
+    expect(result.properties.state.enum).to.be.an('array').that.is.not.empty;
+  });
+
+  it('should return USA state enum for USA', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'USA' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.enum).to.include('CA');
+    expect(result.properties.state.enum).to.include('NY');
+  });
+
+  it('should return AE/AA/AP for military base', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: true,
+        address: { country: 'USA' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.enum).to.deep.equal(['AE', 'AA', 'AP']);
+    expect(result.properties.state.title).to.equal('AE/AA/AP');
+  });
+
+  it('should return generic State/County/Province title for other countries', () => {
+    const formData = {
+      mailingAddressInput: {
+        livesOnMilitaryBase: false,
+        address: { country: 'GBR' },
+      },
+    };
+    const result = updateSchema(formData, { ...baseAddressSchema });
+    expect(result.properties.state.title).to.equal('State/County/Province');
+    expect(result.properties.state.enum).to.be.undefined;
+  });
+});
+
+describe('22-5490 customValidateAddress', () => {
+  const customValidateAddress = getCustomValidateAddress();
+  let errors;
+
+  beforeEach(() => {
+    errors = {
+      state: { addError: sinon.spy() },
+      postalCode: { addError: sinon.spy() },
+    };
+  });
+
+  describe('military zip code validation', () => {
+    it('should accept valid AE zip code (09xxx)', () => {
+      const addressData = { state: 'AE', postalCode: '09123', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should accept valid AA zip code (340xx)', () => {
+      const addressData = { state: 'AA', postalCode: '34012', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should accept valid AP zip code (96[2-6]xx)', () => {
+      const addressData = { state: 'AP', postalCode: '96234', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should reject invalid AE zip code', () => {
+      const addressData = { state: 'AE', postalCode: '12345', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+      expect(errors.postalCode.addError.firstCall.args[0]).to.contain(
+        'valid zip code for the selected military state',
+      );
+    });
+
+    it('should reject invalid AA zip code', () => {
+      const addressData = { state: 'AA', postalCode: '12345', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+    });
+
+    it('should reject invalid AP zip code', () => {
+      const addressData = { state: 'AP', postalCode: '12345', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+    });
+
+    it('should reject AP zip code outside 962-966 range', () => {
+      const addressData = { state: 'AP', postalCode: '96700', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.calledOnce).to.be.true;
+    });
+
+    it('should not validate military zip when state is not military', () => {
+      const addressData = { state: 'CA', postalCode: '90210', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+
+    it('should not validate military zip when postalCode is empty', () => {
+      const addressData = { state: 'AE', postalCode: '', country: 'USA' };
+      customValidateAddress(errors, addressData, {}, { required: [] });
+      expect(errors.postalCode.addError.called).to.be.false;
+    });
+  });
+
+  describe('state required for CAN and MEX', () => {
+    it('should require state for CAN', () => {
+      const addressData = {
+        country: 'CAN',
+        state: undefined,
+        postalCode: 'K1A0B1',
+      };
+      customValidateAddress(errors, addressData, {}, { required: ['state'] });
+      expect(errors.state.addError.calledOnce).to.be.true;
+    });
+
+    it('should require state for MEX', () => {
+      const addressData = {
+        country: 'MEX',
+        state: undefined,
+        postalCode: '01000',
+      };
+      customValidateAddress(errors, addressData, {}, { required: ['state'] });
+      expect(errors.state.addError.calledOnce).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ X No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds Canada and Mexico address support and military zip code validation to the my-education-benefits (22-1990) and survivor-dependent-education-benefit (22-5490) applications.

•  Added CAN and MEX to stateRequiredCountries so state/province is required for Canadian and Mexican addresses
•  Canada displays a "Province" dropdown populated with Canadian provinces/territories
•  Mexico displays a "State" dropdown populated with Mexican states
•  Ported military base zip code prefix validation into customValidateAddress:
◦  AA → must start with 340
◦  AE → must start with 09
◦  AP → must start with 96[2-6]

## Related issue(s)


## Testing done


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
My Education Benefits application, and 5490 survivorship application

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
