### PR TITLE
fix(letters): update Cypress accordion selectors for component-library v55

### DIFF
--- a/src/applications/letters/tests/03-letters-new-design.cypress.spec.js
+++ b/src/applications/letters/tests/03-letters-new-design.cypress.spec.js
@@ -48,10 +48,14 @@ describe('New letters page design', () => {
       'Your VA benefit letters and documents | Veterans Affairs',
     );
     cy.axeCheck('main');
-    cy.get('@lettersAccordion')
-      .shadow()
-      .find('button.va-accordion__button')
-      .click({ multiple: true });
+    cy.get('[data-test-id="letters-accordion"] va-accordion-item').each(
+      $item => {
+        cy.wrap($item)
+          .shadow()
+          .find('button[aria-expanded]')
+          .click({ force: true });
+      },
+    );
     cy.get('va-link[filetype="PDF"]', { timeout: Timeouts.slow }).should(
       'have.length',
       4,
@@ -64,10 +68,14 @@ describe('New letters page design', () => {
     cy.get('[data-test-id="letters-accordion"]', { timeout: Timeouts.slow })
       .as('lettersAccordion')
       .should('be.visible');
-    cy.get('@lettersAccordion')
-      .shadow()
-      .find('button.va-accordion__button')
-      .click({ multiple: true });
+    cy.get('[data-test-id="letters-accordion"] va-accordion-item').each(
+      $item => {
+        cy.wrap($item)
+          .shadow()
+          .find('button[aria-expanded]')
+          .click({ force: true });
+      },
+    );
     cy.get('va-link[filetype="PDF"]', { timeout: Timeouts.slow })
       .first()
       .click({ force: true });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The component-library v55 update (PR #41902) changed the `va-accordion-item` shadow DOM button class from `va-accordion__button` to `usa-accordion__button` (USWDS alignment).
- Two Cypress tests in `03-letters-new-design.cypress.spec.js` were querying `button.va-accordion__button` inside the shadow DOM, which no longer exists, causing them to fail on `main`.
- Updated both tests to iterate over each `va-accordion-item` and click via `button[aria-expanded]` — an ARIA-based selector resilient to future class name changes, matching the pattern the passing BSL tests in the same file already use.
- Letters team / Benefits - Decision Reviews team

## Related issue(s)

- Failing CI run: https://github.com/department-of-veterans-affairs/vets-website/actions/runs/22241687898/job/64348073930
- Component library bump that introduced the breakage: department-of-veterans-affairs/vets-website#41902

## Testing done

- **Before**: The two tests (`confirms non-BSL letters load asynchronously` and `confirms non-BSL letters can be downloaded`) failed with `AssertionError: Timed out retrying after 4000ms: Expected to find element: button.va-accordion__button, but never found it.`
- **After**: Ran the full `03-letters-new-design.cypress.spec.js` spec locally with Cypress — all 4 tests pass (0 failing).
- No other files in the letters app reference the old `va-accordion__button` class.

## Screenshots

N/A — no UI changes; test-only fix.

## What areas of the site does it impact?

Letters application Cypress E2E tests only. No production code changes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A — test-only change)
- [x] Accessibility testing has been performed (N/A — test-only change, axeCheck assertions retained)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — test-only change, existing login mocking retained)

## Requested Feedback

This is a straightforward selector fix. The `button[aria-expanded]` selector is more robust than relying on CSS class names that can change across component library versions.