### PR TITLE
[#133341] Travel Pay, fix expense delete loading bug

### DIFF
--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -770,16 +770,23 @@ export function deleteExpenseDeleteDocument(
         }/travel_pay/v0/claims/${claimId}/documents/${documentId}`;
         await apiRequest(documentUrl, deleteDocumentOptions);
       }
-
-      // Fetch updated claim details after all deletions are attempted
-      const response = await apiRequest(
-        `${environment.API_URL}/travel_pay/v0/claims/${claimId}`,
-      );
-
-      dispatch(deleteExpenseDeleteDocumentSuccess(expenseId, response));
     } catch (error) {
       dispatch(deleteExpenseDeleteDocumentFailure(error, expenseId));
       throw error;
+    }
+
+    /**
+     * After deleting the expense and for non-mileage expenses the document,
+     * fetch the updated claim details. If this fetch fails, we ignore the
+     * error because the deletions have already completed successfully.
+     */
+    try {
+      const response = await apiRequest(
+        `${environment.API_URL}/travel_pay/v0/claims/${claimId}`,
+      );
+      dispatch(deleteExpenseDeleteDocumentSuccess(expenseId, response));
+    } catch (_) {
+      dispatch(deleteExpenseDeleteDocumentSuccess(expenseId, null));
     }
   };
 }

--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -656,40 +656,6 @@ const deleteDocumentFailure = (error, documentId) => ({
   documentId,
 });
 
-export function deleteDocument(claimId, documentId) {
-  return async dispatch => {
-    dispatch(deleteDocumentStart(documentId));
-
-    try {
-      if (!documentId) {
-        throw new Error('Missing document id');
-      }
-
-      const options = {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      };
-
-      const documentUrl = `${
-        environment.API_URL
-      }/travel_pay/v0/claims/${claimId}/documents/${documentId}`;
-      await apiRequest(documentUrl, options);
-
-      // Fetch the complete complex claim details and load expenses into store
-      await dispatch(getComplexClaimDetails(claimId));
-
-      // Dispatch success only after claim details are fetched
-      dispatch(deleteDocumentSuccess(documentId));
-      return { id: documentId };
-    } catch (error) {
-      dispatch(deleteDocumentFailure(error, documentId));
-      throw error;
-    }
-  };
-}
-
 export function updateExpenseDeleteDocument(
   claimId,
   documentId,
@@ -757,6 +723,22 @@ export function updateExpenseDeleteDocument(
   };
 }
 
+// Deleting an expense and its document as a single operation
+const deleteExpenseDeleteDocumentStart = expenseId => ({
+  type: DELETE_EXPENSE_DELETE_DOCUMENT_STARTED,
+  expenseId,
+});
+const deleteExpenseDeleteDocumentSuccess = (expenseId, claimDetails) => ({
+  type: DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS,
+  expenseId,
+  payload: claimDetails,
+});
+const deleteExpenseDeleteDocumentFailure = (error, expenseId) => ({
+  type: DELETE_EXPENSE_DELETE_DOCUMENT_FAILURE,
+  error,
+  expenseId,
+});
+
 /**
  * Deletes an expense and its associated document, in that order.
  * After deletion, fetches updated claim details.
@@ -772,8 +754,7 @@ export function deleteExpenseDeleteDocument(
   expenseId,
 ) {
   return async dispatch => {
-    // Delete the expense first
-    dispatch(deleteExpenseStart(expenseId));
+    dispatch(deleteExpenseDeleteDocumentStart(expenseId));
 
     try {
       if (!expenseType) {
@@ -782,6 +763,7 @@ export function deleteExpenseDeleteDocument(
         throw new Error('Missing expense id');
       }
 
+      // Delete the expense first
       const deleteExpenseOptions = {
         method: 'DELETE',
         headers: {
@@ -794,18 +776,10 @@ export function deleteExpenseDeleteDocument(
       }/travel_pay/v0/expenses/${expenseType}/${expenseId}`;
       await apiRequest(expenseUrl, deleteExpenseOptions);
 
-      dispatch(deleteExpenseSuccess(expenseId));
-    } catch (error) {
-      dispatch(deleteExpenseFailure(error, expenseId));
-      throw error;
-    }
-
-    // Only delete the associated document if this is NOT a mileage expense
-    if (expenseType.toUpperCase() !== EXPENSE_TYPE_KEYS.MILEAGE.toUpperCase()) {
-      // Delete the document for non-mileage expenses
-      try {
-        dispatch(deleteDocumentStart(documentId));
-
+      // Only delete the associated document if this is NOT a mileage expense
+      if (
+        expenseType.toUpperCase() !== EXPENSE_TYPE_KEYS.MILEAGE.toUpperCase()
+      ) {
         if (!documentId) {
           throw new Error('Missing document id');
         }
@@ -821,32 +795,18 @@ export function deleteExpenseDeleteDocument(
           environment.API_URL
         }/travel_pay/v0/claims/${claimId}/documents/${documentId}`;
         await apiRequest(documentUrl, deleteDocumentOptions);
-        dispatch(deleteDocumentSuccess(documentId));
-      } catch (error) {
-        /**
-         * We delete the expense first. If deleting the document fails afterward,
-         * we may end up with an orphaned (unlinked) document. This won’t break
-         * the claim and is acceptable.
-         *
-         * We do this because:
-         * - Once an expense is deleted, there’s no way to “undo” that deletion.
-         * - If we deleted the document first and the expense delete failed,
-         *   we’d still have no reliable way to re-associate the document back
-         *   to the original expense.
-         *
-         * In both failure orders, rolling back is impossible, so we choose the
-         * safer sequence: delete the expense first, then the document.
-         */
-        dispatch(deleteDocumentFailure(error, documentId));
-        throw error;
       }
+
+      // Fetch updated claim details after all deletions succeed
+      const response = await apiRequest(
+        `${environment.API_URL}/travel_pay/v0/claims/${claimId}`,
+      );
+
+      dispatch(deleteExpenseDeleteDocumentSuccess(expenseId, response));
+    } catch (error) {
+      dispatch(deleteExpenseDeleteDocumentFailure(error, expenseId));
+      throw error;
     }
-    /**
-     * After deleting the expense and for nonmileage expenses the document, fetch the
-     * updated claim details. If this fetch fails, we ignore the error because the deletions
-     * have already completed successfully.
-     */
-    await dispatch(getComplexClaimDetails(claimId));
   };
 }
 

--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -582,6 +582,40 @@ const deleteDocumentFailure = (error, documentId) => ({
   documentId,
 });
 
+export function deleteDocument(claimId, documentId) {
+  return async dispatch => {
+    dispatch(deleteDocumentStart(documentId));
+
+    try {
+      if (!documentId) {
+        throw new Error('Missing document id');
+      }
+
+      const options = {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      };
+
+      const documentUrl = `${
+        environment.API_URL
+      }/travel_pay/v0/claims/${claimId}/documents/${documentId}`;
+      await apiRequest(documentUrl, options);
+
+      // Fetch the complete complex claim details and load expenses into store
+      await dispatch(getComplexClaimDetails(claimId));
+
+      // Dispatch success only after claim details are fetched
+      dispatch(deleteDocumentSuccess(documentId));
+      return { id: documentId };
+    } catch (error) {
+      dispatch(deleteDocumentFailure(error, documentId));
+      throw error;
+    }
+  };
+}
+
 export function updateExpenseDeleteDocument(
   claimId,
   documentId,

--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -35,9 +35,6 @@ export const CREATE_COMPLEX_CLAIM_FAILURE = 'CREATE_COMPLEX_CLAIM_FAILURE';
 export const UPDATE_EXPENSE_STARTED = 'UPDATE_EXPENSE_STARTED';
 export const UPDATE_EXPENSE_SUCCESS = 'UPDATE_EXPENSE_SUCCESS';
 export const UPDATE_EXPENSE_FAILURE = 'UPDATE_EXPENSE_FAILURE';
-export const DELETE_EXPENSE_STARTED = 'DELETE_EXPENSE_STARTED';
-export const DELETE_EXPENSE_SUCCESS = 'DELETE_EXPENSE_SUCCESS';
-export const DELETE_EXPENSE_FAILURE = 'DELETE_EXPENSE_FAILURE';
 export const CREATE_EXPENSE_STARTED = 'CREATE_EXPENSE_STARTED';
 export const CREATE_EXPENSE_SUCCESS = 'CREATE_EXPENSE_SUCCESS';
 export const CREATE_EXPENSE_FAILURE = 'CREATE_EXPENSE_FAILURE';
@@ -480,77 +477,6 @@ export function updateExpense(claimId, expenseType, expenseId, expenseData) {
       });
 
       dispatch(updateExpenseFailure(error, expenseId));
-      throw error;
-    }
-  };
-}
-
-// Deleting an expense
-const deleteExpenseStart = expenseId => ({
-  type: DELETE_EXPENSE_STARTED,
-  expenseId,
-});
-const deleteExpenseSuccess = expenseId => ({
-  type: DELETE_EXPENSE_SUCCESS,
-  expenseId,
-});
-const deleteExpenseFailure = (error, expenseId) => ({
-  type: DELETE_EXPENSE_FAILURE,
-  error,
-  expenseId,
-});
-
-export function deleteExpense(claimId, expenseType, expenseId) {
-  return async dispatch => {
-    dispatch(deleteExpenseStart(expenseId));
-
-    try {
-      if (!expenseType) {
-        throw new Error('Missing expense type');
-      } else if (!expenseId) {
-        throw new Error('Missing expense id');
-      }
-
-      recordEvent({
-        event: 'api_call',
-        'api-name': 'DELETE expense',
-        'api-status': 'started',
-      });
-
-      const options = {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      };
-
-      const expenseUrl = `${
-        environment.API_URL
-      }/travel_pay/v0/expenses/${expenseType}/${expenseId}`;
-      await apiRequest(expenseUrl, options);
-
-      // Fetch the complete complex claim details and load expenses into store
-      await dispatch(getComplexClaimDetails(claimId));
-
-      recordEvent({
-        event: 'api_call',
-        'api-name': 'DELETE expense',
-        'api-status': 'successful',
-        'expense-type': expenseType,
-      });
-
-      // Dispatch success only after claim details are fetched
-      dispatch(deleteExpenseSuccess(expenseId));
-      return { id: expenseId };
-    } catch (error) {
-      recordEvent({
-        event: 'api_call',
-        'api-name': 'DELETE expense',
-        'api-status': 'failed',
-        'expense-type': expenseType,
-      });
-
-      dispatch(deleteExpenseFailure(error, expenseId));
       throw error;
     }
   };

--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -751,13 +751,27 @@ export function deleteExpenseDeleteDocument(
           },
         };
 
+        /**
+         * We delete the expense first. If deleting the document fails afterward,
+         * we may end up with an orphaned (unlinked) document. This won’t break
+         * the claim and is acceptable.
+         *
+         * We do this because:
+         * - Once an expense is deleted, there’s no way to “undo” that deletion.
+         * - If we deleted the document first and the expense delete failed,
+         *   we’d still have no reliable way to re-associate the document back
+         *   to the original expense.
+         *
+         * In both failure orders, rolling back is impossible, so we choose the
+         * safer sequence: delete the expense first, then the document.
+         */
         const documentUrl = `${
           environment.API_URL
         }/travel_pay/v0/claims/${claimId}/documents/${documentId}`;
         await apiRequest(documentUrl, deleteDocumentOptions);
       }
 
-      // Fetch updated claim details after all deletions succeed
+      // Fetch updated claim details after all deletions are attempted
       const response = await apiRequest(
         `${environment.API_URL}/travel_pay/v0/claims/${claimId}`,
       );

--- a/src/applications/travel-pay/redux/reducer.js
+++ b/src/applications/travel-pay/redux/reducer.js
@@ -11,6 +11,9 @@ import {
   DELETE_DOCUMENT_FAILURE,
   DELETE_DOCUMENT_STARTED,
   DELETE_DOCUMENT_SUCCESS,
+  DELETE_EXPENSE_DELETE_DOCUMENT_FAILURE,
+  DELETE_EXPENSE_DELETE_DOCUMENT_STARTED,
+  DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS,
   DELETE_EXPENSE_FAILURE,
   DELETE_EXPENSE_STARTED,
   DELETE_EXPENSE_SUCCESS,
@@ -480,7 +483,8 @@ function travelPayReducer(state = initialState, action) {
         },
       };
 
-    case DELETE_EXPENSE_STARTED: {
+    case DELETE_EXPENSE_STARTED:
+    case DELETE_EXPENSE_DELETE_DOCUMENT_STARTED: {
       return {
         ...state,
         complexClaim: {
@@ -516,6 +520,7 @@ function travelPayReducer(state = initialState, action) {
       };
     }
     case DELETE_EXPENSE_FAILURE:
+    case DELETE_EXPENSE_DELETE_DOCUMENT_FAILURE:
       return {
         ...state,
         complexClaim: {
@@ -636,6 +641,32 @@ function travelPayReducer(state = initialState, action) {
           },
         },
       };
+
+    case DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS: {
+      const claimDocuments = action.payload?.documents || [];
+      const newExpenses = action.payload?.expenses || [];
+      const transposedExpenses = transposeExpenses(newExpenses, claimDocuments);
+
+      return {
+        ...state,
+        complexClaim: {
+          ...state.complexClaim,
+          claim: {
+            ...state.complexClaim.claim,
+            data: action.payload,
+          },
+          expenses: {
+            ...state.complexClaim.expenses,
+            delete: {
+              id: '',
+              isLoading: false,
+              error: null,
+            },
+            data: transposedExpenses,
+          },
+        },
+      };
+    }
 
     case DELETE_DOCUMENT_STARTED:
       return {

--- a/src/applications/travel-pay/redux/reducer.js
+++ b/src/applications/travel-pay/redux/reducer.js
@@ -14,9 +14,6 @@ import {
   DELETE_EXPENSE_DELETE_DOCUMENT_FAILURE,
   DELETE_EXPENSE_DELETE_DOCUMENT_STARTED,
   DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS,
-  DELETE_EXPENSE_FAILURE,
-  DELETE_EXPENSE_STARTED,
-  DELETE_EXPENSE_SUCCESS,
   FETCH_APPOINTMENT_FAILURE,
   FETCH_APPOINTMENT_STARTED,
   FETCH_APPOINTMENT_SUCCESS,
@@ -483,7 +480,6 @@ function travelPayReducer(state = initialState, action) {
         },
       };
 
-    case DELETE_EXPENSE_STARTED:
     case DELETE_EXPENSE_DELETE_DOCUMENT_STARTED: {
       return {
         ...state,
@@ -500,26 +496,6 @@ function travelPayReducer(state = initialState, action) {
         },
       };
     }
-    case DELETE_EXPENSE_SUCCESS: {
-      return {
-        ...state,
-        complexClaim: {
-          ...state.complexClaim,
-          expenses: {
-            ...state.complexClaim.expenses,
-            delete: {
-              id: '',
-              isLoading: false,
-              error: null,
-            },
-            data: state.complexClaim.expenses.data.filter(
-              expense => expense.id !== action.expenseId,
-            ),
-          },
-        },
-      };
-    }
-    case DELETE_EXPENSE_FAILURE:
     case DELETE_EXPENSE_DELETE_DOCUMENT_FAILURE:
       return {
         ...state,

--- a/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
@@ -12,6 +12,7 @@ import {
   submitComplexClaim,
   createExpense,
   updateExpense,
+  deleteDocument,
   deleteExpenseDeleteDocument,
   setExpenseBackDestination,
   SET_EXPENSE_BACK_DESTINATION,
@@ -831,6 +832,86 @@ describe('Redux - actions', () => {
       expect(
         mockDispatch.calledWithMatch({
           type: 'UPDATE_EXPENSE_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('Delete Document', () => {
+    const claimId = 'a48d48d4-cdc5-4922-8355-c1a9b2742feb';
+    const documentId = '4f6f751b-87ff-ef11-9341-001dd809b68c';
+    it('should call correct actions for delete document success', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.resolves(); // DELETE requests typically return empty response
+
+      await deleteDocument(claimId, documentId)(mockDispatch);
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_SUCCESS',
+          documentId,
+        }),
+      ).to.be.true;
+    });
+
+    it('should call correct actions for delete document failure', async () => {
+      const mockDispatch = sinon.spy();
+      apiStub.rejects(new Error('Failed to delete document'));
+
+      try {
+        await deleteDocument(claimId, documentId)(mockDispatch);
+      } catch (error) {
+        // Expected to throw
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when document id is missing', async () => {
+      const mockDispatch = sinon.spy();
+
+      try {
+        await deleteDocument(claimId)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing document id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_FAILURE',
+          error: sinon.match.instanceOf(Error),
+        }),
+      ).to.be.true;
+    });
+
+    it('should throw error when document id is undefined', async () => {
+      const mockDispatch = sinon.spy();
+
+      try {
+        await deleteDocument(claimId, undefined)(mockDispatch);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).to.equal('Missing document id');
+      }
+
+      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
+        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_DOCUMENT_FAILURE',
           error: sinon.match.instanceOf(Error),
         }),
       ).to.be.true;

--- a/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
@@ -12,7 +12,6 @@ import {
   submitComplexClaim,
   createExpense,
   updateExpense,
-  deleteExpense,
   deleteExpenseDeleteDocument,
   setExpenseBackDestination,
   SET_EXPENSE_BACK_DESTINATION,
@@ -838,124 +837,6 @@ describe('Redux - actions', () => {
     });
   });
 
-  describe('Delete Expense', () => {
-    it('should call correct actions for delete expense success', async () => {
-      const mockDispatch = sinon.spy();
-      apiStub.resolves(); // DELETE requests typically return empty response
-
-      await deleteExpense('claim123', 'mileage', 'exp123')(mockDispatch);
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_EXPENSE_SUCCESS',
-          expenseId: 'exp123',
-        }),
-      ).to.be.true;
-    });
-
-    it('should call correct actions for delete expense failure', async () => {
-      const mockDispatch = sinon.spy();
-      apiStub.rejects(new Error('Failed to delete expense'));
-
-      try {
-        await deleteExpense('claim123', 'mileage', 'exp123')(mockDispatch);
-      } catch (error) {
-        // Expected to throw
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_EXPENSE_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-
-    it('should throw error when expense type is missing', async () => {
-      const mockDispatch = sinon.spy();
-
-      try {
-        await deleteExpense('claim123', null, 'exp123')(mockDispatch);
-        expect.fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error.message).to.equal('Missing expense type');
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_EXPENSE_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-
-    it('should throw error when expense id is missing', async () => {
-      const mockDispatch = sinon.spy();
-
-      try {
-        await deleteExpense('claim123', 'mileage', null)(mockDispatch);
-        expect.fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error.message).to.equal('Missing expense id');
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_EXPENSE_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-
-    it('should throw error when expense type is undefined', async () => {
-      const mockDispatch = sinon.spy();
-
-      try {
-        await deleteExpense('claim123', undefined, 'exp123')(mockDispatch);
-        expect.fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error.message).to.equal('Missing expense type');
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_EXPENSE_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-
-    it('should throw error when expense id is undefined', async () => {
-      const mockDispatch = sinon.spy();
-
-      try {
-        await deleteExpense('claim123', 'mileage', undefined)(mockDispatch);
-        expect.fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error.message).to.equal('Missing expense id');
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_EXPENSE_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-  });
-
   describe('deleteExpenseDeleteDocument', () => {
     let mockDispatch;
     beforeEach(() => {
@@ -978,14 +859,16 @@ describe('Redux - actions', () => {
         expenseId,
       )(mockDispatch);
 
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_SUCCESS' }))
-        .to.be.true;
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
-        .to.be.true;
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_SUCCESS' }))
-        .to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_DELETE_DOCUMENT_STARTED',
+        }),
+      ).to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS',
+        }),
+      ).to.be.true;
     });
 
     it('should skip document deletion for MILEAGE expense', async () => {
@@ -1000,14 +883,16 @@ describe('Redux - actions', () => {
         expenseId,
       )(mockDispatch);
 
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_STARTED' }))
-        .to.be.true;
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_EXPENSE_SUCCESS' }))
-        .to.be.true;
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
-        .to.be.false; // document deletion should be skipped
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_SUCCESS' }))
-        .to.be.false;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_DELETE_DOCUMENT_STARTED',
+        }),
+      ).to.be.true;
+      expect(
+        mockDispatch.calledWithMatch({
+          type: 'DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS',
+        }),
+      ).to.be.true;
     });
 
     it('should throw error if expenseType is missing', async () => {

--- a/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/redux/actions.unit.spec.jsx
@@ -13,7 +13,6 @@ import {
   createExpense,
   updateExpense,
   deleteExpense,
-  deleteDocument,
   deleteExpenseDeleteDocument,
   setExpenseBackDestination,
   SET_EXPENSE_BACK_DESTINATION,
@@ -951,86 +950,6 @@ describe('Redux - actions', () => {
       expect(
         mockDispatch.calledWithMatch({
           type: 'DELETE_EXPENSE_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-  });
-
-  describe('Delete Document', () => {
-    const claimId = 'a48d48d4-cdc5-4922-8355-c1a9b2742feb';
-    const documentId = '4f6f751b-87ff-ef11-9341-001dd809b68c';
-    it('should call correct actions for delete document success', async () => {
-      const mockDispatch = sinon.spy();
-      apiStub.resolves(); // DELETE requests typically return empty response
-
-      await deleteDocument(claimId, documentId)(mockDispatch);
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_DOCUMENT_SUCCESS',
-          documentId,
-        }),
-      ).to.be.true;
-    });
-
-    it('should call correct actions for delete document failure', async () => {
-      const mockDispatch = sinon.spy();
-      apiStub.rejects(new Error('Failed to delete document'));
-
-      try {
-        await deleteDocument(claimId, documentId)(mockDispatch);
-      } catch (error) {
-        // Expected to throw
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_DOCUMENT_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-
-    it('should throw error when document id is missing', async () => {
-      const mockDispatch = sinon.spy();
-
-      try {
-        await deleteDocument(claimId)(mockDispatch);
-        expect.fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error.message).to.equal('Missing document id');
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_DOCUMENT_FAILURE',
-          error: sinon.match.instanceOf(Error),
-        }),
-      ).to.be.true;
-    });
-
-    it('should throw error when document id is undefined', async () => {
-      const mockDispatch = sinon.spy();
-
-      try {
-        await deleteDocument(claimId, undefined)(mockDispatch);
-        expect.fail('Expected an error to be thrown');
-      } catch (error) {
-        expect(error.message).to.equal('Missing document id');
-      }
-
-      expect(mockDispatch.calledWithMatch({ type: 'DELETE_DOCUMENT_STARTED' }))
-        .to.be.true;
-      expect(
-        mockDispatch.calledWithMatch({
-          type: 'DELETE_DOCUMENT_FAILURE',
           error: sinon.match.instanceOf(Error),
         }),
       ).to.be.true;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Used the existing deleteExpenseDocument start/success/failure actions to update the store during deleteExpenseDocument instead of a combination of deleteExpense and deleteDocument actions. Additionally, calling GET claim details manually to avoid the loading state store updates associated with that action.
Then cleaned up all unused delete actions.

## Related issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/133341

## Testing done

- Removed unit tests for the deleted standalone `deleteExpense` and `deleteDocument` action creators
- Updated existing `deleteExpenseDeleteDocument` tests to assert against the new combined action types (`DELETE_EXPENSE_DELETE_DOCUMENT_STARTED` / `DELETE_EXPENSE_DELETE_DOCUMENT_SUCCESS`) instead of the previous granular `DELETE_EXPENSE_*` + `DELETE_DOCUMENT_*` dispatches
- Verified mileage expense path still skips document deletion by asserting only the combined action types fire
- Existing error-path tests for missing `expenseType`, `expenseId`, and `documentId` remain in place and pass

## Screenshots

https://github.com/user-attachments/assets/78b04be1-6cac-4407-a7b1-490ec86128c0

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user