### PR TITLE
DR 134060 MyVA accordion update for Decision Reviews forms

### DIFF
--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
@@ -141,6 +141,10 @@ const ApplicationsInProgress = ({
     TOGGLE_NAMES.benefitsClaimsIvcChampVaProvider,
   );
 
+  const displayDecisionReviewsForms = useToggleValue(
+    TOGGLE_NAMES.decisionReviewsMyVADisplay,
+  );
+
   // Filter out non-SIP-enabled applications and expired applications
   const verifiedSavedForms = useMemo(
     () =>
@@ -218,7 +222,11 @@ const ApplicationsInProgress = ({
             <p data-testid="applications-in-progress-empty-state">
               {emptyStateText}
             </p>
-            {!hideMissingApplicationHelp && <MissingApplicationHelp />}
+            {!hideMissingApplicationHelp && (
+              <MissingApplicationHelp
+                displayDecisionReviewsForms={displayDecisionReviewsForms}
+              />
+            )}
           </>
         )}
         {hasForms && (
@@ -305,7 +313,11 @@ const ApplicationsInProgress = ({
 
               return null;
             })}
-            {!hideMissingApplicationHelp && <MissingApplicationHelp />}
+            {!hideMissingApplicationHelp && (
+              <MissingApplicationHelp
+                displayDecisionReviewsForms={displayDecisionReviewsForms}
+              />
+            )}
           </div>
         )}
       </DashboardWidgetWrapper>

--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/MissingApplicationHelp.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/MissingApplicationHelp.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Toggler } from '~/platform/utilities/feature-toggles';
 
-const MissingApplicationHelp = () => {
+const MissingApplicationHelp = ({ displayDecisionReviewsForms }) => {
   const content = (
     <>
       <p>
@@ -51,6 +52,22 @@ const MissingApplicationHelp = () => {
           21P-0847)
         </li>
         <li>Sign VA claim forms as an alternate signer (VA Form 21-0972)</li>
+        {displayDecisionReviewsForms && (
+          <>
+            <li data-testid="dr-forms">
+              Application for supplemental claim (VA Form 20-0995)
+            </li>
+            <li data-testid="dr-forms">
+              VA Form 21-4142 submitted with VA Form 20-0995
+            </li>
+            <li data-testid="dr-forms">
+              Application for higher-level review (VA Form 20-0996)
+            </li>
+            <li data-testid="dr-forms">
+              Application for board appeal (VA Form 10182)
+            </li>
+          </>
+        )}
       </ul>
       <p>
         If you have questions about your applications or forms, call us at{' '}
@@ -83,6 +100,10 @@ const MissingApplicationHelp = () => {
       </Toggler.Disabled>
     </Toggler>
   );
+};
+
+MissingApplicationHelp.propTypes = {
+  displayDecisionReviewsForms: PropTypes.bool,
 };
 
 export default MissingApplicationHelp;

--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/MissingApplicationHelp.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/MissingApplicationHelp.jsx
@@ -55,16 +55,17 @@ const MissingApplicationHelp = ({ displayDecisionReviewsForms }) => {
         {displayDecisionReviewsForms && (
           <>
             <li data-testid="dr-forms">
-              Application for supplemental claim (VA Form 20-0995)
+              File a Supplemental Claim (VA Form 20-0995)
             </li>
             <li data-testid="dr-forms">
-              VA Form 21-4142 submitted with VA Form 20-0995
+              Authorize the release of non-VA medical information to VA with a
+              Supplemental Claim (VA Form 21-4142 & 21-4142a with 20-0995)
             </li>
             <li data-testid="dr-forms">
-              Application for higher-level review (VA Form 20-0996)
+              Request a Higher-Level Review (VA Form 20-0996)
             </li>
             <li data-testid="dr-forms">
-              Application for board appeal (VA Form 10182)
+              Request a Board Appeal (VA Form 10182)
             </li>
           </>
         )}

--- a/src/applications/personalization/dashboard/tests/components/benefit-application-drafts/MissingApplicationHelp.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/benefit-application-drafts/MissingApplicationHelp.unit.spec.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import MissingApplicationHelp from '../../../components/benefit-application-drafts/MissingApplicationHelp';
+
+const mockStore = (toggles = {}) => ({
+  getState: () => ({
+    featureToggles: {
+      loading: false,
+      ...toggles,
+    },
+  }),
+  dispatch: () => {},
+  subscribe: () => () => {},
+});
+
+describe('MissingApplicationHelp', () => {
+  describe('when decision reviews feature toggle is off', () => {
+    it('should not render the decision reviews forms in the list', () => {
+      const { container } = render(
+        <Provider store={mockStore()}>
+          <MissingApplicationHelp displayDecisionReviewsForms={false} />
+        </Provider>,
+      );
+
+      const drForms = container.querySelectorAll('[data-testid="dr-forms"]');
+      expect(drForms.length).to.equal(0);
+    });
+  });
+
+  describe('when decision reviews feature toggle is on', () => {
+    it('should render the decision reviews forms in the list', () => {
+      const { container } = render(
+        <Provider store={mockStore()}>
+          <MissingApplicationHelp displayDecisionReviewsForms />
+        </Provider>,
+      );
+
+      const drForms = container.querySelectorAll('[data-testid="dr-forms"]');
+      expect(drForms.length).to.equal(4);
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update the MyVA "If you can't find your application or form" accordion to conditionally include the Decision Reviews forms (only when the feature toggle `my_va_display_decision_reviews_forms` is on).

We're using the form title + form ID for the list items (I pulled these from [Grace's PR screenshots](https://github.com/department-of-veterans-affairs/vets-website/pull/39146). Will need content review.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/134060

## Testing done & screenshots

Feature toggle: `my_va_display_decision_reviews_forms`


| Scenario | Screenshot |
| --- | --- |
| Feature toggle ON | <img width="400" alt="localhost_3001_my-va__postLogin=true (1)" src="https://github.com/user-attachments/assets/5aaafd97-9120-43b9-89ef-d5eaa23d42b0" /> |
| Feature toggle OFF | <img width="400" alt="localhost_3001_my-va__postLogin=true" src="https://github.com/user-attachments/assets/f2c9c0d8-147f-4a7e-91ab-904ddb7aa079" /> |