### PR TITLE
Make claimant overview page full width

### DIFF
--- a/src/applications/accredited-representative-portal/containers/ClaimantOverviewPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/ClaimantOverviewPage.jsx
@@ -147,7 +147,7 @@ const ClaimantOverviewPage = () => {
   const unauthorized = authorized === false;
 
   return (
-    <div>
+    <section className="vads-u-width--full">
       <VaBreadcrumbs
         breadcrumbList={claimantOverviewBC}
         label="claimant overview breadcrumb"
@@ -300,7 +300,7 @@ const ClaimantOverviewPage = () => {
           </div>
         </section>
       </ClaimantDetailsWrapper>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
Update width of claimant overview page 

[Claimant Overview Tab: Creation of sub-tabs #132991](https://github.com/department-of-veterans-affairs/va.gov-team/issues/132991)


### Screenshots

#### Before

<img width="1002" height="661" alt="Screenshot 2026-03-03 at 18 40 03" src="https://github.com/user-attachments/assets/1352853a-e879-41f5-8649-812e5a4774c2" />
 
#### After
<img width="1008" height="655" alt="Screenshot 2026-03-03 at 18 39 54" src="https://github.com/user-attachments/assets/2d625e48-c84d-4596-927d-c92f244676e9" />
