### PR TITLE
ci: skip yarn install and postinstall when cache is hit

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -45,11 +45,23 @@ runs:
           src/platform/*/node_modules
           src/applications/*/node_modules
           src/applications/*/*/node_modules
-        key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-v2-${{ inputs.key }}
+        key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}
         # restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 
+    - name: Verify cache integrity
+      if: steps.cache-dependencies.outputs.cache-hit == 'true'
+      id: cache-verify
+      shell: bash
+      run: |
+        if [ ! -f node_modules/.yarn-integrity ]; then
+          echo "::warning::Cache integrity check failed — running full install"
+          echo "cache-valid=false" >> $GITHUB_OUTPUT
+        else
+          echo "cache-valid=true" >> $GITHUB_OUTPUT
+        fi
+
     - name: Install dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true' || steps.cache-verify.outputs.cache-valid == 'false'
       uses: nick-fields/retry@v3
       with:
         command: |
@@ -62,6 +74,6 @@ runs:
         YARN_CACHE_FOLDER: ${{ inputs.yarn_cache_folder }}
 
     - name: Run postinstall scripts
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true' || steps.cache-verify.outputs.cache-valid == 'false'
       shell: bash
       run: yarn postinstall

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -45,7 +45,7 @@ runs:
           src/platform/*/node_modules
           src/applications/*/node_modules
           src/applications/*/*/node_modules
-        key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}
+        key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-v2-${{ inputs.key }}
         # restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 
     - name: Install dependencies

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -45,6 +45,7 @@ runs:
         # restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 
     - name: Install dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       uses: nick-fields/retry@v3
       with:
         command: |
@@ -57,5 +58,6 @@ runs:
         YARN_CACHE_FOLDER: ${{ inputs.yarn_cache_folder }}
 
     - name: Run postinstall scripts
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       shell: bash
       run: yarn postinstall

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -40,7 +40,11 @@ runs:
       id: cache-dependencies
       uses: actions/cache@v4
       with:
-        path: ${{ inputs.path }}
+        path: |
+          ${{ inputs.path }}
+          src/platform/*/node_modules
+          src/applications/*/node_modules
+          src/applications/*/*/node_modules
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}
         # restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I am not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
- [x] No

## Summary

- The install composite action (`.github/workflows/install/action.yml`) restores `node_modules` from `actions/cache`, but then **unconditionally** runs `yarn install --frozen-lockfile`, `npx cypress install`, and `yarn postinstall` — even on a full cache hit. This adds ~30s of wasted compute time to every CI job.
- This PR checks the `cache-hit` output from `actions/cache@v4` and skips the install and postinstall steps when dependencies are already fully restored from cache.
- The cache key is based on the Node version + `yarn.lock` hash, so a cache hit guarantees `node_modules` matches the lockfile exactly. The redundant `yarn install --frozen-lockfile` verification is unnecessary.
- **Additionally**, the cache path now includes yarn workspace `node_modules` directories (`src/platform/*/node_modules`, `src/applications/*/node_modules`, `src/applications/*/*/node_modules`). Previously, only the root `node_modules` was cached, so workspace dependencies like `jsdom` in `src/platform/testing/node_modules` were missing on cache hit — making it impossible to safely skip `yarn install`.
- This affects **all jobs** across CI workflows that use the shared install action (~18 jobs in `continuous-integration.yml` alone, plus `pull-request.yml`, `e2e-stress-test.yml`, etc.).

## Impact

Measured by comparing the "Install dependencies" composite step duration between a [baseline `main` run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/22598355085) (cache hit but install always runs) and a [cache-hit PR run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/22605256129) (cache hit, install skipped). All 13 jobs in the PR run confirmed cache HIT with `yarn install` and `postinstall` both SKIPPED:

| Job | Before | After | Saved |
|-----|--------|-------|-------|
| Build (vagovdev) | 66s | 34s | 32s |
| Build (vagovprod) | 59s | 41s | 18s |
| Build (vagovstaging) | 58s | 26s | 32s |
| Cypress E2E Tests (0) | 49s | 30s | 19s |
| Cypress E2E Tests (1) | 74s | 29s | 45s |
| Cypress E2E Tests (2) | 50s | 28s | 22s |
| Cypress E2E Tests (3) | 46s | 33s | 13s |
| Determine CD Eligibility | 66s | 33s | 33s |
| Security Audit | 53s | 32s | 21s |
| Testing Reports Prep | 67s | 33s | 34s |
| Tests Prep | 72s | 33s | 39s |
| Unit Tests | 56s | 28s | 28s |

**Average savings: ~28s per job.** On a typical `main` CI run with 18 install jobs, this saves **~500s of total compute time per run**.

The remaining ~31s per job is the cache download and extraction of ~973 MB (`node_modules` + workspace deps). This is irreducible — `actions/cache` must download and unpack the tarball regardless.

### Wall-clock impact

The pipeline has 3-4 sequential waves, each with an install step on the critical path:

| Wave | Jobs (parallel) | Install savings |
|------|----------------|-----------------|
| 1 | Build, Tests Prep, Linting, Security Audit | ~28s |
| 2 | Unit Tests, Cypress (after Wave 1) | ~28s |
| 3 | QA Merge (after Wave 2) | ~28s |
| 4 | Deploy (main only, after Wave 3) | ~28s |

**Estimated end-to-end wall-clock savings: ~1.5-2 minutes** (3-4 sequential install steps × ~28s each), on a pipeline that typically runs ~17-20 minutes. Roughly a **10% reduction** in total pipeline duration.

## Related issue(s)

- Companion PR for Cypress install optimization: department-of-veterans-affairs/vets-website#42399

## Testing done

- Verified via git history that the `cache-hit` output was never checked — this is a net-new optimization, not a regression fix
- The `actions/cache@v4` `cache-hit` output is `true` only on an exact key match, ensuring we only skip install when `node_modules` is fully restored
- On cache miss (e.g. `yarn.lock` changes), the install step runs as before with retry logic
- First CI run confirmed the missing `jsdom` issue when workspace `node_modules` were not cached — fixed by adding workspace paths to the cache
- [Second CI run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/22603862523) (with workspace `node_modules` in cache) passing successfully
- [Third CI run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/22605256129) (no-op commit) confirmed all 13 jobs got cache hits with install fully skipped — all passing

## Screenshots

N/A — CI infrastructure change only, no UI impact.

## What areas of the site does it impact?

No site impact. This only affects CI pipeline execution time.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A — CI change)
- [x] Accessibility testing has been performed (N/A — CI change)

### Error Handling

- [x] Browser console contains no warnings or errors. (N/A)
- [x] Events are being sent to the appropriate logging solution (N/A)
- [x] Feature/bug has a monitor built into Datadog or Grafana (N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A — CI change)

## Requested Feedback

- Please verify the assumption that an exact cache hit on `${NODE_VERSION}-${yarn.lock hash}` guarantees a valid `node_modules`. If there are edge cases where the cache could be stale despite an exact key match, we may want a lightweight verification step instead of a full skip.

