### PR TITLE
686c | Update logic for noSsn submission

### DIFF
--- a/src/applications/dependents/686c-674/config/utilities/submission.js
+++ b/src/applications/dependents/686c-674/config/utilities/submission.js
@@ -68,7 +68,10 @@ function applyNoSsnReasonMappings(
     cleanData.spouseInformation.noSsnReason =
       noSsnReasonMappings[(sourceData?.spouseInformation?.noSsnReason)];
   }
-  if (addOptions.addChild === true && sourceData?.childrenToAdd?.length > 0) {
+  if (
+    (addOptions.addChild === true || addOptions.addDisabledChild === true) &&
+    sourceData?.childrenToAdd?.length > 0
+  ) {
     sourceData.childrenToAdd.forEach((child, index) => {
       if (child.noSsn === true) {
         cleanData.childrenToAdd[index].noSsnReason =

--- a/src/applications/dependents/686c-674/tests/config/utilities.submission.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/utilities.submission.unit.spec.jsx
@@ -430,6 +430,77 @@ describe('buildSubmissionData', () => {
     expect(result.data.spouseSupportingDocuments).to.be.undefined;
   });
 
+  it('should transform noSsnReason enum values for addChild workflow', () => {
+    const payload = createTestData({
+      'view:addDependentOptions': {
+        addSpouse: false,
+        addChild: true,
+        report674: false,
+        addDisabledChild: false,
+      },
+      childrenToAdd: [
+        {
+          fullName: { first: 'Child', last: 'Doe' },
+          noSsn: true,
+          noSsnReason: 'NONRESIDENT_ALIEN',
+        },
+        {
+          fullName: { first: 'Child2', last: 'Doe' },
+          noSsn: true,
+          noSsnReason: 'NONE_ASSIGNED',
+        },
+        { fullName: { first: 'Child3', last: 'Doe' }, noSsn: false },
+      ],
+    });
+    const result = buildSubmissionData(payload);
+
+    expect(result.data.childrenToAdd[0].noSsnReason).to.equal(
+      'Nonresident Alien',
+    );
+    expect(result.data.childrenToAdd[1].noSsnReason).to.equal(
+      'No SSN Assigned by SSA',
+    );
+    expect(result.data.childrenToAdd[2].noSsnReason).to.be.undefined;
+  });
+
+  it('should transform noSsnReason enum values for addDisabledChild workflow (regression test)', () => {
+    // Regression test: disabled children share the childrenToAdd array with regular children
+    // but addDisabledChild is a separate option key from addChild. Previously, the
+    // applyNoSsnReasonMappings function only checked addChild, so disabled children's
+    // no-SSN reasons were sent as raw enum values (NONRESIDENT_ALIEN / NONE_ASSIGNED)
+    // instead of the human-readable payload values.
+    const payload = createTestData({
+      'view:addDependentOptions': {
+        addSpouse: false,
+        addChild: false,
+        report674: false,
+        addDisabledChild: true,
+      },
+      childrenToAdd: [
+        {
+          fullName: { first: 'Disabled', last: 'Child' },
+          noSsn: true,
+          noSsnReason: 'NONRESIDENT_ALIEN',
+        },
+        {
+          fullName: { first: 'Disabled2', last: 'Child' },
+          noSsn: true,
+          noSsnReason: 'NONE_ASSIGNED',
+        },
+        { fullName: { first: 'Disabled3', last: 'Child' }, noSsn: false },
+      ],
+    });
+    const result = buildSubmissionData(payload);
+
+    expect(result.data.childrenToAdd[0].noSsnReason).to.equal(
+      'Nonresident Alien',
+    );
+    expect(result.data.childrenToAdd[1].noSsnReason).to.equal(
+      'No SSN Assigned by SSA',
+    );
+    expect(result.data.childrenToAdd[2].noSsnReason).to.be.undefined;
+  });
+
   it('should not include view:addOrRemoveDependents when no valid options remain', () => {
     const payload = createTestData({
       'view:addDependentOptions': {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates add child submission logic to support "add disabled child" flow no ssn logic to send proper value

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133216

## Testing done

- unit tests added
- submission payload verified

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
