### PR TITLE
Remove development letter notification from ClaimsListItem component and related tests to streamline communication alerts. Update unit tests to reflect changes in decision letter visibility logic.

### DIFF
--- a/src/applications/claims-status/components/ClaimsListItem.jsx
+++ b/src/applications/claims-status/components/ClaimsListItem.jsx
@@ -58,7 +58,6 @@ export default function ClaimsListItem({ claim }) {
     claimPhaseDates,
     claimTypeCode,
     decisionLetterSent,
-    developmentLetterSent,
     documentsNeeded,
     status,
     evidenceSubmissions = [],
@@ -96,11 +95,6 @@ export default function ClaimsListItem({ claim }) {
       subtitle={`Received on ${formattedReceiptDate}`}
     >
       <ul className="communications">
-        {showPrecomms && developmentLetterSent ? (
-          <CommunicationsItem icon="mail">
-            We sent you a development letter
-          </CommunicationsItem>
-        ) : null}
         {decisionLetterSent && (
           <CommunicationsItem icon="mail">
             You have a decision letter ready

--- a/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
@@ -40,7 +40,7 @@ const compensationClaimTypeCode = '110LCMP7IDES'; // 5103 Notice
 
 describe('<ClaimsListItem>', () => {
   context(
-    'cstClaimPhases feature flag enabled and compenstaiton claim type code',
+    'cstClaimPhases feature flag enabled and compensation claim type code',
     () => {
       it('should not show any flags and render proper fields', () => {
         const claim = {
@@ -189,31 +189,7 @@ describe('<ClaimsListItem>', () => {
         );
         getByText('Step 7 of 8: Final review');
       });
-      it('should show development letter flag', () => {
-        const claim = {
-          id: 1,
-          attributes: {
-            claimPhaseDates: {
-              phaseChangeDate: '2024-06-08',
-              phaseType: 'GATHERING_OF_EVIDENCE',
-            },
-            claimTypeCode: compensationClaimTypeCode,
-            decisionLetterSent: false,
-            developmentLetterSent: true,
-            documentsNeeded: false,
-            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
-          },
-        };
-
-        const { getByText } = renderWithRouter(
-          <Provider store={getStore()}>
-            <ClaimsListItem claim={claim} />
-          </Provider>,
-        );
-        getByText('We sent you a development letter');
-        getByText('Step 3 of 8: Evidence gathering');
-      });
-      it('should show decision letter flag decisionLetterSent is true, but not render the other flags', () => {
+      it('should show decision letter and suppress items needed alert when decisionLetterSent is true', () => {
         const claim = {
           id: 1,
           attributes: {
@@ -223,7 +199,6 @@ describe('<ClaimsListItem>', () => {
             },
             claimTypeCode: compensationClaimTypeCode,
             decisionLetterSent: true,
-            developmentLetterSent: true,
             documentsNeeded: true,
             status: 'INITIAL_REVIEW',
           },
@@ -234,7 +209,6 @@ describe('<ClaimsListItem>', () => {
             <ClaimsListItem claim={claim} />
           </Provider>,
         );
-        expect(queryByText('We sent you a development letter')).to.be.null;
         expect(queryByText('We requested more information from you:')).to.be
           .null;
         expect(getByText('You have a decision letter ready')).to.exist;
@@ -471,31 +445,7 @@ describe('<ClaimsListItem>', () => {
         );
         getByText('Step 4 of 5: Preparation for notification');
       });
-      it('should show development letter flag', () => {
-        const claim = {
-          id: 1,
-          attributes: {
-            claimPhaseDates: {
-              phaseChangeDate: '2024-06-08',
-              phaseType: 'GATHERING_OF_EVIDENCE',
-            },
-            claimTypeCode: dependencyClaimTypeCode,
-            decisionLetterSent: false,
-            developmentLetterSent: true,
-            documentsNeeded: false,
-            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
-          },
-        };
-
-        const { getByText } = renderWithRouter(
-          <Provider store={getStore()}>
-            <ClaimsListItem claim={claim} />
-          </Provider>,
-        );
-        getByText('We sent you a development letter');
-        getByText('Step 3 of 5: Evidence gathering, review, and decision');
-      });
-      it('should show decision letter flag decisionLetterSent is true, but not render the other flags', () => {
+      it('should show decision letter and suppress items needed alert when decisionLetterSent is true', () => {
         const claim = {
           id: 1,
           attributes: {
@@ -505,7 +455,6 @@ describe('<ClaimsListItem>', () => {
             },
             claimTypeCode: dependencyClaimTypeCode,
             decisionLetterSent: true,
-            developmentLetterSent: true,
             documentsNeeded: true,
             status: 'INITIAL_REVIEW',
           },
@@ -516,7 +465,6 @@ describe('<ClaimsListItem>', () => {
             <ClaimsListItem claim={claim} />
           </Provider>,
         );
-        expect(queryByText('We sent you a development letter')).to.be.null;
         expect(queryByText('We requested more information from you:')).to.be
           .null;
         expect(getByText('You have a decision letter ready')).to.exist;
@@ -753,31 +701,7 @@ describe('<ClaimsListItem>', () => {
         );
         getByText('Step 4 of 5: Preparation for notification');
       });
-      it('should show development letter flag', () => {
-        const claim = {
-          id: 1,
-          attributes: {
-            claimPhaseDates: {
-              phaseChangeDate: '2024-06-08',
-              phaseType: 'GATHERING_OF_EVIDENCE',
-            },
-            claimTypeCode: compensationClaimTypeCode,
-            decisionLetterSent: false,
-            developmentLetterSent: true,
-            documentsNeeded: false,
-            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
-          },
-        };
-
-        const { getByText } = renderWithRouter(
-          <Provider store={getStore(false)}>
-            <ClaimsListItem claim={claim} />
-          </Provider>,
-        );
-        getByText('We sent you a development letter');
-        getByText('Step 3 of 5: Evidence gathering, review, and decision');
-      });
-      it('should show decision letter flag decisionLetterSent is true, but not render the other flags', () => {
+      it('should show decision letter and suppress items needed alert when decisionLetterSent is true', () => {
         const claim = {
           id: 1,
           attributes: {
@@ -787,7 +711,6 @@ describe('<ClaimsListItem>', () => {
             },
             claimTypeCode: compensationClaimTypeCode,
             decisionLetterSent: true,
-            developmentLetterSent: true,
             documentsNeeded: true,
             status: 'INITIAL_REVIEW',
           },
@@ -798,7 +721,6 @@ describe('<ClaimsListItem>', () => {
             <ClaimsListItem claim={claim} />
           </Provider>,
         );
-        expect(queryByText('We sent you a development letter')).to.be.null;
         expect(queryByText('We requested more information from you:')).to.be
           .null;
         expect(getByText('You have a decision letter ready')).to.exist;

--- a/src/applications/claims-status/tests/e2e/tests/your-claims/claim-cards.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/your-claims/claim-cards.cypress.spec.js
@@ -104,21 +104,6 @@ describe('Claim cards', () => {
   });
 
   describe('Communication notifications', () => {
-    it('should display development letter notification', () => {
-      setupClaimCardsTest([
-        createBenefitsClaimListItem({
-          developmentLetterSent: true,
-          decisionLetterSent: false,
-          status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
-          phaseType: 'GATHERING_OF_EVIDENCE',
-        }),
-      ]);
-
-      cy.findByText('We sent you a development letter');
-
-      cy.axeCheck();
-    });
-
     it('should display decision letter notification', () => {
       setupClaimCardsTest([
         createBenefitsClaimListItem({


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Remove the "We sent you a development letter" communication flag from the claim cards on the Your Claims page. This notification was redundant with the evidence request alerts and displayed for the entire life of a claim once any pre-decision communication was sent, making it unhelpful over time.
- Team: Benefits Management Tools Team 2 (Bee's Knees)

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#131616

## Testing done

- Verified the development letter notification no longer renders on claim cards regardless of the `developmentLetterSent` attribute value
- Decision letter notification ("You have a decision letter ready") continues to display when `decisionLetterSent` is true
- Items needed alert continues to display when `documentsNeeded` is true and no decision letter has been sent
- All communication flags are still suppressed for completed claims
- Unit tests updated and passing (36 passing)
- Cypress E2E tests updated and passing

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/a1188da0-5949-45c1-94ad-d4dda86e1ced" /> | <img width="500" alt="Screenshot 2026-02-26 at 9 18 54 AM" src="https://github.com/user-attachments/assets/5d0340d2-d7ee-4bde-9add-dd862e251ef1" /> |


## What areas of the site does it impact?

Claim Status Tool — specifically the claim cards displayed on the Your Claims list page (`/track-claims/your-claims`).

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This PR addresses Part 1 of the ticket. Part 2 (updating decision letter messaging based on claim type) is out of scope for this change.
