### PR TITLE
534ez fix 4138 alert

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsPages.js
@@ -31,7 +31,6 @@ import {
 } from '../../../utils/labels';
 import { customAddressSchema } from '../../definitions';
 import { seriouslyDisabledDescription } from '../../../utils/helpers';
-import { AdditionalDependentsAlert } from '../../../components/FormAlerts';
 
 /**
  * Dependent children (array builder)
@@ -321,27 +320,12 @@ const householdPage = {
       title: 'Does the child live with you?',
       'ui:required': true,
     }),
-    additionalDependentsAlert: {
-      'ui:description': AdditionalDependentsAlert,
-      'ui:options': {
-        hideIf: (formData, index) => {
-          const item = formData?.veteransChildren?.[index];
-          const value = item?.livesWith ?? formData?.livesWith;
-          return value !== false;
-        },
-        displayEmptyObjectOnReview: true,
-      },
-    },
   },
   schema: {
     type: 'object',
     required: ['livesWith'],
     properties: {
       livesWith: yesNoSchema,
-      additionalDependentsAlert: {
-        type: 'object',
-        properties: {},
-      },
     },
   },
 };

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsResidence.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsResidence.js
@@ -3,7 +3,6 @@ import {
   yesNoUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { isYes } from '../../../utils/helpers';
 import { AdditionalDependentsAlert } from '../../../components/FormAlerts';
 
 /** @type {PageSchema} */
@@ -17,9 +16,9 @@ export default {
     residenceAlert: {
       'ui:description': AdditionalDependentsAlert,
       'ui:options': {
+        // Should hide if undefined when first landing on page or true/yes.
         hideIf: formData =>
-          formData?.childrenLiveTogetherButNotWithSpouse == null ||
-          isYes(formData?.childrenLiveTogetherButNotWithSpouse),
+          formData?.childrenLiveTogetherButNotWithSpouse !== false,
         displayEmptyObjectOnReview: true,
       },
     },

--- a/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsResidence.js
+++ b/src/applications/survivors-benefits/config/chapters/04-household-information/dependentsResidence.js
@@ -18,6 +18,7 @@ export default {
       'ui:description': AdditionalDependentsAlert,
       'ui:options': {
         hideIf: formData =>
+          formData?.childrenLiveTogetherButNotWithSpouse == null ||
           isYes(formData?.childrenLiveTogetherButNotWithSpouse),
         displayEmptyObjectOnReview: true,
       },

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
@@ -240,42 +240,42 @@ describe('Dependents Pages', () => {
     expect(text.getItemName(itemWithoutName)).to.equal('Dependent');
   });
 
-  it('AdditionalDependentsAlert only displays when livesWith is explicitly false', () => {
-    const householdItemUi = findItemUi(dependentHousehold);
-    expect(householdItemUi, 'dependentHousehold item UI not found').to.exist;
-    const alertOptions =
-      householdItemUi.additionalDependentsAlert['ui:options'];
+  // it('AdditionalDependentsAlert only displays when livesWith is explicitly false', () => {
+  //   const householdItemUi = findItemUi(dependentHousehold);
+  //   expect(householdItemUi, 'dependentHousehold item UI not found').to.exist;
+  //   const alertOptions =
+  //     householdItemUi.additionalDependentsAlert['ui:options'];
 
-    // explicit false at item => alert visible (hideIf returns false)
-    const itemFalse = { veteransChildren: [{ livesWith: false }] };
-    expect(alertOptions.hideIf(itemFalse, 0)).to.be.false;
+  //   // explicit false at item => alert visible (hideIf returns false)
+  //   const itemFalse = { veteransChildren: [{ livesWith: false }] };
+  //   expect(alertOptions.hideIf(itemFalse, 0)).to.be.false;
 
-    // explicit true => hidden
-    const itemTrue = { veteransChildren: [{ livesWith: true }] };
-    expect(alertOptions.hideIf(itemTrue, 0)).to.be.true;
+  //   // explicit true => hidden
+  //   const itemTrue = { veteransChildren: [{ livesWith: true }] };
+  //   expect(alertOptions.hideIf(itemTrue, 0)).to.be.true;
 
-    // undefined => hidden
-    const none = { veteranChildrenCount: '0', veteransChildren: [{}] };
-    expect(alertOptions.hideIf(none, 0)).to.be.true;
+  //   // undefined => hidden
+  //   const none = { veteranChildrenCount: '0', veteransChildren: [{}] };
+  //   expect(alertOptions.hideIf(none, 0)).to.be.true;
 
-    // Render the household page with livesWith false so the alert is visible
-    const { dependentHousehold: page } = dependentsPages;
-    const form = render(
-      <DefinitionTester
-        arrayPath="veteransChildren"
-        schema={page.schema}
-        uiSchema={page.uiSchema}
-        pagePerItemIndex={0}
-        data={{
-          veteranChildrenCount: '1',
-          veteransChildren: [{ livesWith: false }],
-        }}
-      />,
-    );
-    const formDOM = getFormDOM(form);
-    const alertEl = $('va-alert-expandable', formDOM);
-    expect(alertEl).to.exist;
-  });
+  //   // Render the household page with livesWith false so the alert is visible
+  //   const { dependentHousehold: page } = dependentsPages;
+  //   const form = render(
+  //     <DefinitionTester
+  //       arrayPath="veteransChildren"
+  //       schema={page.schema}
+  //       uiSchema={page.uiSchema}
+  //       pagePerItemIndex={0}
+  //       data={{
+  //         veteranChildrenCount: '1',
+  //         veteransChildren: [{ livesWith: false }],
+  //       }}
+  //     />,
+  //   );
+  //   const formDOM = getFormDOM(form);
+  //   const alertEl = $('va-alert-expandable', formDOM);
+  //   expect(alertEl).to.exist;
+  // });
 
   // it('dependentMailingAddress depends shows only when livesWith is false', () => {
   //   const { dependentMailingAddress } = dependentsPages;

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsPages.unit.spec.jsx
@@ -240,43 +240,6 @@ describe('Dependents Pages', () => {
     expect(text.getItemName(itemWithoutName)).to.equal('Dependent');
   });
 
-  // it('AdditionalDependentsAlert only displays when livesWith is explicitly false', () => {
-  //   const householdItemUi = findItemUi(dependentHousehold);
-  //   expect(householdItemUi, 'dependentHousehold item UI not found').to.exist;
-  //   const alertOptions =
-  //     householdItemUi.additionalDependentsAlert['ui:options'];
-
-  //   // explicit false at item => alert visible (hideIf returns false)
-  //   const itemFalse = { veteransChildren: [{ livesWith: false }] };
-  //   expect(alertOptions.hideIf(itemFalse, 0)).to.be.false;
-
-  //   // explicit true => hidden
-  //   const itemTrue = { veteransChildren: [{ livesWith: true }] };
-  //   expect(alertOptions.hideIf(itemTrue, 0)).to.be.true;
-
-  //   // undefined => hidden
-  //   const none = { veteranChildrenCount: '0', veteransChildren: [{}] };
-  //   expect(alertOptions.hideIf(none, 0)).to.be.true;
-
-  //   // Render the household page with livesWith false so the alert is visible
-  //   const { dependentHousehold: page } = dependentsPages;
-  //   const form = render(
-  //     <DefinitionTester
-  //       arrayPath="veteransChildren"
-  //       schema={page.schema}
-  //       uiSchema={page.uiSchema}
-  //       pagePerItemIndex={0}
-  //       data={{
-  //         veteranChildrenCount: '1',
-  //         veteransChildren: [{ livesWith: false }],
-  //       }}
-  //     />,
-  //   );
-  //   const formDOM = getFormDOM(form);
-  //   const alertEl = $('va-alert-expandable', formDOM);
-  //   expect(alertEl).to.exist;
-  // });
-
   // it('dependentMailingAddress depends shows only when livesWith is false', () => {
   //   const { dependentMailingAddress } = dependentsPages;
 

--- a/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsResidence.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/04-household-information/dependentsResidence.unit.spec.jsx
@@ -1,26 +1,36 @@
+import React from 'react';
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import page from '../../../../config/chapters/04-household-information/dependentsResidence';
 
 describe('Dependents Residence page', () => {
-  const { uiSchema } = page;
-
-  it('displays residenceAlert if hideIf returns true when childrenLiveTogetherButNotWithSpouse is Yes', () => {
-    const itemYes = {
-      veteranChildrenCount: '1',
-      childrenLiveTogetherButNotWithSpouse: 'Yes',
-    };
-    const itemNo = {
-      veteranChildrenCount: '1',
-      childrenLiveTogetherButNotWithSpouse: 'No',
-    };
-    const none = { veteranChildrenCount: '0' };
-
-    expect(uiSchema, 'dependentsResidence uiSchema not found').to.exist;
-    const alertOptions = uiSchema.residenceAlert['ui:options'];
-    expect(alertOptions, 'residenceAlert options not found').to.exist;
-
-    expect(alertOptions.hideIf(itemYes)).to.be.true;
-    expect(alertOptions.hideIf(itemNo)).to.be.false;
-    expect(alertOptions.hideIf(none)).to.be.false;
+  const { schema, uiSchema } = page;
+  it('displays residenceAlert childrenLiveTogetherButNotWithSpouse is No', () => {
+    const form = render(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{ veteranChildrenCount: '2' }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    const vaRadio = $(
+      'va-radio[label*="Do the children who don’t live with you reside at the same address?"]',
+      formDOM,
+    );
+    expect($$('va-alert-expandable', formDOM).length).to.equal(0);
+    vaRadio.__events.vaValueChange({
+      detail: { value: 'Y' },
+    });
+    expect($$('va-alert-expandable', formDOM).length).to.equal(0);
+    vaRadio.__events.vaValueChange({
+      detail: { value: 'N' },
+    });
+    expect($$('va-alert-expandable', formDOM).length).to.equal(1);
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed va alert from dependent pages array builder section
- Set the alert to only show when No is chosen on dependents residence page, it was showing on page load
- Added unit test

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134642
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131560

## Testing done

- manual testing, remove `childrenLiveTogetherButNotWithSpouse` from the completed-form json if using quick fill locally to make sure there is no value set when manually testing the frontend. 
- added screenshot

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="587" height="490" alt="Screenshot 2026-03-03 at 2 46 57 PM" src="https://github.com/user-attachments/assets/f5c2d941-78c8-461b-b714-bb50904ff1e6" /> | <img width="496" height="401" alt="Screenshot 2026-03-03 at 2 44 29 PM" src="https://github.com/user-attachments/assets/62a984e2-ea79-4abe-b924-6a62cc8eede3" /> |

## What areas of the site does it impact?

Dependents section of the 534ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A
