### PR TITLE
Add submit transform sanitizer to strip double quotes and slashes

### DIFF
--- a/src/applications/simple-forms/21P-601/config/submit-transformer.js
+++ b/src/applications/simple-forms/21P-601/config/submit-transformer.js
@@ -1,12 +1,27 @@
 import { transformForSubmit as defaultTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 
+// Strip characters that break the backend's .json.erb interpolation
+// (unescaped double quotes and backslashes produce invalid JSON)
+const sanitizeString = value =>
+  typeof value === 'string' ? value.replace(/["\\]/g, '') : value;
+
+const sanitizeFormData = obj => {
+  if (Array.isArray(obj)) return obj.map(sanitizeFormData);
+  if (obj !== null && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, val]) => [key, sanitizeFormData(val)]),
+    );
+  }
+  return sanitizeString(obj);
+};
+
 function hasRelativeType(relatives, type) {
   return relatives?.some(r => r.relationship === type) || false;
 }
 
 function transformForSubmit(formConfig, form) {
-  const transformedData = JSON.parse(
-    defaultTransformForSubmit(formConfig, form),
+  const transformedData = sanitizeFormData(
+    JSON.parse(defaultTransformForSubmit(formConfig, form)),
   );
 
   // Helper function to split date into components

--- a/src/applications/simple-forms/21P-601/tests/unit/submit-transform.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-601/tests/unit/submit-transform.unit.spec.jsx
@@ -512,4 +512,51 @@ describe('21P-601 submit transformer', () => {
       expect(result.expenses.expensesList[1].amount).to.equal('100');
     });
   });
+
+  describe('forbidden character sanitization', () => {
+    it('should strip double quotes from text fields', () => {
+      const testData = { data: JSON.parse(JSON.stringify(testDataSpouse)) };
+      testData.data.remarks = 'Filing for "accrued" benefits';
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.remarks).to.equal('Filing for accrued benefits');
+    });
+
+    it('should strip backslashes from text fields', () => {
+      const testData = { data: JSON.parse(JSON.stringify(testDataSpouse)) };
+      testData.data.expenses = [
+        {
+          provider: 'Test\\Hospital',
+          expenseType: 'Medical',
+          amount: '1000',
+          paidBy: 'Self',
+        },
+      ];
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.expenses.expensesList[0].provider).to.equal('TestHospital');
+    });
+
+    it('should strip forbidden characters from nested name fields', () => {
+      const testData = { data: JSON.parse(JSON.stringify(testDataSpouse)) };
+      testData.data.veteranFullName.first = 'John"';
+      testData.data.veteranFullName.last = 'Smi\\th';
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.veteran.fullName.first).to.equal('John');
+      expect(result.veteran.fullName.last).to.equal('Smith');
+    });
+
+    it('should strip forbidden characters from address fields', () => {
+      const testData = { data: JSON.parse(JSON.stringify(testDataSpouse)) };
+      testData.data.claimantAddress.street = '123 "Main" Street';
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.claimant.address.street).to.equal('123 Main Street');
+    });
+  });
 });

--- a/src/applications/simple-forms/21p-0537/config/submit-transformer.js
+++ b/src/applications/simple-forms/21p-0537/config/submit-transformer.js
@@ -1,8 +1,23 @@
 import { transformForSubmit as defaultTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 
+// Strip characters that break the backend's .json.erb interpolation
+// (unescaped double quotes and backslashes produce invalid JSON)
+const sanitizeString = value =>
+  typeof value === 'string' ? value.replace(/["\\]/g, '') : value;
+
+const sanitizeFormData = obj => {
+  if (Array.isArray(obj)) return obj.map(sanitizeFormData);
+  if (obj !== null && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, val]) => [key, sanitizeFormData(val)]),
+    );
+  }
+  return sanitizeString(obj);
+};
+
 function transformForSubmit(formConfig, form) {
-  const transformedData = JSON.parse(
-    defaultTransformForSubmit(formConfig, form),
+  const transformedData = sanitizeFormData(
+    JSON.parse(defaultTransformForSubmit(formConfig, form)),
   );
 
   // Helper function to split date into components

--- a/src/applications/simple-forms/21p-0537/tests/unit/submit-transform.unit.spec.jsx
+++ b/src/applications/simple-forms/21p-0537/tests/unit/submit-transform.unit.spec.jsx
@@ -379,4 +379,35 @@ describe('21P-0537 submit transformer', () => {
       });
     });
   });
+
+  describe('forbidden character sanitization', () => {
+    it('should strip double quotes from text fields', () => {
+      const testData = JSON.parse(JSON.stringify(testDataComplete));
+      testData.data.signature = 'Jane "M" Spouse';
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.recipient.signature).to.equal('Jane M Spouse');
+    });
+
+    it('should strip backslashes from text fields', () => {
+      const testData = JSON.parse(JSON.stringify(testDataComplete));
+      testData.data.veteranFullName.last = 'Mar\\tinez';
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.veteran.fullName.last).to.equal('Martinez');
+    });
+
+    it('should strip forbidden characters from nested remarriage fields', () => {
+      const testData = JSON.parse(JSON.stringify(testDataComplete));
+      testData.data.remarriage.spouseName.first = 'Michael"';
+      testData.data.remarriage.terminationReason = 'Death\\';
+
+      const result = JSON.parse(transformForSubmit(mockFormConfig, testData));
+
+      expect(result.remarriage.spouseName.first).to.equal('Michael');
+      expect(result.remarriage.terminationReason).to.equal('Death');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

  - Strip " and \ characters from form data in the submit transformer to prevent backend .json.erb template from producing invalid JSON
  - Applied to both 21P-601 and 21P-0537 forms
  - Added unit tests for the sanitization  

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#134207

 Test plan                                                                                                                                                                               
                                                                                         
  - Verify existing unit tests still pass                                                                                                                                                 
  - Submit 21P-601 form with " in a text field (e.g. remarks) — should succeed                                                                                                            
  - Submit 21P-0537 form with " in a text field — should succeed


## Screenshots

| Stage | Screenshot |
| --- | --- |
| Submission | <img width="1023" height="851" alt="Screenshot 2026-02-24 at 2 23 04 PM" src="https://github.com/user-attachments/assets/8cb406f1-bc62-4ff6-8fa1-734ade988ef2" /> |
| Confirmation | <img width="1531" height="1246" alt="Screenshot 2026-02-24 at 2 23 52 PM" src="https://github.com/user-attachments/assets/52a6a81d-4c9c-471e-a209-3002f404780b" /> |



## What areas of the site does it impact?

Simple Forms 21p-0537 and 21P-601

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed


### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
