### PR TITLE
Update travel claims section content to travel reimbursement claims

### DIFF
--- a/src/applications/claims-status/components/TravelClaimsSection.jsx
+++ b/src/applications/claims-status/components/TravelClaimsSection.jsx
@@ -5,24 +5,26 @@ export default function TravelClaimsSection() {
   const recordLinkClick = () =>
     recordEvent({
       event: 'nav-link-click',
-      'link-label': 'Review and file travel claims',
+      'link-label': 'Review and file travel reimbursement claims',
       'link-destination': '/my-health/travel-pay/claims',
     });
 
   return (
     <div className="vads-u-margin-y--4">
-      <h2 id="your-travel-claims">Your travel claims</h2>
+      <h2 id="your-travel-reimbursement-claims">
+        Your travel reimbursement claims
+      </h2>
       <a
         className="active-va-link"
         href="/my-health/travel-pay/claims"
         onClick={recordLinkClick}
       >
-        Review and file travel claims
+        Review and file travel reimbursement claims
         <va-icon icon="chevron_right" size={3} aria-hidden="true" />
       </a>
       <p className="vads-u-margin-y--0p5">
-        File new claims for travel reimbursement and review the status of all
-        your travel claims.
+        File new claims for travel pay and review the status of all your travel
+        reimbursement claims.
       </p>
     </div>
   );

--- a/src/applications/claims-status/tests/components/TravelClaimsSection.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/TravelClaimsSection.unit.spec.jsx
@@ -11,13 +11,13 @@ describe('<TravelClaimsSection>', () => {
   it('renders the travel claims section', () => {
     const { getByRole, getByText } = render(<TravelClaimsSection />);
     const heading = getByRole('heading', {
-      name: 'Your travel claims',
+      name: 'Your travel reimbursement claims',
     });
     const link = getByRole('link', {
-      name: 'Review and file travel claims',
+      name: 'Review and file travel reimbursement claims',
     });
     const details = getByText(
-      'File new claims for travel reimbursement and review the status of all your travel claims.',
+      'File new claims for travel pay and review the status of all your travel reimbursement claims.',
     );
 
     expect(heading).to.be.visible;
@@ -30,7 +30,7 @@ describe('<TravelClaimsSection>', () => {
     const recordEventStub = sinon.stub(recordEventModule, 'default');
     const { getByRole } = render(<TravelClaimsSection />);
     const link = getByRole('link', {
-      name: 'Review and file travel claims',
+      name: 'Review and file travel reimbursement claims',
     });
 
     await userEvent.click(link);
@@ -38,7 +38,7 @@ describe('<TravelClaimsSection>', () => {
     expect(
       recordEventStub.calledWith({
         event: 'nav-link-click',
-        'link-label': 'Review and file travel claims',
+        'link-label': 'Review and file travel reimbursement claims',
         'link-destination': '/my-health/travel-pay/claims',
       }),
     ).to.be.true;

--- a/src/applications/claims-status/tests/e2e/tests/your-claims/your-claims.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/your-claims/your-claims.cypress.spec.js
@@ -53,8 +53,8 @@ describe('Your claims', () => {
           name: "What if I can't find my claim, decision review, or appeal?",
         }).should('have.attr', 'href', '#what-if-i-dont-see-my-appeal');
         cy.findByRole('link', {
-          name: 'Your travel claims',
-        }).should('have.attr', 'href', '#your-travel-claims');
+          name: 'Your travel reimbursement claims',
+        }).should('have.attr', 'href', '#your-travel-reimbursement-claims');
         cy.findByRole('link', {
           name: 'Additional services',
         }).should('have.attr', 'href', '#additional-services');
@@ -140,15 +140,15 @@ describe('Your claims', () => {
 
   it('should display the travel claims section', () => {
     cy.findByRole('heading', {
-      name: 'Your travel claims',
+      name: 'Your travel reimbursement claims',
     });
 
     cy.findByRole('link', {
-      name: 'Review and file travel claims',
+      name: 'Review and file travel reimbursement claims',
     }).should('have.attr', 'href', '/my-health/travel-pay/claims');
 
     cy.findByText(
-      'File new claims for travel reimbursement and review the status of all your travel claims.',
+      'File new claims for travel pay and review the status of all your travel reimbursement claims.',
     );
 
     cy.axeCheck();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updated the `TravelClaimsSection` component copy from "travel claims" to "travel reimbursement claims" across the H2 heading, link text, and description paragraph
- H2: "Your travel claims" → "Your travel reimbursement claims"
- Link: "Review and file travel claims" → "Review and file travel reimbursement claims"
- Description: "File new claims for travel reimbursement and review the status of all your travel claims." → "File new claims for travel pay and review the status of all your travel reimbursement claims."
- Updated the `id` attribute from `your-travel-claims` to `your-travel-reimbursement-claims` and the analytics `link-label` to match
- Benefits Management Tools (BMT) teams own this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#134645

## Testing done

- **Old behavior:** The travel claims section on the `/track-claims` page displayed "Your travel claims" as the H2, "Review and file travel claims" as the link, and "File new claims for travel reimbursement and review the status of all your travel claims." as the description
- **Steps to verify:** Navigate to `/track-claims` while logged in and scroll to the travel claims section. Confirm the H2 reads "Your travel reimbursement claims", the link reads "Review and file travel reimbursement claims", and the description reads "File new claims for travel pay and review the status of all your travel reimbursement claims."
- **Unit tests:** 2/2 passing for `TravelClaimsSection.unit.spec.jsx` — verifies heading, link text, link href, description text, and analytics event recording
- **E2E tests:** 11/11 passing for `your-claims.cypress.spec.js` — verifies section renders correctly including "on this page" navigation anchor, heading, link, description, and accessibility checks

## Screenshots
### Figma
<img width="647" height="246" alt="image (7)" src="https://github.com/user-attachments/assets/322b6998-614c-4f8c-a6ec-3d76c92ab9df" />

### Mobile: Before (Staging) vs After (Localhost)

<img width="1304" height="487" alt="Screenshot 2026-02-27 at 11 47 50 AM" src="https://github.com/user-attachments/assets/1b1276f0-153a-4ed5-8a4d-fd7cf23d4cda" />

<img width="1325" height="423" alt="Screenshot 2026-02-27 at 11 47 04 AM" src="https://github.com/user-attachments/assets/8fa40c14-013e-4ba7-971d-94217476f033" />

### Desktop: Before (Staging) vs After (Localhost)

<img width="1668" height="579" alt="Screenshot 2026-02-27 at 11 57 25 AM" src="https://github.com/user-attachments/assets/5feb5712-de63-41ca-a214-bad0f778d0d0" />

<img width="1686" height="395" alt="Screenshot 2026-02-27 at 11 57 47 AM" src="https://github.com/user-attachments/assets/63570fa8-0317-4d50-9deb-c7aea3b6f24d" />

## What areas of the site does it impact?

Claims status overview page (`/track-claims`) — specifically the travel claims section. No other areas affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A — content-only change, no documentation update needed)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Content-only change — no functional or architectural changes. Straightforward copy update across component, unit tests, and E2E tests.