### PR TITLE
Do not filter by facility configuration when changing sort method

### DIFF
--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -495,13 +495,7 @@ export default function formReducer(state = initialState, action) {
     case FORM_PAGE_FACILITY_SORT_METHOD_UPDATED: {
       const formData = state.data;
       const typeOfCareId = getTypeOfCare(formData).id;
-      const {
-        location,
-        cernerSiteIds,
-        sortMethod,
-        calculatedDistance,
-        uiSchema,
-      } = action;
+      const { location, sortMethod, calculatedDistance, uiSchema } = action;
       let facilities = state.facilities[typeOfCareId];
       let sortedFacilities;
       let newSchema = state.pages.vaFacilityV2;
@@ -536,12 +530,8 @@ export default function formReducer(state = initialState, action) {
         requestLocationStatus = FETCH_STATUS.succeeded;
       }
 
-      const typeOfCareFacilities = facilities.filter(facility =>
-        isTypeOfCareSupported(facility, typeOfCareId, cernerSiteIds),
-      );
-
       if (sortMethod === FACILITY_SORT_METHODS.alphabetical) {
-        sortedFacilities = typeOfCareFacilities.sort((a, b) =>
+        sortedFacilities = facilities.sort((a, b) =>
           a.name.localeCompare(b.name),
         );
       } else if (
@@ -549,11 +539,11 @@ export default function formReducer(state = initialState, action) {
         (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation &&
           location)
       ) {
-        sortedFacilities = typeOfCareFacilities.sort(
+        sortedFacilities = facilities.sort(
           (a, b) => a.legacyVAR[sortMethod] - b.legacyVAR[sortMethod],
         );
       } else {
-        sortedFacilities = typeOfCareFacilities;
+        sortedFacilities = facilities;
       }
 
       newSchema = set(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134591

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| After choosing sort alphabetically  |    <img width="683" height="921" alt="image" src="https://github.com/user-attachments/assets/cbddb160-9307-4fa6-bbce-db77f48d816c" />   |   <img width="650" height="921" alt="image" src="https://github.com/user-attachments/assets/7695d2ca-8433-432e-9bd3-09ae792677e4" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

