### PR TITLE
feat(travel-pay): update intro page text for CC appointments and caregiver notice

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -36,9 +36,7 @@ const IntroductionPage = () => {
   const complexClaim = useSelector(selectComplexClaim);
 
   const { useToggleValue } = useFeatureToggle();
-  const isCommunityCareFlagEnabled = useToggleValue(
-    TOGGLE_NAMES.travelPayEnableCommunityCare,
-  );
+  const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
   const title = 'File a travel reimbursement claim';
 
@@ -152,35 +150,34 @@ const IntroductionPage = () => {
                 <li>Parking and tolls from your trip</li>
                 <li>Pre-approved meals and lodging expenses</li>
               </ul>
-              {isCommunityCareFlagEnabled ? (
-                <>
-                  <p>
-                    You’ll be asked to submit receipts when you file your claim.
-                    You'll also need to submit proof of attendance, like a work
+              <p>
+                You’ll be asked to submit receipts when you file your claim.
+                {ccEnabled && appointment?.isCC && (
+                  <>
+                    {' '}
+                    You’ll also need to submit proof of attendance, like a work
                     or school release note from the community care provider or a
                     document on the community provider letterhead showing the
-                    appointment date. when you file your claim.
-                  </p>
-                  <p>
+                    appointment date.
+                  </>
+                )}
+              </p>
+              <p>
+                {ccEnabled ? (
+                  <>
                     If your trip was one way, if you started from somewhere
                     other than your home address, or if you’re a caregiver,
                     you’ll need to file your claim through the Beneficiary
                     Travel Self Service System (BTSSS).{' '}
-                  </p>
-                </>
-              ) : (
-                <>
-                  <p>
-                    You’ll be further asked to submit receipts when you file
-                    your claim.
-                  </p>
-                  <p>
+                  </>
+                ) : (
+                  <>
                     If your trip was one way, or if you started from somewhere
                     other than your home address, you’ll need to file your claim
                     through the Beneficiary Travel Self Service System (BTSSS).{' '}
-                  </p>
-                </>
-              )}
+                  </>
+                )}
+              </p>
               <p>
                 <va-link href={BTSSS_PORTAL_URL} external text="Go to BTSSS" />
               </p>

--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -5,6 +5,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link, useNavigate, useLocation } from 'react-router-dom-v5-compat';
 
 import {
+  useFeatureToggle,
+  TOGGLE_NAMES,
+} from 'platform/utilities/feature-toggles';
+import {
   BTSSS_PORTAL_URL,
   COMPLEX_CLAIMS_ANALYTICS_NAMESPACE,
 } from '../../../constants';
@@ -30,6 +34,11 @@ const IntroductionPage = () => {
 
   const { data: appointment } = useSelector(selectAppointment);
   const complexClaim = useSelector(selectComplexClaim);
+
+  const { useToggleValue } = useFeatureToggle();
+  const isCommunityCareFlagEnabled = useToggleValue(
+    TOGGLE_NAMES.travelPayEnableCommunityCare,
+  );
 
   const title = 'File a travel reimbursement claim';
 
@@ -143,14 +152,35 @@ const IntroductionPage = () => {
                 <li>Parking and tolls from your trip</li>
                 <li>Pre-approved meals and lodging expenses</li>
               </ul>
-              <p>
-                You’ll be asked to submit receipts when you file your claim.
-              </p>
-              <p>
-                If your trip was one way, or if you started from somewhere other
-                than your home address, you’ll need to file your claim through
-                the Beneficiary Travel Self Service System (BTSSS).{' '}
-              </p>
+              {isCommunityCareFlagEnabled ? (
+                <>
+                  <p>
+                    You’ll be asked to submit receipts when you file your claim.
+                    You'll also need to submit proof of attendance, like a work
+                    or school release note from the community care provider or a
+                    document on the community provider letterhead showing the
+                    appointment date. when you file your claim.
+                  </p>
+                  <p>
+                    If your trip was one way, if you started from somewhere
+                    other than your home address, or if you’re a caregiver,
+                    you’ll need to file your claim through the Beneficiary
+                    Travel Self Service System (BTSSS).{' '}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p>
+                    You’ll be further asked to submit receipts when you file
+                    your claim.
+                  </p>
+                  <p>
+                    If your trip was one way, or if you started from somewhere
+                    other than your home address, you’ll need to file your claim
+                    through the Beneficiary Travel Self Service System (BTSSS).{' '}
+                  </p>
+                </>
+              )}
               <p>
                 <va-link href={BTSSS_PORTAL_URL} external text="Go to BTSSS" />
               </p>

--- a/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/IntroductionPage.jsx
@@ -152,15 +152,16 @@ const IntroductionPage = () => {
               </ul>
               <p>
                 You’ll be asked to submit receipts when you file your claim.
-                {ccEnabled && appointment?.isCC && (
-                  <>
-                    {' '}
-                    You’ll also need to submit proof of attendance, like a work
-                    or school release note from the community care provider or a
-                    document on the community provider letterhead showing the
-                    appointment date.
-                  </>
-                )}
+                {ccEnabled &&
+                  appointment?.isCC && (
+                    <>
+                      {' '}
+                      You’ll also need to submit proof of attendance, like a
+                      work or school release note from the community care
+                      provider or a document on the community provider
+                      letterhead showing the appointment date.
+                    </>
+                  )}
               </p>
               <p>
                 {ccEnabled ? (

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
@@ -281,11 +281,7 @@ describe('Travel Pay – IntroductionPage', () => {
       { initialState: state, reducers: reducer },
     );
 
-    expect(
-      getByText(
-        /caregiver,/i,
-      ),
-    ).to.exist;
+    expect(getByText(/caregiver,/i)).to.exist;
     expect(queryByText(/proof of attendance/i)).to.not.exist;
   });
 
@@ -316,11 +312,7 @@ describe('Travel Pay – IntroductionPage', () => {
       { initialState: state, reducers: reducer },
     );
 
-    expect(
-      getByText(
-        /caregiver,/i,
-      ),
-    ).to.exist;
+    expect(getByText(/caregiver,/i)).to.exist;
     expect(getByText(/proof of attendance/i)).to.exist;
   });
 

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/IntroductionPage.unit.spec.jsx
@@ -10,6 +10,7 @@ import {
   Route,
   useLocation,
 } from 'react-router-dom-v5-compat';
+import { TOGGLE_NAMES } from 'platform/utilities/feature-toggles';
 import reducer from '../../../../redux/reducer';
 import IntroductionPage from '../../../../components/complex-claims/pages/IntroductionPage';
 import { BTSSS_PORTAL_URL } from '../../../../constants';
@@ -251,6 +252,112 @@ describe('Travel Pay – IntroductionPage', () => {
     );
 
     expect(getByTestId('introduction-page')).to.exist;
+  });
+
+  it('shows updated caregiver BTSSS text and no POA text for non-CC appt when community care flag is on', () => {
+    const state = {
+      ...getData(),
+      featureToggles: {
+        loading: false,
+        [TOGGLE_NAMES.travelPayEnableCommunityCare]: true,
+      },
+      travelPay: {
+        ...getData().travelPay,
+        appointment: {
+          ...getData().travelPay.appointment,
+          data: {
+            id: '12345',
+            facilityName: 'Test Facility',
+            isCC: false,
+          },
+        },
+      },
+    };
+
+    const { getByText, queryByText } = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <IntroductionPage />
+      </MemoryRouter>,
+      { initialState: state, reducers: reducer },
+    );
+
+    expect(
+      getByText(
+        /caregiver,/i,
+      ),
+    ).to.exist;
+    expect(queryByText(/proof of attendance/i)).to.not.exist;
+  });
+
+  it('shows updated caregiver text AND proof-of-attendance text for CC appt when community care flag is on', () => {
+    const state = {
+      ...getData(),
+      featureToggles: {
+        loading: false,
+        [TOGGLE_NAMES.travelPayEnableCommunityCare]: true,
+      },
+      travelPay: {
+        ...getData().travelPay,
+        appointment: {
+          ...getData().travelPay.appointment,
+          data: {
+            id: '12345',
+            facilityName: 'Test Facility',
+            isCC: true,
+          },
+        },
+      },
+    };
+
+    const { getByText } = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <IntroductionPage />
+      </MemoryRouter>,
+      { initialState: state, reducers: reducer },
+    );
+
+    expect(
+      getByText(
+        /caregiver,/i,
+      ),
+    ).to.exist;
+    expect(getByText(/proof of attendance/i)).to.exist;
+  });
+
+  it('shows original BTSSS text and no POA text when community care flag is off', () => {
+    const state = {
+      ...getData(),
+      featureToggles: {
+        loading: false,
+        [TOGGLE_NAMES.travelPayEnableCommunityCare]: false,
+      },
+      travelPay: {
+        ...getData().travelPay,
+        appointment: {
+          ...getData().travelPay.appointment,
+          data: {
+            id: '12345',
+            facilityName: 'Test Facility',
+            isCC: false,
+          },
+        },
+      },
+    };
+
+    const { getByText, queryByText } = renderWithStoreAndRouter(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <IntroductionPage />
+      </MemoryRouter>,
+      { initialState: state, reducers: reducer },
+    );
+
+    expect(
+      getByText(
+        /if your trip was one way, or if you started from somewhere other than your home address/i,
+      ),
+    ).to.exist;
+    expect(queryByText(/caregiver,/i)).to.not.exist;
+    expect(queryByText(/proof of attendance/i)).to.not.exist;
   });
 
   it('hides the start button when appointment is community care (isCC)', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When travel_pay_enable_community_care flag is enabled:
  - Add caregiver mention to BTSSS redirect sentence for all appointments
  - When it is also CC appointments:
    - Add proof-of-attendance sentence for CC appointments

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133038

## Testing done

- Tested with travelPayEnableCommunityCare enabled and disabled
- Tested using check for isCC is true.

## Screenshots

|         | Before | ccEnabled | isCC |
| ------- | ------ | ----- | ----- |
| Mobile  |        |       |       |
| Desktop |    <img width="357" height="465" alt="Screenshot 2026-03-03 at 10 37 08" src="https://github.com/user-attachments/assets/f4418315-e172-4116-af96-d3ac73bb040c" />    |    <img width="438" height="416" alt="Screenshot 2026-03-03 at 11 36 35" src="https://github.com/user-attachments/assets/c21cca32-8638-422e-a39d-f3cb00abb718" /> |   <img width="355" height="521" alt="Screenshot 2026-03-03 at 10 45 01" src="https://github.com/user-attachments/assets/3cdd7e68-e995-49f6-9b5d-838517f90326" />   |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

