### PR TITLE
10-10CG | Update statement of truth validation

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
-import { normalizeFullName } from '../../utils/helpers';
 import { DEFAULT_SIGNATURE_STATE } from '../../utils/constants';
 import { useSignaturesSync } from '../../hooks/useSignatureSync';
 import SubmitLoadingIndicator from './SubmitLoadingIndicator';
@@ -65,8 +64,13 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
           !hasSubmittedForm &&
           ((dirty && hasInvalidInputValue) || (!dirty && showError));
 
+        const nameToValidate = [fullName.first, fullName.middle, fullName.last]
+          .map(part => part?.trim())
+          .filter(Boolean)
+          .join(' ');
+
         const itemProps = {
-          fullName: normalizeFullName(fullName, true),
+          fullName: nameToValidate,
           hasCheckboxError,
           hasInputError,
           isRep,

--- a/src/applications/caregivers/hooks/useSignatureSync.jsx
+++ b/src/applications/caregivers/hooks/useSignatureSync.jsx
@@ -73,7 +73,7 @@ export const useSignaturesSync = ({ formData, isRep }) => {
         shouldRender: hasSecondaryCaregiverTwo(formData),
       },
     }),
-    [formData, isRep],
+    [formData, isRep, veteranName],
   );
 
   const requiredElements = Object.values(signatureConfig).filter(

--- a/src/applications/caregivers/tests/unit/components/PreSubmitInfo/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/PreSubmitInfo/PreSubmitInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ERROR_MSG_INPUT_REP } from '../../../../components/PreSubmitInfo/Statem
 import * as useSignaturesSyncModule from '../../../../hooks/useSignatureSync';
 import PreSubmitInfo from '../../../../components/PreSubmitInfo';
 
-const MOCK_FULL_NAME = { first: 'John', last: 'Smith' };
+const MOCK_FULL_NAME = { first: 'John ', last: 'Smith', suffix: 'II' };
 
 describe('CG <PreSubmitCheckboxGroup>', () => {
   let dispatch;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the caregiver application form's pre-submit information handling, focusing on improving how full names are processed and ensuring that signature validation logic is more robust. The changes streamline name normalization, enhance input validation, and improve test coverage for name-related logic.

**Improvements to name handling and validation:**

* Replaced the use of `normalizeFullName` with a custom inline approach that trims and joins the `first`, `middle`, and `last` name fields, ensuring cleaner and more consistent name validation for the pre-submit checkbox group.
* Updated the mock full name in the pre-submit info unit test to include a suffix and trailing whitespace, improving test coverage for edge cases in name handling.

**Enhancements to signature synchronization logic:**

* Added `veteranName` as a dependency in the `useSignaturesSync` hook to ensure that signature-related UI updates correctly when the veteran's name changes.

**Code cleanup:**

* Removed the unused import of `normalizeFullName` from the pre-submit info component.

### Test updates:

* Updated the unit test for `PreSubmitInfo` to include a `suffix` field in the `applicantName` object, ensuring the test data aligns with possible real-world input.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#134344

## Testing done

- Prior to the update, validation would occur on all name parts and additional whitespace would be accounted for.
- After the update, validation occurs on the first, middle and last name values and all whitespace is trimmed from values.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Validation accepts first, middle and last name parts only
- All whitespace is trimmed from value validation

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
