### PR TITLE
Fixed AuthApp Looping

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -166,28 +166,27 @@ export default function AuthApp({ location }) {
       userAttributes,
       provisioned,
     });
-    if (
-      !skipToRedirect &&
-      (!isMyVAHealth || needsPortalNotice || needsMyHealth)
-    ) {
+    const needsEmailConfirmation = emailNeedsConfirmation({
+      isEmailInterstitialEnabled,
+      loginType,
+      userAttributes,
+    });
+    const interstitialRedirects = [
+      { condition: needsPortalNotice, url: '/sign-in-health-portal/' },
+      { condition: needsMyHealth, url: '/my-health' },
+      {
+        condition: needsEmailConfirmation,
+        url: '/sign-in-confirm-contact-email',
+      },
+    ];
+    const interstitial = interstitialRedirects.find(r => r.condition);
+    const needsProfileSetup =
+      !skipToRedirect && (!isMyVAHealth || interstitial);
+    if (needsProfileSetup) {
       setupProfileSession(userProfile);
     }
-    if (needsPortalNotice) {
-      window.location.replace('/sign-in-health-portal/');
-      return;
-    }
-    if (needsMyHealth) {
-      window.location.replace('/my-health');
-      return;
-    }
-    if (
-      emailNeedsConfirmation({
-        isEmailInterstitialEnabled,
-        loginType,
-        userAttributes,
-      })
-    ) {
-      window.location.replace('/sign-in-confirm-contact-email');
+    if (interstitial) {
+      window.location.replace(interstitial.url);
       return;
     }
     redirect();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed login looping issue where `AuthApp.jsx`  was not setting up a profile when a user needed email confirmation. Also used this opportunity to clean up the conditional logic in `handleAuthSuccess`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1144)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running: `yarn test:unit src/applications/auth/tests/AuthApp.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts `AuthApp.jsx`.

## Acceptance criteria
- [x] Fix login looping bug
- [x] Clean up conditional logic within `handleAuthSuccess`
- [x] Ensure no breaking changes and that tests run correctly 