### PR TITLE
Fix OH types of care on staging for VAOS

### DIFF
--- a/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
+++ b/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import environment from 'platform/utilities/environment';
 import { getFormData, getTypeOfCare } from '../redux/selectors';
 import { selectFeatureUseVpg } from '../../redux/selectors';
 import { OH_ENABLED_TYPES_OF_CARE } from '../../utils/constants';
@@ -13,7 +14,7 @@ export function useOHScheduling() {
     return false;
   }
 
-  if (process.env.NODE_ENV === 'staging') {
+  if (environment.isStaging()) {
     // env is staging, let's enable all types of care
     return true;
   }

--- a/src/applications/vaos/new-appointment/hooks/useOHScheduling.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/hooks/useOHScheduling.unit.spec.jsx
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import * as redux from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
+import ENVIRONMENTS from 'site/constants/environments';
+import ENVIRONMENT_CONFIGURATIONS from 'site/constants/environments-configs';
 import { useOHScheduling } from './useOHScheduling';
 import * as selectors from '../redux/selectors';
 
@@ -9,22 +11,31 @@ describe('VAOS Hook: useOHScheduling', () => {
   let sandbox;
   let useSelectorStub;
   let getTypeOfCareStub;
-  let originalNodeEnv;
+  let envConfig;
+  let originalBuildtype;
+
+  const setEnvironment = buildtype => {
+    envConfig.BUILDTYPE = buildtype;
+  };
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     useSelectorStub = sandbox.stub(redux, 'useSelector');
     getTypeOfCareStub = sandbox.stub(selectors, 'getTypeOfCare');
-    originalNodeEnv = process.env.NODE_ENV;
+    // The frozen environment export references a mutable config object via
+    // closure. Mutating BUILDTYPE here controls environment.isStaging() and
+    // environment.isProduction() without needing to stub the frozen export.
+    envConfig = ENVIRONMENT_CONFIGURATIONS[global.__BUILDTYPE__];
+    originalBuildtype = envConfig.BUILDTYPE;
   });
 
   afterEach(() => {
     sandbox.restore();
-    process.env.NODE_ENV = originalNodeEnv;
+    envConfig.BUILDTYPE = originalBuildtype;
   });
 
   it('should return false when feature flag is disabled', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     useSelectorStub.onCall(0).returns(false); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'foodAndNutrition' });
@@ -35,7 +46,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return true in staging environment regardless of typeOfCare', () => {
-    process.env.NODE_ENV = 'staging';
+    setEnvironment(ENVIRONMENTS.VAGOVSTAGING);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'primaryCare' }); // Not in OH_ENABLED_TYPES_OF_CARE
@@ -46,7 +57,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return false when typeOfCare is not in OH_ENABLED_TYPES_OF_CARE in production', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'primaryCare' });
@@ -57,7 +68,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return true when feature flag is enabled and typeOfCare is foodAndNutrition in production', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'foodAndNutrition' });
@@ -68,7 +79,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return true when feature flag is enabled and typeOfCare is clinicalPharmacyPrimaryCare in production', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: 'clinicalPharmacyPrimaryCare' });
@@ -79,7 +90,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return false when typeOfCare is undefined in production', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns(undefined);
@@ -90,7 +101,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return false when typeOfCare.idV2 is undefined in production', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns({ idV2: undefined });
@@ -101,7 +112,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should call getTypeOfCare with the form data in production', () => {
-    process.env.NODE_ENV = 'production';
+    setEnvironment(ENVIRONMENTS.VAGOVPROD);
     const mockData = { typeOfCareId: '123' };
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns(mockData); // getFormData
@@ -113,7 +124,7 @@ describe('VAOS Hook: useOHScheduling', () => {
   });
 
   it('should return true in staging even when typeOfCare is undefined', () => {
-    process.env.NODE_ENV = 'staging';
+    setEnvironment(ENVIRONMENTS.VAGOVSTAGING);
     useSelectorStub.onCall(0).returns(true); // selectFeatureUseVpg
     useSelectorStub.onCall(1).returns({}); // getFormData
     getTypeOfCareStub.returns(undefined);


### PR DESCRIPTION
## Summary
Updates the way we are determining environment check in the [`useOHScheduling.js`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/vaos/new-appointment/hooks/useOHScheduling.js#L6) hook.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/134428

## Testing done
- Manual testing
- Updated unit tests

## What areas of the site does it impact?
The VAOS [`useOHScheduling.js`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/vaos/new-appointment/hooks/useOHScheduling.js#L6) hook

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
