### PR TITLE
Fix missing trailing slash in /sign-in-health-portal redirect

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -173,7 +173,7 @@ export default function AuthApp({ location }) {
       setupProfileSession(userProfile);
     }
     if (needsPortalNotice) {
-      window.location.replace('/sign-in-health-portal');
+      window.location.replace('/sign-in-health-portal/');
       return;
     }
     if (needsMyHealth) {

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -448,7 +448,7 @@ describe('AuthApp', () => {
       </Provider>,
     );
     await waitFor(() => expect(window.location.replace.calledOnce).to.be.true);
-    expect(window.location.replace.calledWith('/sign-in-health-portal')).to.be
+    expect(window.location.replace.calledWith('/sign-in-health-portal/')).to.be
       .true;
     window.location = originalLocation;
     sessionStorage.clear();


### PR DESCRIPTION
## Summary

Adds a trailing slash to the `/sign-in-health-portal` redirect in the auth callback flow, eliminating an unnecessary 302 redirect on every request.

## Problem

`window.location.replace('/sign-in-health-portal')` causes two requests per user:
1. `GET /sign-in-health-portal` → **302** (nginx adds trailing slash)
2. `GET /sign-in-health-portal/` → **200** (page served)

## Fix

Changed to `window.location.replace('/sign-in-health-portal/')` and updated the corresponding test assertion.

## Testing

- [x] Unit tests pass (37 passing)

Closes department-of-veterans-affairs/va.gov-team#134356
