### PR TITLE
fix: lodash `lowercase` → `lowerCase` (not a real lodash function)

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { lowercase } from 'lodash';
+import { lowerCase } from 'lodash';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import {
@@ -105,7 +105,7 @@ export const options = {
       }
       const fullName = updatedResolveRecipientFullName(item, formData);
       const possessiveName = formatPossessiveString(fullName);
-      return `${possessiveName} income from a ${lowercase(
+      return `${possessiveName} income from a ${lowerCase(
         ownedAssetTypeLabels[item.assetType],
       )}`;
     },

--- a/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { lowercase } from 'lodash';
+import { lowerCase } from 'lodash';
 
 import {
   arrayBuilderItemFirstPageTitleUI,
@@ -72,7 +72,7 @@ export const options = {
       }
       const fullName = updatedResolveRecipientFullName(item, formData);
       const possessiveName = formatPossessiveString(fullName);
-      return `${possessiveName} income from ${lowercase(
+      return `${possessiveName} income from ${lowerCase(
         generatedIncomeTypeLabels[item.incomeGenerationMethod],
       )}`;
     },

--- a/src/applications/income-and-asset-statement/config/chapters/06-asset-transfers/assetTransferPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/06-asset-transfers/assetTransferPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { lowercase } from 'lodash';
+import { lowerCase } from 'lodash';
 import {
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderItemSubsequentPageTitleUI,
@@ -76,7 +76,7 @@ export const options = {
       `Asset ${
         item?.transferMethod === 'OTHER'
           ? 'transferred'
-          : lowercase(item?.transferMethod)
+          : lowerCase(item?.transferMethod)
       } to ${formatFullNameNoSuffix(item?.newOwnerName)}`,
     cardDescription: item =>
       isDefined(item?.fairMarketValue) &&


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Three files in `src/applications/income-and-asset-statement` import `{ lowercase }` from `lodash`, but **`lowercase` is not a real lodash function** — the correct name is `lowerCase` (camelCase).
- This bug was silently masked by `babel-plugin-lodash`, which performs a **case-insensitive lookup** against known lodash method names and rewrites `lowercase` → `lodash/lowerCase` at build time. The code appeared to work, but only because of this implicit auto-correction.
- Without `babel-plugin-lodash` (e.g., in an rspack/SWC build), `lodash.lowercase` resolves to `undefined`, causing a `TypeError: (0, lodash.lowercase) is not a function` that crashes the React component tree and unmounts the entire form.
- **Fix:** Rename `lowercase` → `lowerCase` in all 3 import statements and their usage sites.
- Team: Forms — income-and-asset-statement application.

## Related issue(s)

- Discovered during rspack migration investigation: department-of-veterans-affairs/vets-website#42397

## Testing done

- Verified `lowerCase` is a valid lodash export: `require('lodash').lowerCase` returns a function.
- Audited all 61 unique named lodash imports across `src/applications/` and `src/platform/` — `lowercase` was the **only** invalid import. All others are correctly cased.
- Ran income-and-asset-statement E2E tests (both veteran and non-veteran flows) — both pass with this fix applied.
- Unit tests pass.

## Screenshots

N/A — no UI changes. The fix corrects a function name typo that was previously auto-corrected at build time.

## What areas of the site does it impact?

Only the **income-and-asset-statement** form application — specifically the owned assets, royalties/other properties, and asset transfers chapters that use `lowerCase()` in their `getItemName` helpers.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A — no UI change)
- [x] Accessibility testing has been performed (N/A — no UI change)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — unauthenticated form)

## Requested Feedback

This is a straightforward typo fix. `babel-plugin-lodash` was silently papering over the incorrect import name via case-insensitive matching. The fix is correct regardless of build tooling.