### PR TITLE
686c | Add explicit logic to remove optional fields in add student flow

### DIFF
--- a/src/applications/dependents/686c-674/config/utilities/submission.js
+++ b/src/applications/dependents/686c-674/config/utilities/submission.js
@@ -379,6 +379,59 @@ function transformStudentBenefitRadioToCheckbox(data) {
 }
 
 /**
+ * Strips stale benefit-conditional fields from student items when their
+ * corresponding form pages are inactive.
+ *
+ * Handles two inactive-page cases:
+ *  - addStudentsPartTen (start date): only active when hasActiveBenefit || hasGovFunding
+ *    → strips benefitPaymentDate when neither condition is met
+ *  - addStudentsPartNine (program name): only active when tuitionIsPaidByGovAgency === true
+ *    → strips schoolInformation.name when gov funding is not active
+ *    (other schoolInformation fields come from always-active attendance pages, so only
+ *    the name key is removed rather than the whole object)
+ *
+ * @param {Object} data - Form data (typeOfProgramOrBenefit already converted to object)
+ * @returns {Object} Cleaned data with stale fields removed where applicable
+ */
+function stripStaleBenefitFields(data) {
+  if (!data?.studentInformation?.length) return data;
+
+  const cleaned = cloneDeep(data);
+  cleaned.studentInformation = cleaned.studentInformation.map(student => {
+    let result = student;
+    const benefit = student.typeOfProgramOrBenefit;
+
+    // After transformStudentBenefitRadioToCheckbox, benefit is always an object
+    // (new format) or was already an object (old cached data). Guard for edge cases.
+    const hasActiveBenefit =
+      benefit && typeof benefit === 'object'
+        ? Object.values(benefit).some(Boolean)
+        : ['ch35', 'fry', 'feca'].includes(benefit);
+
+    const hasGovFunding = student.tuitionIsPaidByGovAgency === true;
+
+    if (!hasActiveBenefit && !hasGovFunding) {
+      // Start date page (addStudentsPartTen) is inactive — strip benefitPaymentDate.
+      /* eslint-disable-next-line no-unused-vars */
+      const { benefitPaymentDate: _stripped, ...rest } = result;
+      result = rest;
+    }
+
+    if (!hasGovFunding && result.schoolInformation?.name !== undefined) {
+      // Program name page (addStudentsPartNine) only shows when tuitionIsPaidByGovAgency
+      // === true. Strip just the name key; leave other schoolInformation fields intact
+      // because they come from always-active attendance pages.
+      /* eslint-disable-next-line no-unused-vars */
+      const { name: _name, ...restSchoolInfo } = result.schoolInformation;
+      result = { ...result, schoolInformation: restSchoolInfo };
+    }
+
+    return result;
+  });
+  return cleaned;
+}
+
+/**
  * Transforms V3 picklist removal data to V2 format if V3 is enabled.
  *
  * @param {Object} data - Form data object
@@ -450,10 +503,16 @@ export function customTransformForSubmit(formConfig, form) {
     dataToTransform,
   );
 
-  // Step 4: Transform V3 picklist data to V2 format if needed
-  const transformedData = applyPicklistTransformations(
+  // Step 3c: Strip stale benefit-conditional fields from students where page depends
+  // evaluate to false. filterInactiveNestedPageData cannot handle this because its
+  // sibling-preservation heuristic always retains fields for student items (which
+  // have many active fields). See stripStaleBenefitFields for full explanation.
+  const dataWithBenefitCleanup = stripStaleBenefitFields(
     dataWithStudentTransform,
   );
+
+  // Step 4: Transform V3 picklist data to V2 format if needed
+  const transformedData = applyPicklistTransformations(dataWithBenefitCleanup);
 
   // Step 5: Enrich reportDivorce with SSN from awarded dependents
   const enrichedData = enrichDataWithSSN(transformedData);

--- a/src/applications/dependents/686c-674/tests/config/utilities.submission.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/utilities.submission.unit.spec.jsx
@@ -639,6 +639,189 @@ describe('buildSubmissionData', () => {
   });
 });
 
+describe('stale student benefit field cleanup (regression for inactive page filtering bug)', () => {
+  // When a user answers 9A "No" (no benefit + no gov funding), the start-date and
+  // school-name pages are inactive. However filterInactivePageData only operates on
+  // top-level form-data keys and cannot reach fields nested inside array items like
+  // studentInformation[0].benefitPaymentDate. This suite verifies that stale data
+  // from those inactive pages is stripped before the payload reaches the backend.
+  //
+  // Note: filterInactiveNestedPageData (the newer helper) still cannot remove these
+  // fields in practice because its sibling-preservation heuristic retains all fields
+  // for any array item with 2+ active fields — which is always true for students.
+  // The actual fix is an explicit stripStaleBenefitFields step in the pipeline.
+
+  const baseStudent = {
+    fullName: { first: 'Test', last: 'Student' },
+    birthDate: '2000-01-01',
+    ssn: '123456789',
+    noSsn: false,
+    address: {
+      country: 'USA',
+      street: '123 Main St',
+      city: 'Testville',
+      state: 'CA',
+      postalCode: '12345',
+    },
+    wasMarried: false,
+    schoolInformation: {
+      studentIsEnrolledFullTime: true,
+    },
+  };
+
+  const createForm674 = (studentOverrides = {}) => ({
+    data: {
+      'view:addOrRemoveDependents': { add: true },
+      'view:addDependentOptions': {
+        report674: true,
+        addSpouse: false,
+        addChild: false,
+        addDisabledChild: false,
+      },
+      'view:selectable686Options': { report674: true },
+      dependents: { hasError: false, hasDependents: false, awarded: [] },
+      studentInformation: [
+        {
+          ...baseStudent,
+          ...studentOverrides,
+          schoolInformation: {
+            ...baseStudent.schoolInformation,
+            ...(studentOverrides.schoolInformation || {}),
+          },
+        },
+      ],
+      veteranInformation: { fullName: { first: 'Test', last: 'Veteran' } },
+      veteranContactInformation: { phoneNumber: '555-1234' },
+      statementOfTruthSignature: 'Test Signature',
+      statementOfTruthCertified: true,
+      metadata: { version: 1 },
+    },
+  });
+
+  it('should remove stale benefitPaymentDate when no benefit program is active and tuition is not gov-funded', () => {
+    // Reproduces the production payload bug: tuition_is_paid_by_gov_agency=false yet
+    // benefit_payment_date was still present in the submission.
+    // Both the start-date page (addStudentsPartTen) and the school-name page
+    // (addStudentsPartNine) have depends conditions that evaluate to false here,
+    // so any previously-entered date must be stripped.
+    const form = createForm674({
+      typeOfProgramOrBenefit: 'none', // new radio format — no benefit
+      tuitionIsPaidByGovAgency: false, // 9A answered "No"
+      benefitPaymentDate: '2022-01-01', // stale — user had previously entered this
+    });
+
+    const result = customTransformForSubmit(formConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    expect(submittedData.studentInformation).to.be.an('array');
+    expect(submittedData.studentInformation).to.have.lengthOf(1);
+    expect(
+      submittedData.studentInformation[0].benefitPaymentDate,
+      'stale benefitPaymentDate should be absent from the payload',
+    ).to.be.undefined;
+  });
+
+  it('should remove stale benefitPaymentDate when typeOfProgramOrBenefit is old object format (cache scenario)', () => {
+    // Simulates a user who filled the form before the radio migration (commit 58faab9).
+    // Old code stored typeOfProgramOrBenefit as a checkbox object; new depends functions
+    // check for a string value so the page is always inactive for old-format data.
+    const form = createForm674({
+      typeOfProgramOrBenefit: { ch35: false, fry: false, feca: false }, // old object format
+      tuitionIsPaidByGovAgency: false,
+      benefitPaymentDate: '2022-01-01', // stale from old session
+    });
+
+    const result = customTransformForSubmit(formConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    expect(
+      submittedData.studentInformation[0].benefitPaymentDate,
+      'stale benefitPaymentDate from old object-format session should be absent',
+    ).to.be.undefined;
+  });
+
+  it('should preserve benefitPaymentDate when a benefit program is selected', () => {
+    const form = createForm674({
+      typeOfProgramOrBenefit: 'fry',
+      tuitionIsPaidByGovAgency: false,
+      benefitPaymentDate: '2022-01-01',
+    });
+
+    const result = customTransformForSubmit(formConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    expect(submittedData.studentInformation[0].benefitPaymentDate).to.equal(
+      '2022-01-01',
+    );
+  });
+
+  it('should preserve benefitPaymentDate when tuition is paid by government agency', () => {
+    const form = createForm674({
+      typeOfProgramOrBenefit: 'none',
+      tuitionIsPaidByGovAgency: true,
+      schoolInformation: {
+        name: 'Federal Academy',
+        studentIsEnrolledFullTime: true,
+      },
+      benefitPaymentDate: '2022-01-01',
+    });
+
+    const result = customTransformForSubmit(formConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    expect(submittedData.studentInformation[0].benefitPaymentDate).to.equal(
+      '2022-01-01',
+    );
+  });
+
+  it('should remove stale schoolInformation.name when tuitionIsPaidByGovAgency is false', () => {
+    // Reproduces the bug shown in the payload screenshot: user originally answered
+    // tuitionIsPaidByGovAgency=true (triggering addStudentsPartNine and entering a
+    // program name), then went back and changed to false. The program name page is now
+    // inactive but filterInactivePageData can't reach the nested field.
+    const form = createForm674({
+      typeOfProgramOrBenefit: 'none',
+      tuitionIsPaidByGovAgency: false,
+      schoolInformation: {
+        name: 'test123', // stale — page is hidden when tuitionIsPaidByGovAgency=false
+        studentIsEnrolledFullTime: true,
+      },
+    });
+
+    const result = customTransformForSubmit(formConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    expect(
+      submittedData.studentInformation[0].schoolInformation?.name,
+      'stale schoolInformation.name should be absent when tuitionIsPaidByGovAgency is false',
+    ).to.be.undefined;
+    // Other schoolInformation fields from always-active attendance pages must be kept
+    expect(
+      submittedData.studentInformation[0].schoolInformation
+        ?.studentIsEnrolledFullTime,
+      'always-active attendance fields in schoolInformation should be preserved',
+    ).to.not.be.undefined;
+  });
+
+  it('should preserve schoolInformation.name when tuitionIsPaidByGovAgency is true', () => {
+    const form = createForm674({
+      typeOfProgramOrBenefit: 'none',
+      tuitionIsPaidByGovAgency: true,
+      schoolInformation: {
+        name: 'Federal Academy',
+        studentIsEnrolledFullTime: true,
+      },
+    });
+
+    const result = customTransformForSubmit(formConfig, form);
+    const submittedData = JSON.parse(result.body);
+
+    expect(
+      submittedData.studentInformation[0].schoolInformation?.name,
+    ).to.equal('Federal Academy');
+  });
+});
+
 describe('customTransformForSubmit integration', () => {
   // Mock formConfig with minimal required structure
   const mockFormConfig = {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds explicit logic to remove fields in add student flow when they are filtered out
- Adds verbose comments to explain the problem
- unit tests added

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134569

## Testing done

- unit tests updated
- payload verified does not contain institution name or benefits payment date when fields are hidden, even if in progress form contains information

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
