### PR TITLE
VEBT-4721: 22-10278 cosmetic fixes | debug submit

### DIFF
--- a/src/applications/edu-benefits/10278/config/transform.js
+++ b/src/applications/edu-benefits/10278/config/transform.js
@@ -21,7 +21,7 @@ export default function transform(formConfig, form) {
 
     if (mailingAddress) {
       clonedData.claimantAddress = {
-        country: mailingAddress.countryCodeIso2 || 'USA',
+        country: mailingAddress.countryCodeIso3 || 'USA',
         street: mailingAddress.addressLine1 || '',
         street2: mailingAddress.addressLine2 || '',
         city: mailingAddress.city || '',

--- a/src/applications/edu-benefits/10278/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10278/containers/IntroductionPage.jsx
@@ -12,6 +12,16 @@ import { TITLE, SUBTITLE } from '../constants';
 import OmbInfo from '../components/OmbInfo';
 import TechnologyProgramAccordion from '../components/TechnologyProgramAccordion';
 
+const customLink = ({ children, ...props }) => (
+  <va-link-action
+    type="primary-entry"
+    text="Start your Authorization to disclose personal information"
+    {...props}
+  >
+    {children}
+  </va-link-action>
+);
+
 export const IntroductionPage = props => {
   const dispatch = useDispatch();
   const userLoggedIn = useSelector(state => isLoggedIn(state));
@@ -82,6 +92,7 @@ export const IntroductionPage = props => {
             formConfig={formConfig}
             pageList={pageList}
             startText="Start your Authorization to disclose personal information"
+            customLink={customLink}
           />
         )}
       </div>

--- a/src/applications/edu-benefits/10278/helpers.js
+++ b/src/applications/edu-benefits/10278/helpers.js
@@ -40,6 +40,7 @@ export const organizationRepresentativesArrayOptions = {
   arrayPath: 'organizationRepresentatives',
   nounSingular: 'representative',
   nounPlural: 'representatives',
+  maxItems: 6,
   required: true,
   isItemIncomplete: item => !item?.fullName?.first || !item?.fullName?.last,
   text: {

--- a/src/applications/edu-benefits/10278/helpers.js
+++ b/src/applications/edu-benefits/10278/helpers.js
@@ -110,7 +110,7 @@ export const validateTerminationDate = (errors, dateString) => {
     today.getDate(),
   );
 
-  if (entered > fiveYearsFromToday) {
+  if (entered < today || entered > fiveYearsFromToday) {
     errors.addError('You must enter a valid date that’s within 5 years');
   }
 };

--- a/src/applications/edu-benefits/10278/pages/informationToDisclose.js
+++ b/src/applications/edu-benefits/10278/pages/informationToDisclose.js
@@ -31,9 +31,9 @@ const OTHER_TEXT_MAX = 30;
 const DisclosureIntro = ({ claimantName, thirdPartyName }) => (
   <>
     <p>
-      I, the claimant <strong>{claimantName || 'N/A'}</strong>, authorize VA to
-      speak with <strong>{thirdPartyName || 'N/A'}</strong> for the purpose of
-      providing the following information pertaining to my VA record.
+      I, the claimant {claimantName}, authorize VA to speak with{' '}
+      {thirdPartyName} for the purpose of providing the following information
+      pertaining to my VA record.
     </p>
   </>
 );
@@ -155,6 +155,7 @@ const InformationToDiscloseField = props => {
         error={groupError}
       >
         <VaCheckbox
+          class="vads-u-margin-top--4"
           label="Select all benefit and claim information"
           checked={allSelected}
           indeterminate={someSelected}

--- a/src/applications/edu-benefits/10278/tests/config/transform.unit.spec.jsx
+++ b/src/applications/edu-benefits/10278/tests/config/transform.unit.spec.jsx
@@ -175,7 +175,7 @@ describe('22-10278 transform', () => {
       const formData = parseResult(transform({}, form));
 
       expect(formData.claimantAddress).to.deep.equal({
-        country: 'US',
+        country: 'USA',
         street: '123 Main St',
         street2: 'Apt 4',
         city: 'Springfield',

--- a/src/applications/edu-benefits/10278/tests/helpers.unit.spec.jsx
+++ b/src/applications/edu-benefits/10278/tests/helpers.unit.spec.jsx
@@ -44,6 +44,12 @@ describe('10278 helpers - validateTerminationDate', () => {
     validateTerminationDate({ addError }, '2030-02-17');
     expect(addError.called).to.equal(false);
   });
+
+  it('adds an error when the date is in the past', () => {
+    const addError = sinon.spy();
+    validateTerminationDate({ addError }, '2024-01-01');
+    expect(addError.called).to.equal(true);
+  });
 });
 
 describe('10278 helpers - getThirdPartyName', () => {

--- a/src/applications/edu-benefits/10278/tests/pages/informationToDisclose.unit.spec.jsx
+++ b/src/applications/edu-benefits/10278/tests/pages/informationToDisclose.unit.spec.jsx
@@ -74,10 +74,11 @@ describe('22-10278 information to disclose page', () => {
       },
     };
 
-    const { getByText } = renderPage({ claimInformation: {} }, storeData);
+    const { container } = renderPage({ claimInformation: {} }, storeData);
+    const paragraphText = container.querySelector('p').textContent;
 
-    expect(getByText('Taras Kurilo')).to.exist;
-    expect(getByText('Jane Doe')).to.exist;
+    expect(paragraphText).to.include('Taras Kurilo');
+    expect(paragraphText).to.include('Jane Doe');
   });
 
   it('setAll(false) clears otherText when unchecking "Select all"', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Make start button in the save in progress intro a banner.
- Increase margin between page description and checkboxes on page 4.
- Unbold the names of the claimant and third party, dynamically loaded into description text on page 4.
- Limit number of entries to 6 on list and loop for third party representatives.
- Read the correct country field to satisfy schema req for country code and ensure successful submission.

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-4721
- https://github.com/department-of-veterans-affairs/vets-website/pull/42682

## Testing done
<img width="1438" height="421" alt="Screenshot 2026-02-27 at 3 15 04 PM" src="https://github.com/user-attachments/assets/616b9a12-26a9-4c26-a97d-b89e2ef95c39" />

## Screenshots

### Before
<img width="789" height="195" alt="Screenshot 2026-02-27 at 3 23 52 PM" src="https://github.com/user-attachments/assets/2b489057-2214-4c27-8fd0-c25cd2e46126" />
|
<img width="626" height="229" alt="Screenshot 2026-02-27 at 3 24 46 PM" src="https://github.com/user-attachments/assets/074992e7-cbfe-4c8c-8d57-b2a55fe192f7" />

### After

<img width="824" height="332" alt="Screenshot 2026-02-27 at 3 20 36 PM" src="https://github.com/user-attachments/assets/a207120a-e74c-42db-9945-6f4a7f55b509" />
|
<img width="705" height="266" alt="Screenshot 2026-02-27 at 3 20 08 PM" src="https://github.com/user-attachments/assets/919d8f31-8055-4e7b-861d-a862ca4926be" />

## What areas of the site does it impact?
edu-benefits/10278

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA