### PR TITLE
Add "In Progress" label to active appeals in AppealListItem component

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealListItem.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItem.jsx
@@ -9,6 +9,7 @@ import {
   getTypeName,
   getStatusContents,
   programAreaMap,
+  isClosed,
 } from '../../utils/appeals-v2-helpers';
 import {
   buildDateFormatter,
@@ -81,10 +82,12 @@ export default function AppealListItem({ appeal, name }) {
 
   const ariaLabel = `Details for ${appealTitle}`;
   const href = `/appeals/${appeal.id}/status`;
+  const inProgress = !isClosed(appeal);
 
   return (
     <ClaimCard
       title={appealTitle}
+      label={inProgress ? 'In Progress' : null}
       subtitle={requestEvent && `Received on ${formatDate(requestEvent.date)}`}
     >
       <div className="card-status">

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItem.unit.spec.jsx
@@ -194,6 +194,19 @@ describe('<AppealListItem>', () => {
     wrapper.unmount();
   });
 
+  it('should show "In Progress" label when the appeal is active', () => {
+    const wrapper = shallow(<AppealListItem {...defaultProps} />);
+    expect(wrapper.find('ClaimCard').prop('label')).to.equal('In Progress');
+    wrapper.unmount();
+  });
+
+  it('should not show a label when the appeal is closed', () => {
+    const props = set('appeal.attributes.active', false, defaultProps);
+    const wrapper = shallow(<AppealListItem {...props} />);
+    expect(wrapper.find('ClaimCard').prop('label')).to.be.null;
+    wrapper.unmount();
+  });
+
   context(
     'when the cst_show_document_upload_status feature toggle is disabled',
     () => {

--- a/src/applications/claims-status/tests/e2e/tests/your-claims/appeal-cards.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/tests/your-claims/appeal-cards.cypress.spec.js
@@ -33,7 +33,8 @@ describe('Appeal cards', () => {
       ]);
 
       cy.findByRole('heading', {
-        name: 'Disability compensation appeal Received on January 1, 2025',
+        name:
+          'In Progress Disability compensation appeal Received on January 1, 2025',
       });
 
       cy.findByText(/Issue on appeal/);
@@ -57,7 +58,7 @@ describe('Appeal cards', () => {
 
       cy.findByRole('heading', {
         name:
-          'Supplemental claim for disability compensation Received on January 1, 2025',
+          'In Progress Supplemental claim for disability compensation Received on January 1, 2025',
       });
 
       cy.findByText(/Issue on review/);
@@ -81,7 +82,7 @@ describe('Appeal cards', () => {
 
       cy.findByRole('heading', {
         name:
-          'Higher-level review for disability compensation Received on January 1, 2025',
+          'In Progress Higher-level review for disability compensation Received on January 1, 2025',
       });
 
       cy.findByText(/Issue on review/);
@@ -104,7 +105,8 @@ describe('Appeal cards', () => {
       ]);
 
       cy.findByRole('heading', {
-        name: 'Disability compensation appeal Received on January 1, 2025',
+        name:
+          'In Progress Disability compensation appeal Received on January 1, 2025',
       });
 
       cy.findByText(/Issue on appeal/);
@@ -169,37 +171,52 @@ describe('Appeal cards', () => {
       },
     ];
 
-    programAreas.forEach(({ programArea, appealTitle, reviewTitle }) => {
-      it(`should display ${appealTitle}`, () => {
-        setupAppealCardsTest([
-          createAppeal({
-            type: 'legacyAppeal',
-            eventType: 'nod',
-            programArea,
-          }),
-        ]);
+    const isActive = [true, false];
 
-        cy.findByRole('heading', {
-          name: `${appealTitle} Received on January 1, 2025`,
+    isActive.forEach(active => {
+      describe(`when appeal is ${active ? 'active' : 'closed'}`, () => {
+        programAreas.forEach(({ programArea, appealTitle, reviewTitle }) => {
+          it(`should display ${appealTitle}`, () => {
+            setupAppealCardsTest([
+              createAppeal({
+                type: 'legacyAppeal',
+                eventType: 'nod',
+                programArea,
+                active,
+              }),
+            ]);
+
+            const expectedHeading = active
+              ? `In Progress ${appealTitle} Received on January 1, 2025`
+              : `${appealTitle} Received on January 1, 2025`;
+            cy.findByRole('heading', {
+              name: expectedHeading,
+            });
+
+            cy.axeCheck();
+          });
+
+          it(`should display ${reviewTitle} appeal`, () => {
+            setupAppealCardsTest([
+              createAppeal({
+                type: 'supplementalClaim',
+                eventType: 'sc_request',
+                programArea,
+                active,
+              }),
+            ]);
+
+            const expectedHeading = active
+              ? `In Progress ${reviewTitle} Received on January 1, 2025`
+              : `${reviewTitle} Received on January 1, 2025`;
+
+            cy.findByRole('heading', {
+              name: expectedHeading,
+            });
+
+            cy.axeCheck();
+          });
         });
-
-        cy.axeCheck();
-      });
-
-      it(`should display ${reviewTitle}`, () => {
-        setupAppealCardsTest([
-          createAppeal({
-            type: 'supplementalClaim',
-            eventType: 'sc_request',
-            programArea,
-          }),
-        ]);
-
-        cy.findByRole('heading', {
-          name: `${reviewTitle} Received on January 1, 2025`,
-        });
-
-        cy.axeCheck();
       });
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Adds an "In Progress" label to Decision Review claim cards (Appeals, Supplemental Claims, Higher-Level Reviews) to match the existing behavior on initial benefits claim cards.
- Previously, `AppealListItem` did not pass a `label` prop to `ClaimCard`, so Decision Review cards had no visible status indicator. This created an inconsistent experience for Veterans comparing active claims of different types.
- Uses the existing `isClosed()` helper from `appeals-v2-helpers` to determine whether an appeal is active, and conditionally passes `label="In Progress"` to `ClaimCard` — the same pattern already used in `ClaimsListItem`.
- Benefits Management Tools Team 2 (Bee's Knees) owns the Claim Status Tool.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132163

## Testing done

- **Old behavior:** Decision Review claim cards (legacy appeals, AMA appeals, supplemental claims, higher-level reviews) displayed no status label on the card.
- **New behavior:** Active Decision Review claim cards now display an "In Progress" label. Closed appeals do not display a label.
- **Unit tests:** Added two new unit tests to `AppealListItem.unit.spec.jsx`:
  - Verifies the `ClaimCard` receives `label="In Progress"` when the appeal is active
  - Verifies the `ClaimCard` receives `label={null}` when the appeal is closed
- **E2E tests:** Updated `appeal-cards.cypress.spec.js` to:
  - Assert the "In Progress" label text appears in card headings for active appeals, supplemental claims, and higher-level reviews
  - Added test matrix covering both active and closed states across all program areas, verifying the label is present/absent accordingly
  - All tests include `cy.axeCheck()` for accessibility validation
- Verified locally that existing unit tests continue to pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._


| Before | After |
| ------ | ----- |
| <img width="660" height="490" alt="Screenshot 2026-03-05 at 10 07 10 AM" src="https://github.com/user-attachments/assets/f2b18df7-992e-4480-bda0-2e0a599635d7" /> | <img width="662" height="569" alt="Screenshot 2026-03-05 at 10 06 48 AM" src="https://github.com/user-attachments/assets/510e0a8f-b390-4a08-9dc2-f5a12c484301" /> |




## What areas of the site does it impact?

The Claim Status Tool — specifically the "Your claims and appeals" list page. Only `AppealListItem` rendering is affected; no changes to claim detail pages, routing, or other applications.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This follows the exact same pattern used by `ClaimsListItem` for initial benefits claims. The `isClosed()` helper reads `appeal.attributes.active` — would appreciate a second look to confirm this covers all edge cases across the different appeal types (legacy, AMA, supplemental claim, higher-level review).
