### PR TITLE
fix(mhv-medications): update v2 refill mock to validate order format

### DIFF
--- a/src/applications/mhv-medications/mocks/api/index.js
+++ b/src/applications/mhv-medications/mocks/api/index.js
@@ -186,15 +186,46 @@ const responses = {
       1500,
     );
   },
-  // Includes both v1 and v2 endpoints for refill prescriptions
+  // V2 refill endpoint — expects body: [{id, stationNumber}, ...]
   'POST /my_health/v2/prescriptions/refill': (req, res) => {
-    // Get requested IDs from query params.
-    const ids = req.body;
-    // Emulate a successful refill for the first ID and failed refill for subsequent IDs
-    const successfulIds = ids[0] ? [ids[0]] : [];
-    const failedIds = ids[1] ? ids.slice(1) : [];
-    // delay response to emulate network latency
-    delaySingleResponse(
+    const orders = req.body;
+
+    if (!Array.isArray(orders) || orders.length === 0) {
+      return res.status(400).json({
+        errors: [
+          {
+            status: '400',
+            title: 'Bad Request',
+            detail: 'Request body must be a non-empty array of orders',
+          },
+        ],
+      });
+    }
+
+    const invalidOrder = orders.find(
+      order =>
+        typeof order !== 'object' ||
+        order === null ||
+        !order.id ||
+        !order.stationNumber,
+    );
+    if (invalidOrder) {
+      return res.status(400).json({
+        errors: [
+          {
+            status: '400',
+            title: 'Bad Request',
+            detail: 'Each order must contain id and stationNumber fields',
+          },
+        ],
+      });
+    }
+
+    // Emulate a successful refill for the first order and failed for subsequent
+    const successfulIds = [orders[0]];
+    const failedIds = orders.length > 1 ? orders.slice(1) : [];
+
+    return delaySingleResponse(
       () =>
         res.status(200).json({
           data: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
- [x] No

## Summary

- **Bug:** The mock API handler for `POST /my_health/v2/prescriptions/refill` was treating the request body as a flat array of IDs, but the v2 controller expects an array of order objects with `id` and `stationNumber` fields.
- **Fix:** Updated the mock to validate the request body format and return 400 errors for invalid payloads (missing array, empty array, or orders without required `id`/`stationNumber` fields), matching the behavior of the Rails v2 prescriptions controller.
- **Team:** MHV Medications
- **Related PR:** department-of-veterans-affairs/vets-website#42705

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#134588

## Testing done

- Verified the mock handler rejects non-array bodies with 400 status
- Verified the mock handler rejects empty arrays with 400 status
- Verified the mock handler rejects orders missing `id` or `stationNumber` with 400 status
- Verified valid requests `[{id, stationNumber}]` return 200 with expected response shape
- Mock-only change; no production code affected

## Screenshots

N/A — mock API change only, no UI impact.

## What areas of the site does it impact?

Local development mock API for MHV Medications only.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated — N/A
- [ ] Screenshot of the developed feature is added — N/A
- [ ] Accessibility testing has been performed — N/A

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, mock only

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user — mock-only change