### PR TITLE
Forms system/internationalTelephone pattern fix validation bug

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/VaTelephoneInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaTelephoneInputField.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { VaTelephoneInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import vaTelephoneInputFieldMapping from './vaTelephoneInputFieldMapping';
 import environment from '../../../../utilities/environment';
@@ -35,8 +35,12 @@ import environment from '../../../../utilities/environment';
  * ```
  * @param {WebComponentFieldProps} props */
 export default function VaTelephoneInputField(props) {
-  const mappedProps = vaTelephoneInputFieldMapping(props);
+  const initialLoad = useRef(true);
+  useEffect(() => {
+    initialLoad.current = false;
+  }, []);
 
+  const mappedProps = vaTelephoneInputFieldMapping(props, initialLoad.current);
   useEffect(() => {
     // component emits event on load that is important for validation
     // it does not get emitted in test env as it does in browser so emit manually

--- a/src/platform/forms-system/src/js/web-component-fields/vaTelephoneInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTelephoneInputFieldMapping.jsx
@@ -8,8 +8,8 @@ export default function VaTelephoneInputFieldMapping(props, initialLoad) {
   return {
     ...commonFieldProps,
     // only include contact prop on initial load to support prefill;
-    // otherwise rely on va-telephone-input to keep track of contact internally and to transmit it to forms-system via event
-    // this avoids a race condition where forms-system can pass an out of date prop to va-telephone-input and suppress an error
+    // otherwise rely on va-telephone-input to keep track of contact internally and to transmit it to the forms-system via vaContact event
+    // this avoids a race condition where forms-system can pass an out of date contact prop to va-telephone-input and suppress an error state within va-telephone-input
     // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5335
     ...(initialLoad
       ? {

--- a/src/platform/forms-system/src/js/web-component-fields/vaTelephoneInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTelephoneInputFieldMapping.jsx
@@ -2,12 +2,19 @@
 import commonFieldMapping from './commonFieldMapping';
 
 /** @param {WebComponentFieldProps} props */
-export default function VaTelephoneInputFieldMapping(props) {
+export default function VaTelephoneInputFieldMapping(props, initialLoad) {
   const { childrenProps } = props;
   const commonFieldProps = commonFieldMapping(props);
   return {
     ...commonFieldProps,
-    contact: childrenProps?.formData?.contact || '',
+    // only include contact on initial load for prefill;
+    // otherwise an internal bad contact may be overwritten
+    // by an immediately previous valid contact and an error will be suppressed
+    ...(initialLoad
+      ? {
+          contact: childrenProps?.formData?.contact || '',
+        }
+      : {}),
     country: childrenProps?.formData?.countryCode || 'US',
     onVaContact: (event, value) => {
       const payload = value || event.detail || {};

--- a/src/platform/forms-system/src/js/web-component-fields/vaTelephoneInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTelephoneInputFieldMapping.jsx
@@ -7,9 +7,10 @@ export default function VaTelephoneInputFieldMapping(props, initialLoad) {
   const commonFieldProps = commonFieldMapping(props);
   return {
     ...commonFieldProps,
-    // only include contact on initial load for prefill;
-    // otherwise an internal bad contact may be overwritten
-    // by an immediately previous valid contact and an error will be suppressed
+    // only include contact prop on initial load to support prefill;
+    // otherwise rely on va-telephone-input to keep track of contact internally and to transmit it to forms-system via event
+    // this avoids a race condition where forms-system can pass an out of date prop to va-telephone-input and suppress an error
+    // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5335
     ...(initialLoad
       ? {
           contact: childrenProps?.formData?.contact || '',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes a bug in the `internationalPhone` pattern in which an error does not show on blurring the contact field. Now the field behaves as it does in [storybook](https://design.va.gov/storybook/?path=/docs/components-va-telephone-input--docs)

## Related issue(s)

[5335](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5335)

## Testing done

local testing

## Screenshots
(note at the end of each video the contact input is blurred to trigger validation)

**Before**:
https://github.com/user-attachments/assets/b200d0f0-4d4a-487a-b04c-5506060ed392

**After**:
https://github.com/user-attachments/assets/980ff8e0-1c73-4267-aba1-65aba8656da8

**Storybook**:
https://github.com/user-attachments/assets/7d40c559-48cf-4c50-a2ad-d0dd3df78e1c


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
