### PR TITLE
DR 134921: Make SC VA treatment dates optional, remove error state

### DIFF
--- a/src/applications/appeals/995/components/evidence/VaDetailsDisplay.jsx
+++ b/src/applications/appeals/995/components/evidence/VaDetailsDisplay.jsx
@@ -23,16 +23,10 @@ export const getFormattedTreatmentDate = (noDate, treatmentDate) => {
   return null;
 };
 
-export const getLocationErrors = (
-  issues,
-  locationAndName,
-  noDate,
-  treatmentDate,
-) => {
+export const getLocationErrors = (issues, locationAndName) => {
   const errors = {
     name: locationAndName ? '' : content.missing.location,
     issues: issues.length ? '' : content.missing.condition,
-    treatmentDate: (noDate || treatmentDate ? '' : content.missing.date) || '',
   };
 
   const hasErrors = Object.values(errors).join('');
@@ -91,8 +85,6 @@ export const VaDetailsDisplay = ({
           const { errors, hasErrors } = getLocationErrors(
             issues,
             locationAndName,
-            noDate,
-            treatmentDate,
           );
 
           const treatmentDateError = !noDate && errors.treatmentDate;

--- a/src/applications/appeals/995/content/evidence/summary.jsx
+++ b/src/applications/appeals/995/content/evidence/summary.jsx
@@ -60,7 +60,6 @@ export const content = {
     location: wrapError('Missing location name'),
     facility: wrapError('Missing provider name'),
     condition: wrapError('Missing condition'),
-    date: wrapError('Missing treatment date'),
     dates: wrapError('Missing treatment dates'),
     from: wrapError('Missing start date', true),
     to: wrapError('Missing end date', true),

--- a/src/applications/appeals/995/tests/components/evidence/VaDetailsDisplay.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/evidence/VaDetailsDisplay.unit.spec.jsx
@@ -193,20 +193,6 @@ describe('VaDetailsDisplay', () => {
       });
     });
 
-    describe('when the treatmentDate is missing', () => {
-      it('should render the proper errors', () => {
-        const partialData = {
-          ...fullData,
-          treatmentDate: '',
-        };
-
-        getContainer(partialData);
-
-        const error = $$('.usa-input-error-message')[0];
-        expect(error.textContent).to.contain('Missing treatment date');
-      });
-    });
-
     describe('when the treatmentDate is missing but noDate is checked', () => {
       it('should not render an error', () => {
         const partialData = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

See [this issue ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/134921) for complete context.

This PR removes the error state (`Missing treatment dates`) from the evidence summary screen (VA section) when no treatment dates are provided, and the "I don't have the date" checkbox is not checked. Essentially, this allows the fields to be truly optional as they are on the input screen.

The only thing preventing this from working properly before was an error state on the evidence summary screen. The app review screen and FE payload logic already handled it properly. When the date or checkbox is not used, the logic follows the same path as though you selected the "I don't have the date" checkbox.

The back end does not need any adjustment as it already handles the scenario where the "I don't have the date" checkbox is checked and our fix is functionally no different.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/134921

## Testing done

### Treatment date provided: January 2000

| Screen | Screenshot |
| --- | --- |
| VA evidence input | <img width="500" alt="Screenshot 2026-03-03 at 3 31 36 PM" src="https://github.com/user-attachments/assets/bd6fc000-d8f6-4673-9853-71fb438caafd" /> |
| Evidence summary | <img width="500" alt="Screenshot 2026-03-03 at 3 14 47 PM" src="https://github.com/user-attachments/assets/9f47253d-82af-47e1-96be-0fe7f6f2a312" /> |
| App review | <img width="500" alt="Screenshot 2026-03-03 at 3 15 00 PM" src="https://github.com/user-attachments/assets/69d43491-6623-4512-8d6f-7b2af75ccfd3" /> |
| Confirmation | <img width="500" alt="Screenshot 2026-03-03 at 3 15 27 PM" src="https://github.com/user-attachments/assets/fe62169c-de7a-48f0-9c5d-6fccc2c950a0" /> |
| Front end payload to back end | <img width="400" alt="Screenshot 2026-03-03 at 3 15 18 PM" src="https://github.com/user-attachments/assets/9259be4a-fee1-4c8c-a97c-484fccd69d89" /> |

<hr />

### "I don't have the date" checkbox checked

| Screen | Screenshot |
| --- | --- |
| VA evidence input | <img width="500" alt="Screenshot 2026-03-03 at 3 16 01 PM" src="https://github.com/user-attachments/assets/02498ab4-0ed3-4cf9-9b5e-9ae48cd6b86c" /> |
| Evidence summary | <img width="500" alt="Screenshot 2026-03-03 at 3 16 10 PM" src="https://github.com/user-attachments/assets/84185079-d350-4e9e-a74b-ab943cc1ddf7" /> |
| App review | <img width="500" alt="Screenshot 2026-03-03 at 3 16 17 PM" src="https://github.com/user-attachments/assets/8e62b54f-b5c0-44d5-af94-8ac5a1eb685f" /> |
| Confirmation | <img width="500" alt="Screenshot 2026-03-03 at 3 16 43 PM" src="https://github.com/user-attachments/assets/0d5eeb4f-dba1-49be-b2ec-dd98a498f972" /> |
| Front end payload to back end | <img width="400" alt="Screenshot 2026-03-03 at 3 16 31 PM" src="https://github.com/user-attachments/assets/6db65c80-9a71-4e1d-866e-8265a248b851" /> |

<hr />

### Omitting both inputs

| Screen | Screenshot |
| --- | --- |
| VA evidence input | <img width="500" alt="Screenshot 2026-03-03 at 3 17 05 PM" src="https://github.com/user-attachments/assets/61a79f1f-5007-483a-94dc-b2f9371f9587" /> |
| Evidence summary | <img width="500" alt="Screenshot 2026-03-03 at 3 17 18 PM" src="https://github.com/user-attachments/assets/ff698ff4-a2fd-40ba-bc0e-eef454d3b2b1" /> |
| App review | <img width="500" alt="Screenshot 2026-03-03 at 3 17 25 PM" src="https://github.com/user-attachments/assets/53af3bf7-089e-48b4-b3e6-c8d612f913c5" /> |
| Confirmation | <img width="500" alt="Screenshot 2026-03-03 at 3 17 47 PM" src="https://github.com/user-attachments/assets/87391b00-95fd-4bce-b4a5-d9d440959f63" /> |
| Front end payload to back end | <img width="400" alt="Screenshot 2026-03-03 at 3 17 35 PM" src="https://github.com/user-attachments/assets/45b4075c-612c-4d19-82bb-372ac1398b84" /> |

<hr />

### Treatment date provided: January 2020 AND "I don't have the date" checkbox checked

| Screen | Screenshot |
| --- | --- |
| VA evidence input | <img width="500" alt="Screenshot 2026-03-03 at 4 47 47 PM" src="https://github.com/user-attachments/assets/8545e616-eecd-454f-9d02-54721f012a71" /> |
| Evidence summary | <img width="500" alt="Screenshot 2026-03-03 at 4 47 53 PM" src="https://github.com/user-attachments/assets/5a8c48b3-1f06-47da-b7ad-6300632bfebe" /> |
| App review | <img width="500" alt="Screenshot 2026-03-03 at 4 48 03 PM" src="https://github.com/user-attachments/assets/077d65c7-0b0f-47f2-af43-33fb81bfb07d" /> |
| Confirmation | <img width="500" alt="Screenshot 2026-03-03 at 4 48 08 PM" src="https://github.com/user-attachments/assets/9a347153-0ca0-447e-b81c-8448cd3d5a8e" /> |
| Front end payload to back end | <img width="400" alt="Screenshot 2026-03-03 at 4 48 20 PM" src="https://github.com/user-attachments/assets/177cf448-98c2-4631-bb96-cc0679cb85d7" /> |