### PR TITLE
revert vamc services dropdown behavior

### DIFF
--- a/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
@@ -76,12 +76,7 @@ function Autosuggest({
   if (showOptionsRestriction) {
     const hasMinimumChars =
       !!inputValue && inputValue.length >= MIN_SEARCH_CHARS;
-    // console.log('hasMinimumChars', hasMinimumChars);
-    // console.log('hasMinimumChars type', typeof hasMinimumChars);
-
     shouldBeShown = isOpen && hasMinimumChars;
-    // console.log('shouldBeShown', shouldBeShown);
-    // console.log('shouldBeShown type', typeof shouldBeShown);
   }
 
   const { id } = getMenuProps();

--- a/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
@@ -44,8 +44,7 @@ function Autosuggest({
   loadingMessage = '',
   useProgressiveDisclosure,
   AutosuggestOptionComponent = AutosuggestOption,
-  showOptionsRestriction = !!inputValue &&
-    inputValue?.length >= MIN_SEARCH_CHARS,
+  showOptionsRestriction = false,
 }) {
   const {
     isOpen,
@@ -74,8 +73,9 @@ function Autosuggest({
 
   let shouldBeShown = isOpen;
 
-  if (showOptionsRestriction !== undefined) {
-    shouldBeShown = isOpen && showOptionsRestriction;
+  if (showOptionsRestriction) {
+    shouldBeShown =
+      isOpen && inputValue && inputValue?.length >= MIN_SEARCH_CHARS;
   }
 
   const { id } = getMenuProps();

--- a/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
@@ -74,8 +74,14 @@ function Autosuggest({
   let shouldBeShown = isOpen;
 
   if (showOptionsRestriction) {
-    shouldBeShown =
-      isOpen && inputValue && inputValue?.length >= MIN_SEARCH_CHARS;
+    const hasMinimumChars =
+      !!inputValue && inputValue.length >= MIN_SEARCH_CHARS;
+    // console.log('hasMinimumChars', hasMinimumChars);
+    // console.log('hasMinimumChars type', typeof hasMinimumChars);
+
+    shouldBeShown = isOpen && hasMinimumChars;
+    // console.log('shouldBeShown', shouldBeShown);
+    // console.log('shouldBeShown type', typeof shouldBeShown);
   }
 
   const { id } = getMenuProps();

--- a/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
@@ -232,9 +232,7 @@ function AddressAutosuggest({
       isLoading={isGeocoding}
       loadingMessage="Searching..."
       useProgressiveDisclosure={useProgressiveDisclosure || false}
-      showOptionsRestriction={
-        !!inputValue && inputValue.length >= MIN_SEARCH_CHARS
-      }
+      showOptionsRestriction
     />
   );
 }

--- a/src/applications/facility-locator/components/search-form/service-type/VAMCServiceAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/VAMCServiceAutosuggest.jsx
@@ -7,8 +7,6 @@ import useServiceType, {
 } from '../../../hooks/useServiceType';
 import Autosuggest from '../autosuggest';
 
-const MIN_SEARCH_CHARS = 3;
-
 const VAMCServiceAutosuggest = ({
   committedServiceDisplay,
   isMobile,
@@ -192,9 +190,6 @@ const VAMCServiceAutosuggest = ({
       options={options}
       showDownCaret
       showError={false}
-      showOptionsRestriction={
-        !!inputValue && inputValue.length >= MIN_SEARCH_CHARS
-      }
       shouldShowNoResults
     />
   );

--- a/src/applications/facility-locator/tests/e2e/addressAutosuggest.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/addressAutosuggest.cypress.spec.js
@@ -30,10 +30,10 @@ describe('Facility Locator Address Autosuggest provides correct results from map
     // Type 1 character — dropdown should NOT open
     cy.get(h.AUTOSUGGEST_ADDRESS_INPUT).type('Po');
     verifyDropdownIsClosed();
+    cy.get(h.AUTOSUGGEST_ADDRESS_INPUT).clear(); // clear input
 
     // Type a 3rd character (total: 3) — should now trigger
-    cy.get(h.AUTOSUGGEST_ADDRESS_INPUT).type('r');
-    cy.wait('@mapbox');
+    cy.get(h.AUTOSUGGEST_ADDRESS_INPUT).type('Por', { delay: 2000 });
     verifyDropdownIsOpen();
   });
 
@@ -41,9 +41,7 @@ describe('Facility Locator Address Autosuggest provides correct results from map
     cy.visit('/find-locations');
     cy.injectAxe();
 
-    cy.get('#street-city-state-zip').type('Port');
-
-    cy.wait('@mapbox');
+    cy.get('#street-city-state-zip').type('Port', { delay: 2000 });
 
     cy.get(h.AUTOSUGGEST_ADDRESS_CONTAINER)
       .find(h.AUTOSUGGEST_ADDRESS_OPTIONS)

--- a/src/applications/facility-locator/tests/e2e/vaHealthServicesAutosuggest.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/vaHealthServicesAutosuggest.cypress.spec.js
@@ -52,7 +52,8 @@ describe('VA health services autosuggest', () => {
 
       // Verify that the autosuggest dropdown does not open when its clicked into with no input
       h.clickElement(h.AUTOSUGGEST_ARROW);
-      verifyDropdownIsClosed();
+      verifyDropdownIsOpen();
+      cy.get(h.AUTOSUGGEST_INPUT).type('{esc}');
 
       h.submitSearchForm();
 

--- a/src/applications/facility-locator/types/index.js
+++ b/src/applications/facility-locator/types/index.js
@@ -307,6 +307,7 @@ export const AutosuggestProps = {
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
   shouldShowNoResults: PropTypes.bool,
   showDownCaret: PropTypes.bool,
+  showOptionsRestriction: PropTypes.bool,
   showError: PropTypes.bool,
   stateReducer: PropTypes.func,
   useProgressiveDisclosure: PropTypes.bool,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Revert the dropdown behavior to the previous iteration, so that the dropdown always appears when its clicked into or when at least one character is typed
- Changes to the input [in this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/42056) cause the dropdown to only appear after 3 characters have been typed, the dropdown will not appear before 3 characters are typed no matter what
- Remove the miniumum character stipulations for the VAMC service input
- Facilities Locator
- Autosuggest flipper

## Related issue(s)

- [[FL] Standardize the number of characters typed that open the dropdowns initially #22889](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22889)
- [Previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/42056) 

## Testing done
- VAMC Services would only show after 3 characters had been typed
- After changes were made, the dropdown was visible after the input was clicked into, or after 1 character had been typed

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  <img width="372" height="412" alt="Screenshot 2026-02-27 at 2 10 54 PM" src="https://github.com/user-attachments/assets/a8daff25-a40f-4893-9a9f-e203e77c5b8d" /><img width="385" height="302" alt="Screenshot 2026-02-27 at 2 11 01 PM" src="https://github.com/user-attachments/assets/84bc30cf-e8d3-449e-8b8d-722fe0d8bc75" /><img width="386" height="385" alt="Screenshot 2026-02-27 at 2 11 08 PM" src="https://github.com/user-attachments/assets/437ebe97-5d9b-421a-9bec-46b944d43a9f" /> | <img width="384" height="467" alt="Screenshot 2026-02-27 at 2 09 56 PM" src="https://github.com/user-attachments/assets/1aa15533-76f8-435c-a206-fa006be08b65" /> <img width="2" height="4" alt="Screenshot 2026-02-27 at 2 10 50 PM" src="https://github.com/user-attachments/assets/56d622b0-9473-481a-bea4-ba2283e9f848" /> <img width="410" height="514" alt="Screenshot 2026-02-27 at 2 10 36 PM" src="https://github.com/user-attachments/assets/ec98ad8b-8c16-4e7d-bc92-ec3347f57a85" /> |

## What areas of the site does it impact?

Facility Locator form: VAMC services input

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [NA] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [NA] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [NA] Events are being sent to the appropriate logging solution
- [NA] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [NA] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a reversion to the previous style of UX/UI of the VAMC services input. 
