### PR TITLE
VEBT-2824: 22-10272 - Form utility testing

### DIFF
--- a/src/applications/edu-benefits/10272/tests/e2e/10272-edu-benefits.cypress.spec.js
+++ b/src/applications/edu-benefits/10272/tests/e2e/10272-edu-benefits.cypress.spec.js
@@ -4,6 +4,8 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import featureToggles from '../fixtures/mocks/feature-toggles.json';
 import user from '../fixtures/mocks/user.json';
 import mockSubmit from '../fixtures/mocks/application-submit.json';
+import prefilledForm from '../fixtures/mocks/prefilled-form.json';
+import sip from '../fixtures/mocks/sip-put.json';
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 
@@ -15,29 +17,58 @@ const testConfig = createTestConfig(
     pageHooks: {
       introduction: ({ afterHook }) => {
         afterHook(() => {
-          cy.findAllByText(/^start/i, { selector: 'a[href="#start"]' })
-            .last()
-            .click({ force: true });
+          cy.get('va-link-action[text="Start your request for reimbursement"')
+            .first()
+            .click();
         });
       },
-      // Example page hook
-      // All paths are already automatically filled out based on fixtures.
-      // But if you want to manually test a page add the path.
-      // 'name-and-date-of-birth': ({ afterHook }) => {
-      //   cy.injectAxeThenAxeCheck();
-      //   afterHook(() => {
-      //     cy.get('@testData').then(() => {
-      //       cy.fillPage(); // fills all fields based on fixtures.
-      //       cy.axeCheck();
-      //       cy.findByText(/continue/i, { selector: 'button' }).click();
-      //     });
-      //   });
-      // },
+      'education-benefits-history': ({ afterHook }) => {
+        afterHook(() => {
+          cy.waitForTextarea();
+          cy.fillPage();
+          cy.tabToSubmitForm();
+        });
+      },
+      remarks: ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(({ remarks }) => {
+            if (remarks) {
+              cy.waitForTextarea();
+              cy.fillPage();
+            }
+          });
+
+          cy.tabToSubmitForm();
+        });
+      },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('#inputField').type('Rita Ann Jackson', { force: true });
+          cy.get('#checkbox-element').check({ force: true });
+          cy.findByText(/Continue/i, { selector: 'button' }).click();
+        });
+      },
     },
     setupPerTest: () => {
-      cy.intercept('GET', '/v0/user', user);
+      Cypress.Commands.add('waitForTextarea', () => {
+        cy.get('#input-type-textarea')
+          .should('be.visible')
+          .and('not.be.disabled')
+          .clear({
+            delay: 250,
+            waitForAnimations: false,
+          });
+      });
+
+      // Default endpoints to intercept
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
+      cy.intercept('GET', '/data/cms/vamc-ehr.json', {});
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+      cy.intercept('PUT', '/v0/in_progress_forms/22-10272', sip);
+
+      // Authenticated endpoints required for login and prefill
+      cy.intercept('GET', '/v0/user', user);
+      cy.intercept('GET', '/v0/in_progress_forms/22-10272', prefilledForm);
       cy.login(user);
     },
     skip: Cypress.env('CI'), // Skip CI initially until content-build is merged

--- a/src/applications/edu-benefits/10272/tests/e2e/10272-edu-benefits.cypress.spec.js
+++ b/src/applications/edu-benefits/10272/tests/e2e/10272-edu-benefits.cypress.spec.js
@@ -29,6 +29,13 @@ const testConfig = createTestConfig(
           cy.tabToSubmitForm();
         });
       },
+      'prep-course-details-3': ({ afterHook }) => {
+        afterHook(() => {
+          cy.waitForMemorableDate();
+          cy.fillPage();
+          cy.tabToSubmitForm();
+        });
+      },
       remarks: ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(({ remarks }) => {
@@ -52,6 +59,16 @@ const testConfig = createTestConfig(
     setupPerTest: () => {
       Cypress.Commands.add('waitForTextarea', () => {
         cy.get('#input-type-textarea')
+          .should('be.visible')
+          .and('not.be.disabled')
+          .clear({
+            delay: 250,
+            waitForAnimations: false,
+          });
+      });
+
+      Cypress.Commands.add('waitForMemorableDate', () => {
+        cy.get('input[name="root_prepCourseStartDateMonth"]')
           .should('be.visible')
           .and('not.be.disabled')
           .clear({

--- a/src/applications/edu-benefits/10272/tests/fixtures/data/maximal-test.json
+++ b/src/applications/edu-benefits/10272/tests/fixtures/data/maximal-test.json
@@ -1,10 +1,76 @@
 {
   "data": {
-    "fullName": {
-      "first": "John",
-      "middle": "Michael",
-      "last": "Doe"
+    "remarks": "Here are some remarks",
+    "organizationName": "Org Name",
+    "organizationAddress": {
+      "view:militaryBaseDescription": {},
+      "street": "Org Street",
+      "street2": "Bldg 4",
+      "street3": "Unit 8",
+      "city": "Org City",
+      "state": "NE",
+      "postalCode": "12345"
     },
-    "dateOfBirth": "1980-01-01"
+    "payeeNumber": "M2",
+    "prepCourseCost": "250.75",
+    "prepCourseStartDate": "2025-08-01",
+    "prepCourseEndDate": "2026-01-01",
+    "prepCourseTakenOnline": false,
+    "prepCourseOrganizationName": "Prep Org",
+    "prepCourseOrganizationAddress": {
+      "view:militaryBaseDescription": {},
+      "street": "Prep Street",
+      "street2": "Floor 25",
+      "street3": "Office 3",
+      "city": "Prep City",
+      "state": "MI",
+      "postalCode": "23456"
+    },
+    "prepCourseName": "Prep Course",
+    "testName": "Test Name",
+    "hasPreviouslyApplied": true,
+    "vaBenefitProgram": "Previously Applied Benefits",
+    "view:vaBenefitProgramNo": {},
+    "veteran": {
+      "mailingAddress": {
+        "badAddress": false,
+        "addressLine1": "10856 Patowmack Dr",
+        "addressPou": "CORRESPONDENCE",
+        "addressType": "DOMESTIC",
+        "city": "Great Falls",
+        "countryName": "United States",
+        "countryCodeIso2": "US",
+        "countryCodeIso3": "USA",
+        "countyCode": "51059",
+        "countyName": "Fairfax County",
+        "stateCode": "VA",
+        "zipCode": "22066",
+        "zipCodeSuffix": "3032"
+      },
+      "homePhone": {
+        "areaCode": "478",
+        "countryCode": "1",
+        "isInternational": false,
+        "isTextable": "",
+        "phoneNumber": "3884567",
+        "phoneType": "HOME"
+      },
+      "mobilePhone": {
+        "areaCode": "514",
+        "countryCode": "1",
+        "extension": "",
+        "isInternational": false,
+        "phoneNumber": "3211232",
+        "phoneType": "MOBILE"
+      },
+      "email": {
+        "emailAddress": "Test@gmail.com"
+      }
+    },
+    "applicantName": { "first": "Rita", "middle": "Ann", "last": "Jackson" },
+    "ssn": "111111111",
+    "vaFileNumber": "111111111",
+    "statementOfTruthSignature": "Rita Ann Jackson",
+    "statementOfTruthCertified": true
   }
 }

--- a/src/applications/edu-benefits/10272/tests/fixtures/data/minimal-test.json
+++ b/src/applications/edu-benefits/10272/tests/fixtures/data/minimal-test.json
@@ -1,9 +1,69 @@
 {
   "data": {
-    "fullName": {
-      "first": "John",
-      "last": "Doe"
+    "organizationName": "Org Name",
+    "organizationAddress": {
+      "view:militaryBaseDescription": {},
+      "street": "Org Street",
+      "city": "Org City",
+      "state": "NE",
+      "postalCode": "12345"
     },
-    "dateOfBirth": "1980-01-01"
+    "payeeNumber": "",
+    "prepCourseCost": "250.75",
+    "prepCourseStartDate": "2025-08-01",
+    "prepCourseEndDate": "2026-01-01",
+    "prepCourseTakenOnline": true,
+    "prepCourseOrganizationName": "Prep Org",
+    "prepCourseOrganizationAddress": {
+      "view:militaryBaseDescription": {},
+      "street": "Prep Street",
+      "city": "Prep City",
+      "state": "MI",
+      "postalCode": "23456"
+    },
+    "prepCourseName": "Prep Course",
+    "testName": "Test Name",
+    "hasPreviouslyApplied": false,
+    "veteran": {
+      "mailingAddress": {
+        "badAddress": false,
+        "addressLine1": "10856 Patowmack Dr",
+        "addressPou": "CORRESPONDENCE",
+        "addressType": "DOMESTIC",
+        "city": "Great Falls",
+        "countryName": "United States",
+        "countryCodeIso2": "US",
+        "countryCodeIso3": "USA",
+        "countyCode": "51059",
+        "countyName": "Fairfax County",
+        "stateCode": "VA",
+        "zipCode": "22066",
+        "zipCodeSuffix": "3032"
+      },
+      "homePhone": {
+        "areaCode": "478",
+        "countryCode": "1",
+        "extension": "",
+        "isInternational": false,
+        "phoneNumber": "3884567",
+        "phoneType": "HOME"
+      },
+      "mobilePhone": {
+        "areaCode": "514",
+        "countryCode": "1",
+        "extension": "",
+        "isInternational": false,
+        "phoneNumber": "3211232",
+        "phoneType": "MOBILE"
+      },
+      "email": {
+        "emailAddress": "Test@gmail.com"
+      }
+    },
+    "applicantName": { "first": "Rita", "middle": "Ann", "last": "Jackson" },
+    "ssn": "111111111",
+    "vaFileNumber": "111111111",
+    "statementOfTruthSignature": "Rita Ann Jackson",
+    "statementOfTruthCertified": true
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Form tester utility to cover `minimal` and `maximal` flows for the 22-10272
- `Cypress.env('CI')` set until form is deployed to prod
- Mocks added for prefill to test authenticated login

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-2824

## Testing done

- Cypress tests ran locally to ensure both flows/datasets run to completion
- Unit tests are not impacted by the form tester utility

## Screenshots

N/A

## What areas of the site does it impact?

- Form 22-10272 | Form tester utility

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
