### PR TITLE
Remove import destructuring rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,12 +48,6 @@ module.exports = {
         message:
           'require.ensure is deprecated. Use dynamic import() instead. See https://webpack.js.org/guides/code-splitting/#dynamic-imports',
       },
-      {
-        selector:
-          'CallExpression[callee.object.type="ImportExpression"][callee.property.name="then"] > :matches(ArrowFunctionExpression, FunctionExpression) > ObjectPattern.params',
-        message:
-          'Do not destructure the parameter in import().then(). Use `module =>` and access `module.default` instead. Example: import("./foo").then(module => { const { Bar } = module.default; })',
-      },
     ],
     camelcase: [2, { properties: 'always' }], // Override airbnb style.
     'react/jsx-wrap-multilines': 'off', // Conflicts with Prettier


### PR DESCRIPTION
## Summary

Removes the rule added in #42496 that disallowed destructuring the parameter in `import().then()` callbacks from `.eslintrc.js`.