### PR TITLE
Remove immediate_care_alert feature toggle

### DIFF
--- a/src/applications/vaos/appointment-list/components/ScheduleNewAppointment.jsx
+++ b/src/applications/vaos/appointment-list/components/ScheduleNewAppointment.jsx
@@ -6,7 +6,6 @@ import { GA_PREFIX } from 'applications/vaos/utils/constants';
 import { startNewAppointmentFlow } from '../redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
 import getNewAppointmentFlow from '../../new-appointment/newAppointmentFlow';
-import { selectFeatureImmediateCareAlert } from '../../redux/selectors';
 
 function handleClick(history, dispatch, pageKey) {
   return e => {
@@ -24,30 +23,15 @@ function handleClick(history, dispatch, pageKey) {
 function ScheduleNewAppointmentButton() {
   const history = useHistory();
   const dispatch = useDispatch();
-  const { typeOfCare } = useSelector(getNewAppointmentFlow);
   const { urgentCareInformation } = useSelector(getNewAppointmentFlow);
-  const featureImmediateCareAlert = useSelector(
-    selectFeatureImmediateCareAlert,
-  );
-
-  if (featureImmediateCareAlert)
-    return (
-      <a
-        className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--2p5"
-        href="/"
-        onClick={handleClick(history, dispatch, urgentCareInformation)}
-      >
-        Schedule a new appointment
-      </a>
-    );
 
   return (
     <a
       className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--2p5"
       href="/"
-      onClick={handleClick(history, dispatch, typeOfCare)}
+      onClick={handleClick(history, dispatch, urgentCareInformation)}
     >
-      Start scheduling an appointment
+      Schedule a new appointment
     </a>
   );
 }

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -236,7 +236,7 @@ describe('VAOS Page: AppointmentsPage', () => {
     // and scheduling button should not be displayed
     expect(
       screen.queryByRole('button', {
-        name: 'Start scheduling an appointment',
+        name: 'Schedule a new appointment',
       }),
     ).not.to.exist;
 
@@ -295,7 +295,7 @@ describe('VAOS Page: AppointmentsPage', () => {
     // and scheduling button should not be displayed
     expect(
       screen.queryByRole('button', {
-        name: 'Start scheduling an appointment',
+        name: 'Schedule a new appointment',
       }),
     ).not.to.exist;
 

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -127,17 +127,15 @@ describe('VAOS Page: AppointmentsPage', () => {
       },
     });
 
-    expect(screen.getByText(/Start scheduling an appointment/)).to.be.ok;
+    expect(screen.getByText(/Schedule a new appointment/)).to.be.ok;
     userEvent.click(
       await screen.findByRole('link', {
-        name: /Start scheduling an appointment/i,
+        name: /Schedule a new appointment/i,
       }),
     );
 
     await waitFor(() =>
-      expect(screen.history.push.lastCall.args[0]).to.equal(
-        '/schedule/type-of-care',
-      ),
+      expect(screen.history.push.lastCall.args[0]).to.equal('/schedule'),
     );
   });
 
@@ -172,9 +170,8 @@ describe('VAOS Page: AppointmentsPage', () => {
     ).not.to.exist;
 
     // and scheduling link should be displayed
-    expect(
-      screen.getByRole('link', { name: 'Start scheduling an appointment' }),
-    ).to.be.ok;
+    expect(screen.getByRole('link', { name: 'Schedule a new appointment' })).to
+      .be.ok;
 
     // and appointment list navigation should be displayed
     expect(screen.getByRole('navigation', { name: 'Appointment list' })).to.be

--- a/src/applications/vaos/new-appointment/components/FormLayout.jsx
+++ b/src/applications/vaos/new-appointment/components/FormLayout.jsx
@@ -14,7 +14,6 @@ import WarningNotification from '../../components/WarningNotification';
 import { getFlowType, getFormData } from '../redux/selectors';
 import { FACILITY_TYPES, FLOW_TYPES } from '../../utils/constants';
 import { routeToPreviousAppointmentPage } from '../redux/actions';
-import { selectFeatureImmediateCareAlert } from '../../redux/selectors';
 
 function Title() {
   const flowType = useSelector(getFlowType);
@@ -56,25 +55,13 @@ function BackLink() {
 
 function Nav({ pageTitle }) {
   const location = useLocation();
-  const featureImmediateCareAlert = useSelector(
-    selectFeatureImmediateCareAlert,
-  );
 
-  if (featureImmediateCareAlert && location.pathname === '/schedule')
+  if (location.pathname === '/schedule')
     return (
       <Breadcrumbs>
         <a href="/my-health/appointments/schedule">{pageTitle}</a>
       </Breadcrumbs>
     );
-
-  if (location.pathname === '/schedule/type-of-care') {
-    if (featureImmediateCareAlert) return <BackLink />;
-    return (
-      <Breadcrumbs>
-        <a href="/my-health/appointments/schedule/type-of-care">{pageTitle}</a>
-      </Breadcrumbs>
-    );
-  }
 
   return <BackLink />;
 }
@@ -84,9 +71,6 @@ Nav.propTypes = {
 
 export default function FormLayout({ children, pageTitle }) {
   const location = useLocation();
-  const featureImmediateCareAlert = useSelector(
-    selectFeatureImmediateCareAlert,
-  );
 
   return (
     <>
@@ -106,13 +90,7 @@ export default function FormLayout({ children, pageTitle }) {
         )}
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            {featureImmediateCareAlert &&
-              !location.pathname.endsWith('schedule') && (
-                <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal">
-                  <Title />
-                </span>
-              )}
-            {!featureImmediateCareAlert && (
+            {!location.pathname.endsWith('schedule') && (
               <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal">
                 <Title />
               </span>

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/TypeOfCareAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/TypeOfCareAlert.jsx
@@ -1,18 +1,12 @@
 import recordEvent from 'platform/monitoring/record-event';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import InfoAlert from '../../../components/InfoAlert';
 import NewTabAnchor from '../../../components/NewTabAnchor';
 import PostFormFieldContent from '../../../components/PostFormFieldContent';
-import { selectFeatureImmediateCareAlert } from '../../../redux/selectors';
 
 export default function TypeOfCareAlert() {
-  const featureImmediateCareAlert = useSelector(
-    selectFeatureImmediateCareAlert,
-  );
-  const content = featureImmediateCareAlert
-    ? 'You’ll need to call your local VA health care facility to schedule an appointment.'
-    : 'You’ll need to call your VA health facility to schedule an appointment.';
+  const content =
+    'You’ll need to call your local VA health care facility to schedule an appointment.';
   const headline = 'Is the type of care you need not listed here?';
 
   return (
@@ -34,14 +28,13 @@ export default function TypeOfCareAlert() {
                 'alert-box-heading':
                   'Is the type of care you need not listed here',
                 'alert-box-subheading': undefined,
-                'alert-box-click-label': 'Find a VA location',
+                'alert-box-click-label':
+                  'Find your local VA health care facility',
               })
             }
             renderAriaLabel={false}
           >
-            {featureImmediateCareAlert
-              ? 'Find your local VA health care facility (opens in a new tab)'
-              : 'Find a VA location (opens in a new tab)'}
+            Find your local VA health care facility (opens in a new tab)
           </NewTabAnchor>
         </p>
       </InfoAlert>

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.unit.spec.jsx
@@ -120,14 +120,20 @@ describe('VAOS Page: TypeOfCarePage', () => {
     ).to.exist;
     expect(
       screen.getByText(
-        /you’ll need to call your va health facility to schedule an appointment./i,
+        /You’ll need to call your local VA health care facility to schedule an appointment./i,
       ),
     ).to.exist;
-    expect(screen.getByRole('link', { name: /find a va location/i })).to.exist;
-    fireEvent.click(screen.getByText(/Find a VA location/i));
+    expect(
+      screen.getByRole('link', {
+        name: /Find your local VA health care facility/i,
+      }),
+    ).to.exist;
+    fireEvent.click(
+      screen.getByText(/Find your local VA health care facility/i),
+    );
 
     expect(global.window.dataLayer[0]).to.eql({
-      'alert-box-click-label': 'Find a VA location',
+      'alert-box-click-label': 'Find your local VA health care facility',
       'alert-box-heading': 'Is the type of care you need not listed here',
       'alert-box-subheading': undefined,
       'alert-box-type': 'informational',

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -36,10 +36,7 @@ import useFormUnsavedDataWarning from '../hooks/useFormUnsavedDataWarning';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 import ScheduleCernerPage from './components/ScheduleCernerPage';
 import UrgentCareInformationPage from './components/UrgentCareInformationPage';
-import {
-  selectFeatureImmediateCareAlert,
-  selectFeatureRemoveFacilityConfigCheck,
-} from '../redux/selectors';
+import { selectFeatureRemoveFacilityConfigCheck } from '../redux/selectors';
 import ScheduleCernerPageV2 from './components/ScheduleCernerPageV2';
 
 export function NewAppointment() {
@@ -48,9 +45,6 @@ export function NewAppointment() {
   const match = useRouteMatch();
   const location = useLocation();
   const pageTitle = 'Schedule an appointment';
-  const featureImmediateCareAlert = useSelector(
-    selectFeatureImmediateCareAlert,
-  );
   const featureRemoveFacilityConfigCheck = useSelector(
     selectFeatureRemoveFacilityConfigCheck,
   );
@@ -68,18 +62,12 @@ export function NewAppointment() {
     shouldRedirect: () =>
       !isNewAppointmentStarted &&
       !location.pathname.endsWith('confirmation') &&
-      (featureImmediateCareAlert
-        ? !location.pathname.endsWith('schedule') ||
-          location.pathname.endsWith('how-to-schedule')
-        : !location.pathname.endsWith('type-of-care')),
+      (!location.pathname.endsWith('schedule') ||
+        location.pathname.endsWith('how-to-schedule')),
   });
 
   if (shouldRedirectToStart) {
-    return (
-      <Redirect
-        to={featureImmediateCareAlert ? '/schedule' : '/schedule/type-of-care'}
-      />
-    );
+    return <Redirect to="/schedule" />;
   }
 
   return (
@@ -184,21 +172,12 @@ export function NewAppointment() {
         >
           <ReviewPage />
         </Route>
-        {featureImmediateCareAlert && (
-          <>
-            <Route path={`${match.url}/type-of-care`}>
-              <TypeOfCarePage />
-            </Route>
-            <Route exact path={match.url}>
-              <UrgentCareInformationPage />
-            </Route>
-          </>
-        )}
-        {!featureImmediateCareAlert && (
-          <Route path={match.url}>
-            <TypeOfCarePage />
-          </Route>
-        )}
+        <Route path={`${match.url}/type-of-care`}>
+          <TypeOfCarePage />
+        </Route>
+        <Route exact path={match.url}>
+          <UrgentCareInformationPage />
+        </Route>
       </Switch>
     </FormLayout>
   );

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -121,9 +121,6 @@ export const selectFeatureListViewClinicInfo = state =>
 export const selectFeatureAddOhAvs = state =>
   toggleValues(state).vaOnlineSchedulingAddOhAvs;
 
-export const selectFeatureImmediateCareAlert = state =>
-  toggleValues(state).vaOnlineSchedulingImmediateCareAlert;
-
 export const selectFeatureRemoveFacilityConfigCheck = state =>
   toggleValues(state).vaOnlineSchedulingRemoveFacilityConfigCheck;
 

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -22,7 +22,6 @@ module.exports = [
   },
   { name: 'vaOnlineSchedulingListViewClinicInfo', value: true },
   { name: 'vaOnlineSchedulingAddOhAvs', value: true },
-  { name: 'vaOnlineSchedulingImmediateCareAlert', value: true },
   { name: 'vaOnlineSchedulingRemoveFacilityConfigCheck', value: true },
   { name: 'vaOnlineSchedulingUseBrowserTimezone', value: true },
   { name: 'vaOnlineSchedulingUseVpg', value: true },

--- a/src/applications/vaos/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PageObject.js
@@ -252,8 +252,10 @@ export default class PageObject {
     return this.clickButton({ label });
   }
 
-  scheduleAppointment(text = 'Start scheduling an appointment') {
-    cy.findByText(text).click({ waitForAnimations: true });
+  scheduleAppointment() {
+    cy.findByText('Schedule a new appointment').click({
+      waitForAnimations: true,
+    });
     return this;
   }
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfCarePageObject.js
@@ -17,29 +17,8 @@ class TypeOfCarePageObject extends PageObject {
   }
 
   assertUrl() {
-    cy.wait('@v0:get:feature_toggles').then((req, _resp) => {
-      const toggles = req.response.body.data.features;
-      const featureImmediateCareAlert = toggles.find(
-        toggle =>
-          (toggle.name === 'vaOnlineSchedulingImmediateCareAlert') === true,
-      );
-
-      if (
-        featureImmediateCareAlert &&
-        featureImmediateCareAlert.value === true
-      ) {
-        cy.url().should('include', '/type-of-care');
-        this.assertLink({ name: 'Back', useShadowDOM: true });
-      } else {
-        super.assertUrl(
-          {
-            url: '/type-of-care',
-            breadcrumb: 'What type of care do you need?',
-          },
-          { timeout: 10000 },
-        );
-      }
-    });
+    cy.url().should('include', '/type-of-care');
+    this.assertLink({ name: 'Back', useShadowDOM: true });
 
     return this;
   }

--- a/src/applications/vaos/tests/e2e/page-objects/UrgentCareInformationPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/UrgentCareInformationPageObject.js
@@ -10,6 +10,13 @@ class UrgentCareInformationPageObject extends PageObject {
       { timeout: 10000 },
     );
   }
+
+  scheduleAppointment() {
+    cy.findByText('Start scheduling an appointment').click({
+      waitForAnimations: true,
+    });
+    return this;
+  }
 }
 
 export default new UrgentCareInformationPageObject();

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -19,7 +19,6 @@ export function mockFeatureToggles(
     vaOnlineSchedulingCCDirectScheduling: false,
     vaOnlineSchedulingCCDirectSchedulingChiropractic: false,
     vaOnlineSchedulingCommunityCareCancellations: false,
-    vaOnlineSchedulingImmediateCareAlert: false,
   },
 ) {
   cy.intercept(

--- a/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/scheduling.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/scheduling.cypress.spec.js
@@ -13,9 +13,7 @@ describe('VAOS schedule flow', () => {
   beforeEach(() => {
     vaosSetup();
     mockAppointmentsGetApi({ response: [] });
-    mockFeatureToggles({
-      vaOnlineSchedulingImmediateCareAlert: true,
-    });
+    mockFeatureToggles();
     mockVamcEhrApi();
   });
 

--- a/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/scheduling.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/scheduling.cypress.spec.js
@@ -24,9 +24,7 @@ describe('VAOS schedule flow', () => {
     // Act
     cy.login(mockUser);
 
-    AppointmentListPageObject.visit().scheduleAppointment(
-      'Schedule a new appointment',
-    );
+    AppointmentListPageObject.visit().scheduleAppointment();
 
     UrgentCareInformationPageObject.assertUrl()
       .clickButton({

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/audiology.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/audiology.cypress.spec.js
@@ -19,6 +19,7 @@ import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointm
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfFacilityPageObject from '../../page-objects/TypeOfFacilityPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -100,6 +101,8 @@ describe('VAOS community care flow - Audiology', () => {
 
       AppointmentListPageObject.visit().scheduleAppointment();
 
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
         .selectTypeOfCare(/Audiology and speech/)
@@ -155,6 +158,8 @@ describe('VAOS community care flow - Audiology', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -212,6 +217,8 @@ describe('VAOS community care flow - Audiology', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert()
@@ -290,6 +297,8 @@ describe('VAOS community care flow - Audiology', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Audiology and speech/)
@@ -349,6 +358,8 @@ describe('VAOS community care flow - Audiology', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert()

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/audiology.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/audiology.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import { TYPE_OF_CARE_IDS } from '../../../../utils/constants';
 import MockAppointmentResponse from '../../../fixtures/MockAppointmentResponse';

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
@@ -23,6 +23,7 @@ import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfEyeCarePageObject from '../../page-objects/TypeOfEyeCarePageObject';
 import TypeOfFacilityPageObject from '../../page-objects/TypeOfFacilityPageObject';
 import TypeOfVisitPageObject from '../../page-objects/TypeOfVisitPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -117,6 +118,8 @@ describe('VAOS direct schedule flow - Optometry', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Eye care/i)
@@ -172,6 +175,8 @@ describe('VAOS direct schedule flow - Optometry', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: true })
@@ -271,6 +276,8 @@ describe('VAOS direct schedule flow - Optometry', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Eye care/i)
@@ -324,6 +331,8 @@ describe('VAOS direct schedule flow - Optometry', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: true })
@@ -424,6 +433,8 @@ describe('VAOS direct schedule flow - Optometry', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/optometry.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import {
   APPOINTMENT_STATUS,

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/podiatry.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/podiatry.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import { TYPE_OF_CARE_IDS } from '../../../../utils/constants';
 import MockAppointmentResponse from '../../../fixtures/MockAppointmentResponse';

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/podiatry.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/podiatry.cypress.spec.js
@@ -15,6 +15,7 @@ import PreferredLanguagePageObject from '../../page-objects/PreferredLanguagePag
 import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointmentPageObject';
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import {
   mockAppointmentCreateApi,
   mockAppointmentGetApi,
@@ -77,6 +78,8 @@ describe('VAOS community care flow - Podiatry', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .selectTypeOfCare(/Podiatry/)
@@ -145,6 +148,8 @@ describe('VAOS community care flow - Podiatry', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .selectTypeOfCare(/Podiatry/)
             .clickNextButton();
@@ -195,6 +200,8 @@ describe('VAOS community care flow - Podiatry', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .selectTypeOfCare(/Podiatry/)
@@ -266,6 +273,8 @@ describe('VAOS community care flow - Podiatry', () => {
       // Act
       cy.login(new MockUser());
       AppointmentListPageObject.visit().scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl()
         .selectTypeOfCare(/Podiatry/)

--- a/src/applications/vaos/tests/e2e/workflows/community-care-workflow/primary-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/community-care-workflow/primary-care.cypress.spec.js
@@ -19,6 +19,7 @@ import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointm
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfFacilityPageObject from '../../page-objects/TypeOfFacilityPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import {
   mockAppointmentCreateApi,
   mockAppointmentGetApi,
@@ -81,6 +82,8 @@ describe('VAOS community care flow - Primary care', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -134,6 +137,8 @@ describe('VAOS community care flow - Primary care', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert()
@@ -206,6 +211,8 @@ describe('VAOS community care flow - Primary care', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -264,6 +271,8 @@ describe('VAOS community care flow - Primary care', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert()
@@ -341,6 +350,8 @@ describe('VAOS community care flow - Primary care', () => {
 
       AppointmentListPageObject.visit().scheduleAppointment();
 
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
         .selectTypeOfCare(/Primary care/i)
@@ -404,6 +415,8 @@ describe('VAOS community care flow - Primary care', () => {
           });
         },
       }).scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/calendar-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/calendar-dead-ends.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { addDays } from 'date-fns';
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import { TYPE_OF_CARE_IDS } from '../../../../utils/constants';

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/calendar-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/calendar-dead-ends.cypress.spec.js
@@ -12,6 +12,7 @@ import ClinicChoicePageObject from '../../page-objects/ClinicChoicePageObject';
 import DateTimeSelectPageObject from '../../page-objects/DateTimeSelectPageObject';
 import PreferredDatePageObject from '../../page-objects/PreferredDatePageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -88,6 +89,8 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -138,6 +141,8 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -185,6 +190,8 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -272,6 +279,8 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -322,6 +331,8 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -369,6 +380,8 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/cerner.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/cerner.cypress.spec.js
@@ -6,6 +6,7 @@ import MockUser from '../../../fixtures/MockUser';
 import AppointmentListPageObject from '../../page-objects/AppointmentList/AppointmentListPageObject';
 import ScheduleCernerPageObject from '../../page-objects/ScheduleCernerPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -59,6 +60,8 @@ describe('VAOS direct schedule flow - Cerner', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -107,6 +110,8 @@ describe('VAOS direct schedule flow - Cerner', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -164,6 +169,8 @@ describe('VAOS direct schedule flow - Cerner', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -226,6 +233,8 @@ describe('VAOS direct schedule flow - Cerner', () => {
             cy.login(mockUser);
 
             AppointmentListPageObject.visit().scheduleAppointment();
+
+            UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })
@@ -297,6 +306,8 @@ describe('VAOS direct schedule flow - Cerner', () => {
             cy.login(mockUser);
 
             AppointmentListPageObject.visit().scheduleAppointment();
+
+            UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/cerner.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/cerner.cypress.spec.js
@@ -44,7 +44,6 @@ describe('VAOS direct schedule flow - Cerner', () => {
           response: [new MockFacilityResponse()],
         });
         mockFeatureToggles({
-          vaOnlineSchedulingImmediateCareAlert: false,
           vaOnlineSchedulingRemoveFacilityConfigCheck: false,
         });
         mockEligibilityCCApi({ cceType, isEligible: false });
@@ -94,7 +93,6 @@ describe('VAOS direct schedule flow - Cerner', () => {
           }),
         });
         mockFeatureToggles({
-          vaOnlineSchedulingImmediateCareAlert: false,
           vaOnlineSchedulingRemoveFacilityConfigCheck: false,
         });
         mockEligibilityCCApi({ cceType, isEligible: false });

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
@@ -21,6 +21,7 @@ import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointm
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfMentalHealthPageObject from '../../page-objects/TypeOfMentalHealthPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -174,6 +175,8 @@ describe('VAOS direct schedule flow - Mental health', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(typeOfCareRegex)
@@ -256,6 +259,8 @@ describe('VAOS direct schedule flow - Mental health', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -347,6 +352,8 @@ describe('VAOS direct schedule flow - Mental health', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(typeOfCareRegex)
@@ -436,6 +443,8 @@ describe('VAOS direct schedule flow - Mental health', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { addMonths, subDays } from 'date-fns';
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import {

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-clinics-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-clinics-dead-ends.cypress.spec.js
@@ -8,6 +8,7 @@ import MockUser from '../../../fixtures/MockUser';
 import AppointmentListPageObject from '../../page-objects/AppointmentList/AppointmentListPageObject';
 import ClinicChoicePageObject from '../../page-objects/ClinicChoicePageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -86,6 +87,8 @@ describe('VAOS direct schedule flow - Multiple clinics dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-facilities-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-facilities-dead-ends.cypress.spec.js
@@ -7,6 +7,7 @@ import MockClinicResponse from '../../../fixtures/MockClinicResponse';
 import MockUser from '../../../fixtures/MockUser';
 import AppointmentListPageObject from '../../page-objects/AppointmentList/AppointmentListPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -52,6 +53,8 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -91,6 +94,8 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -152,6 +157,8 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -219,6 +226,8 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -280,6 +289,8 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -346,6 +357,8 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-facilities-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-facilities-dead-ends.cypress.spec.js
@@ -31,7 +31,6 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
 
     mockAppointmentsGetApi({ response: [] });
     mockFeatureToggles({
-      vaOnlineSchedulingImmediateCareAlert: false,
       vaOnlineSchedulingRemoveFacilityConfigCheck: false,
       vaOnlineSchedulingUseVpg: false,
     });

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/ophthalmology.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/ophthalmology.cypress.spec.js
@@ -21,6 +21,7 @@ import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointm
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfEyeCarePageObject from '../../page-objects/TypeOfEyeCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -145,6 +146,8 @@ describe('VAOS request schedule flow - Audiology', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/ophthalmology.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/ophthalmology.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { addMonths, subDays } from 'date-fns';
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import {

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -39,7 +39,6 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
     mockAppointmentsGetApi({ response: [] });
     mockFeatureToggles({
-      vaOnlineSchedulingImmediateCareAlert: true,
       vaOnlineSchedulingUseVpg: true,
     });
     mockVamcEhrApi({ isCerner: true });

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -95,9 +95,7 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
             // Act
             cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
+            AppointmentListPageObject.visit().scheduleAppointment();
             UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })
@@ -171,9 +169,7 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
             // Act
             cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
+            AppointmentListPageObject.visit().scheduleAppointment();
             UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })
@@ -257,9 +253,7 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
             // Act
             cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
+            AppointmentListPageObject.visit().scheduleAppointment();
             UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })
@@ -337,9 +331,7 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
             // Act
             cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
+            AppointmentListPageObject.visit().scheduleAppointment();
             UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })
@@ -423,9 +415,7 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
             // Act
             cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
+            AppointmentListPageObject.visit().scheduleAppointment();
             UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })
@@ -496,9 +486,7 @@ describe('OH direct schedule flow - Food and Nutrition', () => {
 
             // Act
             cy.login(mockUser);
-            AppointmentListPageObject.visit().scheduleAppointment(
-              'Schedule a new appointment',
-            );
+            AppointmentListPageObject.visit().scheduleAppointment();
             UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
             TypeOfCarePageObject.assertUrl()
               .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/primary-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/primary-care.cypress.spec.js
@@ -22,6 +22,7 @@ import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointm
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfFacilityPageObject from '../../page-objects/TypeOfFacilityPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -106,6 +107,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Primary care/i)
@@ -180,6 +183,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: true })
             .selectTypeOfCare(/Primary care/i)
@@ -247,6 +252,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -328,6 +335,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Primary care/i)
@@ -366,6 +375,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -444,6 +455,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Primary care/i)
@@ -506,6 +519,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: true })
@@ -576,6 +591,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -661,6 +678,8 @@ describe('VAOS direct schedule flow - Primary care', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/primary-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/primary-care.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { addMonths } from 'date-fns';
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import {

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-clinic-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-clinic-dead-ends.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import { TYPE_OF_CARE_IDS } from '../../../../utils/constants';
 import MockClinicResponse from '../../../fixtures/MockClinicResponse';

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-clinic-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-clinic-dead-ends.cypress.spec.js
@@ -8,6 +8,7 @@ import MockUser from '../../../fixtures/MockUser';
 import AppointmentListPageObject from '../../page-objects/AppointmentList/AppointmentListPageObject';
 import ClinicChoicePageObject from '../../page-objects/ClinicChoicePageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -78,6 +79,8 @@ describe('VAOS direct schedule flow - Single clinic dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -136,6 +139,8 @@ describe('VAOS direct schedule flow - Single clinic dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -172,6 +177,8 @@ describe('VAOS direct schedule flow - Single clinic dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-facility-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-facility-dead-ends.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import { TYPE_OF_CARE_IDS } from '../../../../utils/constants';
 import MockEligibilityResponse from '../../../fixtures/MockEligibilityResponse';

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-facility-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-facility-dead-ends.cypress.spec.js
@@ -7,6 +7,7 @@ import MockFacilityResponse from '../../../fixtures/MockFacilityResponse';
 import MockUser from '../../../fixtures/MockUser';
 import AppointmentListPageObject from '../../page-objects/AppointmentList/AppointmentListPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -65,6 +66,8 @@ describe('VAOS direct schedule flow - Single facility dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -116,6 +119,8 @@ describe('VAOS direct schedule flow - Single facility dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -169,6 +174,8 @@ describe('VAOS direct schedule flow - Single facility dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
@@ -228,6 +235,8 @@ describe('VAOS direct schedule flow - Single facility dead ends', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/Primary care/i)
@@ -280,6 +289,8 @@ describe('VAOS direct schedule flow - Single facility dead ends', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/home-sleep-testing.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/home-sleep-testing.cypress.spec.js
@@ -18,6 +18,7 @@ import DateTimeRequestPageObject from '../../page-objects/DateTimeRequestPageObj
 import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointmentPageObject';
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -115,6 +116,8 @@ describe('VAOS request schedule flow - sleep care', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
@@ -20,6 +20,7 @@ import ReasonForAppointmentPageObject from '../../page-objects/ReasonForAppointm
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfMentalHealthPageObject from '../../page-objects/TypeOfMentalHealthPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -117,6 +118,8 @@ describe('VAOS request schedule flow - Mental health', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
@@ -262,6 +265,8 @@ describe('VAOS request schedule flow - Mental health', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { addMonths } from 'date-fns';
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import {

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/oracle-health/food-nutrition.cypress.spec.js
@@ -53,7 +53,6 @@ describe('OH request flow - Food and Nutrition', () => {
     mockAppointmentCreateApi({ response });
     mockAppointmentsGetApi({ response: [] });
     mockFeatureToggles({
-      vaOnlineSchedulingImmediateCareAlert: true,
       vaOnlineSchedulingUseVpg: true,
     });
     mockVamcEhrApi({ isCerner: true });

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/primary-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/primary-care.cypress.spec.js
@@ -18,6 +18,7 @@ import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
 import TypeOfFacilityPageObject from '../../page-objects/TypeOfFacilityPageObject';
 import TypeOfVisitPageObject from '../../page-objects/TypeOfVisitPageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -111,6 +112,8 @@ describe('VAOS request schedule flow - Primary care', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Primary care/i)
@@ -169,6 +172,8 @@ describe('VAOS request schedule flow - Primary care', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: true })
@@ -269,6 +274,8 @@ describe('VAOS request schedule flow - Primary care', () => {
 
           AppointmentListPageObject.visit().scheduleAppointment();
 
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: false })
             .selectTypeOfCare(/Primary care/i)
@@ -326,6 +333,8 @@ describe('VAOS request schedule flow - Primary care', () => {
           cy.login(mockUser);
 
           AppointmentListPageObject.visit().scheduleAppointment();
+
+          UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
           TypeOfCarePageObject.assertUrl()
             .assertAddressAlert({ exist: true })
@@ -425,6 +434,8 @@ describe('VAOS request schedule flow - Primary care', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/primary-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/primary-care.cypress.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { getTypeOfCareById } from '../../../../utils/appointment';
 import {
   APPOINTMENT_STATUS,

--- a/src/applications/vaos/tests/e2e/workflows/vaccine-workflow/covid19.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/vaccine-workflow/covid19.cypress.spec.js
@@ -16,6 +16,7 @@ import PlanAheadPageObject from '../../page-objects/PlanAheadPageObject';
 import ReviewPageObject from '../../page-objects/ReviewPageObject';
 import SecondDosePageObject from '../../page-objects/SecondDosePageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentCreateApi,
@@ -104,6 +105,8 @@ describe('VAOS covid-19 vaccine flow', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/COVID-19 vaccine/i)
@@ -164,6 +167,8 @@ describe('VAOS covid-19 vaccine flow', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert()
@@ -267,6 +272,8 @@ describe('VAOS covid-19 vaccine flow', () => {
 
         AppointmentListPageObject.visit().scheduleAppointment();
 
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: false })
           .selectTypeOfCare(/COVID-19 vaccine/i)
@@ -332,6 +339,8 @@ describe('VAOS covid-19 vaccine flow', () => {
         cy.login(mockUser);
 
         AppointmentListPageObject.visit().scheduleAppointment();
+
+        UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
         TypeOfCarePageObject.assertUrl()
           .assertAddressAlert({ exist: true })
@@ -407,6 +416,8 @@ describe('VAOS covid-19 vaccine flow', () => {
 
       AppointmentListPageObject.visit().scheduleAppointment();
 
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
         .selectTypeOfCare(/COVID-19 vaccine/i)
@@ -449,6 +460,8 @@ describe('VAOS covid-19 vaccine flow', () => {
       cy.login(mockUser);
 
       AppointmentListPageObject.visit().scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
@@ -498,6 +511,8 @@ describe('VAOS covid-19 vaccine flow', () => {
       cy.login(mockUser);
 
       AppointmentListPageObject.visit().scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
@@ -551,6 +566,8 @@ describe('VAOS covid-19 vaccine flow', () => {
       cy.login(mockUser);
 
       AppointmentListPageObject.visit().scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })

--- a/src/applications/vaos/tests/e2e/workflows/vaccine-workflow/select-date.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/vaccine-workflow/select-date.cypress.spec.js
@@ -10,6 +10,7 @@ import DateTimeSelectPageObject from '../../page-objects/DateTimeSelectPageObjec
 import DosesReceivedPageObject from '../../page-objects/DosesReceivedPageObject';
 import PlanAheadPageObject from '../../page-objects/PlanAheadPageObject';
 import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
 import VAFacilityPageObject from '../../page-objects/VAFacilityPageObject';
 import {
   mockAppointmentsGetApi,
@@ -80,6 +81,8 @@ describe('VAOS select appointment date', () => {
 
       AppointmentListPageObject.visit().scheduleAppointment();
 
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
         .selectTypeOfCare(/COVID-19 vaccine/i)
@@ -142,6 +145,8 @@ describe('VAOS select appointment date', () => {
 
       AppointmentListPageObject.visit().scheduleAppointment();
 
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
         .selectTypeOfCare(/COVID-19 vaccine/i)
@@ -202,6 +207,8 @@ describe('VAOS select appointment date', () => {
       cy.login(mockUser);
 
       AppointmentListPageObject.visit().scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl({
         url: '/type-of-care',
@@ -276,6 +283,8 @@ describe('VAOS select appointment date', () => {
 
       AppointmentListPageObject.visit().scheduleAppointment();
 
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })
         .selectTypeOfCare(/COVID-19 vaccine/i)
@@ -336,6 +345,8 @@ describe('VAOS select appointment date', () => {
       cy.login(mockUser);
 
       AppointmentListPageObject.visit().scheduleAppointment();
+
+      UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
 
       TypeOfCarePageObject.assertUrl()
         .assertAddressAlert({ exist: false })

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -350,7 +350,6 @@
   "vaOnlineSchedulingAddSubstanceUseDisorder": "va_online_scheduling_add_substance_use_disorder",
   "vaOnlineSchedulingListViewClinicInfo": "va_online_scheduling_list_view_clinic_info",
   "vaOnlineSchedulingAddOhAvs": "va_online_scheduling_add_OH_avs",
-  "vaOnlineSchedulingImmediateCareAlert": "va_online_scheduling_immediate_care_alert",
   "vaOnlineSchedulingRemoveFacilityConfigCheck": "va_online_scheduling_remove_facility_config_check",
   "vaOnlineSchedulingUseBrowserTimezone": "va_online_scheduling_use_browser_timezone",
   "vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative": "va_online_scheduling_add_primary_care_mental_health_initiative",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removing fully released feature toggle
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123628

## Testing done

- Updated unit tests and e2e tests

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

