### PR TITLE
feat: Hide SHA warning when new BDD SHA enforcement workflow is enabled

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -230,6 +230,7 @@ export const Form526Entry = ({
     'disability526ToxicExposureOptOutDataPurge',
     'disability526SupportingEvidenceEnhancement',
     'disability526ExtraBDDPagesEnabled',
+    'disability526NewBddShaEnforcementWorkflowEnabled',
   ]);
 
   // including this helper to showLoading when feature toggles are loading

--- a/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
+++ b/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
@@ -11,7 +11,9 @@ export const uiSchema = {
   'view:selfAssessmentAlert': {
     'ui:title': selfAssessmentAlert,
     'ui:options': {
-      hideIf: formData => !isBDD(formData),
+      hideIf: formData =>
+        !isBDD(formData) ||
+        formData.disability526NewBddShaEnforcementWorkflowEnabled,
     },
   },
   additionalDocuments: {

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -5,13 +5,11 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
-import { createStore } from 'redux';
 import { render } from '@testing-library/react';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
-import { SAVED_SEPARATION_DATE } from '../../constants';
 import { selfAssessmentHeadline } from '../../content/selfAssessmentAlert';
-import { daysFromToday } from '../../utils/dates/formatting';
+import * as utils from '../../utils';
 
 const invalidDocumentData = {
   additionalDocuments: [
@@ -32,9 +30,45 @@ const validDocumentData = {
   ],
 };
 
+const getDocumentDataWithDisability526NewBddShaEnforcementWorkflowEnabledFlagSet = featureFlagValue => ({
+  ...validDocumentData,
+  disability526NewBddShaEnforcementWorkflowEnabled: featureFlagValue,
+});
+
 describe('526EZ document upload', () => {
   const page = formConfig.chapters.supportingEvidence.pages.additionalDocuments;
   const { schema, uiSchema, arrayPath } = page;
+
+  let sandbox;
+
+  /**
+   * Utility for reducing the noise in tests and highlighting only the important signals of the test.
+   *
+   * @param {*} props - Overrides to the default value of DefinitionTester. Primarily used to pass the data prop.
+   * @returns {JSX.Element} The rendered DefinitionTester component.
+   */
+  const DefaultDefinitionTester = props => {
+    return (
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          uiSchema={uiSchema}
+          {...props}
+        />
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   it('should render', async () => {
     const form = mount(
@@ -128,47 +162,60 @@ describe('526EZ document upload', () => {
     form.unmount();
   });
 
-  it('should not display alert if not BDD', () => {
-    const { queryByText } = render(
-      <Provider store={uploadStore}>
-        <DefinitionTester
-          arrayPath={arrayPath}
-          pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
-          schema={schema}
-          data={validDocumentData}
-          uiSchema={uiSchema}
-        />
-      </Provider>,
-    );
+  describe('Separation Health Assessment Alert', () => {
+    const configureMocksAndGetData = ({
+      isBddReturn,
+      bddShaEnforcementWorkflowFlagReturn,
+    }) => {
+      sandbox.stub(utils, 'isBDD').returns(isBddReturn);
+      return getDocumentDataWithDisability526NewBddShaEnforcementWorkflowEnabledFlagSet(
+        bddShaEnforcementWorkflowFlagReturn,
+      );
+    };
 
-    expect(queryByText(selfAssessmentHeadline)).to.not.exist;
-  });
+    it('should not display if submission is not considered BDD and new BDD SHA enforcement workflow is not enabled', () => {
+      const data = configureMocksAndGetData({
+        isBddReturn: false,
+        bddShaEnforcementWorkflowFlagReturn: false,
+      });
 
-  it('should display alert when BDD SHA enabled', () => {
-    const fakeStore = createStore(() => ({
-      featureToggles: {},
-    }));
+      const { queryByText } = render(<DefaultDefinitionTester data={data} />);
 
-    // mock BDD
-    window.sessionStorage.setItem(SAVED_SEPARATION_DATE, daysFromToday(90));
+      expect(queryByText(selfAssessmentHeadline)).to.not.exist;
+    });
 
-    const form = render(
-      <Provider store={fakeStore}>
-        <DefinitionTester
-          arrayPath={arrayPath}
-          pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
-          schema={schema}
-          data={validDocumentData}
-          uiSchema={uiSchema}
-        />
-      </Provider>,
-    );
+    it('should not display if submission is not considered BDD but new BDD SHA enforcement workflow is enabled', () => {
+      const data = configureMocksAndGetData({
+        isBddReturn: false,
+        bddShaEnforcementWorkflowFlagReturn: true,
+      });
 
-    form.getByText(
-      'Please submit your Separation Health Assessment - Part A Self-Assessment as soon as possible',
-    );
+      const { queryByText } = render(<DefaultDefinitionTester data={data} />);
+
+      expect(queryByText(selfAssessmentHeadline)).to.not.exist;
+    });
+
+    it('should display when submission is considered BDD and new BDD SHA enforcement workflow is not enabled', () => {
+      const data = configureMocksAndGetData({
+        isBddReturn: true,
+        bddShaEnforcementWorkflowFlagReturn: false,
+      });
+
+      const { queryByText } = render(<DefaultDefinitionTester data={data} />);
+
+      expect(queryByText(selfAssessmentHeadline)).to.exist;
+    });
+
+    it('should not display alert when submission is considered BDD but new BDD SHA enforcement workflow is enabled', () => {
+      const data = configureMocksAndGetData({
+        isBddReturn: true,
+        bddShaEnforcementWorkflowFlagReturn: true,
+      });
+
+      const { queryByText } = render(<DefaultDefinitionTester data={data} />);
+
+      expect(queryByText(selfAssessmentHeadline)).to.not.exist;
+    });
   });
 
   describe('ui:confirmationField', () => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This adds a new check to the condition that controls whether the Separation Health Assessment alert shows on the Additional Evidence upload page. Because we are creating a new SHA Upload page, this warning will no longer be needed.

This PR also makes some changes to...
* Reduce some of the noise in tests by creating utility functions
* Move away from using session storage to set up the BDD scenario by creating a mock around `isBDD`. This allows the internal implementation of isBDD to change while still ensuring we're just testing off the contract.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#134061

## Testing done

1. Start a Form 21-526EZ form. Select "yes" to indicate you are still in active service and select a date 90-180 days from the current date to qualify for BDD.
2. Fill out form until Supporting Evidence orientation page
3. Skip service treatment record.
4. Answer "yes" when asked if you want to provide additional evidence and select the "Required Separation Health Assessment - Part A Self-Assessment or other documents like your DD Form 214, supporting (lay) statements, or other evidence" option.

Old behavior: SHA alert shows
New behavior: No SHA alert shows when feature flag is on.

[TestRails Test Case](https://dsvavsp.testrail.io/index.php?/cases/view/166096)

## Screenshots

Only difference is that the SHA Alert no longer appears if the feature flag is enabled.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="822" height="5824" alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_additional-evidence (1)" src="https://github.com/user-attachments/assets/4591b69f-489f-483d-8fc6-c65718758f25" />      |   <img width="1178" height="4406" alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_additional-evidence (3)" src="https://github.com/user-attachments/assets/589dc656-16ac-41bf-b55d-2e5b33a07a93" />   |
| Desktop |  <img width="3196" height="5802" alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_additional-evidence" src="https://github.com/user-attachments/assets/2d253f10-5b30-46c7-8199-892e61e76628" />      |   <img width="3196" height="4900" alt="localhost_3001_disability_file-disability-claim-form-21-526ez_mental-health-form-0781_support" src="https://github.com/user-attachments/assets/b236d26d-24d6-4a84-99c0-bdc31c17b8a5" />    |

## What areas of the site does it impact?

Code changed only impacts Additional Evidence Upload page of Form 21-526EZ.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)  - N/A
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - N/A

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

No special considerations.