### PR TITLE
Updated AuthApp to Enforce Profile Setup for Interstitial Pages

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -184,10 +184,10 @@ export default function AuthApp({ location }) {
       !skipToRedirect && (!isMyVAHealth || interstitial);
     if (needsProfileSetup) {
       setupProfileSession(userProfile);
-    }
-    if (interstitial) {
-      window.location.replace(interstitial.url);
-      return;
+      if (interstitial) {
+        window.location.replace(interstitial.url);
+        return;
+      }
     }
     redirect();
   };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated `AuthApp.jsx` to ensure that profile setup occurs prior to loading interstitial pages. Not doing so was causing sign-in looping issues.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1144)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running: `yarn test:unit src/applications/auth/tests/AuthApp.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts `AuthApp.jsx`.

## Acceptance criteria
- [x] Fix login looping bug
- [x] Ensure profile is setup before interstitial pages are loaded
- [x] Ensure no breaking changes and that tests run correctly 