### PR TITLE
feat: React Router v5 platform infrastructure for migration

### DIFF
--- a/src/platform/forms-system/src/js/routing/convertLegacyRoutes.js
+++ b/src/platform/forms-system/src/js/routing/convertLegacyRoutes.js
@@ -29,7 +29,7 @@ export function convertLegacyRoutes(routeConfigs, { urlPrefix = '' } = {}) {
       if (routeConfig.onEnter && !routeConfig.component) {
         // Extract the redirect target by calling onEnter with a mock replace
         let redirectTo = urlPrefix || '/';
-        routeConfig.onEnter({}, (path) => {
+        routeConfig.onEnter({}, path => {
           redirectTo = path;
         });
         return (
@@ -55,7 +55,7 @@ export function convertLegacyRoutes(routeConfigs, { urlPrefix = '' } = {}) {
           key={routeConfig.path || `route-${index}`}
           path={routePath}
           exact={routeConfig.path === '/' || !routeConfig.path}
-          render={(routeProps) => (
+          render={routeProps => (
             <RouteComponent {...routeProps} route={routeConfig} />
           )}
         />

--- a/src/platform/forms-system/src/js/routing/convertLegacyRoutes.js
+++ b/src/platform/forms-system/src/js/routing/convertLegacyRoutes.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+
+/**
+ * Convert v3 plain-object route configs to v5 <Route> JSX elements.
+ * Each route component receives `props.route` containing its full config
+ * (matching v3 behavior where route config is spread as component props).
+ *
+ * Handles:
+ *   { path, component }                    → <Route path render with route prop>
+ *   { onEnter: (_, replace) => replace() } → <Redirect>
+ *   { path: '*' }                          → <Redirect to={fallback}>
+ *   { indexRoute: { component } }          → <Route exact path="/">
+ *
+ * @param {Array<Object>} routeConfigs - v3-style route config objects from createRoutes()
+ * @param {Object} [options]
+ * @param {string} [options.urlPrefix=''] - Base path prefix for all routes
+ * @returns {Array<React.Element>} Array of <Route> and <Redirect> elements
+ */
+export function convertLegacyRoutes(routeConfigs, { urlPrefix = '' } = {}) {
+  return routeConfigs
+    .map((routeConfig, index) => {
+      // Catch-all redirect
+      if (routeConfig.path === '*') {
+        return <Redirect key="catchall" to={urlPrefix || '/'} />;
+      }
+
+      // onEnter redirect (v3 pattern)
+      if (routeConfig.onEnter && !routeConfig.component) {
+        // Extract the redirect target by calling onEnter with a mock replace
+        let redirectTo = urlPrefix || '/';
+        routeConfig.onEnter({}, (path) => {
+          redirectTo = path;
+        });
+        return (
+          <Redirect
+            key={`redirect-${routeConfig.path || index}`}
+            from={routeConfig.path}
+            to={redirectTo}
+            exact
+          />
+        );
+      }
+
+      const RouteComponent = routeConfig.component;
+      if (!RouteComponent) return null;
+
+      // Normalize path: prefix with urlPrefix unless already absolute
+      const routePath = routeConfig.path
+        ? `${urlPrefix}/${routeConfig.path}`.replace(/\/+/g, '/')
+        : urlPrefix || '/';
+
+      return (
+        <Route
+          key={routeConfig.path || `route-${index}`}
+          path={routePath}
+          exact={routeConfig.path === '/' || !routeConfig.path}
+          render={(routeProps) => (
+            <RouteComponent {...routeProps} route={routeConfig} />
+          )}
+        />
+      );
+    })
+    .filter(Boolean);
+}

--- a/src/platform/forms-system/src/js/routing/v5-compatibility.js
+++ b/src/platform/forms-system/src/js/routing/v5-compatibility.js
@@ -75,7 +75,9 @@ export function withRouterV5Compat(WrappedComponent) {
     );
   }
 
-  WithRouterV5Compat.displayName = `withRouterV5Compat(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+  WithRouterV5Compat.displayName = `withRouterV5Compat(${WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    'Component'})`;
   WithRouterV5Compat.WrappedComponent = WrappedComponent;
   return WithRouterV5Compat;
 }

--- a/src/platform/forms-system/src/js/routing/v5-compatibility.js
+++ b/src/platform/forms-system/src/js/routing/v5-compatibility.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
+
+/**
+ * Parse query string preserving repeated keys as arrays.
+ * ?foo=1&foo=2 → { foo: ['1', '2'] }
+ * ?bar=3       → { bar: '3' }
+ *
+ * Replaces v3's location.query which was auto-populated by the router.
+ */
+export function parseQuery(search) {
+  const params = new URLSearchParams(search);
+  const result = {};
+  for (const key of new Set(params.keys())) {
+    const values = params.getAll(key);
+    result[key] = values.length === 1 ? values[0] : values;
+  }
+  return result;
+}
+
+/**
+ * v5 withRouter shim providing the same prop interface as React Router v3's
+ * withRouter HOC. Allows class components to remain unchanged during migration.
+ *
+ * Props provided:
+ *   router.push(path)         → history.push(path)
+ *   router.push({pathname})   → history.push({pathname}) (object form, ContactInfo)
+ *   router.replace(path)      → history.replace(path)
+ *   router.goBack()           → history.goBack()
+ *   router.go(n)              → history.go(n)
+ *   router.params             → useParams() (BackLink.jsx reads router.params)
+ *   router.setRouteLeaveHook  → console.warn in dev, noop in prod
+ *   location                  → useLocation() + synthesized .query and .basename
+ *   params                    → useParams()
+ *   route                     → forwarded from props (set by convertLegacyRoutes)
+ */
+export function withRouterV5Compat(WrappedComponent) {
+  function WithRouterV5Compat(props) {
+    const history = useHistory();
+    const location = useLocation();
+    const params = useParams();
+
+    const query = parseQuery(location.search);
+    const locationWithQuery = {
+      ...location,
+      query,
+      basename: props.formConfig?.urlPrefix || props.route?.urlPrefix || '',
+    };
+
+    const router = {
+      push: history.push,
+      replace: history.replace,
+      goBack: history.goBack,
+      go: history.go,
+      params,
+      setRouteLeaveHook: (...args) => {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            'setRouteLeaveHook is a no-op in v5. Use <Prompt> or history.block().',
+            args,
+          );
+        }
+      },
+    };
+
+    return (
+      <WrappedComponent
+        {...props}
+        router={router}
+        location={locationWithQuery}
+        params={params}
+        route={props.route}
+      />
+    );
+  }
+
+  WithRouterV5Compat.displayName = `withRouterV5Compat(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+  WithRouterV5Compat.WrappedComponent = WrappedComponent;
+  return WithRouterV5Compat;
+}

--- a/src/platform/forms-system/test/js/routing/convertLegacyRoutes.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/routing/convertLegacyRoutes.unit.spec.jsx
@@ -30,7 +30,7 @@ describe('convertLegacyRoutes', () => {
 
   it('should pass route config as route prop to component', () => {
     let receivedRoute;
-    const PageComponent = (props) => {
+    const PageComponent = props => {
       receivedRoute = props.route;
       return <div data-testid="page">Page</div>;
     };
@@ -49,7 +49,7 @@ describe('convertLegacyRoutes', () => {
 
   it('should pass formConfig on intro/review routes', () => {
     let receivedRoute;
-    const IntroPage = (props) => {
+    const IntroPage = props => {
       receivedRoute = props.route;
       return <div data-testid="intro">Intro</div>;
     };
@@ -140,7 +140,7 @@ describe('convertLegacyRoutes', () => {
 
   it('should provide react-router routeProps (match, location, history)', () => {
     let receivedProps;
-    const PageComponent = (props) => {
+    const PageComponent = props => {
       receivedProps = props;
       return <div>Page</div>;
     };
@@ -180,7 +180,7 @@ describe('convertLegacyRoutes', () => {
     ];
     const converted = convertLegacyRoutes(routes);
 
-    const keys = converted.map((el) => el.key);
+    const keys = converted.map(el => el.key);
     expect(new Set(keys).size).to.equal(keys.length);
   });
 });

--- a/src/platform/forms-system/test/js/routing/convertLegacyRoutes.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/routing/convertLegacyRoutes.unit.spec.jsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Router, Switch } from 'react-router-dom';
+import { createMemoryHistory } from 'history-v4';
+
+import { convertLegacyRoutes } from '../../../src/js/routing/convertLegacyRoutes';
+
+describe('convertLegacyRoutes', () => {
+  function renderRoutes(routes, { path = '/', urlPrefix = '' } = {}) {
+    const history = createMemoryHistory({ initialEntries: [path] });
+    const converted = convertLegacyRoutes(routes, { urlPrefix });
+    return {
+      ...render(
+        <Router history={history}>
+          <Switch>{converted}</Switch>
+        </Router>,
+      ),
+      history,
+    };
+  }
+
+  it('should convert a basic route with component', () => {
+    const PageComponent = () => <div data-testid="page">Page Content</div>;
+    const routes = [{ path: 'my-page', component: PageComponent }];
+    const { getByTestId } = renderRoutes(routes, { path: '/my-page' });
+
+    expect(getByTestId('page')).to.exist;
+  });
+
+  it('should pass route config as route prop to component', () => {
+    let receivedRoute;
+    const PageComponent = (props) => {
+      receivedRoute = props.route;
+      return <div data-testid="page">Page</div>;
+    };
+    const routeConfig = {
+      path: 'my-page',
+      component: PageComponent,
+      pageConfig: { name: 'test' },
+      pageList: ['/page1', '/page2'],
+    };
+    renderRoutes([routeConfig], { path: '/my-page' });
+
+    expect(receivedRoute).to.deep.equal(routeConfig);
+    expect(receivedRoute.pageConfig).to.deep.equal({ name: 'test' });
+    expect(receivedRoute.pageList).to.deep.equal(['/page1', '/page2']);
+  });
+
+  it('should pass formConfig on intro/review routes', () => {
+    let receivedRoute;
+    const IntroPage = (props) => {
+      receivedRoute = props.route;
+      return <div data-testid="intro">Intro</div>;
+    };
+    const routeConfig = {
+      path: 'introduction',
+      component: IntroPage,
+      formConfig: { formId: '123' },
+      pageList: ['/intro'],
+    };
+    renderRoutes([routeConfig], { path: '/introduction' });
+
+    expect(receivedRoute.formConfig).to.deep.equal({ formId: '123' });
+    expect(receivedRoute.pageConfig).to.be.undefined;
+  });
+
+  it('should handle catch-all route as redirect', () => {
+    const FallbackPage = () => <div data-testid="fallback">Fallback</div>;
+    const routes = [{ path: '/', component: FallbackPage }, { path: '*' }];
+    const converted = convertLegacyRoutes(routes, { urlPrefix: '/form' });
+
+    // Should have 2 elements: a Route and a Redirect
+    expect(converted).to.have.length(2);
+    // The catch-all should be a Redirect (type name check)
+    expect(converted[1].props.to).to.equal('/form');
+  });
+
+  it('should handle onEnter redirect pattern', () => {
+    const routes = [
+      {
+        path: '/',
+        onEnter: (nextState, replace) => {
+          replace('/introduction');
+        },
+      },
+    ];
+    const converted = convertLegacyRoutes(routes);
+
+    expect(converted).to.have.length(1);
+    expect(converted[0].props.to).to.equal('/introduction');
+    expect(converted[0].props.from).to.equal('/');
+  });
+
+  it('should skip routes with no component and no onEnter', () => {
+    const routes = [{ path: 'empty-route' }];
+    const converted = convertLegacyRoutes(routes);
+
+    expect(converted).to.have.length(0);
+  });
+
+  it('should apply urlPrefix to route paths', () => {
+    const PageComponent = () => <div data-testid="page">Page</div>;
+    const routes = [{ path: 'my-page', component: PageComponent }];
+    const { getByTestId } = renderRoutes(routes, {
+      path: '/form/my-page',
+      urlPrefix: '/form',
+    });
+
+    expect(getByTestId('page')).to.exist;
+  });
+
+  it('should normalize double slashes in paths', () => {
+    const PageComponent = () => <div data-testid="page">Page</div>;
+    const routes = [{ path: '/my-page', component: PageComponent }];
+    // urlPrefix + '/' + path could produce '/form//my-page'
+    const { getByTestId } = renderRoutes(routes, {
+      path: '/form/my-page',
+      urlPrefix: '/form',
+    });
+
+    expect(getByTestId('page')).to.exist;
+  });
+
+  it('should make root path exact', () => {
+    const RootPage = () => <div data-testid="root">Root</div>;
+    const ChildPage = () => <div data-testid="child">Child</div>;
+    const routes = [
+      { path: '/', component: RootPage },
+      { path: 'child', component: ChildPage },
+    ];
+    // When navigating to /child, root should NOT match (exact)
+    const { queryByTestId, getByTestId } = renderRoutes(routes, {
+      path: '/child',
+    });
+
+    expect(queryByTestId('root')).to.be.null;
+    expect(getByTestId('child')).to.exist;
+  });
+
+  it('should provide react-router routeProps (match, location, history)', () => {
+    let receivedProps;
+    const PageComponent = (props) => {
+      receivedProps = props;
+      return <div>Page</div>;
+    };
+    const routes = [{ path: 'test-page', component: PageComponent }];
+    renderRoutes(routes, { path: '/test-page' });
+
+    expect(receivedProps.match).to.be.an('object');
+    expect(receivedProps.location).to.be.an('object');
+    expect(receivedProps.history).to.be.an('object');
+  });
+
+  it('should handle onEnter with default redirect when replace is not called', () => {
+    const routes = [
+      {
+        path: '/',
+        onEnter: () => {
+          // onEnter that doesn't call replace
+        },
+      },
+    ];
+    const converted = convertLegacyRoutes(routes, { urlPrefix: '/my-app' });
+
+    expect(converted[0].props.to).to.equal('/my-app');
+  });
+
+  it('should handle empty routeConfigs array', () => {
+    const converted = convertLegacyRoutes([]);
+    expect(converted).to.deep.equal([]);
+  });
+
+  it('should preserve unique keys for routes', () => {
+    const Page1 = () => <div>1</div>;
+    const Page2 = () => <div>2</div>;
+    const routes = [
+      { path: 'page-1', component: Page1 },
+      { path: 'page-2', component: Page2 },
+    ];
+    const converted = convertLegacyRoutes(routes);
+
+    const keys = converted.map((el) => el.key);
+    expect(new Set(keys).size).to.equal(keys.length);
+  });
+});

--- a/src/platform/forms-system/test/js/routing/v5-compatibility.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/routing/v5-compatibility.unit.spec.jsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history-v4';
+
+import {
+  parseQuery,
+  withRouterV5Compat,
+} from '../../../src/js/routing/v5-compatibility';
+
+describe('v5-compatibility', () => {
+  describe('parseQuery', () => {
+    it('should parse single-value query params', () => {
+      const result = parseQuery('?foo=1&bar=2');
+      expect(result).to.deep.equal({ foo: '1', bar: '2' });
+    });
+
+    it('should parse repeated keys as arrays', () => {
+      const result = parseQuery('?foo=1&foo=2');
+      expect(result).to.deep.equal({ foo: ['1', '2'] });
+    });
+
+    it('should return empty object for empty search', () => {
+      expect(parseQuery('')).to.deep.equal({});
+    });
+
+    it('should handle params with no value', () => {
+      const result = parseQuery('?foo=&bar');
+      expect(result.foo).to.equal('');
+      expect(result.bar).to.equal('');
+    });
+
+    it('should handle mixed single and repeated keys', () => {
+      const result = parseQuery('?a=1&b=2&b=3&c=4');
+      expect(result).to.deep.equal({ a: '1', b: ['2', '3'], c: '4' });
+    });
+  });
+
+  describe('withRouterV5Compat', () => {
+    function renderWithRouter(ui, { path = '/', search = '' } = {}) {
+      const history = createMemoryHistory({
+        initialEntries: [{ pathname: path, search }],
+      });
+      return {
+        ...render(<Router history={history}>{ui}</Router>),
+        history,
+      };
+    }
+
+    it('should provide router.push from history', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      const { history } = renderWithRouter(<Wrapped />);
+
+      expect(receivedRouter.push).to.be.a('function');
+      receivedRouter.push('/new-path');
+      expect(history.location.pathname).to.equal('/new-path');
+    });
+
+    it('should provide router.replace from history', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      const { history } = renderWithRouter(<Wrapped />);
+
+      receivedRouter.replace('/replaced');
+      expect(history.location.pathname).to.equal('/replaced');
+    });
+
+    it('should provide location with synthesized query', () => {
+      let receivedLocation;
+      const TestComponent = (props) => {
+        receivedLocation = props.location;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped />, { search: '?page=2&status=active' });
+
+      expect(receivedLocation.query).to.deep.equal({
+        page: '2',
+        status: 'active',
+      });
+    });
+
+    it('should provide location.basename from route.urlPrefix', () => {
+      let receivedLocation;
+      const TestComponent = (props) => {
+        receivedLocation = props.location;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      const route = { urlPrefix: '/my-form' };
+      renderWithRouter(<Wrapped route={route} />);
+
+      expect(receivedLocation.basename).to.equal('/my-form');
+    });
+
+    it('should provide location.basename from formConfig.urlPrefix', () => {
+      let receivedLocation;
+      const TestComponent = (props) => {
+        receivedLocation = props.location;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      const formConfig = { urlPrefix: '/form-prefix' };
+      renderWithRouter(<Wrapped formConfig={formConfig} />);
+
+      expect(receivedLocation.basename).to.equal('/form-prefix');
+    });
+
+    it('should forward route prop to wrapped component', () => {
+      let receivedRoute;
+      const TestComponent = (props) => {
+        receivedRoute = props.route;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      const route = { pageConfig: { some: 'config' }, pageList: ['/page1'] };
+      renderWithRouter(<Wrapped route={route} />);
+
+      expect(receivedRoute).to.deep.equal(route);
+    });
+
+    it('should provide params prop', () => {
+      let receivedParams;
+      const TestComponent = (props) => {
+        receivedParams = props.params;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped />);
+
+      expect(receivedParams).to.be.an('object');
+    });
+
+    it('should provide router.params', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped />);
+
+      expect(receivedRouter.params).to.be.an('object');
+    });
+
+    it('should provide router.goBack', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped />);
+
+      expect(receivedRouter.goBack).to.be.a('function');
+    });
+
+    it('should provide router.go', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped />);
+
+      expect(receivedRouter.go).to.be.a('function');
+    });
+
+    it('should provide setRouteLeaveHook as a no-op', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped />);
+
+      expect(receivedRouter.setRouteLeaveHook).to.be.a('function');
+      // Should not throw
+      receivedRouter.setRouteLeaveHook({}, () => {});
+    });
+
+    it('should set displayName', () => {
+      const TestComponent = () => <div />;
+      TestComponent.displayName = 'MyComponent';
+      const Wrapped = withRouterV5Compat(TestComponent);
+      expect(Wrapped.displayName).to.equal('withRouterV5Compat(MyComponent)');
+    });
+
+    it('should expose WrappedComponent', () => {
+      const TestComponent = () => <div />;
+      const Wrapped = withRouterV5Compat(TestComponent);
+      expect(Wrapped.WrappedComponent).to.equal(TestComponent);
+    });
+
+    it('should forward additional props', () => {
+      let receivedProps;
+      const TestComponent = (props) => {
+        receivedProps = props;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      renderWithRouter(<Wrapped customProp="hello" anotherProp={42} />);
+
+      expect(receivedProps.customProp).to.equal('hello');
+      expect(receivedProps.anotherProp).to.equal(42);
+    });
+
+    it('should support router.push with object argument', () => {
+      let receivedRouter;
+      const TestComponent = (props) => {
+        receivedRouter = props.router;
+        return <div>test</div>;
+      };
+      const Wrapped = withRouterV5Compat(TestComponent);
+      const { history } = renderWithRouter(<Wrapped />);
+
+      receivedRouter.push({ pathname: '/contact', state: { from: 'form' } });
+      expect(history.location.pathname).to.equal('/contact');
+      expect(history.location.state).to.deep.equal({ from: 'form' });
+    });
+  });
+});

--- a/src/platform/forms-system/test/js/routing/v5-compatibility.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/routing/v5-compatibility.unit.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history-v4';
@@ -51,7 +50,7 @@ describe('v5-compatibility', () => {
 
     it('should provide router.push from history', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };
@@ -65,7 +64,7 @@ describe('v5-compatibility', () => {
 
     it('should provide router.replace from history', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };
@@ -78,7 +77,7 @@ describe('v5-compatibility', () => {
 
     it('should provide location with synthesized query', () => {
       let receivedLocation;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedLocation = props.location;
         return <div>test</div>;
       };
@@ -93,7 +92,7 @@ describe('v5-compatibility', () => {
 
     it('should provide location.basename from route.urlPrefix', () => {
       let receivedLocation;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedLocation = props.location;
         return <div>test</div>;
       };
@@ -106,7 +105,7 @@ describe('v5-compatibility', () => {
 
     it('should provide location.basename from formConfig.urlPrefix', () => {
       let receivedLocation;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedLocation = props.location;
         return <div>test</div>;
       };
@@ -119,7 +118,7 @@ describe('v5-compatibility', () => {
 
     it('should forward route prop to wrapped component', () => {
       let receivedRoute;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRoute = props.route;
         return <div>test</div>;
       };
@@ -132,7 +131,7 @@ describe('v5-compatibility', () => {
 
     it('should provide params prop', () => {
       let receivedParams;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedParams = props.params;
         return <div>test</div>;
       };
@@ -144,7 +143,7 @@ describe('v5-compatibility', () => {
 
     it('should provide router.params', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };
@@ -156,7 +155,7 @@ describe('v5-compatibility', () => {
 
     it('should provide router.goBack', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };
@@ -168,7 +167,7 @@ describe('v5-compatibility', () => {
 
     it('should provide router.go', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };
@@ -180,7 +179,7 @@ describe('v5-compatibility', () => {
 
     it('should provide setRouteLeaveHook as a no-op', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };
@@ -207,7 +206,7 @@ describe('v5-compatibility', () => {
 
     it('should forward additional props', () => {
       let receivedProps;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedProps = props;
         return <div>test</div>;
       };
@@ -220,7 +219,7 @@ describe('v5-compatibility', () => {
 
     it('should support router.push with object argument', () => {
       let receivedRouter;
-      const TestComponent = (props) => {
+      const TestComponent = props => {
         receivedRouter = props.router;
         return <div>test</div>;
       };

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -222,7 +222,10 @@ const mapDispatchToProps = {
 };
 
 export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(SaveInProgressErrorPage),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(SaveInProgressErrorPage),
 );
 
 export { SaveInProgressErrorPage };

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -30,7 +30,12 @@ const DEFAULT_FORBIDDEN_MESSAGE = `
 class SaveInProgressErrorPage extends React.Component {
   componentDidMount() {
     if (this.props.loadedStatus === LOAD_STATUSES.notAttempted) {
-      this.props.router.replace(this.props.location.basename);
+      // location.basename is v3-only; use formConfig.urlPrefix for v5 compat
+      const basename =
+        this.props.location.basename ||
+        this.props.route?.formConfig?.urlPrefix ||
+        '/';
+      this.props.router.replace(basename);
     }
   }
 
@@ -217,10 +222,7 @@ const mapDispatchToProps = {
 };
 
 export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(SaveInProgressErrorPage),
+  connect(mapStateToProps, mapDispatchToProps)(SaveInProgressErrorPage),
 );
 
 export { SaveInProgressErrorPage };

--- a/src/platform/startup/package.json
+++ b/src/platform/startup/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "history": "*",
+    "history-v4": "*",
     "react": "*",
     "react-dom": "*",
     "react-redux": "*",

--- a/src/platform/startup/router.js
+++ b/src/platform/startup/router.js
@@ -64,7 +64,7 @@ export default function startApp({
   try {
     store.dispatch(updateRoute(history.location));
 
-    history.listen((location) => {
+    history.listen(location => {
       if (location) {
         store.dispatch(updateRoute(location));
       }

--- a/src/platform/startup/router.js
+++ b/src/platform/startup/router.js
@@ -4,8 +4,10 @@
  */
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
+import { createBrowserHistory } from 'history-v4';
 import { CompatRouter } from 'react-router-dom-v5-compat';
+import { updateRoute } from 'platform/site-wide/user-nav/actions';
 import startReactApp from './react';
 import setUpCommonFunctionality from './setup';
 
@@ -50,20 +52,44 @@ export default function startApp({
     additionalMiddlewares,
   });
 
+  // Create a history instance we control, rather than relying on
+  // BrowserRouter's internal history. This lets us dispatch updateRoute
+  // to Redux synchronously on every navigation — matching the v3 startup
+  // behavior in platform/startup/index.js. Without this, Redux route state
+  // lags one render frame behind the actual URL.
+  const history = createBrowserHistory({
+    basename: url || '',
+  });
+
+  try {
+    store.dispatch(updateRoute(history.location));
+
+    history.listen((location) => {
+      if (location) {
+        store.dispatch(updateRoute(location));
+      }
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Error dispatching route change', e);
+  }
+
   let content = component;
   if (createRoutesWithStore) {
     content = (
-      <BrowserRouter basename={url}>
+      <Router history={history}>
         <CompatRouter>{createRoutesWithStore(store)}</CompatRouter>
-      </BrowserRouter>
+      </Router>
     );
   } else if (routes) {
     content = (
-      <BrowserRouter basename={url}>
+      <Router history={history}>
         <CompatRouter>{routes}</CompatRouter>
-      </BrowserRouter>
+      </Router>
     );
   }
 
   startReactApp(<Provider store={store}>{content}</Provider>);
+
+  return store;
 }

--- a/src/platform/startup/tests/router.unit.spec.jsx
+++ b/src/platform/startup/tests/router.unit.spec.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as historyV4 from 'history-v4';
+import * as navActions from 'platform/site-wide/user-nav/actions';
+import * as reactApp from '../react';
+import * as commonFunctionality from '../setup';
+import startApp from '../router';
+
+describe('startApp (v5 router)', () => {
+  let sandbox;
+  let storeStub;
+  let setUpCommonFunctionalityStub;
+  let startReactAppStub;
+  let updateRouteStub;
+  let historyStub;
+  let listenStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    storeStub = {
+      dispatch: sinon.stub(),
+      getState: sinon.stub(),
+    };
+    listenStub = sinon.stub();
+    historyStub = {
+      location: { pathname: '/', search: '', hash: '' },
+      listen: listenStub,
+      push: sinon.stub(),
+      replace: sinon.stub(),
+    };
+    setUpCommonFunctionalityStub = sandbox
+      .stub(commonFunctionality, 'default')
+      .returns(storeStub);
+    startReactAppStub = sandbox.stub(reactApp, 'default');
+    updateRouteStub = sandbox
+      .stub(navActions, 'updateRoute')
+      .returns({ type: 'UPDATE_ROUTE', location: {} });
+    sandbox.stub(historyV4, 'createBrowserHistory').returns(historyStub);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should create a store with setUpCommonFunctionality', () => {
+    startApp({ entryName: 'testApp' });
+    expect(setUpCommonFunctionalityStub.called).to.be.true;
+  });
+
+  it('should pass entryName and url to setUpCommonFunctionality', () => {
+    startApp({ entryName: 'testApp', url: '/foo' });
+    const callArgs = setUpCommonFunctionalityStub.firstCall.args[0];
+    expect(callArgs.entryName).to.equal('testApp');
+    expect(callArgs.url).to.equal('/foo');
+  });
+
+  it('should create browser history with basename from url', () => {
+    startApp({ entryName: 'testApp', url: '/my-app' });
+    expect(historyV4.createBrowserHistory.calledWith({ basename: '/my-app' }))
+      .to.be.true;
+  });
+
+  it('should create browser history with empty basename when no url', () => {
+    startApp({ entryName: 'testApp' });
+    expect(historyV4.createBrowserHistory.calledWith({ basename: '' })).to.be
+      .true;
+  });
+
+  it('should dispatch updateRoute with initial location', () => {
+    startApp({ entryName: 'testApp', url: '/foo' });
+    expect(updateRouteStub.calledWith(historyStub.location)).to.be.true;
+    expect(storeStub.dispatch.called).to.be.true;
+  });
+
+  it('should subscribe to history changes', () => {
+    startApp({ entryName: 'testApp', url: '/foo' });
+    expect(listenStub.calledOnce).to.be.true;
+  });
+
+  it('should dispatch updateRoute on history change', () => {
+    startApp({ entryName: 'testApp', url: '/foo' });
+
+    // Get the listener callback that was registered
+    const listener = listenStub.firstCall.args[0];
+    const newLocation = { pathname: '/bar', search: '', hash: '' };
+    listener(newLocation);
+
+    // updateRoute called twice: once for initial, once for listen
+    expect(updateRouteStub.calledWith(newLocation)).to.be.true;
+    expect(storeStub.dispatch.callCount).to.equal(2);
+  });
+
+  it('should not dispatch updateRoute on null location from listen', () => {
+    startApp({ entryName: 'testApp', url: '/foo' });
+
+    const listener = listenStub.firstCall.args[0];
+    listener(null);
+
+    // Only the initial dispatch, not a second one
+    expect(storeStub.dispatch.callCount).to.equal(1);
+  });
+
+  it('should render React component with routes', () => {
+    const routes = <div>Routes</div>;
+    startApp({ entryName: 'testApp', routes });
+    expect(startReactAppStub.called).to.be.true;
+  });
+
+  it('should render React component with createRoutesWithStore', () => {
+    const createRoutesWithStore = sinon.stub().returns(<div>Routes</div>);
+    startApp({ entryName: 'testApp', createRoutesWithStore });
+    expect(createRoutesWithStore.calledWith(storeStub)).to.be.true;
+    expect(startReactAppStub.called).to.be.true;
+  });
+
+  it('should render React component with plain component', () => {
+    const component = <div>Component</div>;
+    startApp({ entryName: 'testApp', component });
+    expect(startReactAppStub.called).to.be.true;
+  });
+
+  it('should return the store', () => {
+    const result = startApp({ entryName: 'testApp' });
+    expect(result).to.equal(storeStub);
+  });
+
+  it('should not throw when updateRoute throws', () => {
+    updateRouteStub.throws(new Error('test error'));
+    expect(() => startApp({ entryName: 'testApp', url: '/foo' })).to.not.throw;
+  });
+});

--- a/src/platform/utilities/real-user-monitoring.jsx
+++ b/src/platform/utilities/real-user-monitoring.jsx
@@ -82,25 +82,24 @@ const useBrowserMonitoring = ({ location, toggleName }) => {
   const isLoadingFeatureFlags = useToggleLoadingValue();
   const isBrowserMonitoringEnabled = useToggleValue(toggleName);
 
-  useEffect(
-    () => {
-      datadogRum.startView({ name: location.basename + location.pathname });
-    },
-    [location],
-  );
+  useEffect(() => {
+    // location.basename is v3-only; fall back to pathname which already
+    // includes the base path in v5 (history is created with basename option)
+    const viewName = location.basename
+      ? location.basename + location.pathname
+      : location.pathname;
+    datadogRum.startView({ name: viewName });
+  }, [location]);
 
-  useEffect(
-    () => {
-      if (isLoadingFeatureFlags) return;
-      if (isBrowserMonitoringEnabled) {
-        initializeRealUserMonitoring();
-        initializeBrowserLogging();
-      } else {
-        delete window.DD_RUM;
-      }
-    },
-    [isBrowserMonitoringEnabled, isLoadingFeatureFlags],
-  );
+  useEffect(() => {
+    if (isLoadingFeatureFlags) return;
+    if (isBrowserMonitoringEnabled) {
+      initializeRealUserMonitoring();
+      initializeBrowserLogging();
+    } else {
+      delete window.DD_RUM;
+    }
+  }, [isBrowserMonitoringEnabled, isLoadingFeatureFlags]);
 };
 
 export { useBrowserMonitoring };

--- a/src/platform/utilities/real-user-monitoring.jsx
+++ b/src/platform/utilities/real-user-monitoring.jsx
@@ -82,24 +82,30 @@ const useBrowserMonitoring = ({ location, toggleName }) => {
   const isLoadingFeatureFlags = useToggleLoadingValue();
   const isBrowserMonitoringEnabled = useToggleValue(toggleName);
 
-  useEffect(() => {
-    // location.basename is v3-only; fall back to pathname which already
-    // includes the base path in v5 (history is created with basename option)
-    const viewName = location.basename
-      ? location.basename + location.pathname
-      : location.pathname;
-    datadogRum.startView({ name: viewName });
-  }, [location]);
+  useEffect(
+    () => {
+      // location.basename is v3-only; fall back to pathname which already
+      // includes the base path in v5 (history is created with basename option)
+      const viewName = location.basename
+        ? location.basename + location.pathname
+        : location.pathname;
+      datadogRum.startView({ name: viewName });
+    },
+    [location],
+  );
 
-  useEffect(() => {
-    if (isLoadingFeatureFlags) return;
-    if (isBrowserMonitoringEnabled) {
-      initializeRealUserMonitoring();
-      initializeBrowserLogging();
-    } else {
-      delete window.DD_RUM;
-    }
-  }, [isBrowserMonitoringEnabled, isLoadingFeatureFlags]);
+  useEffect(
+    () => {
+      if (isLoadingFeatureFlags) return;
+      if (isBrowserMonitoringEnabled) {
+        initializeRealUserMonitoring();
+        initializeBrowserLogging();
+      } else {
+        delete window.DD_RUM;
+      }
+    },
+    [isBrowserMonitoringEnabled, isLoadingFeatureFlags],
+  );
 };
 
 export { useBrowserMonitoring };


### PR DESCRIPTION
**Note**: This is the first PR in a multi-PR series migrating React Router v3 → v5 across vets-website.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] Yes, and changes are backward-compatible. The modified platform files (`startup/router.js`, `SaveInProgressErrorPage.jsx`, `real-user-monitoring.jsx`) add fallback logic that preserves existing v3 behavior while enabling v5 compatibility. No visual or behavioral changes for end users.

## Summary

- **What**: Adds the platform infrastructure needed to migrate 89 React Router v3 apps to v5 without breaking existing behavior. This includes a v5 compatibility shim, a route config converter, and a bug fix for the existing v5 startup path.
- **Bug fix (startup/router.js)**: The existing v5 startup used `<BrowserRouter>` which hides its internal history instance, so `updateRoute` was never dispatched to Redux. The 7 apps using this path (vaos, profile, mhv-secure-messaging, gi, enrollment-verification, education-letters, combined-debt-portal) had stale route state in Redux. Fixed by replacing `<BrowserRouter>` with `<Router history={history}>` using `createBrowserHistory` from `history-v4`, adding `history.listen()` for ongoing dispatches.
- **New utility (v5-compatibility.js)**: `withRouterV5Compat` HOC that provides `router`, `location` (with synthesized `.query` from URLSearchParams), and `params` props — matching the v3 API surface so migrated components work without code changes.
- **New utility (convertLegacyRoutes.js)**: Converts v3 plain-object route configs (as produced by `createRoutes.js`) into v5 `<Route>`/`<Redirect>` JSX elements, handling `onEnter` redirects, catch-all routes, path normalization, and exact root matching.
- **Basename fallbacks**: `SaveInProgressErrorPage.jsx` and `real-user-monitoring.jsx` used v3-only `location.basename`; added fallback to `route.formConfig.urlPrefix` and `location.pathname` respectively.
- **Team**: Benefits Portfolio

## Related issue(s)

- Previous closed PRs: department-of-veterans-affairs/vets-website#37833, department-of-veterans-affairs/vets-website#38260, department-of-veterans-affairs/vets-website#38279

## Testing done

- **84 unit tests passing, 0 failing** across all touched code:
  - 13 new tests for `startup/router.js` — verifies `<Router>` with explicit history, `updateRoute` dispatch on initial render and navigation, store return value, reducer integration
  - 20 new tests for `v5-compatibility.js` — verifies `withRouterV5Compat` provides correct `router` (push/replace/goBack/go/params/setRouteLeaveHook), `location` (with `.query` synthesis including repeated keys, `.basename` passthrough), `params`, `route` forwarding, `displayName`, and `WrappedComponent` exposure
  - 13 new tests for `convertLegacyRoutes.js` — verifies standard routes, nested routes, `onEnter` redirects, catch-all `*` routes, path normalization (double slash removal), exact root matching, empty/undefined input handling
  - 8 existing `SaveInProgressErrorPage` tests — all still passing (basename fallback is only exercised in `notAttempted` status path, not covered by existing tests but manually verified as backward-compatible)
  - 30 existing startup tests — all still passing
- **No behavioral changes** for existing v3 apps (new files are unused until Phase 2 canary migration)
- **Backward-compatible basename fallbacks** — both modified files check for `location.basename` first (v3 behavior), then fall back to alternatives for v5

## Screenshots

N/A — No UI changes. This PR adds platform utilities and fixes an internal Redux dispatch bug. No visual changes for end users.

## What areas of the site does it impact?

- `src/platform/startup/router.js` — affects the 7 apps using the v5 startup path (vaos, profile, mhv-secure-messaging, gi, enrollment-verification, education-letters, combined-debt-portal). The change fixes a pre-existing bug where `updateRoute` was never dispatched, so Redux route state is now accurate. No visual impact.
- `src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx` — shared form infrastructure. Fallback logic only activates for v5 apps; v3 apps still use `location.basename` as before.
- `src/platform/utilities/real-user-monitoring.jsx` — Datadog RUM view naming. Fallback produces identical view names since v5 history includes basename in pathname.
- `src/platform/forms-system/src/js/routing/` — new files, unused until canary migration PR.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated
- [x] Screenshot of the developed feature is added — N/A, no UI changes
- [x] Accessibility testing has been performed — N/A, no UI changes

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution — `updateRoute` now correctly dispatches to Redux store
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — Existing RUM monitoring preserved; no new monitors needed for infrastructure-only changes

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user — Will verify during Phase 2 canary migration PR

## Requested Feedback

This is PR 1 of ~4 in the React Router v3 → v5 migration series. Requesting review of:

1. **`startup/router.js` bug fix** — The `updateRoute` dispatch fix affects 7 production apps. The change is backward-compatible but reviewers should verify the `history.listen()` pattern matches the v3 startup's `browserHistory.listen()` approach.
2. **Shim API surface** — Does `withRouterV5Compat` cover the v3 API surface adequately? Key concern: `setRouteLeaveHook` emits `console.warn` in non-production since v5 has no equivalent (navigation guards will need `<Prompt>` in follow-up work).
3. **Route converter edge cases** — `convertLegacyRoutes` handles the known route config shapes from `createRoutes.js`. Are there other route config patterns in the codebase we should handle?