### PR TITLE
[ARC/135182] - fixing html structure on itf confirmation

### DIFF
--- a/src/applications/representative-form-upload/components/ConfirmationPageViewITF.jsx
+++ b/src/applications/representative-form-upload/components/ConfirmationPageViewITF.jsx
@@ -42,14 +42,7 @@ export const ConfirmationPageViewITF = ({
   );
 
   return (
-    <div>
-      <div className="print-only">
-        <img
-          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-          alt="VA logo"
-          width="300"
-        />
-      </div>
+    <section className="itf-confirmation">
       {submitDate && (
         <va-alert status="success" ref={alertRef}>
           <h2 slot="headline">We recorded the intent to file</h2>
@@ -69,13 +62,22 @@ export const ConfirmationPageViewITF = ({
           {last}, {first}
         </h2>
         {formattedAddress && <div>{formattedAddress}</div>}
-        <p className="vads-u-margin-bottom--0">
-          <b>Benefit:</b> {benefitType && benefitCopy(benefitType)}
-          <br />
-          <b>ITF Date:</b> {formattedSubmitDate} (Expires in 365 days)
-        </p>
+        <ul className="itf-confirmation__list">
+          <li>
+            <p>
+              <strong>Benefit:</strong>
+            </p>
+            <p> {benefitType && benefitCopy(benefitType)}</p>
+          </li>
+          <li>
+            <p>
+              <strong>TF Date:</strong>
+            </p>
+            <p role="text">{formattedSubmitDate} (Expires in 365 days)</p>
+          </li>
+        </ul>
       </va-card>
-      <section>
+      <div>
         <h2 className="vads-u-margin-top--4">What to expect</h2>
         <va-process-list>
           <va-process-list-item header="We'll confirm the intent to file was recorded" />
@@ -90,7 +92,7 @@ export const ConfirmationPageViewITF = ({
             </p>
           </va-process-list-item>
         </va-process-list>
-      </section>
+      </div>
       <va-link-action
         href="/representative/submissions"
         label="Go back to submissions"
@@ -98,7 +100,7 @@ export const ConfirmationPageViewITF = ({
         text="Go back to submissions"
         type="primary"
       />
-    </div>
+    </section>
   );
 };
 

--- a/src/applications/representative-form-upload/helpers/index.js
+++ b/src/applications/representative-form-upload/helpers/index.js
@@ -228,16 +228,11 @@ export const expiresSoonIcon = expDate => {
 export const benefitCopy = ITFType => {
   switch (ITFType) {
     case 'compensation':
-      return <span>Disability compensation (VA Form 21-526EZ)</span>;
+      return 'Disability compensation (VA Form 21-526EZ)';
     case 'pension':
-      return <span>Pension (VA Form 21P-527EZ)</span>;
+      return 'Pension (VA Form 21P-527EZ)';
     case 'survivor':
-      return (
-        <span>
-          Survivors pension and/or dependency and indemnity compensation (DIC)
-          (VA Form 21P-534 or VA Form 21P-534EZ)
-        </span>
-      );
+      return 'Survivors pension and/or dependency and indemnity compensation (DIC) (VA Form 21P-534 or VA Form 21P-534EZ)';
     default:
       return null;
   }

--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -290,3 +290,18 @@
     }
   }
 }
+.itf-confirmation {
+  &__list {
+    list-style: none;
+    padding: 0;
+    li, p {
+      margin: 0;
+    }
+    li {
+      display: flex;
+      p:first-child {
+        margin-right: 4px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixing html structure as noted in ticket
https://github.com/department-of-veterans-affairs/va.gov-team/issues/135182

Removing hidden image, removing extra spans, adding role=text on date line to avoid multiple swipes on mobile

<img width="629" height="587" alt="Screenshot 2026-03-05 at 11 37 41 AM" src="https://github.com/user-attachments/assets/6785c52d-bc8e-4a3d-9ab4-ff894b1af06b" />
<img width="1618" height="592" alt="Screenshot 2026-03-05 at 11 35 29 AM" src="https://github.com/user-attachments/assets/6d28c05d-3612-48ba-9084-9f1b14195a03" />
