### PR TITLE
Pension - update introduction page text

### DIFF
--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -81,7 +81,7 @@ const IntroductionPage = props => {
             </li>
             <li>
               <strong>Your dependents information:</strong> This includes their
-              date of birthday and Social Security number.{' '}
+              date of birth and Social Security number.{' '}
             </li>
             <li>
               <strong>Your financial information:</strong> This includes your


### PR DESCRIPTION
### Summary of Changes

[Design QA comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/130281#issuecomment-3922308615)

This PR makes a small follow-up content correction on the **Pension Benefits (VA Form 21P-527EZ)** introduction page by updating a bullet point in the “Gather your information” section from **“date of birthday”** to **“date of birth.”**

This is a text-only update and does not affect any functionality.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130281

### How to Set Up in Local Environment
1. Run the local environment
2. Navigate to the Pension Benefits form introduction page:  
   http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/

### How to Test
1. Open the Pension introduction page.
2. Locate the “Gather your information” section.
3. Verify the bullet point now reads **“date of birth”** (and no longer “date of birthday”).
4. Confirm there are no console errors or layout regressions.

### Feature Flag Note
- No feature flags are required for this update.

### Acceptance Criteria
- [x] Bullet point text is updated to “date of birth.”
- [x] No other content or layout changes introduced.
- [x] No console errors or accessibility regressions.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally.
- [ ] Tests verified passing.