### PR TITLE
Add error wrapper handling to all api calls

### DIFF
--- a/src/applications/vass/pages/CancelConfirmation.jsx
+++ b/src/applications/vass/pages/CancelConfirmation.jsx
@@ -4,10 +4,15 @@ import Wrapper from '../layout/Wrapper';
 import AppointmentCard from '../components/AppointmentCard';
 import { VASS_PHONE_NUMBER } from '../utils/constants';
 import { useGetAppointmentQuery } from '../redux/api/vassApi';
+import { isServerError, isAppointmentNotFoundError } from '../utils/errors';
 
 const CancelConfirmation = () => {
   const { appointmentId } = useParams();
-  const { data: appointmentData, isLoading } = useGetAppointmentQuery({
+  const {
+    data: appointmentData,
+    isLoading,
+    error: appointmentError,
+  } = useGetAppointmentQuery({
     appointmentId,
   });
   return (
@@ -17,6 +22,10 @@ const CancelConfirmation = () => {
       loading={isLoading}
       pageTitle="You have canceled your appointment"
       loadingMessage="Loading appointment details. This may take up to 30 seconds. Please don’t refresh the page."
+      errorAlert={
+        isServerError(appointmentError) ||
+        isAppointmentNotFoundError(appointmentError)
+      }
     >
       <p
         className="vads-u-margin-bottom--4"

--- a/src/applications/vass/pages/CancelConfirmation.unit.spec.jsx
+++ b/src/applications/vass/pages/CancelConfirmation.unit.spec.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
+import { waitFor } from '@testing-library/react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 as renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 
 import CancelConfirmation from './CancelConfirmation';
 import { getDefaultRenderOptions } from '../utils/test-utils';
@@ -9,7 +16,12 @@ import {
   createAppointmentData,
   createVassApiStateWithAppointment,
 } from '../utils/appointments';
+import * as authUtils from '../utils/auth';
 import { URLS } from '../utils/constants';
+import {
+  createServiceError,
+  createAppointmentNotFoundError,
+} from '../services/mocks/utils/errors';
 
 const appointmentId = 'abcdef123456';
 const appointmentData = createAppointmentData({ appointmentId });
@@ -39,5 +51,74 @@ describe('VASS Component: CancelConfirmation', () => {
     );
     expect(getByTestId('cancel-confirmation-phone')).to.exist;
     expect(getByTestId('appointment-card')).to.exist;
+  });
+
+  describe('API error handling', () => {
+    let getVassTokenStub;
+
+    beforeEach(() => {
+      mockFetch();
+      getVassTokenStub = sinon
+        .stub(authUtils, 'getVassToken')
+        .returns('mock-token');
+    });
+
+    afterEach(() => {
+      resetFetch();
+      getVassTokenStub.restore();
+    });
+
+    it('should display error alert when getAppointment returns a server error', async () => {
+      setFetchJSONFailure(global.fetch.onCall(0), createServiceError());
+
+      const { getByTestId, queryByTestId } = renderWithStoreAndRouter(
+        <Routes>
+          <Route
+            path={`${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/:appointmentId`}
+            element={<CancelConfirmation />}
+          />
+        </Routes>,
+        {
+          ...getDefaultRenderOptions(),
+          initialEntries: [
+            `${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/${appointmentId}`,
+          ],
+        },
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('api-error-alert')).to.exist;
+        expect(queryByTestId('header')).to.not.exist;
+        expect(queryByTestId('cancel-confirmation-message')).to.not.exist;
+      });
+    });
+
+    it('should display error alert when getAppointment returns appointment not found', async () => {
+      setFetchJSONFailure(
+        global.fetch.onCall(0),
+        createAppointmentNotFoundError(),
+      );
+
+      const { getByTestId, queryByTestId } = renderWithStoreAndRouter(
+        <Routes>
+          <Route
+            path={`${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/:appointmentId`}
+            element={<CancelConfirmation />}
+          />
+        </Routes>,
+        {
+          ...getDefaultRenderOptions(),
+          initialEntries: [
+            `${URLS.CANCEL_APPOINTMENT_CONFIRMATION}/${appointmentId}`,
+          ],
+        },
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('api-error-alert')).to.exist;
+        expect(queryByTestId('header')).to.not.exist;
+        expect(queryByTestId('appointment-card')).to.not.exist;
+      });
+    });
   });
 });

--- a/src/applications/vass/pages/EnterOTP.jsx
+++ b/src/applications/vass/pages/EnterOTP.jsx
@@ -16,6 +16,7 @@ import {
   isAccountLockedError,
   isServerError,
   isAppointmentAlreadyBookedError,
+  isNotWhithinCohortError,
 } from '../utils/errors';
 
 const getErrorMessage = (errorCode, attemptsRemaining = 0) => {
@@ -63,7 +64,7 @@ const EnterOTP = () => {
   ] = usePostOTPVerificationMutation();
   const [
     getAppointmentAvailability,
-    { isFetching: isCheckingAvailability },
+    { isFetching: isCheckingAvailability, error: appointmentAvailabilityError },
   ] = useLazyGetAppointmentAvailabilityQuery();
 
   const handleSubmit = async () => {
@@ -93,6 +94,13 @@ const EnterOTP = () => {
     }
 
     const availabilityCheck = await getAppointmentAvailability();
+
+    if (
+      isServerError(availabilityCheck.error) ||
+      isNotWhithinCohortError(availabilityCheck.error)
+    ) {
+      return;
+    }
 
     if (isAppointmentAlreadyBookedError(availabilityCheck.error)) {
       const { appointmentId } = availabilityCheck.error.appointment;
@@ -127,7 +135,11 @@ const EnterOTP = () => {
           ? errorMessage
           : undefined
       }
-      errorAlert={isServerError(postOTPVerificationError)}
+      errorAlert={
+        isServerError(postOTPVerificationError) ||
+        isServerError(appointmentAvailabilityError) ||
+        isNotWhithinCohortError(appointmentAvailabilityError)
+      }
     >
       {!postOTPVerificationError?.code && (
         <va-alert

--- a/src/applications/vass/pages/EnterOTP.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTP.unit.spec.jsx
@@ -20,6 +20,8 @@ import {
   createOTPInvalidError,
   createOTPAccountLockedError,
   createAppointmentAlreadyBookedError,
+  createVassApiError,
+  createNotWithinCohortError,
 } from '../services/mocks/utils/errors';
 import { createAppointmentAvailabilityResponse } from '../services/mocks/utils/responses';
 
@@ -241,6 +243,92 @@ describe('VASS Component: EnterOTP', () => {
       await waitFor(() => {
         const otpInput = getByTestId('otp-input');
         expect(otpInput.getAttribute('value')).to.equal('');
+      });
+    });
+
+    describe('appointment availability', () => {
+      it('should display error alert when availability check returns a server error', async () => {
+        setFetchJSONResponse(global.fetch.onCall(0), {
+          data: {
+            token: 'jwt-token',
+            expiresIn: 3600,
+            tokenType: 'Bearer',
+          },
+        });
+        setFetchJSONFailure(global.fetch.onCall(1), createVassApiError());
+
+        const { container, getByTestId, queryByTestId } = renderComponent();
+        inputVaTextInput(container, '123456', 'va-text-input[name="otp"]');
+        const continueButton = getByTestId('continue-button');
+        continueButton.click();
+
+        await waitFor(() => {
+          expect(getByTestId('api-error-alert')).to.exist;
+          expect(queryByTestId('header')).to.not.exist;
+        });
+      });
+
+      it('should display error alert when availability check returns a not-within-cohort error', async () => {
+        setFetchJSONResponse(global.fetch.onCall(0), {
+          data: {
+            token: 'jwt-token',
+            expiresIn: 3600,
+            tokenType: 'Bearer',
+          },
+        });
+        setFetchJSONFailure(
+          global.fetch.onCall(1),
+          createNotWithinCohortError(),
+        );
+
+        const { container, getByTestId, queryByTestId } = renderComponent();
+        inputVaTextInput(container, '123456', 'va-text-input[name="otp"]');
+        const continueButton = getByTestId('continue-button');
+        continueButton.click();
+
+        await waitFor(() => {
+          expect(getByTestId('api-error-alert')).to.exist;
+          expect(queryByTestId('header')).to.not.exist;
+        });
+      });
+
+      it('should not navigate when availability check returns a server error', async () => {
+        setFetchJSONResponse(global.fetch.onCall(0), {
+          data: {
+            token: 'jwt-token',
+            expiresIn: 3600,
+            tokenType: 'Bearer',
+          },
+        });
+        setFetchJSONFailure(global.fetch.onCall(1), createVassApiError());
+
+        const { container, getByTestId } = renderWithStoreAndRouterV6(
+          <>
+            <Routes>
+              <Route path={URLS.ENTER_OTP} element={<EnterOTP />} />
+              <Route
+                path={URLS.DATE_TIME}
+                element={<div>Date Time Page</div>}
+              />
+            </Routes>
+            <LocationDisplay />
+          </>,
+          {
+            ...defaultRenderOptions,
+            initialEntries: [URLS.ENTER_OTP],
+          },
+        );
+
+        inputVaTextInput(container, '123456', 'va-text-input[name="otp"]');
+        const continueButton = getByTestId('continue-button');
+        continueButton.click();
+
+        await waitFor(() => {
+          expect(getByTestId('api-error-alert')).to.exist;
+          expect(getByTestId('location-display').textContent).to.equal(
+            URLS.ENTER_OTP,
+          );
+        });
       });
     });
   });

--- a/src/applications/vass/pages/EnterOTP.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTP.unit.spec.jsx
@@ -223,6 +223,7 @@ describe('VASS Component: EnterOTP', () => {
         );
       });
     });
+
     it('should hide success alert when error is displayed', async () => {
       setFetchJSONFailure(global.fetch.onCall(0), createOTPInvalidError(2));
       const { container, getByTestId, queryByTestId } = renderComponent();
@@ -232,17 +233,6 @@ describe('VASS Component: EnterOTP', () => {
       await waitFor(() => {
         expect(getByTestId('enter-otp-error-alert')).to.exist;
         expect(queryByTestId('enter-otp-success-alert')).to.not.exist;
-      });
-    });
-    it('should clear the otp input after an error', async () => {
-      setFetchJSONFailure(global.fetch.onCall(0), createOTPInvalidError(2));
-      const { container, getByTestId } = renderComponent();
-      inputVaTextInput(container, '123456', 'va-text-input[name="otp"]');
-      const continueButton = getByTestId('continue-button');
-      continueButton.click();
-      await waitFor(() => {
-        const otpInput = getByTestId('otp-input');
-        expect(otpInput.getAttribute('value')).to.equal('');
       });
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Two VASS pages (EnterOTP and CancelConfirmation) were missing errorAlert handling for certain
  API calls, meaning API failures could leave users on a broken or stuck page with no feedback.
  - EnterOTP.jsx: After successful OTP verification, the getAppointmentAvailability lazy query was
  only checking for isAppointmentAlreadyBookedError. Server errors (isServerError) and
  not-within-cohort errors (isNotWhithinCohortError) were silently swallowed. Now these errors
  trigger the errorAlert prop on Wrapper, which renders the <ErrorAlert /> component, and an early
  return in handleSubmit prevents unintended navigation.
  - CancelConfirmation.jsx: The useGetAppointmentQuery hook's error was never destructured or
  checked. If the API returned a server error or appointment-not-found error, the page would show a
   loading spinner indefinitely. Now it destructures error: appointmentError and passes
  errorAlert={isServerError(appointmentError) || isAppointmentNotFoundError(appointmentError)} to
  Wrapper.
  - Both fixes follow the same pattern already used across all other VASS pages (Verify,
  DateTimeSelection, TopicSelection, Review, Confirmation, CancelAppointment, AlreadyScheduled).
  - Team: VASS / VA Solid Start Scheduling. This team owns maintenance of this component.

## Related issue(s)
  - department-of-veterans-affairs/va.gov-team#134473

## Testing done

- Old behavior (EnterOTP): If getAppointmentAvailability returned a server error or
  not-within-cohort error after successful OTP verification, the page silently failed — no error UI
   was shown and the user was stuck with no indication of what went wrong.
  - Old behavior (CancelConfirmation): If getAppointment returned a server error or
  appointment-not-found error, the page displayed a loading spinner indefinitely with no error
  message.
  - Steps to verify:
    a. On EnterOTP, submit a valid 6-digit OTP code. If the availability API returns a
  vass_api_error, service_error, or not_within_cohort error, the <ErrorAlert /> component should
  render in place of the page content (header and form hidden).
    b. On CancelConfirmation, if the getAppointment API returns a service_error or
  appointment_not_found error, the <ErrorAlert /> component should render in place of the
  confirmation message and appointment card.
    c. Verify that all other existing flows (happy path, OTP errors, already-booked redirect,
  cancel flow) continue to work as before.
  - Unit tests added and passing (5 new tests):
    - EnterOTP.unit.spec.jsx — 3 new tests under API error handling > appointment availability:
        - Displays api-error-alert and hides header on server error from availability check
      - Displays api-error-alert and hides header on not-within-cohort error from availability
  check
      - Does not navigate away when availability check returns a server error
    - CancelConfirmation.unit.spec.jsx — 2 new tests under API error handling:
        - Displays api-error-alert and hides header/content on server error from getAppointment
      - Displays api-error-alert and hides header/appointment card on appointment-not-found error
  - All 19 EnterOTP tests and 3 CancelConfirmation tests pass locally.

## Screenshots

  N/A — No visual UI changes. The <ErrorAlert /> component already exists and is rendered
  identically to how it appears on all other VASS pages when an API error occurs. This change only
  ensures it is triggered in the two pages where it was previously missing.

## What areas of the site does it impact?

  This change only impacts the VASS (VA Solid Start Scheduling) application under
  /src/applications/vass. Specifically:
  - /enter-otp page — error handling after the appointment availability check
  - /cancel-appointment-confirmation/:appointmentId page — error handling for the appointment
  details fetch

  No other applications or platform code are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
