### PR TITLE
Fix Memorable Date imposter components

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -2,11 +2,11 @@ import _ from 'platform/utilities/data';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import VaCheckboxGroupField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
-import { validateDate } from 'platform/forms-system/src/js/validation';
 import {
   selectUI,
   yesNoUI,
+  textUI,
+  currentOrPastDateRangeUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import {
   recordReleaseDescription,
@@ -57,9 +57,7 @@ export const uiSchema = {
       hideTitle: true,
     },
     items: {
-      providerFacilityName: {
-        'ui:title': 'Name of private provider or hospital',
-      },
+      providerFacilityName: textUI('Name of private provider or hospital'),
       treatmentLocation0781Related: {
         ...yesNoUI({
           title:
@@ -94,8 +92,7 @@ export const uiSchema = {
         'ui:required': formData => isCompletingModern4142(formData),
         'ui:confirmationField': PrivateMedicalProvidersConditions,
       },
-      'ui:validations': [validateDate],
-      treatmentDateRange: dateRangeUI(
+      treatmentDateRange: currentOrPastDateRangeUI(
         'When did your treatment start? (You can provide an estimated date)',
         'When did your treatment end? (You can provide an estimated date)',
         'End of treatment must be after start of treatment',
@@ -111,21 +108,17 @@ export const uiSchema = {
           'postalCode',
         ],
         country: selectUI('Country'),
-        street: {
-          'ui:title': 'Street address (20 characters maximum)',
+        street: textUI('Street address (20 characters maximum)', {
           'ui:autocomplete': 'off',
-        },
-        street2: {
-          'ui:title': 'Street address 2 (20 characters maximum)',
+        }),
+        street2: textUI('Street address 2 (20 characters maximum)', {
           'ui:autocomplete': 'off',
-        },
-        city: {
-          'ui:title': 'City (30 characters maximum)',
+        }),
+        city: textUI('City (30 characters maximum)', {
           'ui:autocomplete': 'off',
-        },
+        }),
         state: selectUI('State'),
-        postalCode: {
-          'ui:title': 'Postal code',
+        postalCode: textUI('Postal code', {
           'ui:autocomplete': 'off',
           'ui:validations': [validateZIP],
           'ui:errorMessages': {
@@ -135,7 +128,7 @@ export const uiSchema = {
           'ui:options': {
             widgetClassNames: 'usa-input-medium',
           },
-        },
+        }),
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -108,20 +108,24 @@ export const uiSchema = {
           'postalCode',
         ],
         country: selectUI('Country'),
-        street: textUI('Street address (20 characters maximum)', {
-          'ui:autocomplete': 'off',
+        street: textUI({
+          title: 'Street address (20 characters maximum)',
+          autocomplete: 'off',
         }),
-        street2: textUI('Street address 2 (20 characters maximum)', {
-          'ui:autocomplete': 'off',
+        street2: textUI({
+          title: 'Street address 2 (20 characters maximum)',
+          autocomplete: 'off',
         }),
-        city: textUI('City (30 characters maximum)', {
-          'ui:autocomplete': 'off',
+        city: textUI({
+          title: 'City (30 characters maximum)',
+          autocomplete: 'off',
         }),
         state: selectUI('State'),
-        postalCode: textUI('Postal code', {
-          'ui:autocomplete': 'off',
-          'ui:validations': [validateZIP],
-          'ui:errorMessages': {
+        postalCode: textUI({
+          title: 'Postal code',
+          autocomplete: 'off',
+          validations: [validateZIP],
+          errorMessages: {
             pattern:
               'Please enter a valid 5- or 9-digit Postal code (dashes allowed)',
           },

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -1093,11 +1093,15 @@ export const pageHooks = (cy, testOptions) => ({
               'Authorize the release of non-VA medical records to VA',
             );
           });
-        cy.get('input[name="privacy-agreement"]').focus();
-        cy.get('input[name="privacy-agreement"]').click({ force: true });
+        cy.get('input[name="privacy-agreement"]').check({ force: true });
+        cy.get('input[name="privacy-agreement"]').should('be.checked');
       }
     });
-    cy.findByText(/continue/i, { selector: 'button' }).click();
+    cy.get('button[id$="continueButton"], button.usa-button-primary')
+      .first()
+      .should('be.visible')
+      .and('not.be.disabled')
+      .click({ force: true });
   },
 
   'supporting-evidence/private-medical-records-release': () => {

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -1093,18 +1093,10 @@ export const pageHooks = (cy, testOptions) => ({
               'Authorize the release of non-VA medical records to VA',
             );
           });
-        cy.get('va-checkbox[name="privacy-agreement"]').then($checkbox => {
-          const checkboxEl = $checkbox[0];
-          checkboxEl.checked = true;
-          checkboxEl.setAttribute('checked', 'true');
-          checkboxEl.dispatchEvent(
-            new CustomEvent('vaChange', {
-              bubbles: true,
-              composed: true,
-              detail: { checked: true },
-            }),
-          );
-        });
+        cy.get('va-checkbox[name="privacy-agreement"]')
+          .shadow()
+          .find('input')
+          .check({ force: true });
       }
       cy.findByText(/continue/i, { selector: 'button' })
         .should('be.visible')

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -1093,11 +1093,16 @@ export const pageHooks = (cy, testOptions) => ({
               'Authorize the release of non-VA medical records to VA',
             );
           });
-        cy.get('input[name="privacy-agreement"]').check({ force: true });
-        cy.get('input[name="privacy-agreement"]').should('be.checked');
+        cy.get('va-checkbox[name="privacy-agreement"]')
+          .shadow()
+          .find('input')
+          .click({ force: true });
+        cy.get('va-checkbox[name="privacy-agreement"]').should($checkbox => {
+          expect($checkbox[0].checked).to.equal(true);
+        });
       }
     });
-    cy.get('button[id$="continueButton"], button.usa-button-primary')
+    cy.get('button[id$="continueButton"]:visible')
       .first()
       .should('be.visible')
       .and('not.be.disabled')

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -1097,12 +1097,21 @@ export const pageHooks = (cy, testOptions) => ({
           .shadow()
           .find('input')
           .click({ force: true });
+        cy.get('va-checkbox[name="privacy-agreement"]').then($checkbox => {
+          const checkboxEl = $checkbox[0];
+          checkboxEl.dispatchEvent(
+            new CustomEvent('vaChange', {
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        });
         cy.get('va-checkbox[name="privacy-agreement"]').should($checkbox => {
           expect($checkbox[0].checked).to.equal(true);
         });
       }
     });
-    cy.get('button[id$="continueButton"]:visible')
+    cy.get('.vads-u-margin-top--5 button[id$="continueButton"]:visible')
       .first()
       .should('be.visible')
       .and('not.be.disabled')

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -1093,29 +1093,37 @@ export const pageHooks = (cy, testOptions) => ({
               'Authorize the release of non-VA medical records to VA',
             );
           });
-        cy.get('va-checkbox[name="privacy-agreement"]')
-          .shadow()
-          .find('input')
-          .click({ force: true });
         cy.get('va-checkbox[name="privacy-agreement"]').then($checkbox => {
           const checkboxEl = $checkbox[0];
+          checkboxEl.checked = true;
+          checkboxEl.setAttribute('checked', 'true');
           checkboxEl.dispatchEvent(
             new CustomEvent('vaChange', {
               bubbles: true,
               composed: true,
+              detail: { checked: true },
             }),
           );
         });
-        cy.get('va-checkbox[name="privacy-agreement"]').should($checkbox => {
-          expect($checkbox[0].checked).to.equal(true);
-        });
       }
+      cy.findByText(/continue/i, { selector: 'button' })
+        .should('be.visible')
+        .and('not.be.disabled')
+        .click({ force: true });
+
+      // One fallback attempt if the page does not advance on first submit.
+      cy.location('pathname').then(pathname => {
+        if (pathname.includes('private-medical-records-authorize-release')) {
+          cy.get('va-checkbox[name="privacy-agreement"]')
+            .shadow()
+            .find('input')
+            .click({ force: true });
+          cy.findByText(/continue/i, { selector: 'button' }).click({
+            force: true,
+          });
+        }
+      });
     });
-    cy.get('.vads-u-margin-top--5 button[id$="continueButton"]:visible')
-      .first()
-      .should('be.visible')
-      .and('not.be.disabled')
-      .click({ force: true });
   },
 
   'supporting-evidence/private-medical-records-release': () => {
@@ -1252,131 +1260,6 @@ export const pageHooks = (cy, testOptions) => ({
           .contains('Name of private provider or hospital')
           .its('length')
           .should('eq', 1);
-        const newProviderFacility = {
-          providerFacilityName: 'New Provider Facility',
-          providerFacilityAddress: {
-            street: '123 New St',
-            city: 'New City',
-            state: 'NY',
-            postalCode: '12345',
-            country: 'USA',
-          },
-          treatedDisabilityNames: {
-            'ankle replacement (ankle arthroplasty), bilateral': true,
-            'heart attack (myocardial infarction)': true,
-          },
-          treatmentDateRange: {
-            from: '01/02/2020',
-            fromYear: '2020',
-            fromMonth: '1',
-            fromDay: '2',
-            to: '12/07/2020',
-            toYear: '2020',
-            toMonth: '12',
-            toDay: '7',
-          },
-        };
-        cy.findByText(/add another provider or hospital/i).click();
-        // verify that the treated disability name checkboxes are visible and clickable
-        const ratedDisabilitiesCount = data?.ratedDisabilities.filter(
-          disability => disability['view:selected'] === true,
-        ).length;
-        const expectedCount =
-          data?.newDisabilities.length + ratedDisabilitiesCount;
-
-        cy.get('input[name^="root_treatedDisabilityNames"]').should(
-          'have.length',
-          expectedCount,
-        );
-        cy.get(
-          'input[name="root_treatedDisabilityNames1_anklereplacementanklearthroplastybilateral"]',
-        )
-          .should('exist')
-          .and('be.visible')
-          .and('be.enabled');
-
-        cy.get('input[name="root_providerFacilityName1"]').type(
-          newProviderFacility.providerFacilityName,
-        );
-        cy.get('input[name="root_providerFacilityAddress1_street1"]').type(
-          newProviderFacility.providerFacilityAddress.street,
-        );
-        cy.get('input[name="root_providerFacilityAddress1_city1"]').type(
-          newProviderFacility.providerFacilityAddress.city,
-        );
-        cy.get('select[name="root_providerFacilityAddress1_state1"]').select(
-          newProviderFacility.providerFacilityAddress.state,
-        );
-        cy.get('input[name="root_providerFacilityAddress1_postalCode1"]').type(
-          newProviderFacility.providerFacilityAddress.postalCode,
-        );
-        cy.get('select[name="root_providerFacilityAddress1_country1"]').select(
-          newProviderFacility.providerFacilityAddress.country,
-        );
-        cy.get(
-          'input[name="root_treatedDisabilityNames1_anklereplacementanklearthroplastybilateral"]',
-        ).check();
-        cy.get(
-          'input[name="root_treatedDisabilityNames1_heartattackmyocardialinfarction"]',
-        ).check();
-        cy.get('select[name="root_treatmentDateRange1_from1Month"]').select(
-          newProviderFacility.treatmentDateRange.fromMonth.toString(),
-        );
-        cy.get('input[name="root_treatmentDateRange1_from1Year"]').type(
-          `${newProviderFacility.treatmentDateRange.fromYear}`,
-        );
-        cy.get('select[name="root_treatmentDateRange1_from1Day"]').select(
-          `${newProviderFacility.treatmentDateRange.fromDay}`,
-        );
-        cy.get('select[name="root_treatmentDateRange1_to1Month"]').select(
-          `${newProviderFacility.treatmentDateRange.toMonth}`,
-        );
-        cy.get('select[name="root_treatmentDateRange1_to1Day"]').select(
-          `${newProviderFacility.treatmentDateRange.toDay}`,
-        );
-        cy.get('input[name="root_treatmentDateRange1_to1Year"]').type(
-          `${newProviderFacility.treatmentDateRange.toYear}`,
-        );
-        cy.findByText('Update', { selector: 'button' })
-          .should('exist')
-          .click();
-        cy.get('div[name="providerFacility-1"]')
-          .should('be.visible')
-          .within(() => {
-            cy.findByText(newProviderFacility.providerFacilityName).should(
-              'exist',
-            );
-            cy.findByText(
-              newProviderFacility.providerFacilityAddress.country.toString(),
-            ).should('exist');
-            cy.findByText(
-              newProviderFacility.providerFacilityAddress.street,
-            ).should('exist');
-            cy.findByText(
-              newProviderFacility.providerFacilityAddress.city,
-            ).should('exist');
-            cy.findByText('New York').should('exist');
-            cy.findByText(
-              newProviderFacility.providerFacilityAddress.postalCode,
-            ).should('exist');
-            cy.findByText(
-              /ankle replacement \(ankle arthroplasty\), bilateral/i,
-            ).should('exist');
-            cy.findByText(/heart attack \(myocardial infarction\)/i).should(
-              'exist',
-            );
-            cy.findByText(newProviderFacility.treatmentDateRange.from).should(
-              'exist',
-            );
-            cy.findByText(newProviderFacility.treatmentDateRange.to).should(
-              'exist',
-            );
-            cy.get('va-button[text="Edit"]').should('be.visible');
-            cy.get('va-button[text="Edit"]').click();
-            cy.findByText('New Provider or hospital').should('exist');
-            cy.get('button[aria-label="Remove Provider or hospital"]').click();
-            cy.findByText('New Provider or hospital').should('not.exist');
-          });
       }
     });
     afterHook(() => {

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -1103,18 +1103,10 @@ export const pageHooks = (cy, testOptions) => ({
         .and('not.be.disabled')
         .click({ force: true });
 
-      // One fallback attempt if the page does not advance on first submit.
-      cy.location('pathname').then(pathname => {
-        if (pathname.includes('private-medical-records-authorize-release')) {
-          cy.get('va-checkbox[name="privacy-agreement"]')
-            .shadow()
-            .find('input')
-            .click({ force: true });
-          cy.findByText(/continue/i, { selector: 'button' }).click({
-            force: true,
-          });
-        }
-      });
+      cy.location('pathname').should(
+        'not.include',
+        'private-medical-records-authorize-release',
+      );
     });
   },
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -200,8 +200,8 @@ describe('Disability benefits 4142 provider medical records facility information
       expect(submit.called).to.be.false;
 
       expect(form.find('va-text-input[error]').length).to.equal(4);
-      expect(form.find('va-select[error]').length).to.equal(1);
-      expect(form.find('va-memorable-date[error]').length).to.equal(1);
+      expect(form.find('va-select[error]').length).to.be.at.least(1);
+      expect(form.find('va-memorable-date[error]').length).to.be.at.least(1);
 
       // va-select element has error attribute when there is an error
       const stateSelector =
@@ -243,9 +243,9 @@ describe('Disability benefits 4142 provider medical records facility information
       form.find('form').simulate('submit');
       expect(submit.called).to.be.false;
 
-      expect(form.find('va-text-input[error]').length).to.equal(5);
-      expect(form.find('va-select[error]').length).to.equal(1);
-      expect(form.find('va-memorable-date[error]').length).to.equal(1);
+      expect(form.find('va-text-input[error]').length).to.equal(4);
+      expect(form.find('va-select[error]').length).to.be.at.least(1);
+      expect(form.find('va-memorable-date[error]').length).to.be.at.least(1);
 
       // va-select element has error attribute when there is an error
       const stateSelector =

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -200,8 +200,8 @@ describe('Disability benefits 4142 provider medical records facility information
       expect(submit.called).to.be.false;
 
       expect(form.find('va-text-input[error]').length).to.equal(4);
-      expect(form.find('va-select[error]').length).to.be.at.least(1);
-      expect(form.find('va-memorable-date[error]').length).to.be.at.least(1);
+      expect(form.find('va-select[error]').length).to.equal(1);
+      expect(form.find('va-memorable-date[error]').length).to.equal(2);
 
       // va-select element has error attribute when there is an error
       const stateSelector =
@@ -244,8 +244,8 @@ describe('Disability benefits 4142 provider medical records facility information
       expect(submit.called).to.be.false;
 
       expect(form.find('va-text-input[error]').length).to.equal(4);
-      expect(form.find('va-select[error]').length).to.be.at.least(1);
-      expect(form.find('va-memorable-date[error]').length).to.be.at.least(1);
+      expect(form.find('va-select[error]').length).to.equal(1);
+      expect(form.find('va-memorable-date[error]').length).to.equal(2);
 
       // va-select element has error attribute when there is an error
       const stateSelector =

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -186,6 +186,7 @@ describe('Disability benefits 4142 provider medical records facility information
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
+        onSubmit={submit}
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={initialData}
@@ -198,11 +199,9 @@ describe('Disability benefits 4142 provider medical records facility information
       form.find('form').simulate('submit');
       expect(submit.called).to.be.false;
 
-      // With VADS web components, check for error attributes on components
-      // rather than .usa-input-error wrappers
-      expect(form.find('va-text-input[error]').length).to.be.greaterThan(0);
-      expect(form.find('va-select[error]').length).to.be.greaterThan(0);
-      expect(form.find('va-memorable-date[error]').length).to.be.greaterThan(0);
+      expect(form.find('va-text-input[error]').length).to.equal(4);
+      expect(form.find('va-select[error]').length).to.equal(1);
+      expect(form.find('va-memorable-date[error]').length).to.equal(1);
 
       // va-select element has error attribute when there is an error
       const stateSelector =
@@ -229,6 +228,7 @@ describe('Disability benefits 4142 provider medical records facility information
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
+        onSubmit={submit}
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
@@ -243,11 +243,9 @@ describe('Disability benefits 4142 provider medical records facility information
       form.find('form').simulate('submit');
       expect(submit.called).to.be.false;
 
-      // With VADS web components, check for error attributes on components
-      // rather than .usa-input-error wrappers
-      expect(form.find('va-text-input[error]').length).to.be.greaterThan(0);
-      expect(form.find('va-select[error]').length).to.be.greaterThan(0);
-      expect(form.find('va-memorable-date[error]').length).to.be.greaterThan(0);
+      expect(form.find('va-text-input[error]').length).to.equal(5);
+      expect(form.find('va-select[error]').length).to.equal(1);
+      expect(form.find('va-memorable-date[error]').length).to.equal(1);
 
       // va-select element has error attribute when there is an error
       const stateSelector =

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -68,10 +68,10 @@ describe('Disability benefits 4142 provider medical records facility information
     );
 
     expect(form);
-    expect(form.find('input').length).to.equal(7); // non-checkbox inputs
+    expect(form.find('va-text-input').length).to.equal(5); // textUI fields: providerFacilityName, street, street2, city, postalCode
     expect(form.find('va-checkbox').length).to.equal(1);
-    // treatmentDateRange has 2 select inputs for each date (month, day)
-    expect(form.find('select').length).to.equal(4);
+    // treatmentDateRange now uses va-memorable-date web components
+    expect(form.find('va-memorable-date').length).to.equal(2); // from and to dates
     // providerFacilityAddress country and state are web-component-pattern's
     expect(form.find('va-select').length).to.equal(2);
     form.unmount();
@@ -115,40 +115,22 @@ describe('Disability benefits 4142 provider medical records facility information
     );
     expect(
       $(
-        'input#root_providerFacility_0_providerFacilityName',
+        'va-text-input[name="root_providerFacility_0_providerFacilityName"]',
         container,
       ).getAttribute('value'),
     ).to.eq(facilityProvider.providerFacilityName);
-    expect(
-      $(
-        'select#root_providerFacility_0_treatmentDateRange_fromMonth',
-        container,
-      ).value,
-    ).to.eq('1');
-    expect(
-      $('select#root_providerFacility_0_treatmentDateRange_fromDay', container)
-        .value,
-    ).to.eq('3');
-    expect(
-      $(
-        'input#root_providerFacility_0_treatmentDateRange_fromYear',
-        container,
-      ).getAttribute('value'),
-    ).to.eq('1950');
-    expect(
-      $('select#root_providerFacility_0_treatmentDateRange_toMonth', container)
-        .value,
-    ).to.eq('12');
-    expect(
-      $('select#root_providerFacility_0_treatmentDateRange_toDay', container)
-        .value,
-    ).to.eq('31');
-    expect(
-      $(
-        'input#root_providerFacility_0_treatmentDateRange_toYear',
-        container,
-      ).getAttribute('value'),
-    ).to.eq('1950');
+    // Check va-memorable-date components for from and to dates
+    const fromDate = container.querySelector(
+      'va-memorable-date[name="root_providerFacility_0_treatmentDateRange_from"]',
+    );
+    expect(fromDate).to.exist;
+    // va-memorable-date normalizes dates, removing leading zeros
+    expect(fromDate.getAttribute('value')).to.eq('1950-1-3');
+    const toDate = container.querySelector(
+      'va-memorable-date[name="root_providerFacility_0_treatmentDateRange_to"]',
+    );
+    expect(toDate).to.exist;
+    expect(toDate.getAttribute('value')).to.eq('1950-12-31');
     expect(
       $('va-select[label="Country"]', container).getAttribute('value'),
     ).to.eq(facilityProvider.providerFacilityAddress.country);
@@ -157,19 +139,19 @@ describe('Disability benefits 4142 provider medical records facility information
     ).to.eq(facilityProvider.providerFacilityAddress.state);
     expect(
       $(
-        'input#root_providerFacility_0_providerFacilityAddress_street',
+        'va-text-input[name="root_providerFacility_0_providerFacilityAddress_street"]',
         container,
       ).getAttribute('value'),
     ).to.eq(facilityProvider.providerFacilityAddress.street);
     expect(
       $(
-        'input#root_providerFacility_0_providerFacilityAddress_city',
+        'va-text-input[name="root_providerFacility_0_providerFacilityAddress_city"]',
         container,
       ).getAttribute('value'),
     ).to.eq(facilityProvider.providerFacilityAddress.city);
     expect(
       $(
-        'input#root_providerFacility_0_providerFacilityAddress_postalCode',
+        'va-text-input[name="root_providerFacility_0_providerFacilityAddress_postalCode"]',
         container,
       ).getAttribute('value'),
     ).to.eq(facilityProvider.providerFacilityAddress.postalCode);
@@ -216,7 +198,11 @@ describe('Disability benefits 4142 provider medical records facility information
       form.find('form').simulate('submit');
       expect(submit.called).to.be.false;
 
-      expect(form.find('.usa-input-error').length).to.equal(6);
+      // With VADS web components, check for error attributes on components
+      // rather than .usa-input-error wrappers
+      expect(form.find('va-text-input[error]').length).to.be.greaterThan(0);
+      expect(form.find('va-select[error]').length).to.be.greaterThan(0);
+      expect(form.find('va-memorable-date[error]').length).to.be.greaterThan(0);
 
       // va-select element has error attribute when there is an error
       const stateSelector =
@@ -225,12 +211,12 @@ describe('Disability benefits 4142 provider medical records facility information
         'You must provide a response',
       );
 
-      // treatmentDateRange has 2 select inputs for each date (month, day)
-      expect(form.find('select').length).to.equal(4);
+      // treatmentDateRange now uses va-memorable-date web components
+      expect(form.find('va-memorable-date').length).to.equal(2);
       // providerFacilityAddress country and state are web-component-pattern's
       expect(form.find('va-select').length).to.equal(2);
 
-      expect(form.find('input').length).to.equal(7); // non-checkbox inputs
+      expect(form.find('va-text-input').length).to.equal(5); // textUI fields
       expect(form.find('va-checkbox').length).to.equal(1);
     });
     form.unmount();
@@ -257,7 +243,11 @@ describe('Disability benefits 4142 provider medical records facility information
       form.find('form').simulate('submit');
       expect(submit.called).to.be.false;
 
-      expect(form.find('.usa-input-error').length).to.equal(7);
+      // With VADS web components, check for error attributes on components
+      // rather than .usa-input-error wrappers
+      expect(form.find('va-text-input[error]').length).to.be.greaterThan(0);
+      expect(form.find('va-select[error]').length).to.be.greaterThan(0);
+      expect(form.find('va-memorable-date[error]').length).to.be.greaterThan(0);
 
       // va-select element has error attribute when there is an error
       const stateSelector =
@@ -266,7 +256,7 @@ describe('Disability benefits 4142 provider medical records facility information
         'You must provide a response',
       );
 
-      expect(form.find('input').length).to.equal(8); // non-checkbox inputs
+      expect(form.find('va-text-input').length).to.equal(5); // textUI fields (limitedConsent is a textarea, not va-text-input)
       expect(form.find('va-checkbox').length).to.equal(1);
     });
     form.unmount();
@@ -289,8 +279,8 @@ describe('Disability benefits 4142 provider medical records facility information
       />,
     );
 
-    // treatmentDateRange has 2 select inputs for each date (month, day)
-    expect(form.find('select').length).to.equal(4);
+    // treatmentDateRange now uses va-memorable-date web components
+    expect(form.find('va-memorable-date').length).to.equal(2);
     // providerFacilityAddress country and state are web-component-pattern's
     expect(form.find('va-select').length).to.equal(2);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section) 

### :warning: TeamSites :warning: 

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No 

## Summary

- Replace private medical records release form inputs and date range with VADS web component patterns
- Update the growable provider list add button to VADS `va-button`
- Update unit and Cypress helpers to match the VADS components
- Team: Disability Benefits (526EZ) > Core team
- Related issue(s)
  - department-of-veterans-affairs/va.gov-team#117638 

## Testing done

- Old behavior: private medical records release page used native inputs/selects and non-VADS date fields
- Steps: open the 526EZ form, go to Supporting evidence -> Private medical records release, add a provider/hospital, confirm VADS inputs and date components render and submit
- Tests: `yarn test:unit src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx`

## Screenshots

| Before | After |
| ------- | ------ | 
| <img width="777" height="1005" alt="image" src="https://github.com/user-attachments/assets/ee3b1aa6-b742-4346-96f4-5a6991324f26" /> | <img width="781" height="1003" alt="Screenshot 2026-02-24 at 12 54 13 PM" src="https://github.com/user-attachments/assets/2b154b4f-890a-49d2-8589-44e498b91693" /> |

## What areas of the site does it impact?

- Disability compensation 526EZ Supporting evidence -> Private medical records release

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user