### PR TITLE
A11y defect error page has no h1 and focus is lost erroralert suppresses h1

### DIFF
--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -48,36 +48,45 @@ const Wrapper = props => {
   const navigate = useNavigate();
 
   // Warn on page refresh/close
-  useEffect(() => {
-    if (disableBeforeUnload) {
-      return undefined;
-    }
+  useEffect(
+    () => {
+      if (disableBeforeUnload) {
+        return undefined;
+      }
 
-    const handleBeforeUnload = e => {
-      e.preventDefault();
-      e.returnValue = '';
-    };
+      const handleBeforeUnload = e => {
+        e.preventDefault();
+        e.returnValue = '';
+      };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
+      window.addEventListener('beforeunload', handleBeforeUnload);
 
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [disableBeforeUnload]);
+      return () => {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+      };
+    },
+    [disableBeforeUnload],
+  );
 
-  useEffect(() => {
-    if (!loading) {
-      focusElement('h1');
-    }
-  }, [loading]);
+  useEffect(
+    () => {
+      if (!loading) {
+        focusElement('h1');
+      }
+    },
+    [loading],
+  );
 
-  useEffect(() => {
-    if (verificationError) {
-      setTimeout(() => {
-        focusElement('va-alert[data-testid="verification-error-alert"]');
-      }, 100);
-    }
-  }, [verificationError]);
+  useEffect(
+    () => {
+      if (verificationError) {
+        setTimeout(() => {
+          focusElement('va-alert[data-testid="verification-error-alert"]');
+        }, 100);
+      }
+    },
+    [verificationError],
+  );
 
   if (loading) {
     return (
@@ -101,21 +110,22 @@ const Wrapper = props => {
       })}
       data-testid={testID}
     >
-      {!errorAlert && showBackLink && (
-        <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
-          <nav aria-label="Back">
-            <va-link
-              back
-              data-testid="back-link"
-              text="Back"
-              onClick={e => {
-                e.preventDefault();
-                navigate(-1);
-              }}
-            />
-          </nav>
-        </div>
-      )}
+      {!errorAlert &&
+        showBackLink && (
+          <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
+            <nav aria-label="Back">
+              <va-link
+                back
+                data-testid="back-link"
+                text="Back"
+                onClick={e => {
+                  e.preventDefault();
+                  navigate(-1);
+                }}
+              />
+            </nav>
+          </div>
+        )}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
           {pageTitle && (

--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -48,45 +48,36 @@ const Wrapper = props => {
   const navigate = useNavigate();
 
   // Warn on page refresh/close
-  useEffect(
-    () => {
-      if (disableBeforeUnload) {
-        return undefined;
-      }
+  useEffect(() => {
+    if (disableBeforeUnload) {
+      return undefined;
+    }
 
-      const handleBeforeUnload = e => {
-        e.preventDefault();
-        e.returnValue = '';
-      };
+    const handleBeforeUnload = e => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
 
-      window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('beforeunload', handleBeforeUnload);
 
-      return () => {
-        window.removeEventListener('beforeunload', handleBeforeUnload);
-      };
-    },
-    [disableBeforeUnload],
-  );
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [disableBeforeUnload]);
 
-  useEffect(
-    () => {
-      if (!loading) {
-        focusElement('h1');
-      }
-    },
-    [loading],
-  );
+  useEffect(() => {
+    if (!loading) {
+      focusElement('h1');
+    }
+  }, [loading]);
 
-  useEffect(
-    () => {
-      if (verificationError) {
-        setTimeout(() => {
-          focusElement('va-alert[data-testid="verification-error-alert"]');
-        }, 100);
-      }
-    },
-    [verificationError],
-  );
+  useEffect(() => {
+    if (verificationError) {
+      setTimeout(() => {
+        focusElement('va-alert[data-testid="verification-error-alert"]');
+      }, 100);
+    }
+  }, [verificationError]);
 
   if (loading) {
     return (
@@ -110,22 +101,21 @@ const Wrapper = props => {
       })}
       data-testid={testID}
     >
-      {!errorAlert &&
-        showBackLink && (
-          <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
-            <nav aria-label="Back">
-              <va-link
-                back
-                data-testid="back-link"
-                text="Back"
-                onClick={e => {
-                  e.preventDefault();
-                  navigate(-1);
-                }}
-              />
-            </nav>
-          </div>
-        )}
+      {!errorAlert && showBackLink && (
+        <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--0">
+          <nav aria-label="Back">
+            <va-link
+              back
+              data-testid="back-link"
+              text="Back"
+              onClick={e => {
+                e.preventDefault();
+                navigate(-1);
+              }}
+            />
+          </nav>
+        </div>
+      )}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
           {pageTitle && (

--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -128,17 +128,16 @@ const Wrapper = props => {
         )}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-          {!errorAlert &&
-            pageTitle && (
-              <h1 tabIndex="-1" data-testid="header">
-                {pageTitle}
-                {required && (
-                  <span className="vass-usa-label--required vads-u-font-family--sans">
-                    (*Required)
-                  </span>
-                )}
-              </h1>
-            )}
+          {pageTitle && (
+            <h1 tabIndex="-1" data-testid="header">
+              {pageTitle}
+              {required && (
+                <span className="vass-usa-label--required vads-u-font-family--sans">
+                  (*Required)
+                </span>
+              )}
+            </h1>
+          )}
           <DowntimeNotification
             appTitle="VA Solid Start"
             dependencies={[externalServices.vass]}

--- a/src/applications/vass/layout/Wrapper.unit.spec.jsx
+++ b/src/applications/vass/layout/Wrapper.unit.spec.jsx
@@ -239,6 +239,7 @@ describe('VASS Component: Wrapper', () => {
       expect(beforeunloadHandler).to.be.undefined;
     });
   });
+
   describe('when loading prop is true', () => {
     it('should render loading indicator', () => {
       const { getByTestId } = renderWithStoreAndRouter(
@@ -276,6 +277,87 @@ describe('VASS Component: Wrapper', () => {
         defaultRenderOptions,
       );
       expect(queryByTestId('loading-indicator')).to.not.exist;
+    });
+  });
+
+  describe('when errorAlert is true', () => {
+    it('should render ErrorAlert component', () => {
+      const { getByTestId } = renderWithStoreAndRouter(
+        <Wrapper errorAlert>
+          <div data-testid="child-content">Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      expect(getByTestId('api-error-alert')).to.exist;
+    });
+
+    it('should not render children content', () => {
+      const { queryByTestId } = renderWithStoreAndRouter(
+        <Wrapper errorAlert>
+          <div data-testid="child-content">Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      expect(queryByTestId('child-content')).to.not.exist;
+    });
+
+    it('should not render back link even when showBackLink is true', () => {
+      const { queryByTestId } = renderWithStoreAndRouter(
+        <Wrapper errorAlert showBackLink>
+          <div>Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      expect(queryByTestId('back-link')).to.not.exist;
+    });
+
+    it('should render schedule error header by default', () => {
+      const screen = renderWithStoreAndRouter(
+        <Wrapper errorAlert>
+          <div>Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      expect(
+        screen.getByText(/We can\u2019t schedule your appointment right now/),
+      ).to.exist;
+    });
+
+    it('should render cancel error header when flowType is CANCEL', () => {
+      const screen = renderWithStoreAndRouter(
+        <Wrapper errorAlert flowType="cancel">
+          <div>Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      const errorAlert = screen.getByTestId('api-error-alert');
+      expect(errorAlert).to.exist;
+      expect(errorAlert.textContent).to.include(
+        'We can’t cancel your appointment right now',
+      );
+    });
+
+    it('should still render page title when provided', () => {
+      const screen = renderWithStoreAndRouter(
+        <Wrapper errorAlert pageTitle="Test Page Title">
+          <div>Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      expect(screen.getByTestId('header')).to.exist;
+      expect(
+        screen.getByRole('heading', { level: 1, name: /test page title/i }),
+      ).to.exist;
+    });
+
+    it('should still render NeedHelp component', () => {
+      const screen = renderWithStoreAndRouter(
+        <Wrapper errorAlert>
+          <div>Content</div>
+        </Wrapper>,
+        defaultRenderOptions,
+      );
+      expect(screen.getByTestId('help-footer')).to.exist;
     });
   });
 

--- a/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelAppointment.unit.spec.jsx
@@ -173,7 +173,7 @@ describe('VASS Page: CancelAppointment', () => {
       await waitFor(() => {
         expect(getByTestId('api-error-alert')).to.exist;
         expect(queryByTestId('back-link')).to.not.exist;
-        expect(queryByTestId('header')).to.not.exist;
+        expect(queryByTestId('header')).to.exist;
       });
     });
 

--- a/src/applications/vass/pages/Review.unit.spec.jsx
+++ b/src/applications/vass/pages/Review.unit.spec.jsx
@@ -208,7 +208,7 @@ describe('VASS Component: Review', () => {
       await waitFor(() => {
         expect(getByTestId('api-error-alert')).to.exist;
         expect(queryByTestId('back-link')).to.not.exist;
-        expect(queryByTestId('header')).to.not.exist;
+        expect(queryByTestId('header')).to.exist;
       });
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Expose the Wrapper H1 when the error alert is shown. This keeps the focus h1 on screen 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#133293

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="1170" height="2532" alt="Screen Shot 2026-02-24 at 11 25 27" src="https://github.com/user-attachments/assets/4fc7f593-daa7-4a58-8f0d-663ae9f0ee08" />|<img width="1242" height="2688" alt="Screen Shot 2026-02-24 at 11 26 37" src="https://github.com/user-attachments/assets/725ca0b9-ef3d-440f-8f25-5d136f21e228" />|
| Desktop |<img width="1620" height="2160" alt="Screen Shot 2026-02-24 at 11 25 35" src="https://github.com/user-attachments/assets/bf980182-6482-4a05-a3a0-766da7c89120" />|<img width="1620" height="2160" alt="Screen Shot 2026-02-24 at 11 26 24" src="https://github.com/user-attachments/assets/81a01e30-188c-42b9-b07d-f2cede68d721" />|

## What areas of the site does it impact?

- VASS

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
