### PR TITLE
fix: pin e2e-allow-list-cleanup workflow to ubuntu-22.04

### DIFF
--- a/.github/workflows/e2e-allow-list-cleanup.yml
+++ b/.github/workflows/e2e-allow-list-cleanup.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fetch-allow-lists:
     name: Fetch Test Stability Allow Lists
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -93,7 +93,7 @@ jobs:
 
   clean-up-allow-list:
     name: Clean up E2E Test Stability Allow List
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       id-token: write


### PR DESCRIPTION
## Summary

The `e2e-allow-list-cleanup` workflow has been **failing on every run for 3+ months** (~200 consecutive failures) due to an OpenSSL incompatibility introduced when GitHub rolled `ubuntu-latest` from Ubuntu 22.04 to 24.04.

### Root Cause

Ubuntu 24.04 ships OpenSSL 3.x, which is incompatible with the Node.js version used by `qa-standards-dashboard-data`. The error:

```
error:25066067:DSO support routines:dlfcn_load:could not load the shared library
TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be of type string or...
```

### Impact

Because cleanup has not run since ~December 2024, the BigQuery allow list has accumulated stale entries for deleted/renamed specs. For example, `mhv-secure-messaging` has **229 entries in BigQuery** but only **152 actual spec files** — meaning 77 stale entries inflate the stress test matrix unnecessarily, adding wall-clock time to every CI run.

### Fix

Pin both jobs (`fetch-allow-lists` and `clean-up-allow-list`) to `ubuntu-22.04`, matching the runner used by the working `stress-test-cypress-tests` job in `continuous-integration.yml`.

## Related issue(s)

N/A — discovered during CI performance analysis.

## Testing done

- The same `init-data-repo` action and `get-allow-list.js` script already run successfully on `ubuntu-22.04` in the `stress-test-cypress-tests` job of `continuous-integration.yml`.
- This is a workflow-only change — no application code is affected.
- The fix can be verified by observing the next scheduled run (weekdays at noon UTC) or by triggering a manual workflow dispatch.

## Screenshots

N/A — workflow-only change.

## What areas of the site does it impact?

CI/CD only — no user-facing impact.
