### PR TITLE
RES-19495 Application discontinued letter download

### DIFF
--- a/src/applications/vre/track-your-vre-benefits/actions/ch31-case-status-details.js
+++ b/src/applications/vre/track-your-vre-benefits/actions/ch31-case-status-details.js
@@ -71,12 +71,12 @@ export function downloadCh31PdfLetter(resCaseId) {
       return Promise.resolve();
     }
 
-    const url = `${environment.API_URL}/vre/v0/ch31_discontinued_letter`;
+    const url = `${environment.API_URL}/vre/v0/case_get_document`;
 
     return apiRequest(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ resCaseId }),
+      body: JSON.stringify({ resCaseId, documentType: 626 }),
     })
       .then(response => response.blob())
       .then(blob => {

--- a/src/applications/vre/track-your-vre-benefits/tests/unit/actions/ch31-case-status-details.unit.spec.jsx
+++ b/src/applications/vre/track-your-vre-benefits/tests/unit/actions/ch31-case-status-details.unit.spec.jsx
@@ -133,12 +133,13 @@ describe('ch31-case-status-details actions', () => {
       await downloadCh31PdfLetter('ABC123')(dispatch);
 
       const [url, options] = apiStub.firstCall.args;
-      expect(url).to.equal(
-        `${environment.API_URL}/vre/v0/ch31_discontinued_letter`,
-      );
+      expect(url).to.equal(`${environment.API_URL}/vre/v0/case_get_document`);
       expect(options.method).to.equal('POST');
       expect(options.headers['Content-Type']).to.equal('application/json');
-      expect(JSON.parse(options.body)).to.deep.equal({ resCaseId: 'ABC123' });
+      expect(JSON.parse(options.body)).to.deep.equal({
+        resCaseId: 'ABC123',
+        documentType: 626,
+      });
       expect(response.blob.calledOnce).to.be.true;
       expect(downloadPdfBlobStub.calledOnce).to.be.true;
       expect(downloadPdfBlobStub.firstCall.args).to.deep.equal([


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- updated endpoint to download ch31 discontinued letter and pass documentType parameter in api call payload

## Related issue(s)

https://jira.devops.va.gov/browse/RES-19495

## Testing done

- unit testing
- test document download locally with vets-api server running 

## Screenshots

https://github.com/user-attachments/assets/5eabf6a7-2910-45f9-bc93-974d40801a60


## What areas of the site does it impact?

VRE track-your-vre-benefits

## Acceptance criteria

- ch31 discontinued alert letter downloads when clicking on download button from alert in the my case management hub component

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

