### PR TITLE
0969: Income and asset -  Add migration redirect

### DIFF
--- a/src/applications/income-and-asset-statement/config/form.js
+++ b/src/applications/income-and-asset-statement/config/form.js
@@ -5,6 +5,7 @@ import { minimalHeaderFormConfigOptions } from 'platform/forms-system/src/js/pat
 import PreSubmitInfo from '../containers/PreSubmitInfo';
 
 import manifest from '../manifest.json';
+import migrations from '../migrations';
 import prefillTransformer from './prefill-transformer';
 
 import IntroductionPage from '../containers/IntroductionPage';
@@ -47,8 +48,8 @@ const formConfig = {
     //   saved: 'Your benefits application has been saved.',
     // },
   },
-  version: 0,
-  migrations: [],
+  version: 1,
+  migrations,
   prefillEnabled: true,
   prefillTransformer,
   dev: {

--- a/src/applications/income-and-asset-statement/migrations.js
+++ b/src/applications/income-and-asset-statement/migrations.js
@@ -1,0 +1,37 @@
+const claimantTypeToRouteSuffix = {
+  VETERAN: 'veteran',
+  SPOUSE: 'spouse',
+  CHILD: 'child',
+  PARENT: 'parent',
+  CUSTODIAN: 'custodian',
+};
+
+const getDiscontinuedIncomeSummaryRoute = formData => {
+  const suffix =
+    claimantTypeToRouteSuffix[(formData?.claimantType)] || 'veteran';
+
+  return `/discontinued-income-summary-${suffix}`;
+};
+
+export default [
+  // 0 -> 1, redirect user to discontinued incomes summary when legacy data exists
+  // Reason: incomeType changed from a text field to a radio field, so in-progress users
+  // should be routed back through the updated flow to review/update their entries.
+  ({ formData, metadata }) => {
+    const hasDiscontinuedIncomes =
+      Array.isArray(formData?.discontinuedIncomes) &&
+      formData.discontinuedIncomes.length > 0;
+
+    if (!hasDiscontinuedIncomes) {
+      return { formData, metadata };
+    }
+
+    return {
+      formData,
+      metadata: {
+        ...metadata,
+        returnUrl: getDiscontinuedIncomeSummaryRoute(formData),
+      },
+    };
+  },
+];

--- a/src/applications/income-and-asset-statement/tests/unit/migrations.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/migrations.unit.spec.jsx
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+
+import migrations from '../../migrations';
+
+describe('0969 migrations', () => {
+  it('should not change returnUrl when discontinuedIncomes does not exist', () => {
+    const { formData, metadata } = migrations[0]({
+      formData: {
+        claimantType: 'VETERAN',
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(formData).to.be.an('object');
+    expect(metadata.returnUrl).to.equal('/original-url');
+  });
+
+  it('should not change returnUrl when discontinuedIncomes is empty', () => {
+    const { formData, metadata } = migrations[0]({
+      formData: {
+        claimantType: 'VETERAN',
+        discontinuedIncomes: [],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(formData).to.be.an('object');
+    expect(metadata.returnUrl).to.equal('/original-url');
+  });
+
+  it('should redirect to veteran summary when claimantType is VETERAN and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        claimantType: 'VETERAN',
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal('/discontinued-income-summary-veteran');
+  });
+
+  it('should redirect to spouse summary when claimantType is SPOUSE and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        claimantType: 'SPOUSE',
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal('/discontinued-income-summary-spouse');
+  });
+
+  it('should redirect to child summary when claimantType is CHILD and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        claimantType: 'CHILD',
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal('/discontinued-income-summary-child');
+  });
+
+  it('should redirect to parent summary when claimantType is PARENT and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        claimantType: 'PARENT',
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal('/discontinued-income-summary-parent');
+  });
+
+  it('should redirect to custodian summary when claimantType is CUSTODIAN and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        claimantType: 'CUSTODIAN',
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal(
+      '/discontinued-income-summary-custodian',
+    );
+  });
+
+  it('should default to veteran summary when claimantType is missing and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal('/discontinued-income-summary-veteran');
+  });
+
+  it('should default to veteran summary when claimantType is unrecognized and discontinuedIncomes exists', () => {
+    const { metadata } = migrations[0]({
+      formData: {
+        claimantType: 'NOT_A_REAL_TYPE',
+        discontinuedIncomes: [{ incomeType: 'some legacy text value' }],
+      },
+      metadata: {
+        returnUrl: '/original-url',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal('/discontinued-income-summary-veteran');
+  });
+});


### PR DESCRIPTION
### Summary of Changes
This PR adds a **form data migration + version bump** for the 0969 form to safely handle in-progress users who have existing `discontinuedIncomes` data from a previous schema version where `incomeType` was a **text field**. Since `incomeType` is now a **radio field**, older in-progress data can be incompatible with current validation and page flow.

To prevent users from getting stuck, this change:
- Bumps the form `version` to trigger migrations for saved-in-progress users.
- Adds a migration that detects existing `discontinuedIncomes` and redirects the user back to the discontinued income summary flow so they can review/update the `incomeType` selection under the new radio-based schema.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134878

### How to Set Up in Local Environment
1. Run the local environment
2. Navigate to the 0969 form:  
   http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/

### How to Test
1. Create an in-progress form state representing the old schema:
   - Ensure `formData.discontinuedIncomes` exists with at least one item where `incomeType` reflects the prior text-based format.
2. Bump the form version (included in this PR) and reload/resume the in-progress application.
3. Verify:
   - The migration runs due to the version bump.
   - Users with `discontinuedIncomes` are redirected to the discontinued income summary flow (and not left on an invalid/blocked page).
   - Users without `discontinuedIncomes` are not redirected and continue normally.
4. Confirm the user can update the discontinued income item and select the new `incomeType` radio option successfully.
5. Confirm no console errors.

### Feature Flag Note
- No new feature flags introduced.

### Acceptance Criteria
- [x] Form `version` is bumped to ensure migrations run for saved-in-progress users.
- [x] Migration detects `discontinuedIncomes` from prior schema versions and redirects users to the appropriate discontinued income summary flow.
- [x] Users without `discontinuedIncomes` are not impacted.
- [x] Users can continue after updating `incomeType` under the new radio field schema.
- [x] No regressions in navigation, validation, or accessibility.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally using an in-progress state that includes legacy `discontinuedIncomes`.
- [ ] Unit tests added/updated to cover migration behavior and redirect logic.
- [ ] Tests verified passing.