### PR TITLE
0781 Enhancement - Feat: Flatten Additional Documents on Submit

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.jsx
@@ -1937,4 +1937,192 @@ describe('flattenAttachments', () => {
       ],
     });
   });
+
+  it('should return cloned data when additionalDocuments is undefined', () => {
+    const formData = {
+      veteranFullName: { first: 'John', last: 'Doe' },
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result).to.deep.equal(formData);
+    expect(result).to.not.equal(formData);
+  });
+
+  it('should return cloned data when additionalDocuments is an empty array', () => {
+    const formData = {
+      additionalDocuments: [],
+      veteranFullName: { first: 'John', last: 'Doe' },
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result).to.deep.equal(formData);
+    expect(result.additionalDocuments).to.be.an('array').that.is.empty;
+  });
+
+  it('should return cloned data when additionalDocuments has no additionalData', () => {
+    const formData = {
+      additionalDocuments: [
+        {
+          name: 'document.pdf',
+          confirmationCode: 'abc123',
+          size: 1024,
+        },
+      ],
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result).to.deep.equal(formData);
+    expect(result.additionalDocuments[0]).to.not.have.property(
+      'additionalData',
+    );
+  });
+
+  it('should flatten additionalData properties into additionalDocuments attachment object', () => {
+    const formData = {
+      additionalDocuments: [
+        {
+          name: 'evidence.pdf',
+          confirmationCode: 'xyz789',
+          isEncrypted: false,
+          size: 2048,
+          type: 'application/pdf',
+          additionalData: {
+            attachmentId: 'L702',
+          },
+        },
+      ],
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result.additionalDocuments).to.have.lengthOf(1);
+    expect(result.additionalDocuments[0]).to.deep.equal({
+      name: 'evidence.pdf',
+      confirmationCode: 'xyz789',
+      isEncrypted: false,
+      size: 2048,
+      type: 'application/pdf',
+      attachmentId: 'L702',
+    });
+    expect(result.additionalDocuments[0]).to.not.have.property(
+      'additionalData',
+    );
+  });
+
+  it('should handle multiple additionalDocuments with additionalData', () => {
+    const formData = {
+      additionalDocuments: [
+        {
+          name: 'doc1.pdf',
+          confirmationCode: 'code1',
+          size: 1024,
+          additionalData: {
+            attachmentId: 'L015',
+          },
+        },
+        {
+          name: 'doc2.pdf',
+          confirmationCode: 'code2',
+          size: 2048,
+          additionalData: {
+            attachmentId: 'L702',
+          },
+        },
+        {
+          name: 'doc3.pdf',
+          confirmationCode: 'code3',
+          size: 3072,
+          additionalData: {
+            attachmentId: 'L107',
+          },
+        },
+      ],
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result.additionalDocuments).to.have.lengthOf(3);
+    expect(result.additionalDocuments[0].attachmentId).to.equal('L015');
+    expect(result.additionalDocuments[1].attachmentId).to.equal('L702');
+    expect(result.additionalDocuments[2].attachmentId).to.equal('L107');
+    result.additionalDocuments.forEach(doc => {
+      expect(doc).to.not.have.property('additionalData');
+    });
+  });
+
+  it('should handle both privateMedicalRecordAttachments and additionalDocuments with additionalData', () => {
+    const formData = {
+      privateMedicalRecordAttachments: [
+        {
+          name: 'medical-record.pdf',
+          confirmationCode: 'pmr123',
+          size: 5120,
+          additionalData: {
+            attachmentId: 'L049',
+          },
+        },
+      ],
+      additionalDocuments: [
+        {
+          name: 'evidence.pdf',
+          confirmationCode: 'doc456',
+          size: 2048,
+          additionalData: {
+            attachmentId: 'L702',
+          },
+        },
+      ],
+      veteranFullName: { first: 'Jane', last: 'Smith' },
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result.privateMedicalRecordAttachments).to.have.lengthOf(1);
+    expect(result.privateMedicalRecordAttachments[0].attachmentId).to.equal(
+      'L049',
+    );
+    expect(result.privateMedicalRecordAttachments[0]).to.not.have.property(
+      'additionalData',
+    );
+
+    expect(result.additionalDocuments).to.have.lengthOf(1);
+    expect(result.additionalDocuments[0].attachmentId).to.equal('L702');
+    expect(result.additionalDocuments[0]).to.not.have.property(
+      'additionalData',
+    );
+
+    expect(result.veteranFullName).to.deep.equal({
+      first: 'Jane',
+      last: 'Smith',
+    });
+  });
+
+  it('should preserve other formData properties when flattening additionalDocuments', () => {
+    const formData = {
+      additionalDocuments: [
+        {
+          name: 'document.pdf',
+          confirmationCode: 'abc123',
+          size: 1024,
+          additionalData: {
+            attachmentId: 'L023',
+          },
+        },
+      ],
+      veteranFullName: { first: 'Bob', last: 'Johnson' },
+      disabilities: ['Back pain', 'Knee injury'],
+    };
+
+    const result = flattenAttachments(formData);
+
+    expect(result.veteranFullName).to.deep.equal({
+      first: 'Bob',
+      last: 'Johnson',
+    });
+    expect(result.disabilities).to.deep.equal(['Back pain', 'Knee injury']);
+    expect(result.additionalDocuments[0].attachmentId).to.equal('L023');
+  });
 });

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -918,7 +918,6 @@ export const addForm8940 = formData => {
 export const flattenAttachments = formData => {
   const pmrAttachments = formData.privateMedicalRecordAttachments;
   const addtnlDcs = formData.additionalDocuments;
-  // TODO: add additionalDocuments into this function as it utilizes the V3 component.
   const clonedData = _.cloneDeep(formData);
   // V3 file input always (until deprecated) includes additionalData on all attachments when the
   // enhancement toggle is on, so checking the first element is sufficient.

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -917,6 +917,7 @@ export const addForm8940 = formData => {
  */
 export const flattenAttachments = formData => {
   const pmrAttachments = formData.privateMedicalRecordAttachments;
+  const addtnlDcs = formData.additionalDocuments;
   // TODO: add additionalDocuments into this function as it utilizes the V3 component.
   const clonedData = _.cloneDeep(formData);
   // V3 file input always (until deprecated) includes additionalData on all attachments when the
@@ -928,6 +929,12 @@ export const flattenAttachments = formData => {
         return { ...rest, ...additionalData };
       },
     );
+  }
+  if (addtnlDcs && addtnlDcs[0]?.additionalData) {
+    clonedData.additionalDocuments = addtnlDcs.map(attachment => {
+      const { additionalData, ...rest } = attachment;
+      return { ...rest, ...additionalData };
+    });
   }
   return clonedData;
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

While utilizing the V3 File Input Component, we need to flatten the attachments for supporting documents as the V3 File Input component encapsulates the document type inside `additionalData`. This wouldn't allow a veteran to successfully submit as the `vets-json-schema` expects a `attachmentId` which is in `additionalData`. This is the fix to flatten the supporting evidence uploads for successful submissions.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/133908

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/133908

## Testing done

- wrote additional unit tests
- Locally submitted a payload

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
- 526 on submit

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user