### PR TITLE
Filter VistA hostnames from lab location fields on detail pages

### DIFF
--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -74,11 +74,15 @@ const initialState = {
   warnings: [],
 };
 
+const VISTA_HOSTNAME_PATTERN = /\.MED\.VA\.GOV$/i;
+
 export const extractLabLocation = (performer, record) => {
   if (!isArrayAndHasItems(performer)) return null;
   const locationRef = performer.find(item => item.reference);
   const labLocation = extractContainedResource(record, locationRef?.reference);
-  return labLocation?.name || null;
+  const name = labLocation?.name || null;
+  if (name && VISTA_HOSTNAME_PATTERN.test(name)) return null;
+  return name;
 };
 
 export const distillChemHemNotes = (notes, valueProp) => {
@@ -222,7 +226,9 @@ export const extractPerformingLabLocation = record => {
     fhirResourceTypes.ORGANIZATION,
     record.performer,
   );
-  return performingLab?.name || null;
+  const name = performingLab?.name || null;
+  if (name && VISTA_HOSTNAME_PATTERN.test(name)) return null;
+  return name;
 };
 
 export const extractOrderedBy = record => {

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-view-labs-chem-hem-details.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-view-labs-chem-hem-details.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Medical Records View Labs And Tests', () => {
         record.contained[1].name[0].given[1]
       } ${record.contained[1].name[0].family}`,
     );
-    ChemHemDetailsPage.verifyLabCollectingLocation(record.contained[3].name);
+    ChemHemDetailsPage.verifyLabCollectingLocation('None recorded');
     // There might be a new line in this provider notes example.  we need to check later
     ChemHemDetailsPage.verifyProviderNotesSingle(
       record.extension[0].valueString,

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.jsx
@@ -61,6 +61,26 @@ describe('extractLabLocation', () => {
     };
     expect(extractLabLocation(record.performer, record)).to.be.null;
   });
+
+  it('should return null when location name is a VistA hostname', () => {
+    const record = {
+      contained: [
+        { id: 'OrgPerformer-989', name: 'DAYT29.FO-BAYPINES.MED.VA.GOV' },
+      ],
+      performer: [{ reference: '#OrgPerformer-989' }],
+    };
+    expect(extractLabLocation(record.performer, record)).to.be.null;
+  });
+
+  it('should return the name when it is not a VistA hostname', () => {
+    const record = {
+      contained: [{ id: 'Organization-552', name: 'DAYTON, OH VAMC' }],
+      performer: [{ reference: '#Organization-552' }],
+    };
+    expect(extractLabLocation(record.performer, record)).to.equal(
+      'DAYTON, OH VAMC',
+    );
+  });
 });
 
 describe('distillChemHemNotes', () => {
@@ -575,6 +595,20 @@ describe('extractPerformingLabLocation', () => {
   };
   it('gets the performing lab location', () => {
     expect(extractPerformingLabLocation(record)).to.eq('Org Name');
+  });
+
+  it('returns null when Organization name is a VistA hostname', () => {
+    const hostnameRecord = {
+      contained: [
+        {
+          id: 'OrgPerformer-989',
+          resourceType: fhirResourceTypes.ORGANIZATION,
+          name: 'SLC4.FO-BAYPINES.MED.VA.GOV',
+        },
+      ],
+      performer: [{ reference: '#OrgPerformer-989' }],
+    };
+    expect(extractPerformingLabLocation(hostnameRecord)).to.be.null;
   });
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The PHR FHIR API returns VistA server hostnames (e.g., `DAYT29.FO-BAYPINES.MED.VA.GOV`) as the contained Organization name for performing labs. The legacy lab location extraction functions (`extractLabLocation` and `extractPerformingLabLocation`) pass this value through to the UI, displaying a hostname instead of a facility name on the Labs & Tests detail page.
- **To reproduce**: View a chem/hem, microbiology, or pathology lab result detail page for a VistA record where the performer Organization name is a server hostname. The Location field displays the hostname.
- **Solution**: Add a `*.MED.VA.GOV` hostname pattern check to both `extractLabLocation` (chem/hem) and `extractPerformingLabLocation` (microbiology/pathology). When detected, return null so the UI displays the empty field placeholder ("None recorded") instead of the raw hostname. This serves as defense-in-depth alongside the backend fix which resolves hostnames to real facility names.
- Team: MHV Medical Records (TEAM-mhv-medical-records). Yes, our team owns this component.
- Not behind a flipper.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132102
- Backend companion PR: department-of-veterans-affairs/vets-api#26846

## Testing done

- **Old behavior**: `extractLabLocation` and `extractPerformingLabLocation` returned the Organization name as-is, including VistA server hostnames. The Cypress e2e test asserted the hostname as the expected location value.
- **New behavior**: Names matching `*.MED.VA.GOV` are filtered out and return null, displaying "None recorded" in the UI.
- **Verification steps**:
  1. Run `npm run test:unit -- 'src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.jsx'` — 75 passing
  2. New unit test cases cover: hostname filtered to null for `extractLabLocation`, hostname filtered to null for `extractPerformingLabLocation`, and valid facility names passing through unchanged
  3. Updated Cypress e2e test to expect "None recorded" instead of the hostname

## Screenshots

N/A — The location field changes from displaying a hostname string to "None recorded". No layout or component changes.

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | Location: DAYT29.FO-BAYPINES.MED.VA.GOV | Location: None recorded |

## What areas of the site does it impact?

MHV Medical Records — Labs & Tests detail pages (chem/hem, microbiology, pathology). Only the location extraction functions in `reducers/labsAndTests.js` are modified. No other domains are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated — N/A, no documentation changes needed
- [x] Screenshot of the developed feature is added
- [x] Accessibility testing has been performed — No UI component changes, axe check in Cypress e2e test passes

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution — N/A, frontend filtering only
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user