### PR TITLE
fix: prettier formatting in VAOS Breadcrumbs.jsx

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -79,9 +79,12 @@ export default function VAOSBreadcrumbs({ children, labelOverride }) {
   const searchParams = new URLSearchParams(location.search);
   const referrer = searchParams.get('referrer');
 
-  useEffect(() => {
-    setBreadcrumb(newLabel);
-  }, [location, newLabel]);
+  useEffect(
+    () => {
+      setBreadcrumb(newLabel);
+    },
+    [location, newLabel],
+  );
 
   const getBreadcrumbList = () => {
     const isPast = location.pathname.includes('/past');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _This is an additional fix PR for the linting issue surfaced by the Platform Frontend CoP._

## Related issue(s)

- [Platform CoP thread](https://dsva.slack.com/archives/C04868KS69L/p1771964421654739)


## Testing done

- _File change passes local and CI linting commands_

