### PR TITLE
DR 133459: DD RUM config adjustment

### DIFF
--- a/src/applications/appeals/shared/utils/useBrowserMonitoring.js
+++ b/src/applications/appeals/shared/utils/useBrowserMonitoring.js
@@ -47,9 +47,10 @@ const initializeRealUserMonitoring = customRumSettings => {
   // Set user property regardless of whether we initialized RUM above,
   // since the platform may have already initialized it.
   if (customRumSettings?.addUserAccountId) {
-    datadogRum.setUserProperty({
-      userAccountId: customRumSettings?.accountUuid || null,
-    });
+    datadogRum.setUserProperty(
+      'userAccountId',
+      customRumSettings?.accountUuid || 'unknown',
+    );
   }
 };
 
@@ -85,18 +86,28 @@ const initializeBrowserLogging = customLogSettings => {
   }
 };
 
-const useBrowserMonitoring = ({ loggedIn, ...settings }) => {
+const useBrowserMonitoring = ({
+  loggedIn,
+  addUserAccountId,
+  accountUuid,
+  ...settings
+}) => {
   useEffect(
     () => {
       if (!loggedIn) {
         return;
       }
 
-      initializeRealUserMonitoring(settings);
+      initializeRealUserMonitoring({
+        ...settings,
+        addUserAccountId,
+        accountUuid,
+      });
+
       initializeBrowserLogging(settings);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [loggedIn],
+    [loggedIn, addUserAccountId, accountUuid],
   );
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In two previous PRs ([first](https://github.com/department-of-veterans-affairs/vets-website/pull/42525) and [second](https://github.com/department-of-veterans-affairs/vets-website/pull/42751)), we configured our RUM to accept a `user_account_id` property, but we did it incorrectly. 

Rather than calling `setUserProperty` with an object, we should have been calling with two arguments as [HCA does here](https://github.com/department-of-veterans-affairs/vets-website/blob/d129793567dba2370b401e4e3c450df3bd1d3fd6/src/applications/hca/hooks/useBrowserMonitoring.jsx#L54), first a string for the key, then a string for the value ([Datadog docs](https://docs.datadoghq.com/logs/log_collection/javascript/?tab=npm#user-context)).

Original: `datadogRum.setUserProperty({ userAccountId: customRumSettings?.accountUuid || null })`
New: `datadogRum.setUserProperty('userAccountId', customRumSettings?.accountUuid || 'unknown')`

I also added the feature toggle and the account ID as a dependency in the `useEffect` array so we will be sure to set the value after the feature toggle and user data have completely loaded.

Reminder that we can't test this locally, so we have to wait until this merges to staging.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/133459