### PR TITLE
Veteran Status Page Alert

### DIFF
--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusPageLevelError.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusPageLevelError.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const VeteranStatusPageLevelError = () => {
+  return (
+    <va-alert
+      class="vads-u-margin-bottom--4"
+      status="warning"
+      visible
+      data-testid="veteran-status-page-level-error"
+      uswds
+    >
+      <h2 slot="headline">This page isn’t working right now</h2>
+      <p>
+        We’re sorry. Something went wrong on our end. Refresh this page or try
+        again later.
+      </p>
+    </va-alert>
+  );
+};
+
+export default VeteranStatusPageLevelError;

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
@@ -14,7 +14,7 @@ import Headline from '../ProfileSectionHeadline';
 import VeteranStatusCard from './VeteranStatusCard';
 import FrequentlyAskedQuestions from './FrequentlyAskedQuestions';
 import { DynamicVeteranStatusAlert } from './VeteranStatusAlerts';
-import LoadFail from '../alerts/LoadFail';
+import VeteranStatusPageLevelError from './VeteranStatusPageLevelError';
 import '../../sass/veteran-status-card.scss';
 import { useBrowserMonitoring } from './hooks/useBrowserMonitoring';
 
@@ -168,7 +168,7 @@ const VeteranStatusSharedService = ({
     }
 
     if (error) {
-      return <LoadFail />;
+      return <VeteranStatusPageLevelError />;
     }
 
     if (data?.type === 'veteran_status_alert') {

--- a/src/applications/personalization/profile/mocks/endpoints/veteran-status-card.js
+++ b/src/applications/personalization/profile/mocks/endpoints/veteran-status-card.js
@@ -87,9 +87,87 @@ const systemError = {
   },
 };
 
+// Warning alert - ineligible service (service history doesn't meet requirements)
+const ineligibleService = {
+  type: 'veteran_status_alert',
+  veteranStatus: 'not confirmed',
+  serviceSummaryCode: 'B',
+  notConfirmedReason: 'INELIGIBLE_SERVICE',
+  attributes: {
+    header: "You're not eligible for a Veteran Status Card",
+    body: [
+      {
+        type: 'text',
+        value:
+          "Your service history doesn't meet the requirements for a Veteran Status Card.",
+      },
+      {
+        type: 'text',
+        value:
+          "If you think this is incorrect, call us. We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.",
+      },
+      { type: 'phone', value: '866-279-3677', tty: true },
+    ],
+    alertType: 'warning',
+  },
+};
+
+// Warning alert - currently serving
+const currentlyServing = {
+  type: 'veteran_status_alert',
+  veteranStatus: 'not confirmed',
+  serviceSummaryCode: 'C',
+  notConfirmedReason: 'CURRENTLY_SERVING',
+  attributes: {
+    header: "You're not eligible for a Veteran Status Card",
+    body: [
+      {
+        type: 'text',
+        value:
+          "You can't get a Veteran Status Card if you're currently serving.",
+      },
+      {
+        type: 'text',
+        value:
+          "If you have a previous period of service, call us. We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.",
+      },
+      { type: 'phone', value: '866-279-3677', tty: true },
+    ],
+    alertType: 'warning',
+  },
+};
+
+// Warning alert - eligibility unknown
+const eligibilityUnknown = {
+  type: 'veteran_status_alert',
+  veteranStatus: 'not confirmed',
+  serviceSummaryCode: 'E',
+  notConfirmedReason: 'ELIGIBILITY_UNKNOWN',
+  attributes: {
+    header: "We don't know if you're eligible for this card",
+    body: [
+      {
+        type: 'text',
+        value:
+          'Your record is missing information about your service history or discharge status.',
+      },
+      {
+        type: 'text',
+        value:
+          "To fix the problem, call us. We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.",
+      },
+      { type: 'phone', value: '866-279-3677', tty: true },
+    ],
+    alertType: 'warning',
+  },
+};
+
 module.exports = {
   eligible,
   dishonorableDischarge,
   personNotFound,
   systemError,
+  ineligibleService,
+  currentlyServing,
+  eligibilityUnknown,
 };

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -140,12 +140,21 @@ const responses = {
   },
   // New veteran status card endpoint (shared service)
   'GET /v0/veteran_status_card': (_req, res) => {
+    // Eligible - shows the veteran status card
     return res.json(veteranStatusCard.eligible);
-    // Uncomment below for ineligible/alert response scenarios:
+    // Dishonorable discharge - "You're not eligible for a Veteran Status Card"
     // return res.json(veteranStatusCard.dishonorableDischarge);
+    // Person not found - "You're not eligible for a Veteran Status Card"
     // return res.json(veteranStatusCard.personNotFound);
+    // Ineligible service - "You're not eligible for a Veteran Status Card"
+    // return res.json(veteranStatusCard.ineligibleService);
+    // Currently serving - "You can't get a Veteran Status Card if you're currently serving"
+    // return res.json(veteranStatusCard.currentlyServing);
+    // Eligibility unknown - "We don't know if you're eligible for this card"
+    // return res.json(veteranStatusCard.eligibilityUnknown);
+    // System error (200 response) - "Something went wrong"
     // return res.json(veteranStatusCard.systemError);
-    // 500 error - triggers page level error alert
+    // 500 error - triggers page level error alert "This page isn't working right now"
     // return res.status(500).json(error500);
   },
   'GET /v0/user': (_req, res) => {

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -145,6 +145,8 @@ const responses = {
     // return res.json(veteranStatusCard.dishonorableDischarge);
     // return res.json(veteranStatusCard.personNotFound);
     // return res.json(veteranStatusCard.systemError);
+    // 500 error - triggers page level error alert
+    // return res.status(500).json(error500);
   },
   'GET /v0/user': (_req, res) => {
     const [shouldReturnUser, updatedUserResponse] = handleUserUpdate(
@@ -334,6 +336,7 @@ const responses = {
   },
   'GET /v0/profile/vet_verification_status': (_req, res) => {
     return res.status(200).json(vetVerificationStatus.confirmed);
+    // return res.status(500).json(error500);
     // return res.status(200).json(vetVerificationStatus.notConfirmedProblem);
     // return res.status(200).json(vetVerificationStatus.notConfirmedIneligible);
     // return res.status(504).json(vetVerificationStatus.apiError);

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -242,7 +242,7 @@ describe('VeteranStatusSharedService', () => {
   });
 
   describe('when an API error occurs', () => {
-    it('should render the LoadFail alert when an API error occurs', async () => {
+    it('should render the page level error alert when an API error occurs', async () => {
       apiRequestStub.rejects(new Error('API Error'));
       const initialState = createBasicInitialState();
       const view = renderWithProfileReducers(<VeteranStatusSharedService />, {
@@ -251,7 +251,7 @@ describe('VeteranStatusSharedService', () => {
 
       await waitFor(() => {
         sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
-        expect(view.getByText("This page isn't available right now.")).to.exist;
+        expect(view.getByText("This page isn't working right now")).to.exist;
 
         // Check that the description is not rendered
         expect(

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -251,7 +251,7 @@ describe('VeteranStatusSharedService', () => {
 
       await waitFor(() => {
         sinon.assert.calledWith(apiRequestStub, '/veteran_status_card');
-        expect(view.getByText("This page isn't working right now")).to.exist;
+        expect(view.getByText('This page isn’t working right now')).to.exist;
 
         // Check that the description is not rendered
         expect(


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Update page alert data to match figma

## Related issue(s)

[2418](https://va.ghe.com/software/va-cve/issues/2418)

## Testing done
- Manual test 
- Updated unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|Feature Flag Value| True | False |
| ------- | ------ | ----- |
| Desktop |<img width="783" height="263" alt="Screenshot 2026-03-02 at 10 14 33 AM" src="https://github.com/user-attachments/assets/03a27a44-f24c-423b-bc4c-878261b21aef" />|<img width="814" height="555" alt="Screenshot 2026-03-02 at 10 16 59 AM" src="https://github.com/user-attachments/assets/c631910c-1274-4666-be1b-1797d4292f14" />|

## What areas of the site does it impact?
Veteran Status Card

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- [x] Page displays an unavailable alert that matches the figma design
- [x] The feature/s being implemented are covered by unit tests - If not, create tests for them on this ticket
### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
