### PR TITLE
Add back Sass function imports for profile application

### DIFF
--- a/src/applications/personalization/dashboard/sass/dashboard.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard.scss
@@ -1,3 +1,4 @@
+@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/functions";
 @import "~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/mixins";
 @import "./user-profile";

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -1,3 +1,4 @@
+@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/functions";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/mixins";
 @import "./shared";
 @import "./profile-subnav";


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

We [accidentally removed](https://github.com/department-of-veterans-affairs/vets-website/pull/41902/changes#diff-edcd99cc3da4fa4ad12234f46ee025fb5b101983892b83c1bd0a05ab8dd6c332) the functions import for the profile application. That was affecting the `units-px` and `units` functions which are being used for padding in various places for this application.

## Related issue(s)

No available issue. I just noticed it when using the site.

## Testing done

I ran some e2e tests so that I could visually confirm the padding but I'm also reaching out to the vsa-authd-exp-frontend group so that they can help confirm that it's all visually correct now.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### Before

<img width="362" height="414" alt="Screenshot 2026-03-02 at 7 59 20 AM" src="https://github.com/user-attachments/assets/1c39e7db-b2fe-40e5-9d29-0f60b7ab47e9" />

<img width="547" height="561" alt="Screenshot 2026-03-02 at 8 45 42 AM" src="https://github.com/user-attachments/assets/2d5cfe45-7c2b-43b2-a628-688075818cad" />

<img width="3086" height="2020" alt="image" src="https://github.com/user-attachments/assets/f398a84f-3c3a-4a08-bcf2-483324d3b00a" />

<img width="444" height="219" alt="Screenshot 2026-03-02 at 8 01 29 AM" src="https://github.com/user-attachments/assets/5e330a3b-1107-40f1-9771-ed152e6c2f7c" />

### After

<img width="3086" height="2164" alt="image" src="https://github.com/user-attachments/assets/e57ec616-d6fd-4e9d-bdb4-e244db1acb02" />

<img width="3094" height="2008" alt="image (1)" src="https://github.com/user-attachments/assets/70663e56-8307-44d9-85a1-7659f995ee5f" />

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
