### PR TITLE
Update edit button text to be distinct

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -495,7 +495,7 @@ export default class ArrayField extends React.Component {
                     aria-label={`Edit ${itemName}`}
                     onClick={() => this.handleEdit(index)}
                   >
-                    Edit
+                    Edit {itemName}
                   </button>
                 </div>
               </div>

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -544,7 +544,7 @@ export default class ArrayField extends React.Component {
                     secondary
                     label={`Edit ${ariaItemName}`}
                     onClick={() => this.handleEdit(index)}
-                    text="Edit"
+                    text={`Edit ${ariaItemName}`}
                   />
                 </div>
               </CardOrDiv>

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -163,10 +163,19 @@ class ObjectField extends React.Component {
     const defaultEditButton = ({
       label = editLabel,
       onEdit = formContext?.onEdit,
-      text = 'Edit',
-    } = {}) => (
-      <va-button secondary label={label} onClick={onEdit} text={text} uswds />
-    );
+      text,
+    } = {}) => {
+      const buttonText = text !== undefined ? text : label || 'Edit';
+      return (
+        <va-button
+          secondary
+          label={label}
+          onClick={onEdit}
+          text={buttonText}
+          uswds
+        />
+      );
+    };
 
     if (isReactComponent(ObjectViewField)) {
       return (

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -211,7 +211,7 @@ describe('Schemaform <ArrayField>', () => {
     const button = container.querySelectorAll('button');
     expect(button.length).to.equal(1);
 
-    expect(container.innerHTML).to.contain('text="Edit"');
+    expect(container.innerHTML).to.contain('text="Edit item"');
     expect(container.innerHTML).to.contain('text="Remove"');
     expect(container.innerHTML).to.contain('text="Save"');
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### TeamSites

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR fixes an accessibility defect identified in staging review where Edit buttons for array items (medical providers, hospitals, employment history, etc.) displayed identical text "Edit" without context, violating WCAG 2.4.6 (Headings and Labels) and creating confusion for screen reader users.

The solution updates the platform review Edit button and array field Edit button to display descriptive text (e.g., "Edit Dr. Smith", "Edit Johns Hopkins Hospital") while preserving the existing aria-label. This ensures both the visible button text and the accessible name provide clear, unique labels that communicate each button's purpose.

The Disability Benefits Conditions team owns the maintenance of the disability-benefits/all-claims application. This fix updates platform components used by that application.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#117630

## Testing done

### Old Behavior
Prior to this change, all Edit buttons in array field sections displayed identical text "Edit" regardless of which item they controlled. The aria-label attribute provided context (e.g., "Edit Dr. Smith") but the visible button text remained generic.

### Verification Steps
1. Navigate to Form 21-526EZ disability claim application
2. Complete sections containing array fields:
   - Private medical records release (treatment providers)
   - Hospitalization history
   - Employment history
   - Education and training
   - Recent job applications
   - Alternate names
   - Secondary incident authorities
   - Individuals involved
3. Add multiple items to any array field
4. Verify each Edit button displays unique text including the item name
5. Test with screen reader to confirm both visual text and aria-label match
6. Verify Remove buttons continue functioning as expected

### Test Results

**Direct Impact Tests (All Passing)**
- `yarn test:unit src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx` → 16 passing
- `yarn test:unit src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx` → 44 passing  
- `yarn test:unit src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx` → 31 passing
- Subtotal: 91 passing

**Regression Test Results (Platform-Wide)**
- `find src/platform/forms-system/test/js/fields -name "*.unit.spec.jsx" -type f | xargs yarn test:unit` → 83 passing
- `find src/platform/forms-system/test/js/review -name "*.unit.spec.jsx" -type f | xargs yarn test:unit` → 223 passing
- `yarn test:unit src/applications/ask-va/tests/components/ArrayField.unit.spec.jsx` → 14 passing
- `yarn test:unit src/applications/disability-benefits/all-claims/tests/components/PaymentViewObjectField.unit.spec.jsx` → 4 passing
- `yarn test:unit src/applications/income-and-asset-statement/tests/unit/config/form.unit.spec.jsx` → 7 passing
- `yarn test:unit src/applications/personalization/profile/tests/components/personal-information/DeselectableObjectField.unit.spec.jsx` → 4 passing
- Total regression tests: 335 passing

**Code Quality**
- `npx eslint src/platform/forms-system/src/js/review/ObjectField.jsx src/platform/forms-system/src/js/fields/ArrayField.jsx src/applications/disability-benefits/all-claims/components/ArrayField.jsx` → 0 errors
- `npx prettier --check src/platform/forms-system/src/js/review/ObjectField.jsx src/platform/forms-system/src/js/fields/ArrayField.jsx src/applications/disability-benefits/all-claims/components/ArrayField.jsx` → passed

**Summary:** 410+ unit tests passing across platform core and dependent applications. No regressions detected. 

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="699" height="539" alt="Screenshot 2026-02-26 at 4 40 35 PM" src="https://github.com/user-attachments/assets/f161af96-9898-4b5a-9954-042e67993609" /> | <img width="689" height="519" alt="Screenshot 2026-02-26 at 4 40 49 PM" src="https://github.com/user-attachments/assets/9218adc9-0493-4939-bf6b-683dc7669a20" /> |

## What areas of the site does it impact?

This change modifies platform forms-system components (`ObjectField.jsx` and `ArrayField.jsx`) used across multiple VA.gov applications. While the accessibility defect was identified in the disability-benefits/all-claims application (Form 21-526EZ), this fix affects any form throughout va.gov that uses review pages or array fields with edit functionality, including health care enrollment, education benefits, housing assistance, and other complex forms.

In Form 21-526EZ specifically, this impacts:
- Private medical records release
- Hospitalization history  
- Employment history
- Past education and training
- Recent education and training
- Recent job applications
- Alternate names
- Secondary incident authorities
- Individuals involved
- Doctor care for unemployability

Reviewers should verify this change does not introduce unintended visual regressions in other applications leveraging these platform components.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed (no new warnings introduced)
- [x] Documentation has been updated (if necessary)
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user