### PR TITLE
fix(vaos): override formation CSS to prevent garbled radio/checkbox characters

### DIFF
--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -109,3 +109,23 @@ va-textarea::part(input-type-textarea) {
 .vaos-form__button-container {
   row-gap: 16px;
 }
+
+// TEMPORARY WORKAROUND for character encoding bug in formation radio/checkbox
+// styles. The preferred long-term fix is migrating from native HTML radio/checkbox
+// inputs to the VADS va-radio and va-checkbox web components, which are not
+// affected by this encoding issue.
+//
+// The css-library's formation stylesheet uses content: '\a0' which Sass compiles
+// into raw UTF-8 bytes. Webpack strips the @charset "UTF-8" declaration during
+// production bundling, causing browsers to intermittently render "Â" in radio
+// buttons and checkboxes when interpreting the bytes as Latin-1 from cache.
+// Using unquote() forces Sass to output the ASCII CSS escape \00a0 literally,
+// rather than resolving it to raw UTF-8 bytes.
+//
+// Remove this override once all native radio/checkbox inputs have been replaced
+// with va-radio / va-checkbox web components.
+// See: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5350
+[type="radio"] + label::before,
+[type="checkbox"] + label::before {
+  content: unquote('"\\00a0"');
+}

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/radio-encoding.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/radio-encoding.cypress.spec.js
@@ -1,0 +1,95 @@
+import MockUser from '../../../fixtures/MockUser';
+import AppointmentListPageObject from '../../page-objects/AppointmentList/AppointmentListPageObject';
+import TypeOfCarePageObject from '../../page-objects/TypeOfCarePageObject';
+import UrgentCareInformationPageObject from '../../page-objects/UrgentCareInformationPageObject';
+import {
+  mockAppointmentsGetApi,
+  mockFeatureToggles,
+  mockVamcEhrApi,
+  vaosSetup,
+} from '../../vaos-cypress-helpers';
+
+/**
+ * Regression test for CSS character encoding bug.
+ *
+ * The css-library's formation stylesheet uses `content: '\a0'` on radio and
+ * checkbox pseudo-elements. Sass compiles this into raw UTF-8 bytes (0xC2 0xA0).
+ * Webpack strips the @charset "UTF-8" declaration during production bundling.
+ * When a browser interprets these bytes as Latin-1 (e.g. from cache), the byte
+ * 0xC2 renders as "Â" inside radio buttons and checkboxes.
+ *
+ * This test forces the worst-case scenario by intercepting CSS responses and
+ * setting charset=iso-8859-1, which guarantees the raw bytes are decoded as
+ * Latin-1. With the fix applied (content: \00a0 via unquote), the CSS escape
+ * is pure ASCII and renders correctly regardless of charset.
+ *
+ * @see https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5350
+ */
+describe('VAOS radio button encoding', () => {
+  beforeEach(() => {
+    vaosSetup();
+    mockAppointmentsGetApi({ response: [] });
+    mockFeatureToggles();
+    mockVamcEhrApi();
+
+    // Force browser to interpret CSS as Latin-1 instead of UTF-8.
+    // This simulates the cache-dependent bug where raw UTF-8 bytes
+    // 0xC2 0xA0 get decoded as "Â " in Latin-1.
+    cy.intercept('GET', '**/generated/style.css', req => {
+      req.continue(res => {
+        res.headers['content-type'] = 'text/css; charset=iso-8859-1';
+      });
+    });
+    cy.intercept('GET', '**/generated/vaos.css', req => {
+      req.continue(res => {
+        res.headers['content-type'] = 'text/css; charset=iso-8859-1';
+      });
+    });
+  });
+
+  it('radio buttons render without garbled characters', () => {
+    const mockUser = new MockUser({ addressLine1: '123 Main St.' });
+
+    cy.login(mockUser);
+
+    AppointmentListPageObject.visit().scheduleAppointment();
+
+    UrgentCareInformationPageObject.assertUrl().scheduleAppointment();
+
+    TypeOfCarePageObject.assertUrl();
+
+    // Verify radio buttons are visible
+    cy.get('.form-radio-buttons label').should('have.length.greaterThan', 0);
+
+    cy.axeCheckBestPractice();
+
+    // Check the computed content of radio button ::before pseudo-elements.
+    // Under Latin-1 decoding (forced by cy.intercept above), raw UTF-8
+    // bytes 0xC2 0xA0 become "Â " (two chars). With the fix (ASCII escape
+    // \00a0), the content is a single non-breaking space regardless of charset.
+    cy.get('.form-radio-buttons label')
+      .first()
+      .then($label => {
+        const { content } = window.getComputedStyle($label[0], '::before');
+        // CSS content values are returned quoted, e.g. '" "' for a space.
+        // Strip the outer quotes to get the raw string value.
+        const raw = content.replace(/^"|"$/g, '');
+
+        expect(
+          raw,
+          `::before content should be a single non-breaking space character, ` +
+            `not garbled "Â" + nbsp. Got: ${JSON.stringify(
+              content,
+            )}. See issue #5350.`,
+        ).to.not.contain('\u00c2');
+
+        expect(
+          raw.length,
+          `::before content should be exactly 1 character (\\u00a0), ` +
+            `not ${raw.length}. Got: ${JSON.stringify(
+              content,
+            )}. See issue #5350.`,
+        ).to.equal(1);
+      });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug**: The css-library's formation stylesheet uses `content: '\a0'` on radio/checkbox `::before` pseudo-elements. Sass compiles this into raw UTF-8 bytes (0xC2 0xA0). Webpack strips the `@charset "UTF-8"` declaration during production bundling. When browsers interpret the CSS as Latin-1 (e.g. from cache), byte 0xC2 renders as "Â" inside radio buttons and checkboxes.
- **Reproduction**: Navigate to the VAOS type-of-care page at `/my-health/appointments/schedule/type-of-care`. Under certain cache conditions, radio button labels display a garbled "Â" character.
- **Solution**: Added a CSS override in `vaos.scss` using `content: unquote('"\\00a0"')` which forces Sass to output the ASCII CSS escape `\00a0` literally, rather than resolving it to raw UTF-8 bytes. This renders correctly regardless of charset interpretation.
- **Temporary workaround**: The preferred long-term fix is migrating from native HTML radio/checkbox inputs to the VADS `va-radio` and `va-checkbox` web components.
- VAOS team owns this component.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5350

## Testing done

- **Before**: Under Latin-1 charset interpretation, `::before` pseudo-element content is 2 characters ("Â" + nbsp) due to raw UTF-8 bytes being decoded as Latin-1.
- **After**: `::before` pseudo-element content is exactly 1 character (non-breaking space `\u00a0`) regardless of charset.
- Added a Cypress regression test (`radio-encoding.cypress.spec.js`) that:
  1. Uses `cy.intercept` to force `charset=iso-8859-1` on CSS responses, deterministically reproducing the cache-dependent bug
  2. Navigates to the VAOS type-of-care page
  3. Asserts that radio button `::before` pseudo-element content does not contain the garbled "Â" character
  4. Asserts content is exactly 1 character (non-breaking space)
- Verified RED/GREEN TDD cycle: test fails without fix, passes with fix
- ESLint passes with zero errors
- Includes `cy.axeCheckBestPractice()` accessibility check

## Screenshots

N/A - This is a CSS-only change to pseudo-element content. The visual fix prevents "Â" from appearing in radio buttons, but cannot be captured in a static screenshot since it depends on charset interpretation.

## What areas of the site does it impact?

VAOS (VA Online Scheduling) — specifically any page using native HTML radio buttons or checkboxes styled by formation CSS. The override applies globally within the VAOS app via `vaos.scss`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is a temporary CSS workaround. The long-term fix is migrating VAOS native radio/checkbox inputs to VADS `va-radio` / `va-checkbox` web components. Reviewers: please assess whether the `unquote()` approach is the right interim fix, and whether the Cypress test adequately covers the regression.