### PR TITLE
Remove stale sections from E2E testing README

### DIFF
--- a/src/applications/claims-status/tests/e2e/README.md
+++ b/src/applications/claims-status/tests/e2e/README.md
@@ -4,29 +4,6 @@
 - In November 2025 the E2E tests for the `claims-status` application were rewritten to improve coverage, maintainability, and scalability while modernizing the E2E tests
 - This README for `claims-status` E2E testing is to align the team on best practices gathered from Cypress, VA Platform, and the team
 
-## Directory Structure
-
-```
-tests/
-├── claim-letters/       # Claim letters page tests
-├── details/             # Detail page tests
-│   ├── appeals/         # Appeals detail page tests
-│   └── claims/          # Claims detail page tests
-├── shared/              # Cross-cutting tests (loading states, etc.)
-└── your-claims/         # List page tests
-
-support/
-├── fixtures/            # Test data factories by endpoint
-│   ├── appeals.js       # Appeal data for /v0/appeals
-│   ├── benefitsClaims.js # Claim data for /v0/benefits_claims
-│   ├── claimLetters.js  # Claim letter data for /v0/claim_letters
-│   └── stemClaims.js    # STEM claim data for /v0/education_benefits_claims/stem_claim_status
-└── helpers/             # Reusable test utilities
-    ├── mocks.js         # API mocking (mockFeatureToggles)
-    ├── setup.js         # Test setup (setupClaimTest, setupAppealTest)
-    └── assertions.js    # Common assertions
-```
-
 ## Writing Tests
 
 ### Element Selection
@@ -128,19 +105,6 @@ describe('Feature flag: cstShowDocumentUploadStatus', () => {
 });
 ```
 
-#### Permanently Enabled Flags
-
-The following flags are permanently enabled in production and should **not** have "disabled" tests.
-
-- `claim_letters_access`
-- `cst_claim_phases`
-- `cst_include_ddl_5103_letters`
-- `cst_include_ddl_boa_letters`
-- `cst_timezone_discrepancy_mitigation`
-- `stem_automated_decision`
-
-These are set as defaults in `support/helpers/mocks.js` via `mockFeatureToggles()`.
-
 ### Path Constants
 
 Define path constants at the top of test files for reusable URL segments:
@@ -188,30 +152,6 @@ npx nyc report --reporter=html --reporter=json-summary --reporter=text
 # View HTML report
 open coverage/index.html
 ```
-
-### Progress
-
-| Stage                                                                                 | % Stmts | % Branch | % Funcs | % Lines |
-| --------------------------------------------------------------------------------------| ------- | -------- | ------- | ------- |
-| Initial                                                                               | 75.07   | 62.43    | 82.86   | 75.13   |
-| [First PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40123) | 76.58   | 64.54    | 83.61   | 76.62   |
-| [Second PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40467) | 78.94   | 69.34    | 85.33   | 78.88   |
-| [Third PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40825) | 80.13   | 70.10    | 86.22   | 80.09   |
-| [Fourth PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40909) | 81.68   | 73.36    | 87.54   | 81.64   |
-
-
-### Next Priority
-
-| Priority | File                       | Branch % | Uncovered Lines                     |
-| -------- | -------------------------- | -------- | ----------------------------------- |
-| 1        | appeals-v2-helpers.jsx     | 27.96    | 1646-1965,1984-1986,2022,2056,2069  |
-| 2        | Decision.jsx               | 53.84    | 12,15,43,57                         |
-| 3        | AppealsV2StatusPage.jsx    | 64.70    | 64-72,86-87                         |
-| 4        | helpers.js                 | 68.53    | 1493-1495,1500,1522,1531,1562,1620  |
-| 5        | FilesReceived.jsx          | 82.22    | 29,54,100                           |
-| 6        | Standard5103NoticePage.jsx | 0        | 20-86                               |
-| 7        | StemClaimStatusPage.jsx    | 0        | 15-88                               |
-| 8        | StemDeniedDetails.jsx      | 0        | 15-221                              |
 
 ## Reference
 


### PR DESCRIPTION
> **Documentation only** — no code changes, no testing required.

## Summary

- Remove sections from the claims-status E2E testing README that are already out of date and would require constant maintenance
- Removed: directory structure listing, code coverage progress table, next priority table, and permanently enabled flags list
- Kept: writing conventions, code coverage how-to, Cypress best practices reference, and platform practices
- Benefits Management Tools team, claims-status application

## Related issue(s)

N/A — standalone documentation cleanup