### PR TITLE
Fix phone remapping fix GA event

### DIFF
--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -4,7 +4,7 @@ import get from '../../../utilities/data/get';
 import omit from '../../../utilities/data/omit';
 import set from '../../../utilities/data/set';
 import unset from '../../../utilities/data/unset';
-import { recordEventOnce } from '../../../monitoring/record-event';
+import recordEvent from '../../../monitoring/record-event';
 import navigationState from './utilities/navigation/navigationState';
 import { isActivePage, parseISODate, minYear, maxYear } from './helpers';
 import {
@@ -681,8 +681,11 @@ export function rectifyData(data) {
       data.Touched !== undefined ||
       data.Error !== undefined;
 
-    if (hasCapitalKeys) {
-      recordEventOnce(
+    const sessionKey = 'va-sip-underscore-capital-transformation-tracked';
+    const alreadyRecorded = sessionStorage.getItem(sessionKey);
+
+    if (hasCapitalKeys && !alreadyRecorded) {
+      recordEvent(
         {
           event: 'api_call',
           'api-name': 'International Phone SIP Corruption Fix Detected',
@@ -691,6 +694,7 @@ export function rectifyData(data) {
         },
         'event',
       );
+      sessionStorage.setItem(sessionKey, 'true');
     }
   }
 


### PR DESCRIPTION
## Summary

- Use `recordEvent` instead of `recordEventOnce` for firing GA event for international phone remapping bug.
- This is because `recordEventOnce` is not compatible with `api_call` due to it being a shared event and already firing.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133012

## Testing done

- In browser testing.

## Screenshots

<img width="938" height="310" alt="image" src="https://github.com/user-attachments/assets/6c9b4846-0f1a-4666-a0f8-cda2ce60ca05" />

## What areas of the site does it impact?

observability

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
