### PR TITLE
2452 remove latest service from veteran status card

### DIFF
--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusCard.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusCard.jsx
@@ -19,8 +19,12 @@ const VeteranStatusCard = ({
       <div className="vads-u-padding-left--2p5 vads-u-padding-right--2p5 vads-u-padding-bottom--2p5 dd-privacy-mask">
         <h3>Name</h3>
         <p>{formattedFullName}</p>
-        <h3>Latest period of service</h3>
-        <p>{latestService}</p>
+        {latestService && (
+          <>
+            <h3>Latest period of service</h3>
+            <p>{latestService}</p>
+          </>
+        )}
         <div className="veteran-status-card-row">
           <h3>DoD ID Number</h3>
           <p>{edipi}</p>
@@ -41,7 +45,7 @@ const VeteranStatusCard = ({
 };
 
 VeteranStatusCard.propTypes = {
-  edipi: PropTypes.number,
+  edipi: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   formattedFullName: PropTypes.string,
   latestService: PropTypes.string,
   totalDisabilityRating: PropTypes.number,

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusSharedService.jsx
@@ -9,7 +9,6 @@ import DowntimeNotification, {
   externalServices,
 } from '~/platform/monitoring/DowntimeNotification';
 import { datadogRum } from '@datadog/browser-rum';
-import { getServiceBranchDisplayName } from '../../helpers';
 import Headline from '../ProfileSectionHeadline';
 import VeteranStatusCard from './VeteranStatusCard';
 import FrequentlyAskedQuestions from './FrequentlyAskedQuestions';
@@ -79,28 +78,10 @@ const VeteranStatusSharedService = ({
   }, []);
 
   const isCardEligible =
-    data?.type === 'veteran_status_card' && data?.veteranStatus === 'confirmed';
+    data?.type === 'veteran_status_card' &&
+    data?.attributes?.veteranStatus === 'confirmed';
 
   const formattedFullName = data?.attributes?.fullName || '';
-
-  const getLatestService = () => {
-    const latestServiceData = data?.attributes?.latestService;
-    if (latestServiceData) {
-      const { branch, beginDate, endDate } = latestServiceData;
-      const serviceStartYear = beginDate ? beginDate.substring(0, 4) : '';
-      const serviceEndYear = endDate ? endDate.substring(0, 4) : '';
-      const latestServiceDateRange =
-        serviceStartYear.length || serviceEndYear.length
-          ? `${serviceStartYear}–${serviceEndYear}`
-          : '';
-      return `${getServiceBranchDisplayName(
-        branch,
-      )} • ${latestServiceDateRange}`;
-    }
-    return null;
-  };
-
-  const latestService = getLatestService();
 
   const disabilityRating =
     data?.attributes?.disabilityRating ?? totalDisabilityRating;
@@ -111,9 +92,9 @@ const VeteranStatusSharedService = ({
     title: `Veteran status card for ${formattedFullName}`,
     details: {
       fullName: formattedFullName,
-      latestService,
       totalDisabilityRating: disabilityRating,
       edipi: cardEdipi,
+      useSharedService: true,
       image: {
         title: 'VA logo',
         url: '/img/design/logo/logo-black-and-white.png',
@@ -204,7 +185,6 @@ const VeteranStatusSharedService = ({
               <VeteranStatusCard
                 edipi={cardEdipi}
                 formattedFullName={formattedFullName}
-                latestService={latestService}
                 totalDisabilityRating={disabilityRating}
               />
             </div>
@@ -233,7 +213,7 @@ const VeteranStatusSharedService = ({
 };
 
 VeteranStatusSharedService.propTypes = {
-  edipi: PropTypes.number,
+  edipi: PropTypes.string,
   mockUserAgent: PropTypes.string,
   totalDisabilityRating: PropTypes.number,
 };

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -67,7 +67,6 @@ const groupItemReducer = facilities => (groups, group) => {
   const newGroup = { ...group };
   const filteredItems = newGroup.communicationItems
     .filter(item => {
-      // Removes the RX tracking item if there are no facilities that support that
       if (item.id === 4) {
         return facilities.some(facility =>
           RX_TRACKING_SUPPORTING_FACILITIES.has(facility.facilityId),

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -67,6 +67,7 @@ const groupItemReducer = facilities => (groups, group) => {
   const newGroup = { ...group };
   const filteredItems = newGroup.communicationItems
     .filter(item => {
+      // Removes the RX tracking item if there are no facilities that support that
       if (item.id === 4) {
         return facilities.some(facility =>
           RX_TRACKING_SUPPORTING_FACILITIES.has(facility.facilityId),

--- a/src/applications/personalization/profile/mocks/endpoints/veteran-status-card.js
+++ b/src/applications/personalization/profile/mocks/endpoints/veteran-status-card.js
@@ -9,11 +9,6 @@ const eligible = {
   attributes: {
     fullName: 'Jane Veteran',
     disabilityRating: 50,
-    latestService: {
-      branch: 'Army',
-      beginDate: '2010-01-01',
-      endDate: '2020-12-31',
-    },
     edipi: 1234567890,
   },
 };

--- a/src/applications/personalization/profile/mocks/endpoints/veteran-status-card.js
+++ b/src/applications/personalization/profile/mocks/endpoints/veteran-status-card.js
@@ -3,22 +3,20 @@
 // Eligible response - shows the veteran status card
 const eligible = {
   type: 'veteran_status_card',
-  veteranStatus: 'confirmed',
-  serviceSummaryCode: 'A1',
-  notConfirmedReason: null,
   attributes: {
     fullName: 'Jane Veteran',
     disabilityRating: 50,
     edipi: 1234567890,
+    veteranStatus: 'confirmed',
+    notConfirmedReason: null,
+    confirmationStatus: 'CONFIRMED',
+    serviceSummaryCode: 'A1',
   },
 };
 
 // Warning alert - dishonorable discharge
 const dishonorableDischarge = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'A5',
-  notConfirmedReason: 'DISHONORABLE_DISCHARGE',
   attributes: {
     header: "You're not eligible for a Veteran Status Card",
     body: [
@@ -40,15 +38,16 @@ const dishonorableDischarge = {
       },
     ],
     alertType: 'warning',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'DISHONORABLE_DISCHARGE',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'A5',
   },
 };
 
 // Warning alert - person not found
 const personNotFound = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'D',
-  notConfirmedReason: 'PERSON_NOT_FOUND',
   attributes: {
     header: "You're not eligible for a Veteran Status Card",
     body: [
@@ -60,15 +59,16 @@ const personNotFound = {
       { type: 'phone', value: '800-698-2411', tty: true },
     ],
     alertType: 'warning',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'PERSON_NOT_FOUND',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'D',
   },
 };
 
 // Error alert - system error
 const systemError = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'VNA',
-  notConfirmedReason: 'ERROR',
   attributes: {
     header: 'Something went wrong',
     body: [
@@ -79,15 +79,16 @@ const systemError = {
       },
     ],
     alertType: 'error',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'ERROR',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'VNA',
   },
 };
 
 // Warning alert - ineligible service (service history doesn't meet requirements)
 const ineligibleService = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'B',
-  notConfirmedReason: 'INELIGIBLE_SERVICE',
   attributes: {
     header: "You're not eligible for a Veteran Status Card",
     body: [
@@ -104,15 +105,16 @@ const ineligibleService = {
       { type: 'phone', value: '866-279-3677', tty: true },
     ],
     alertType: 'warning',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'INELIGIBLE_SERVICE',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'B',
   },
 };
 
 // Warning alert - currently serving
 const currentlyServing = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'C',
-  notConfirmedReason: 'CURRENTLY_SERVING',
   attributes: {
     header: "You're not eligible for a Veteran Status Card",
     body: [
@@ -129,15 +131,16 @@ const currentlyServing = {
       { type: 'phone', value: '866-279-3677', tty: true },
     ],
     alertType: 'warning',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'CURRENTLY_SERVING',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'C',
   },
 };
 
 // Warning alert - eligibility unknown
 const eligibilityUnknown = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'E',
-  notConfirmedReason: 'ELIGIBILITY_UNKNOWN',
   attributes: {
     header: "We don't know if you're eligible for this card",
     body: [
@@ -154,6 +157,10 @@ const eligibilityUnknown = {
       { type: 'phone', value: '866-279-3677', tty: true },
     ],
     alertType: 'warning',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'ELIGIBILITY_UNKNOWN',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'E',
   },
 };
 

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusCard.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusCard.unit.spec.jsx
@@ -31,10 +31,17 @@ describe('VeteranStatusCard', () => {
     expect(view.queryByText(/Name/)).to.exist;
     expect(view.queryByText(/First Last/)).to.exist;
   });
-  it('should render the latest service', () => {
+  it('should render the latest service when provided', () => {
     const view = renderWithTestData(testData);
     expect(view.queryByText(/Latest period of service/)).to.exist;
     expect(view.queryByText(/United States Army • 2009-2013/)).to.exist;
+  });
+  it('should not render the latest service when not provided', () => {
+    const view = renderWithTestData({
+      ...testData,
+      latestService: null,
+    });
+    expect(view.queryByText(/Latest period of service/)).not.to.exist;
   });
   it('should render the DoD ID Number', () => {
     const view = renderWithTestData(testData);

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusCard.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusCard.unit.spec.jsx
@@ -31,12 +31,14 @@ describe('VeteranStatusCard', () => {
     expect(view.queryByText(/Name/)).to.exist;
     expect(view.queryByText(/First Last/)).to.exist;
   });
-  it('should render the latest service when provided', () => {
+  it('should render the latest service when cveVeteranStatusNewService feature flag is disabled', () => {
+    // When the feature flag is disabled, the old VeteranStatus component passes latestService
     const view = renderWithTestData(testData);
     expect(view.queryByText(/Latest period of service/)).to.exist;
     expect(view.queryByText(/United States Army • 2009-2013/)).to.exist;
   });
-  it('should not render the latest service when not provided', () => {
+  it('should not render the latest service when cveVeteranStatusNewService feature flag is enabled', () => {
+    // When the new shared service feature flag is enabled, latestService is not passed
     const view = renderWithTestData({
       ...testData,
       latestService: null,

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -29,21 +29,19 @@ const downtime = maintenanceWindows => {
 // Mock API responses for the new shared service endpoint
 const veteranStatusCardConfirmed = {
   type: 'veteran_status_card',
-  veteranStatus: 'confirmed',
-  serviceSummaryCode: 'A1',
-  notConfirmedReason: null,
   attributes: {
     fullName: 'John Doe',
     disabilityRating: 40,
     edipi: 1234567890,
+    veteranStatus: 'confirmed',
+    notConfirmedReason: null,
+    confirmationStatus: 'CONFIRMED',
+    serviceSummaryCode: 'A1',
   },
 };
 
 const veteranStatusAlertWarning = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'D',
-  notConfirmedReason: 'PERSON_NOT_FOUND',
   attributes: {
     header: "You're not eligible for a Veteran Status Card",
     body: [
@@ -51,14 +49,15 @@ const veteranStatusAlertWarning = {
       { type: 'phone', value: '800-698-2411', tty: true },
     ],
     alertType: 'warning',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'PERSON_NOT_FOUND',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'D',
   },
 };
 
 const veteranStatusAlertError = {
   type: 'veteran_status_alert',
-  veteranStatus: 'not confirmed',
-  serviceSummaryCode: 'VNA',
-  notConfirmedReason: 'ERROR',
   attributes: {
     header: 'Something went wrong',
     body: [
@@ -69,6 +68,10 @@ const veteranStatusAlertError = {
       },
     ],
     alertType: 'error',
+    veteranStatus: 'not confirmed',
+    notConfirmedReason: 'ERROR',
+    confirmationStatus: 'NOT_CONFIRMED',
+    serviceSummaryCode: 'VNA',
   },
 };
 

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusSharedService.unit.spec.jsx
@@ -35,11 +35,6 @@ const veteranStatusCardConfirmed = {
   attributes: {
     fullName: 'John Doe',
     disabilityRating: 40,
-    latestService: {
-      branch: 'Army',
-      beginDate: '2009-04-12',
-      endDate: '2013-04-11',
-    },
     edipi: 1234567890,
   },
 };
@@ -158,9 +153,6 @@ describe('VeteranStatusSharedService', () => {
 
         // Check that the user's full name from API is rendered on the card
         expect(view.getByText('John Doe')).to.exist;
-
-        // Check that service history is rendered
-        expect(view.getByText('United States Army • 2009–2013')).to.exist;
 
         // Check that the FAQ section is rendered
         expect(view.getByText('Frequently asked questions')).to.exist;

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
@@ -33,13 +33,14 @@ const vetStatusConfirmed = {
 
 const veteranStatusCardConfirmed = {
   type: 'veteran_status_card',
-  veteranStatus: 'confirmed',
-  serviceSummaryCode: 'A1',
-  notConfirmedReason: null,
   attributes: {
     fullName: 'John Doe',
     disabilityRating: 40,
     edipi: 1234567890,
+    veteranStatus: 'confirmed',
+    notConfirmedReason: null,
+    confirmationStatus: 'CONFIRMED',
+    serviceSummaryCode: 'A1',
   },
 };
 

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusWrapper.unit.spec.jsx
@@ -39,11 +39,6 @@ const veteranStatusCardConfirmed = {
   attributes: {
     fullName: 'John Doe',
     disabilityRating: 40,
-    latestService: {
-      branch: 'Army',
-      beginDate: '2009-04-12',
-      endDate: '2013-04-11',
-    },
     edipi: 1234567890,
   },
 };

--- a/src/platform/pdf/templates/veteran_status_new.js
+++ b/src/platform/pdf/templates/veteran_status_new.js
@@ -60,7 +60,10 @@ const fetchImage = async url => {
 };
 
 const validate = data => {
-  const requiredFields = ['fullName', 'latestService']; // If there is no latestService, there is also no DoD ID
+  // When using the new shared service, latestService is not required
+  const requiredFields = data.useSharedService
+    ? ['fullName']
+    : ['fullName', 'latestService'];
 
   const missingFields = requiredFields.filter(field => !data[field]);
   if (missingFields.length) {
@@ -186,6 +189,8 @@ const generate = async data => {
     {
       heading: 'Latest period of service',
       content: `${data.details.latestService}`,
+      // Hide latestService when using the new shared service (behind feature flag)
+      condition: !data.details.useSharedService && !!data.details.latestService,
     },
     {
       heading: 'DoD ID Number',
@@ -195,6 +200,9 @@ const generate = async data => {
 
   let lastHeaderY;
   infoItems.forEach(item => {
+    // Skip items with a condition that evaluates to false
+    if (item.condition === false) return;
+
     lastHeaderY = doc.y;
     const header = doc.struct('H2', () => {
       doc


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Remove Latest Service From Veteran Status Card 
- changed  data?.veteranStatus === 'confirmed'; to     data?.attributes?.veteranStatus === 'confirmed'; to match the backend data correctly and fix veteran card not displaying



## Related issue(s)
- [] https://va.ghe.com/software/va-cve/issues/2452

## Testing done

- Manual testing 
- Unit tests
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|Feature Flag| False | True |
| ------- | ------ | ----- |
| Card |<img width="772" height="436" alt="Screenshot 2026-03-04 at 10 49 42 AM" src="https://github.com/user-attachments/assets/66e38fbf-5855-4eee-b29e-bfadde196dc9" />|<img width="826" height="436" alt="Screenshot 2026-03-04 at 10 44 16 AM" src="https://github.com/user-attachments/assets/125708d2-b2a7-4dc5-b6f6-0ce7d91bb9e5" />|
| Pdf  |<img width="913" height="526" alt="Screenshot 2026-03-04 at 10 49 48 AM" src="https://github.com/user-attachments/assets/41136c56-f9d2-4a8a-9897-006f27e834e5" />|<img width="729" height="532" alt="Screenshot 2026-03-04 at 10 44 25 AM" src="https://github.com/user-attachments/assets/91a85a4d-839c-4b70-9548-c7ae52db6bf1" />|


## What areas of the site does it impact?
Veteran Status Card Page
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
