### PR TITLE
ci: optimize workflow ordering and fix bugs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Configure AWS credentials
         if: ${{ matrix.buildtype == 'vagovprod' }}
@@ -111,8 +112,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -161,6 +160,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -335,8 +335,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -431,8 +429,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -546,6 +542,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -576,6 +573,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -1659,6 +1657,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -1885,6 +1884,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -2005,6 +2005,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install dependencies
         if: env.ALERT_TEAMS == 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -134,64 +134,12 @@ jobs:
         if: ${{ always() }}
         id: deploy-to-prod
         run: echo "can_deploy=$CAN_DEPLOY_TO_PROD" >> $GITHUB_OUTPUT
-  fetch-allow-lists:
-    name: Fetch Test Stability Allow Lists
+  tests-prep:
+    name: Tests Prep
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-
-      - name: Configure AWS credentials
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_region: us-gov-west-1
-          role: ${{ vars.AWS_ASSUME_ROLE }}
-
-      - name: Get va-vsp-bot token
-        uses: ./.github/workflows/inject-secrets
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
-
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
-
-      - name: Fetch E2E Test Stability Allow List
-        run: yarn get-allow-list
-        working-directory: qa-standards-dashboard-data
-        env:
-          TEST_TYPE: e2e
-
-      - name: Fetch Unit Test Stability Allow List
-        run: yarn get-allow-list
-        working-directory: qa-standards-dashboard-data
-        env:
-          TEST_TYPE: unit_test
-
-      - name: Archive E2E Test Stability Allow List
-        if: ${{ always() }}
-        uses: ./.github/workflows/upload-artifact
-        with:
-          name: e2e-allow-list
-          path: qa-standards-dashboard-data/e2e_allow_list.json
-
-      - name: Archive Unit Test Stability Allow List
-        if: ${{ always() }}
-        uses: ./.github/workflows/upload-artifact
-        with:
-          name: unit-test-allow-list
-          path: qa-standards-dashboard-data/unit_test_allow_list.json
-
-  tests-prep:
-    name: Tests Prep
-    needs: [fetch-allow-lists]
-    runs-on: ubuntu-22.04
     outputs:
       app_folders: ${{ steps.get-changed-apps.outputs.folders }}
       apps-to-stress-test: ${{ steps.apps-to-stress-test.outputs.apps_to_test }}
@@ -231,17 +179,40 @@ jobs:
           delimiter: ','
           output-type: 'entry_name, url, folder'
 
-      - name: Download Unit Test Stability Allow List
-        uses: ./.github/workflows/download-artifact
+      - name: Configure AWS credentials
+        uses: ./.github/workflows/configure-aws-credentials
         with:
-          name: unit-test-allow-list
-          path: .
+          aws_region: us-gov-west-1
+          role: ${{ vars.AWS_ASSUME_ROLE }}
 
-      - name: Download E2E Test Stability Allow List
-        uses: ./.github/workflows/download-artifact
+      - name: Get va-vsp-bot token
+        uses: ./.github/workflows/inject-secrets
         with:
-          name: e2e-allow-list
-          path: .
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        uses: ./.github/workflows/init-data-repo
+
+      - name: Set Up BigQuery Creds
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Fetch E2E Test Stability Allow List
+        run: yarn get-allow-list
+        working-directory: qa-standards-dashboard-data
+        env:
+          TEST_TYPE: e2e
+
+      - name: Fetch Unit Test Stability Allow List
+        run: yarn get-allow-list
+        working-directory: qa-standards-dashboard-data
+        env:
+          TEST_TYPE: unit_test
+
+      - name: Copy allow lists to workspace root
+        run: |
+          cp qa-standards-dashboard-data/e2e_allow_list.json .
+          cp qa-standards-dashboard-data/unit_test_allow_list.json .
 
       - name: Select E2E Tests
         run: node script/github-actions/select-e2e-tests.js
@@ -332,10 +303,24 @@ jobs:
         id: matrix
         run: echo ci_node_index=$CI_NODE_INDEX >> $GITHUB_OUTPUT
 
+      - name: Archive E2E Test Stability Allow List
+        if: ${{ always() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: e2e-allow-list
+          path: qa-standards-dashboard-data/e2e_allow_list.json
+
+      - name: Archive Unit Test Stability Allow List
+        if: ${{ always() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: unit-test-allow-list
+          path: qa-standards-dashboard-data/unit_test_allow_list.json
+
   unit-tests:
     name: Unit Tests
     # if: ${{ needs.tests-prep.outputs.tests_ran == 'true' }}
-    needs: [fetch-allow-lists, tests-prep]
+    needs: [tests-prep]
     timeout-minutes: 30
     runs-on: ubuntu-16-cores-22.04
     permissions:
@@ -430,8 +415,8 @@ jobs:
     name: Unit Test Stability Review
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    needs: [fetch-allow-lists, tests-prep]
-    if: ${{ always() && !cancelled() && needs.tests-prep.outputs.unit-tests-to-stress-test == 'true' && github.ref != 'refs/heads/main' && needs.fetch-allow-lists.result == 'success' && needs.tests-prep.result == 'success' }}
+    needs: [tests-prep]
+    if: ${{ always() && !cancelled() && needs.tests-prep.outputs.unit-tests-to-stress-test == 'true' && github.ref != 'refs/heads/main' && needs.tests-prep.result == 'success' }}
 
     env:
       APPS_TO_VERIFY: ${{ needs.tests-prep.outputs.apps-to-stress-test }}
@@ -496,7 +481,7 @@ jobs:
   update-unit-test-allow-list:
     name: Update Unit Test Stability Allow List
     runs-on: ubuntu-22.04
-    needs: [unit-tests-stress-test, fetch-allow-lists]
+    needs: [unit-tests-stress-test]
     permissions:
       id-token: write
       contents: read
@@ -686,7 +671,6 @@ jobs:
     name: Fetch ECR Credentials
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    needs: [build]
     permissions:
       id-token: write
       contents: read
@@ -1017,7 +1001,6 @@ jobs:
         testing-reports-prep,
         tests-prep,
         stress-test-cypress-tests,
-        fetch-allow-lists,
       ]
     permissions:
       checks: write
@@ -1553,7 +1536,7 @@ jobs:
       checks: write
       id-token: write
       contents: read
-    if: ${{ always() && (needs.stress-test-cypress-tests.result == 'success' || needs.stresss-test-cypress-tests.result == 'failure') }}
+    if: ${{ always() && (needs.stress-test-cypress-tests.result == 'success' || needs.stress-test-cypress-tests.result == 'failure') }}
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     continue-on-error: true


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
- [x] No

## Summary

Optimizes the CI workflow (`continuous-integration.yml`) in three areas: job ordering, bug fixes, and checkout performance.

### 1. Job ordering improvements
- **Removed `needs: [build]` from `fetch-ecr-credentials`** — This job only performs an AWS ECR login and does not use any build artifacts. Removing the dependency lets it start immediately at T+0:00 instead of waiting ~14 minutes for builds to finish, unblocking downstream Cypress jobs sooner.
- **Merged `fetch-allow-lists` into `tests-prep`** — These two jobs ran sequentially (tests-prep waited for fetch-allow-lists). Since they share the same AWS/BigQuery setup, consolidating them into a single job eliminates ~27s of overhead and simplifies the dependency graph. Downstream jobs (`unit-tests`, `unit-tests-stress-test`, `update-unit-test-allow-list`, `update-e2e-allow-list`) no longer need to reference `fetch-allow-lists`.

### 2. Bug fix
- **Fixed `stresss-test-cypress-tests` typo** in the `testing-reports-cypress-stress-test` job condition — The extra "s" meant the condition `needs.stresss-test-cypress-tests.result` never matched, silently breaking the Slack notification logic for stress test failures.

### 3. Checkout performance (blobless clones)
- **Added `filter: blob:none`** to 7 jobs that use `fetch-depth: 0` — This fetches the full commit graph (needed for merge base detection in `git diff origin/main...` and `git merge-base --is-ancestor`) but skips downloading file blob objects upfront. Blobs are lazily fetched only when the working tree is checked out, reducing `.git` size from ~461MB to ~142MB (69% reduction).
- **Removed `fetch-depth: 0`** from 3 jobs that don't need git history (`determine-cd-eligibility`, `unit-tests`, `unit-tests-stress-test`) — These jobs use test outputs from `tests-prep`, not git diffs, so they can use the default shallow clone (depth=1, ~53MB).

**Jobs affected by `filter: blob:none`**: build, tests-prep, security-audit, linting, test-stability-review-merge-status, deploy, notify-failure

**Jobs switched to shallow clone**: determine-cd-eligibility, unit-tests, unit-tests-stress-test

### Measured results (CI run comparison)

| Job | Before (full clone) | After (blobless/shallow) | Change |
|---|---|---|---|
| Security Audit | 62s | 49s | -13s (-21%) |
| Build (vagovdev) | 22s | 13s | -9s (-41%) |
| Build (vagovprod) | 19s | 13s | -6s (-32%) |
| Build (vagovstaging) | 21s | 13s | -8s (-38%) |
| Unit Tests | 19s | 6s | -13s (-68%) |
| **Total** | **143s** | **94s** | **-49s (-34%)** |

Local benchmarks on Codespace:

| Method | Time | .git size | Merge base works? |
|---|---|---|---|
| Full clone (old `fetch-depth: 0`) | 16.9s | 460MB | Yes |
| Blobless clone (`filter: blob:none`) | 11.1s | 140MB | Yes |
| Shallow clone (`depth=1`) | 5.5s | 53MB | No |

## Related issue(s)




## Testing done

- Verified all three clone strategies locally on Codespace: full, blobless, and shallow. Confirmed blobless clone preserves merge base detection (`git diff --name-only origin/main...` works correctly) while reducing `.git` size by 69%.
- Pushed both commits and verified the CI run (22634954785) completed successfully with all jobs passing.
- Compared checkout step durations between the previous run (22632756609, full clones) and the new run (22634954785, blobless/shallow clones) — 81% aggregate reduction in checkout time across comparable jobs.
- Confirmed `fetch-ecr-credentials` now starts at T+0:00 instead of waiting for builds.
- Confirmed `tests-prep` correctly produces all outputs previously split between `tests-prep` and `fetch-allow-lists`.

## Screenshots

| Before | After |
| -- | -- |
| <img width="774" height="509" alt="Screenshot 2026-03-03 at 09 44 12" src="https://github.com/user-attachments/assets/b5887727-5f20-4bac-be99-16d5dc76be8c" /> | <img width="831" height="712" alt="Screenshot 2026-03-03 at 11 16 13" src="https://github.com/user-attachments/assets/214f4178-f9dc-4b44-a0ff-9e2029eff2bc" /> |
## What areas of the site does it impact?

No site functionality is impacted. Changes are limited to CI workflow configuration.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - N/A: CI workflow changes only. Verified via CI run results.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated — N/A
- [x] Screenshot of the developed feature is added — N/A (no UI)
- [x] Accessibility testing has been performed — N/A (no UI)

### Error Handling

- [x] Browser console contains no warnings or errors. — N/A (no UI)
- [x] Events are being sent to the appropriate logging solution — N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user — N/A (no UI)

## Requested Feedback

Please review the blobless clone approach (`filter: blob:none` + `fetch-depth: 0`). This is a well-supported Git feature (partial clones) but may be new to the team. The key trade-off: blobs are fetched lazily on demand instead of upfront, which means git operations that touch file contents (e.g. `git diff` with file content, `git log -p`) will trigger network requests. For CI jobs that only need the commit graph for merge base detection, this is a significant win.
