### PR TITLE
fix: add render waits to prevent flaky E2E tests

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PilotEnvPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PilotEnvPage.js
@@ -234,6 +234,9 @@ class PilotEnvPage {
       .should('be.visible')
       .click({ force: true });
 
+    // Wait for the dropdown list to be visible before selecting an item
+    cy.get(`.usa-combo-box__list`).should('be.visible');
+
     cy.get(`.usa-combo-box__list > li`)
       .eq(index)
       .should('be.visible')

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js
@@ -24,6 +24,9 @@ describe('Secure Messaging Reply Axe Check', () => {
     );
     PatientInterstitialPage.getContinueButton().click();
 
+    // Wait for reply form to fully render before interacting with textarea
+    PatientReplyPage.verifyReplyHeader();
+
     PatientReplyPage.getMessageBodyField()
       .should('not.be.disabled')
       .clear()

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js
@@ -17,6 +17,11 @@ describe('Secure Messaging Reply Axe Check', () => {
     PatientInboxPage.loadInboxMessages();
     PatientMessageDetailsPage.loadSingleThread(updatedSingleThreadResponse);
     PatientReplyPage.clickReplyButton(updatedSingleThreadResponse);
+
+    // Wait for interstitial page to render before clicking
+    GeneralFunctionsPage.verifyPageHeader(
+      'Only use messages for non-urgent needs',
+    );
     PatientInterstitialPage.getContinueButton().click();
 
     PatientReplyPage.getMessageBodyField()


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Two E2E tests were intermittently failing in CI due to race conditions — Cypress was trying to interact with elements before the page finished rendering.

- secure-messaging-reply: wait for interstitial page header before clicking continue button
- PilotEnvPage.selectTriageGroup: wait for combo box dropdown list to be visible before selecting an item


## Testing done
src/applications/mhv-secure-messaging/tests/e2e/pages/PilotEnvPage.js 
src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js 


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] No error nor warning in the console.
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
