### PR TITLE
10-7959c | Update statement of truth validation

### DIFF
--- a/src/applications/ivc-champva/10-7959C/components/PreSubmitInfo/index.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/PreSubmitInfo/index.jsx
@@ -51,7 +51,7 @@ const PreSubmitInfo = ({ formData, showError, onSectionComplete }) => {
 
   const applicantName = useMemo(
     () => {
-      const { first, middle, last } = formData.applicantName;
+      const { first, middle, last } = formData.applicantName || {};
       return [first, middle, last]
         .map(part => part?.trim())
         .filter(Boolean)

--- a/src/applications/ivc-champva/10-7959C/components/PreSubmitInfo/index.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/PreSubmitInfo/index.jsx
@@ -9,10 +9,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import content from '../../locales/en/content.json';
-import {
-  formatFullName,
-  replaceStrValues,
-} from '../../utils/helpers/formatting';
+import { replaceStrValues } from '../../utils/helpers/formatting';
 import { VaStatementOfTruth } from '../../utils/imports';
 
 const STATEMENT_TEXT_DEFAULT = content['statement-of-truth--default'];
@@ -53,7 +50,13 @@ const PreSubmitInfo = ({ formData, showError, onSectionComplete }) => {
   );
 
   const applicantName = useMemo(
-    () => formatFullName(formData.applicantName, { includeMiddle: true }),
+    () => {
+      const { first, middle, last } = formData.applicantName;
+      return [first, middle, last]
+        .map(part => part?.trim())
+        .filter(Boolean)
+        .join(' ');
+    },
     [formData.applicantName],
   );
 

--- a/src/applications/ivc-champva/10-7959C/tests/unit/components/PreSubmitInfo/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/unit/components/PreSubmitInfo/PreSubmitInfo.unit.spec.jsx
@@ -32,7 +32,7 @@ const subject = ({
   };
   const props = {
     formData: {
-      applicantName: { first: 'John', middle: 'Q', last: 'Doe' },
+      applicantName: { first: 'John ', middle: 'Q', last: 'Doe', suffix: 'II' },
       certifierRole: role,
       signature,
     },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR simplifies the way applicant names are formatted in the `PreSubmitInfo` component by removing the dependency on the `formatFullName` helper and implementing the formatting logic directly within the component. This change also updates the relevant unit test data to include a `suffix` field.

### Refactoring and simplification:

* Removed the import and usage of the `formatFullName` helper from `PreSubmitInfo/index.jsx`, and replaced it with inline logic to concatenate the applicant's first, middle, and last names, trimming whitespace and filtering out empty values.

### Test updates:

* Updated the unit test for `PreSubmitInfo` to include a `suffix` field in the `applicantName` object, ensuring the test data aligns with possible real-world input.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#134307

## Testing done

- Prior to the update, validation would occur on all name parts and additional whitespace would be accounted for.
- After the update, validation occurs on the first, middle and last name values and all whitespace is trimmed from values.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Validation accepts first, middle and last name parts only
- All whitespace is trimmed from value validation

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
