### PR TITLE
134428 enable all OH types of care staging

### DIFF
--- a/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
+++ b/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
@@ -7,5 +7,22 @@ export function useOHScheduling() {
   const featureUseVpg = useSelector(selectFeatureUseVpg);
   const data = useSelector(getFormData);
   const typeOfCare = getTypeOfCare(data);
-  return featureUseVpg && OH_ENABLED_TYPES_OF_CARE.includes(typeOfCare?.idV2);
+
+  // Enable all types of care in all environments other than production, in
+  // production utilize the constants that are defined in src/applications/vaos/utils/constants.js
+  const enableAllTypesOfCare =
+    process.env.NODE_ENV !== 'production' || process.env.NODE_ENV !== 'test';
+
+  if (!featureUseVpg) {
+    // OH only works when VPG is used
+    return false;
+  }
+
+  if (enableAllTypesOfCare) {
+    // env is not production or test
+    return true;
+  }
+
+  // Otherwise check constant for enabled types of care
+  return OH_ENABLED_TYPES_OF_CARE.includes(typeOfCare?.idV2);
 }

--- a/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
+++ b/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
@@ -8,18 +8,13 @@ export function useOHScheduling() {
   const data = useSelector(getFormData);
   const typeOfCare = getTypeOfCare(data);
 
-  // Enable all types of care in all environments other than production, in
-  // production utilize the constants that are defined in src/applications/vaos/utils/constants.js
-  const enableAllTypesOfCare =
-    process.env.NODE_ENV !== 'production' || process.env.NODE_ENV !== 'test';
-
   if (!featureUseVpg) {
     // OH only works when VPG is used
     return false;
   }
 
-  if (enableAllTypesOfCare) {
-    // env is not production or test
+  if (process.env.NODE_ENV === 'staging') {
+    // env is staging, let's enable all types of care
     return true;
   }
 

--- a/src/applications/vaos/new-appointment/hooks/useOHScheduling.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/hooks/useOHScheduling.unit.spec.jsx
@@ -9,20 +9,24 @@ describe('VAOS Hook: useOHScheduling', () => {
   let sandbox;
   let useSelectorStub;
   let getTypeOfCareStub;
+  let originalNodeEnv;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     useSelectorStub = sandbox.stub(redux, 'useSelector');
     getTypeOfCareStub = sandbox.stub(selectors, 'getTypeOfCare');
+    originalNodeEnv = process.env.NODE_ENV;
   });
 
   afterEach(() => {
     sandbox.restore();
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('should return false when feature flag is disabled', () => {
-    useSelectorStub.onCall(0).returns(false); // featureUseVpg
-    useSelectorStub.onCall(1).returns({}); // data
+    process.env.NODE_ENV = 'production';
+    useSelectorStub.onCall(0).returns(false); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'foodAndNutrition' });
 
     const { result } = renderHook(() => useOHScheduling());
@@ -30,9 +34,21 @@ describe('VAOS Hook: useOHScheduling', () => {
     expect(result.current).to.be.false;
   });
 
-  it('should return false when typeOfCare is not in OH_ENABLED_TYPES_OF_CARE', () => {
-    useSelectorStub.onCall(0).returns(true); // featureUseVpg
-    useSelectorStub.onCall(1).returns({}); // data
+  it('should return true in staging environment regardless of typeOfCare', () => {
+    process.env.NODE_ENV = 'staging';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
+    getTypeOfCareStub.returns({ idV2: 'primaryCare' }); // Not in OH_ENABLED_TYPES_OF_CARE
+
+    const { result } = renderHook(() => useOHScheduling());
+
+    expect(result.current).to.be.true;
+  });
+
+  it('should return false when typeOfCare is not in OH_ENABLED_TYPES_OF_CARE in production', () => {
+    process.env.NODE_ENV = 'production';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'primaryCare' });
 
     const { result } = renderHook(() => useOHScheduling());
@@ -40,9 +56,10 @@ describe('VAOS Hook: useOHScheduling', () => {
     expect(result.current).to.be.false;
   });
 
-  it('should return true when feature flag is enabled and typeOfCare is foodAndNutrition', () => {
-    useSelectorStub.onCall(0).returns(true); // featureUseVpg
-    useSelectorStub.onCall(1).returns({}); // data
+  it('should return true when feature flag is enabled and typeOfCare is foodAndNutrition in production', () => {
+    process.env.NODE_ENV = 'production';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'foodAndNutrition' });
 
     const { result } = renderHook(() => useOHScheduling());
@@ -50,9 +67,21 @@ describe('VAOS Hook: useOHScheduling', () => {
     expect(result.current).to.be.true;
   });
 
-  it('should return false when typeOfCare is undefined', () => {
-    useSelectorStub.onCall(0).returns(true); // featureUseVpg
-    useSelectorStub.onCall(1).returns({}); // data
+  it('should return true when feature flag is enabled and typeOfCare is clinicalPharmacyPrimaryCare in production', () => {
+    process.env.NODE_ENV = 'production';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
+    getTypeOfCareStub.returns({ idV2: 'clinicalPharmacyPrimaryCare' });
+
+    const { result } = renderHook(() => useOHScheduling());
+
+    expect(result.current).to.be.true;
+  });
+
+  it('should return false when typeOfCare is undefined in production', () => {
+    process.env.NODE_ENV = 'production';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns(undefined);
 
     const { result } = renderHook(() => useOHScheduling());
@@ -60,9 +89,10 @@ describe('VAOS Hook: useOHScheduling', () => {
     expect(result.current).to.be.false;
   });
 
-  it('should return false when typeOfCare.idV2 is undefined', () => {
-    useSelectorStub.onCall(0).returns(true); // featureUseVpg
-    useSelectorStub.onCall(1).returns({}); // data
+  it('should return false when typeOfCare.idV2 is undefined in production', () => {
+    process.env.NODE_ENV = 'production';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: undefined });
 
     const { result } = renderHook(() => useOHScheduling());
@@ -70,14 +100,26 @@ describe('VAOS Hook: useOHScheduling', () => {
     expect(result.current).to.be.false;
   });
 
-  it('should call getTypeOfCare with the form data', () => {
+  it('should call getTypeOfCare with the form data in production', () => {
+    process.env.NODE_ENV = 'production';
     const mockData = { typeOfCareId: '123' };
-    useSelectorStub.onCall(0).returns(true); // featureUseVpg
-    useSelectorStub.onCall(1).returns(mockData); // data
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns(mockData); // getFormData
     getTypeOfCareStub.returns({ idV2: 'foodAndNutrition' });
 
     renderHook(() => useOHScheduling());
 
     expect(getTypeOfCareStub.calledWith(mockData)).to.be.true;
+  });
+
+  it('should return true in staging even when typeOfCare is undefined', () => {
+    process.env.NODE_ENV = 'staging';
+    useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
+    useSelectorStub.onCall(1).returns({}); // getFormData
+    getTypeOfCareStub.returns(undefined);
+
+    const { result } = renderHook(() => useOHScheduling());
+
+    expect(result.current).to.be.true;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This updates the `useOHScheduling` hook in the new appointment flow to allow for scheduling of all types of OH care when the environment is _staging_. 

The behavior stays the same in _production_, with only Nutrition and Food and Pharmacy enabled.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/134428

## Testing done

- Manual local testing
- Updated unit tests

## What areas of the site does it impact?

VAOS new appointment flow 

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed


### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

