### PR TITLE
Add VSO Select Filter Behind Feature Flag

### DIFF
--- a/src/applications/representative-search/components/search/SearchControls.jsx
+++ b/src/applications/representative-search/components/search/SearchControls.jsx
@@ -5,10 +5,98 @@ import {
   VaModal,
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '~/platform/utilities/ui';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import RepTypeSelector from './RepTypeSelector';
 import { ErrorTypes } from '../../constants';
 import { searchAreaOptions } from '../../config';
+
+const ORGANIZATIONS = [
+  'African American PTSD Association',
+  'Alabama Department of Veterans Affairs',
+  'American Legion',
+  'American Veterans',
+  'Arizona Department of Veterans Services',
+  'Arkansas Department of Veterans Affairs',
+  'Armed Forces Services Corporation',
+  'Blinded Veterans Association',
+  'California Department of Veterans Affairs',
+  'Catholic War Veterans of the USA',
+  'Colorado Division of Veterans Affairs',
+  'Commonwealth of the Northern Mariana Islands Division',
+  'Connecticut Department of Veterans Affairs',
+  'Dale K. Graham Veterans Foundation',
+  'Delaware Commission of Veterans Affairs',
+  'Disabled American Veterans',
+  'Fleet Reserve Association',
+  'Florida Department of Veterans Affairs',
+  'Georgia Department of Veterans Service',
+  'Gila River Indian Community Vet.&Fam. Svcs Office',
+  'Green Beret Foundation',
+  'Guam Office of Veterans Affairs',
+  'Hawaii Office of Veterans Services',
+  'IAM Veterans Benefits Support (IAM VBS)',
+  'Idaho Division of Veterans Services',
+  'Illinois Department of Veterans Affairs',
+  'Indiana Department of Veterans Affairs',
+  'Iowa Department of Veterans Affairs',
+  'Jewish War Veterans of the USA',
+  'Kansas Office of Veterans Services',
+  'Kentucky Department of Veterans Affairs',
+  'Louisiana Department of Veterans Affairs',
+  "Maine Veterans' Services",
+  'Marine Corps League',
+  'Maryland Department of Veterans Affairs',
+  'Massachusetts Executive Office of Veterans Service',
+  'Michigan Veterans Affairs Agency',
+  'Minnesota Department of Veterans Affairs',
+  'Mississippi Veterans Affairs',
+  'Missouri Veterans Commission',
+  'Montana Veterans Affairs (MVAD)',
+  'National Association for Black Veterans, Inc.',
+  'National Association of County Veterans Service Officers',
+  'National Law School Veterans Clinic Consortium',
+  'National Montford Point Marine Association, Inc.',
+  'National Veterans Legal Services Program',
+  'Navajo Nation Veterans Administration',
+  'Navy Mutual Aid Association',
+  'Nebraska Department of Veterans Affairs',
+  'Nevada Department of Veterans Services',
+  'New Hampshire Division of Veteran Services',
+  'New Jersey Department of Military and Veterans Affairs',
+  'New Mexico Department of Veterans Services',
+  "New York State Department of Veterans' Services",
+  'North Carolina Dept Military and Veterans Affairs',
+  'North Dakota Department Veterans Affairs',
+  'Office of Veterans Affairs American Samoa Government',
+  'Ohio Department of Veterans Services',
+  'Oklahoma Department of Veterans Affairs',
+  'Oregon Department of Veterans Affairs',
+  'Paralyzed Veterans of America',
+  'Pennsylvania Department of Military and Veterans Affairs',
+  'Polish Legion of American Veterans',
+  'Puerto Rico Veterans Advocate Office',
+  'Rhode Island Office of Veterans Services (RIVETS)',
+  'South Dakota Department of Veterans Affairs',
+  'Swords to Plowshares',
+  'Tennessee Department of Veterans Services',
+  'Texas Veterans Commission',
+  'The Retired Enlisted Association',
+  'The South Carolina Department of Veterans Affairs',
+  'UDT-SEAL Association',
+  'Utah Department of Veterans and Military Affairs',
+  'Vermont Office of Veterans Affairs',
+  'Veterans of Foreign Wars',
+  "Veterans' Voice of America",
+  'Vietnam Veterans of America',
+  'Virgin Islands Office of Veterans Affairs',
+  'Virginia Department of Veterans Services',
+  'Washington Department of Veterans Affairs',
+  'West Virginia Dept of Veterans Assistance',
+  'Wisconsin Department of Veterans Affairs',
+  'Wounded Warrior Project',
+  'Wyoming Veterans Commission',
+];
 
 /* eslint-disable @department-of-veterans-affairs/prefer-button-component */
 
@@ -29,12 +117,19 @@ const SearchControls = props => {
     geolocationInProgress,
     isErrorEmptyInput,
     searchArea,
+    organizationFilter,
   } = currentQuery;
 
   const onlySpaces = str => /^\s+$/.test(str);
 
   const showEmptyError = isErrorEmptyInput && !geolocationInProgress;
   const showGeolocationError = geocodeError && !geolocationInProgress;
+
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+
+  const organizationFilterEnabled = useToggleValue(
+    TOGGLE_NAMES.findARepresentativeEnabled,
+  );
 
   const searchAreaSelectOptions = Object.keys(searchAreaOptions).map(
     optionKey => (
@@ -43,6 +138,12 @@ const SearchControls = props => {
       </option>
     ),
   );
+
+  const organizationSelectOptions = ORGANIZATIONS.map(organization => (
+    <option key={organization} value={organization}>
+      {organization}
+    </option>
+  ));
 
   const handleLocationChange = e => {
     onChange({
@@ -55,6 +156,13 @@ const SearchControls = props => {
   const handleSearchAreaChange = e => {
     onChange({
       searchArea: onlySpaces(e.target.value)
+        ? e.target.value.trim()
+        : e.target.value,
+    });
+  };
+  const handleOrganizationChange = e => {
+    onChange({
+      organizationFilter: onlySpaces(e.target.value)
         ? e.target.value.trim()
         : e.target.value,
     });
@@ -176,7 +284,6 @@ const SearchControls = props => {
               </va-text-input>
             </div>
           </div>
-
           <div className="search-area-dropdown">
             <VaSelect
               name="area"
@@ -188,7 +295,20 @@ const SearchControls = props => {
               {searchAreaSelectOptions}
             </VaSelect>
           </div>
-
+          {organizationFilterEnabled &&
+            representativeType === 'veteran_service_officer' && (
+              <div className="organization-select">
+                <VaSelect
+                  name="organization"
+                  value={organizationFilter}
+                  label="Veterans Service Organization (VSO)"
+                  onVaSelect={handleOrganizationChange}
+                  uswds
+                >
+                  {organizationSelectOptions}
+                </VaSelect>
+              </div>
+            )}
           <div className="representative-name-input vads-u-margin-top--4">
             <va-text-input
               hint={null}

--- a/src/applications/representative-search/components/search/SearchControls.jsx
+++ b/src/applications/representative-search/components/search/SearchControls.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import {
   VaModal,
   VaSelect,
+  VaComboBox,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from '~/platform/utilities/ui';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
@@ -298,7 +299,7 @@ const SearchControls = props => {
           {organizationFilterEnabled &&
             representativeType === 'veteran_service_officer' && (
               <div className="organization-select">
-                <VaSelect
+                <VaComboBox
                   name="organization"
                   value={organizationFilter}
                   label="Veterans Service Organization (VSO)"
@@ -306,7 +307,7 @@ const SearchControls = props => {
                   uswds
                 >
                   {organizationSelectOptions}
-                </VaSelect>
+                </VaComboBox>
               </div>
             )}
           <div className="representative-name-input vads-u-margin-top--4">

--- a/src/applications/representative-search/tests/components/SearchControls.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchControls.unit.spec.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+import SearchControls from '../../components/search/SearchControls';
+
+describe('SearchResults', () => {
+  const mockStore = configureMockStore();
+  let store;
+
+  const mockOnChange = sinon.spy();
+  const mockOnSubmit = sinon.spy();
+  const currentQuery = {
+    representativeType: 'veteran_service_officer',
+  };
+
+  beforeEach(() => {
+    store = mockStore({
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        find_a_representative_enabled: true,
+      },
+    });
+  });
+  describe('VSO filter options feature flag enabled', () => {
+    it('should display VSO filter box when VSO is selected', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <SearchControls
+            onChange={mockOnChange}
+            onSubmit={mockOnSubmit}
+            currentQuery={currentQuery}
+            geocodeError={0}
+            locationChanged={false}
+          />
+        </Provider>,
+      );
+
+      expect(wrapper.find('.organization-select')).to.have.lengthOf(1);
+      wrapper.unmount();
+    });
+
+    it('should not display VSO filter box when attorney is selected', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <SearchControls
+            onChange={mockOnChange}
+            onSubmit={mockOnSubmit}
+            currentQuery={{
+              representativeType: 'attorney',
+            }}
+            geocodeError={0}
+            locationChanged={false}
+          />
+        </Provider>,
+      );
+
+      expect(wrapper.find('.organization-select')).to.have.lengthOf(0);
+      wrapper.unmount();
+    });
+  });
+  describe('VSO filter options feature flag disabled', () => {
+    beforeEach(() => {
+      store = mockStore({
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          find_a_representative_enabled: false,
+        },
+      });
+    });
+    it('should not display VSO filter box when VSO is selected', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <SearchControls
+            onChange={mockOnChange}
+            onSubmit={mockOnSubmit}
+            currentQuery={currentQuery}
+            geocodeError={0}
+            locationChanged={false}
+          />
+        </Provider>,
+      );
+
+      expect(wrapper.find('.organization-select')).to.have.lengthOf(0);
+      wrapper.unmount();
+    });
+    it('should not display VSO filter box when attorney is selected', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <SearchControls
+            onChange={mockOnChange}
+            onSubmit={mockOnSubmit}
+            currentQuery={{
+              representativeType: 'attorney',
+            }}
+            geocodeError={0}
+            locationChanged={false}
+          />
+        </Provider>,
+      );
+
+      expect(wrapper.find('.organization-select')).to.have.lengthOf(0);
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -106,6 +106,7 @@
   "financialStatusReportExpensesUpdate": "financial_status_report_expenses_update",
   "financialStatusReportReviewPageNavigation": "financial_status_report_review_page_navigation",
   "findARepresentativeEnableFrontend": "find_a_representative_enable_frontend",
+  "findARepresentativeEnabled": "find_a_representative_enabled",
   "findARepresentativeFlagResultsEnabled": "find_a_representative_flag_results_enabled",
   "findARepresentativeUseAccreditedModels": "find_a_representative_use_accredited_models",
   "form1010dBrowserMonitoringEnabled": "form1010d_browser_monitoring_enabled",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add new select box when "VSO" option is selected, this will allow filtering by VSO organization but right now does not do anything. It is behind the flipper `find_a_representative_enabled`
- Accredited Rep Crew
- This flipper is being targeted for the V3 feature set for ARC, expected end of march to early april

## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/133251

## Testing done

- This adds new select box, old page behavior is unaffected
- Tested with flipper on and off, and selecting VSO and other representative options
- Specs added to test for flipper and vso option showing/hiding new element

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="640" height="960" alt="Screen Shot 2026-03-02 at 14 09 27" src="https://github.com/user-attachments/assets/7dcdfca2-5929-4d9b-8719-024b6e2e3032" /> | <img width="640" height="960" alt="Screen Shot 2026-03-02 at 14 11 50" src="https://github.com/user-attachments/assets/d6834ed5-aae7-4002-9344-93397e98ee28" /> |
| Desktop | <img width="1487" height="755" alt="Screenshot 2026-03-02 at 14 07 30" src="https://github.com/user-attachments/assets/84df0fa3-64c7-4a77-9051-7dc0be7d9123" /> |  <img width="1615" height="995" alt="Screenshot 2026-03-02 at 13 52 26" src="https://github.com/user-attachments/assets/7e9acec2-09f6-42b4-8b64-a0a798034e3a" /> <img width="1494" height="761" alt="Screenshot 2026-03-02 at 13 51 59" src="https://github.com/user-attachments/assets/a5165062-58a5-4be1-8b1f-1d7086881dee" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user