### PR TITLE
DR 133459 Adjust RUM user property setting to outside of init check

### DIFF
--- a/src/applications/appeals/shared/utils/useBrowserMonitoring.js
+++ b/src/applications/appeals/shared/utils/useBrowserMonitoring.js
@@ -42,12 +42,14 @@ const initializeRealUserMonitoring = customRumSettings => {
 
     // If sessionReplaySampleRate > 0, we need to manually start the recording
     datadogRum.startSessionReplayRecording();
+  }
 
-    if (customRumSettings?.addUserAccountId) {
-      datadogRum.setUserProperty({
-        userAccountId: customRumSettings?.accountUuid || null,
-      });
-    }
+  // Set user property regardless of whether we initialized RUM above,
+  // since the platform may have already initialized it.
+  if (customRumSettings?.addUserAccountId) {
+    datadogRum.setUserProperty({
+      userAccountId: customRumSettings?.accountUuid || null,
+    });
   }
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Originally, when I added the Datadog `setUserProperty` method, I thought it would be ok to call it within the `if` block that checks the Node environment, Platform environment, and the initial Datadog configuration. I think this was a mistake, though, because I have noticed other teams didn't tuck their configuration within that check ([see my original code example from the 10-10EZ form](https://github.com/department-of-veterans-affairs/vets-website/blob/d129793567dba2370b401e4e3c450df3bd1d3fd6/src/applications/hca/hooks/useBrowserMonitoring.jsx#L52)). I'm not seeing the user property being set in staging, and I think that might be because the feature toggle is not set at the same time that Datadog RUM is initialized, so we're losing the opportunity to set the user property entirely. I still can't really test this locally, so we'll have to check when it gets to staging.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/133459