### PR TITLE
Add type of care dependent clinic history filtering

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/useClinicFormState.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/useClinicFormState.jsx
@@ -5,13 +5,16 @@ import { getSiteIdFromFacilityId } from '../../../services/location';
 
 import { selectFeatureMentalHealthHistoryFiltering } from '../../../redux/selectors';
 import {
+  filterPastAppointmentsByTypeOfCare,
+  typeOfCareRequiresPastHistory,
+} from '../../../services/patient';
+import {
   getClinicsForChosenFacility,
   getFormData,
   getTypeOfCare,
   selectPastAppointments,
 } from '../../redux/selectors';
 import AppointmentsRadioWidget from '../AppointmentsRadioWidget';
-import { typeOfCareRequiresPastHistory } from '../../../services/patient';
 
 const initialSchema = {
   type: 'object',
@@ -50,11 +53,18 @@ export default function useClinicFormState(pageTitle, singleClinicTitlePrefix) {
     featurePastVisitMHFilter,
   );
 
+  const filteredPastAppointments = isCheckTypeOfCare
+    ? filterPastAppointmentsByTypeOfCare(
+        pastAppointments,
+        selectedTypeOfCare.id,
+      )
+    : pastAppointments;
+
   if (isCheckTypeOfCare) {
     const pastAppointmentDateMap = new Map();
     const siteId = getSiteIdFromFacilityId(initialData.vaFacility);
 
-    pastAppointments.forEach(appt => {
+    filteredPastAppointments.forEach(appt => {
       const apptTime = appt.version === 2 ? appt.start : appt.startDate;
       const clinicId =
         appt.version === 2 ? appt.location.clinicId : appt.clinicId;

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -3,17 +3,19 @@
  * @module services/Patient
  */
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import { recordEligibilityFailure, recordVaosError } from '../../utils/events';
-import { captureError } from '../../utils/error';
+import { subMonths } from 'date-fns';
 import {
+  CLINIC_HISTORY_MONTHS,
   ELIGIBILITY_REASONS,
-  TYPE_OF_CARE_IDS,
   INELIGIBILITY_CODES_VAOS,
+  TYPE_OF_CARE_IDS,
 } from '../../utils/constants';
 import { promiseAllFromObject } from '../../utils/data';
+import { captureError } from '../../utils/error';
+import { recordEligibilityFailure, recordVaosError } from '../../utils/events';
+import { getLongTermAppointmentHistoryV2 } from '../appointment';
 import { getAvailableHealthcareServices } from '../healthcare-service';
 import { getPatientEligibility, getPatientRelationships } from '../vaos';
-import { getLongTermAppointmentHistoryV2 } from '../appointment';
 import { transformPatientRelationships } from './transformers';
 
 /**
@@ -39,6 +41,23 @@ export function typeOfCareRequiresPastHistory(
   }
 
   return !exempted.has(typeOfCareId);
+}
+
+/**
+ * Filters past appointments to only include those within the history window for the type of care, if applicable
+ * @param {Object[]} pastAppointments The list of past appointments
+ * @param {string} typeOfCareId The type of care ID
+ * @returns {Object[]} The filtered list of past appointments
+ */
+export function filterPastAppointmentsByTypeOfCare(
+  pastAppointments,
+  typeOfCareId,
+) {
+  if (typeOfCareId in CLINIC_HISTORY_MONTHS) {
+    const cutoff = subMonths(new Date(), CLINIC_HISTORY_MONTHS[typeOfCareId]);
+    return pastAppointments.filter(appt => appt.start >= cutoff);
+  }
+  return pastAppointments;
 }
 
 function createErrorHandler(errorKey) {
@@ -355,6 +374,7 @@ export async function fetchFlowEligibilityAndClinics({
     (!removeFacilityConfigCheck || patientEligibility.direct?.eligible);
 
   const additionalApiCalls = {};
+
   if (shouldFetchClinics) {
     additionalApiCalls.clinics = getAvailableHealthcareServices({
       facilityId: location.id,
@@ -473,12 +493,18 @@ export async function fetchFlowEligibilityAndClinics({
       (removeFacilityConfigCheck && typeOfCareRequiresCheck) ||
       (keepFacilityConfigCheck &&
         directTypeOfCareSettings.patientHistoryRequired);
+    const filteredPastAppointments = typeOfCareRequiresCheck
+      ? filterPastAppointmentsByTypeOfCare(
+          results.pastAppointments,
+          typeOfCare.id,
+        )
+      : results.pastAppointments;
     if (
       !isCerner &&
       requiresMatchingClinics &&
       !hasMatchingClinics(
         results.clinics,
-        results.pastAppointments,
+        filteredPastAppointments,
         typeOfCareRequiresCheck,
       )
     ) {
@@ -501,5 +527,5 @@ export async function fetchFlowEligibilityAndClinics({
     eligibility,
     clinics: results.clinics,
     pastAppointments: results.pastAppointments,
-  }; // clinics and past appointments are returned in addition to eligibilty to be cached for later user
+  }; // clinics and past appointments are returned in addition to eligibility to be cached for later user
 }

--- a/src/applications/vaos/services/patient/index.unit.spec.jsx
+++ b/src/applications/vaos/services/patient/index.unit.spec.jsx
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
-import { addDays } from 'date-fns';
+import { addDays, subMonths } from 'date-fns';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import {
   fetchPatientRelationships,
+  filterPastAppointmentsByTypeOfCare,
   hasEligibilityError,
   typeOfCareRequiresPastHistory,
 } from '.';
@@ -215,6 +216,54 @@ describe('VAOS Services: Patient ', () => {
         typeOfCareRequiresPastHistory(FOOD_AND_NUTRITION_ID, true) &&
         typeOfCareRequiresPastHistory(FOOD_AND_NUTRITION_ID, false);
       expect(result).to.be.true;
+    });
+  });
+  describe('filterPastAppointmentsByTypeOfCare', () => {
+    it('Should return only past appointments within the specified period if type of care has a history override', () => {
+      const pastAppointments = [
+        {
+          id: '1',
+          start: subMonths(new Date(), 6),
+        },
+        {
+          id: '2',
+          start: subMonths(new Date(), 13),
+        },
+        {
+          id: '3',
+          start: subMonths(new Date(), 2),
+        },
+      ];
+
+      const result = filterPastAppointmentsByTypeOfCare(
+        pastAppointments,
+        TYPE_OF_CARE_IDS.MENTAL_HEALTH_PRIMARY_CARE_ID,
+      );
+
+      expect(result.map(appt => appt.id)).to.deep.equal(['1', '3']);
+    });
+    it('Should return all past appointment if type of care does not have a history override', () => {
+      const pastAppointments = [
+        {
+          id: '1',
+          start: subMonths(new Date(), 6),
+        },
+        {
+          id: '2',
+          start: subMonths(new Date(), 13),
+        },
+        {
+          id: '3',
+          start: subMonths(new Date(), 2),
+        },
+      ];
+
+      const result = filterPastAppointmentsByTypeOfCare(
+        pastAppointments,
+        TYPE_OF_CARE_IDS.PRIMARY_CARE,
+      );
+
+      expect(result.map(appt => appt.id)).to.deep.equal(['1', '2', '3']);
     });
   });
 });

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -491,6 +491,10 @@ export const OH_ENABLED_TYPES_OF_CARE = [
   // 'socialWork',
 ];
 
+export const CLINIC_HISTORY_MONTHS = {
+  [TYPE_OF_CARE_IDS.MENTAL_HEALTH_PRIMARY_CARE_ID]: 12,
+};
+
 export const TRAVEL_CLAIM_MESSAGES = {
   noClaim: 'No claims found.',
   error: 'Travel Pay service unavailable.',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We are adding an additional constraint to only include the last X months of appointments history when performing the past history check for certain types of care. This is a new business requirement for PCMHI.
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132015

## Testing done

- Tested locally and added unit tests

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
