### PR TITLE
Remove unused testId from tracked item content links

### DIFF
--- a/src/applications/claims-status/components/TrackedItemContent/InlineRenderer.jsx
+++ b/src/applications/claims-status/components/TrackedItemContent/InlineRenderer.jsx
@@ -54,7 +54,6 @@ export const InlineRenderer = ({ content }) => {
           <VaLink
             text={content.text}
             href={content.href}
-            data-testid={content.testId}
             {...content.style === 'active' && { active: true }}
             {...content.style === 'external' && { external: true }}
           />

--- a/src/applications/claims-status/components/TrackedItemContent/contentPropTypes.js
+++ b/src/applications/claims-status/components/TrackedItemContent/contentPropTypes.js
@@ -20,7 +20,6 @@ const inlineContentShape = PropTypes.oneOfType([
     text: PropTypes.string,
     href: PropTypes.string,
     style: PropTypes.oneOf(['active', 'default', 'external']),
-    testId: PropTypes.string,
     // Telephone-specific properties
     contact: PropTypes.string,
     tty: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
@@ -59,7 +58,6 @@ export const InlineContentPropType = PropTypes.oneOfType([
     text: PropTypes.string,
     href: PropTypes.string,
     style: PropTypes.oneOf(['active', 'default', 'external']),
-    testId: PropTypes.string,
     contact: PropTypes.string,
     tty: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   }),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Remove the unused `content.testId` reference from the `InlineRenderer` component and `testId` from prop type definitions in `contentPropTypes.js`
- The `testId` property was removed from the vets-api `override_content.json` and JSON schema in department-of-veterans-affairs/va.gov-team#134461, so this field now resolves to `undefined` on rendered `VaLink` components
- BMT Team 2 (Bee's Knees) owns the Claim Status Tool

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#134828
- department-of-veterans-affairs/va.gov-team#134461 (vets-api removal of `testId`)

## Testing done

- **Before:** `VaLink` elements rendered with `data-testid="undefined"` since `testId` was removed from API data
- **After:** `VaLink` elements render without a `data-testid` attribute
- Ran all `InlineRenderer` unit tests (13 passing) and `TrackedItemContent` unit tests (6 passing) — all green
- Confirmed no other references to `testId` exist in the `TrackedItemContent` directory
- No E2E tests rely on these `data-testid` values (E2E tests use component-level IDs like `item-13`)

## Screenshots

N/A — no visual changes. The removed `data-testid` attribute is not user-facing.

## What areas of the site does it impact?

Claim Status Tool — specifically the tracked item content links rendered via `InlineRenderer` within evidence request details.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated — N/A
- [ ] Screenshot of the developed feature is added — N/A, no visual change
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution — N/A
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user — N/A, no route or auth changes

## Requested Feedback

Straightforward cleanup — just removing references to a field that no longer exists in the API response.
