### PR TITLE
feat: Add digital BDD SHA feature flag

### DIFF
--- a/src/applications/disability-benefits/all-claims/local-dev-mock-api/featureToggles.json
+++ b/src/applications/disability-benefits/all-claims/local-dev-mock-api/featureToggles.json
@@ -23,6 +23,10 @@
         "value": true
       },
       {
+        "name": "disability_526_new_bdd_sha_enforcement_workflow_enabled",
+        "value": true
+      },
+      {
         "name": "disability_526_maximum_rating",
         "value": true
       },

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
@@ -23,6 +23,10 @@
         "value": true
       },
       {
+        "name": "disability_526_new_bdd_sha_enforcement_workflow_enabled",
+        "value": false
+      },
+      {
         "name": "disability_compensation_toxic_exposure_destruction_modal",
         "value": false
       },
@@ -41,4 +45,3 @@
     ]
   }
 }
-

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -15,6 +15,7 @@
   "authExpVbaDowntimeMessage": "auth_exp_vba_downtime_message",
   "avsEnabled": "avs_enabled",
   "bannerUseAlternativeBanners": "banner_use_alternative_banners",
+  "disability526NewBddShaEnforcementWorkflowEnabled": "disability_526_new_bdd_sha_enforcement_workflow_enabled",
   "benefitsDocumentsUseLighthouse": "benefits_documents_use_lighthouse",
   "benefitsNonDisabilityCh31V2": "benefits_non_disability_ch31_v2",
   "bioHeartMMSSubmit": "bio_heart_mms_submit",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds a new feature toggle disability_526_new_bdd_sha_enforcement_workflow_enabled to enable the new digital BDD SHA upload experience
- Team: Benefits Disability Experience
- Success criteria: Feature toggle will be used to safely test and roll out the new SHA upload experience in the 526 disability compensation form.

## Related issue(s)

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/133650
Backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/26781

## Testing done

- Feature toggle registration only - no behavioral changes until toggle is enabled
- Toggle defaults to `false` in mock and test fixtures
- Added toggle to `useFormFeatureToggleSync` hook for automatic sync to formData
- Verified all JSON files pass syntax validation
- Lint-staged checks passed

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

N/A - Config only

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added, N/A, config only
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user