### PR TITLE
[#130332] Fixed clearing alerts when navigating away from review page

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
@@ -52,6 +52,16 @@ const ReviewPage = () => {
     [alertMessage],
   );
 
+  // Clear alert when user navigates away from review page
+  useEffect(
+    () => {
+      return () => {
+        dispatch(clearReviewPageAlert());
+      };
+    },
+    [dispatch],
+  );
+
   // Get total by expense type and return expenses in EXPENSE_TYPES order
   const totalByExpenseType = Object.fromEntries(
     Object.entries(

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ReviewPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ReviewPage.unit.spec.jsx
@@ -502,4 +502,51 @@ describe('Travel Pay – ReviewPage', () => {
       );
     });
   });
+
+  it('clears alert when navigating away from review page', async () => {
+    const AlertDisplay = () => {
+      const alert = useSelector(state => state.travelPay.reviewPageAlert);
+      return (
+        <div data-testid="alert-display">
+          {alert ? 'has-alert' : 'no-alert'}
+        </div>
+      );
+    };
+
+    const OtherPage = () => <div data-testid="other-page">Other Page</div>;
+
+    const { getByTestId, container } = renderWithStoreAndRouter(
+      <MemoryRouter
+        initialEntries={[`/file-new-claim/${apptId}/${claimId}/review`]}
+      >
+        <Routes>
+          <Route
+            path="/file-new-claim/:apptId/:claimId/review"
+            element={<ReviewPage />}
+          />
+          <Route
+            path="/file-new-claim/:apptId/:claimId/other"
+            element={<OtherPage />}
+          />
+        </Routes>
+        <AlertDisplay />
+      </MemoryRouter>,
+      {
+        initialState: getData(),
+        reducers: reducer,
+      },
+    );
+
+    // Verify alert is initially present
+    expect(getByTestId('alert-display').textContent).to.equal('has-alert');
+
+    // Navigate away from review page to trigger unmount
+    const addButton = container.querySelector('#add-expense-button');
+    fireEvent.click(addButton);
+
+    // Wait for navigation and check alert is cleared
+    await waitFor(() => {
+      expect(getByTestId('alert-display').textContent).to.equal('no-alert');
+    });
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No

## Summary
- Added functionality to clear alerts when the user navigates away from the review page. 
   - Old scenario: User would edit an expense --> see success alert --> start to edit a second expense --> cancel editing --> returns to review page and the previous success alert was still displayed
   
- _(Which team do you work for, does your team own the maintenance of this component?)_
    - Travel Pay

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/130332

## Testing done
- Added tests in `src/applications/travel-pay/tests/components/complex-claims/pages/ReviewPage.unit.spec.jsx`

## Screenshots

https://github.com/user-attachments/assets/1bc91438-42b4-4dca-9a93-47f12844f9cf

## What areas of the site does it impact?
Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
