### PR TITLE
[CVE 2437] create new confirmation page, selector, and tests

### DIFF
--- a/src/applications/lgy/coe/form/config/form.js
+++ b/src/applications/lgy/coe/form/config/form.js
@@ -4,8 +4,8 @@ import environment from 'platform/utilities/environment';
 import { profileContactInfoPages } from 'platform/forms-system/src/js/patterns/prefill/ContactInfo';
 import { getContent } from 'platform/forms-system/src/js/utilities/data/profile';
 
-import { IntroductionPageSelector } from '../containers/IntroductionPageSelector';
-import ConfirmationPage from '../containers/ConfirmationPage';
+import { IntroductionPageSelector } from '../containers/selectors/IntroductionPageSelector';
+import { ConfirmationPageSelector } from '../containers/selectors/ConfirmationPageSelector';
 import { GetFormHelp } from '../components/GetFormHelp';
 import manifest from '../manifest.json';
 import { customCOEsubmit } from './helpers';
@@ -33,9 +33,6 @@ import { servicePeriodsPages } from '../pages/servicePeriodsPages';
 import serviceStatus2 from '../pages/serviceStatus2';
 import { uploadDocumentsSchema, getUiSchema } from '../pages/uploadDocuments';
 
-// TODO: When schema is migrated to vets-json-schema, remove common
-// definitions from form schema and get them from common definitions instead
-
 import {
   certificateUseOptions,
   serviceStatuses,
@@ -62,7 +59,7 @@ const formConfig = {
     reviewPageTitle: 'Review your request',
   },
   introduction: IntroductionPageSelector,
-  confirmation: ConfirmationPage,
+  confirmation: ConfirmationPageSelector,
   dev: {
     showNavLinks: true,
     collapsibleNavLinks: true,

--- a/src/applications/lgy/coe/form/containers/ConfirmationPage2.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage2.jsx
@@ -15,8 +15,10 @@ const PrintThisConfirmationPage = () => {
     window.print();
   };
   return (
-    <div className="confirmation-print-this-page-section screen-only">
-      <h2 className="vads-u-font-size--h4">Print this confirmation page</h2>
+    <div className="confirmation-print-this-page-section screen-only vads-u-margin-bottom--8">
+      <h2 className="vads-u-font-size--h4 vads-u-margin-top--0 vads-u-margin-bottom--2">
+        Print this confirmation page
+      </h2>
 
       <p>
         If you’d like to keep a copy of the information on this page, you can
@@ -32,8 +34,10 @@ const PrintThisConfirmationPage = () => {
 };
 
 const WhatToExpect = () => (
-  <div className="confirmation-whats-next-process-list-section">
-    <h2>What to expect</h2>
+  <div className="confirmation-whats-next-process-list-section vads-u-margin-top--0 vads-u-margin-bottom--3">
+    <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
+      What to expect
+    </h2>
 
     <VaProcessList>
       <VaProcessListItem header="We’ll confirm when we are reviewing your request">
@@ -63,11 +67,13 @@ const WhatToExpect = () => (
 );
 
 const CheckStatus = ({ statusURL }) => (
-  <div className="vads-u-margin-top--4">
-    <h2>How can I check the status of my request?</h2>
+  <div>
+    <h2 className="vads-u-margin-top--0">
+      How can I check the status of my request?
+    </h2>
     <p>You can check the status of your request online.</p>
 
-    <p>
+    <p className="vads-u-margin-top--3 vads-u-margin-bottom--5">
       <strong>Note:</strong> If it’s been more than 5 days since you submitted
       your request and you haven’t received a response, you can call us at{' '}
       <va-telephone contact="8778273702" /> (TTY:
@@ -123,7 +129,10 @@ export const ConfirmationPage2 = ({ route }) => {
         }
       />
       <ConfirmationView.SavePdfDownload />
-      <ConfirmationView.ChapterSectionCollection collapsible />
+      <ConfirmationView.ChapterSectionCollection
+        collapsible
+        className="vads-u-margin-bottom--5"
+      />
       <PrintThisConfirmationPage />
       <WhatToExpect />
       <CheckStatus statusURL={statusURL} />

--- a/src/applications/lgy/coe/form/containers/ConfirmationPage2.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage2.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { format, isValid } from 'date-fns';
+import {
+  VaLinkAction,
+  VaProcessList,
+  VaProcessListItem,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
+import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
+
+const PrintThisConfirmationPage = () => {
+  const onPrintPageClick = () => {
+    window.print();
+  };
+  return (
+    <div className="confirmation-print-this-page-section screen-only">
+      <h2 className="vads-u-font-size--h4">Print this confirmation page</h2>
+
+      <p>
+        If you’d like to keep a copy of the information on this page, you can
+        print it now.
+      </p>
+
+      <va-button
+        onClick={onPrintPageClick}
+        text="Print this page for your records"
+      />
+    </div>
+  );
+};
+
+const WhatToExpect = () => (
+  <div className="confirmation-whats-next-process-list-section">
+    <h2>What to expect</h2>
+
+    <VaProcessList>
+      <VaProcessListItem header="We’ll confirm when we are reviewing your request">
+        <p>
+          A status will be displayed on the COE status page to let you know when
+          your request is in review. The review should take about 5 days.
+        </p>
+      </VaProcessListItem>
+
+      <VaProcessListItem header="We’ll let you know if we need additional documentation">
+        <p>
+          In some cases you may need to upload documents before we can make a
+          decision on your COE request. We’ll also provide additional updates on
+          the VA home loan COE status page.
+        </p>
+      </VaProcessListItem>
+
+      <VaProcessListItem header="We’ll provide a decision">
+        <p>
+          You’ll receive an email about your eligibility and how to get your COE
+          if you qualify. You will be able to download your COE on the COE
+          application page or from the VA home loan COE status page.
+        </p>
+      </VaProcessListItem>
+    </VaProcessList>
+  </div>
+);
+
+const CheckStatus = ({ statusURL }) => (
+  <div className="vads-u-margin-top--4">
+    <h2>How can I check the status of my request?</h2>
+    <p>You can check the status of your request online.</p>
+
+    <p>
+      <strong>Note:</strong> If it’s been more than 5 days since you submitted
+      your request and you haven’t received a response, you can call us at{' '}
+      <va-telephone contact="8778273702" /> (TTY:
+      <va-telephone contact="711" tty />
+      ).
+    </p>
+
+    <VaLinkAction href={statusURL} text="Check the status of your request" />
+  </div>
+);
+
+CheckStatus.propTypes = {
+  statusURL: PropTypes.string.isRequired,
+};
+
+export const ConfirmationPage2 = ({ route }) => {
+  const form = useSelector(state => state.form || {});
+  const submission = form?.submission || {};
+  const submitDate = submission?.timestamp || null;
+  const confirmationNumber = submission?.response?.confirmationNumber || '';
+  const alertTitle = `Request submission started${
+    isValid(submitDate) ? ` on ${format(submitDate, 'MMMM d, yyyy')}` : ''
+  }`;
+  const statusURL =
+    getAppUrl('coe-status') ||
+    '/housing-assistance/home-loans/check-coe-status/your-coe';
+
+  return (
+    <ConfirmationView
+      submitDate={submitDate}
+      confirmationNumber={confirmationNumber}
+      formConfig={route?.formConfig}
+      pdfUrl={submission?.response?.pdfUrl}
+      devOnly={{ showButtons: true }}
+    >
+      <ConfirmationView.SubmissionAlert
+        title={alertTitle}
+        content={
+          <>
+            <p>Your submission is in progress.</p>
+
+            <p>
+              After we receive your request, we’ll review your information and
+              notify you by email on how to get your COE.
+            </p>
+          </>
+        }
+        actions={
+          <VaLinkAction
+            href={statusURL}
+            text="Check the status of your COE request"
+          />
+        }
+      />
+      <ConfirmationView.SavePdfDownload />
+      <ConfirmationView.ChapterSectionCollection collapsible />
+      <PrintThisConfirmationPage />
+      <WhatToExpect />
+      <CheckStatus statusURL={statusURL} />
+      <ConfirmationView.HowToContact />
+      <ConfirmationView.GoBackLink text="Go back to VA.gov" />
+
+      <ConfirmationView.NeedHelp />
+    </ConfirmationView>
+  );
+};
+ConfirmationPage2.propTypes = {
+  route: PropTypes.shape({
+    formConfig: PropTypes.object,
+  }),
+};
+export default ConfirmationPage2;

--- a/src/applications/lgy/coe/form/containers/selectors/ConfirmationPageSelector.jsx
+++ b/src/applications/lgy/coe/form/containers/selectors/ConfirmationPageSelector.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { getFormData } from 'platform/forms-system/src/js/state/selectors';
+import ConfirmationPage from '../ConfirmationPage';
+import ConfirmationPage2 from '../ConfirmationPage2';
+import { TOGGLE_KEY } from '../../constants';
+
+// Changed this from Intro version for testing purposes including using Boolean instead of !!
+export const shouldUseNewConfirmation = formData =>
+  Boolean(formData?.[`view:${TOGGLE_KEY}`]);
+
+export const ConfirmationPageSelector = props => {
+  const formData = useSelector(getFormData) || {};
+  const ConfirmationPageComponent = shouldUseNewConfirmation(formData)
+    ? ConfirmationPage2
+    : ConfirmationPage;
+  return <ConfirmationPageComponent {...props} />;
+};
+
+ConfirmationPageSelector.propTypes = {
+  route: PropTypes.object,
+};
+
+export default ConfirmationPageSelector;

--- a/src/applications/lgy/coe/form/containers/selectors/ConfirmationPageSelector.jsx
+++ b/src/applications/lgy/coe/form/containers/selectors/ConfirmationPageSelector.jsx
@@ -1,20 +1,32 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getFormData } from 'platform/forms-system/src/js/state/selectors';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 import ConfirmationPage from '../ConfirmationPage';
 import ConfirmationPage2 from '../ConfirmationPage2';
-import { TOGGLE_KEY } from '../../constants';
 
 // Changed this from Intro version for testing purposes including using Boolean instead of !!
-export const shouldUseNewConfirmation = formData =>
-  Boolean(formData?.[`view:${TOGGLE_KEY}`]);
+export const shouldUseNewConfirmation = enabled => Boolean(enabled);
 
 export const ConfirmationPageSelector = props => {
-  const formData = useSelector(getFormData) || {};
-  const ConfirmationPageComponent = shouldUseNewConfirmation(formData)
+  const {
+    TOGGLE_NAMES,
+    useToggleLoadingValue,
+    useToggleValue,
+  } = useFeatureToggle();
+  const enableNewConfirmation = useToggleValue(
+    TOGGLE_NAMES.coeFormRebuildCveteam,
+  );
+  const isLoading = useToggleLoadingValue(TOGGLE_NAMES.coeFormRebuildCveteam);
+  const ConfirmationPageComponent = shouldUseNewConfirmation(
+    enableNewConfirmation,
+  )
     ? ConfirmationPage2
     : ConfirmationPage;
+
+  if (isLoading) {
+    return <va-loading-indicator message="Loading your application..." />;
+  }
+
   return <ConfirmationPageComponent {...props} />;
 };
 

--- a/src/applications/lgy/coe/form/containers/selectors/IntroductionPageSelector.jsx
+++ b/src/applications/lgy/coe/form/containers/selectors/IntroductionPageSelector.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { getFormData } from 'platform/forms-system/src/js/state/selectors';
-import IntroductionPage from './IntroductionPage';
-import IntroductionPage2 from './IntroductionPage2';
+import IntroductionPage from '../IntroductionPage';
+import IntroductionPage2 from '../IntroductionPage2';
 
 const TOGGLE_KEY = 'view:coeFormRebuildCveteam';
 

--- a/src/applications/lgy/coe/form/tests/unit/containers/ConfirmationPage2.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/unit/containers/ConfirmationPage2.unit.spec.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { cleanup, render } from '@testing-library/react';
+import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
+import formConfig from '../../../config/form';
+import ConfirmationPage2 from '../../../containers/ConfirmationPage2';
+import { TOGGLE_KEY } from '../../../constants';
+
+const mockStore = state => createStore(() => state);
+const initConfirmationPage = ({
+  formData = {},
+  submissionResponse = {},
+} = {}) => {
+  const store = mockStore({
+    form: {
+      ...createInitialState(formConfig),
+      submission: {
+        response: {
+          confirmationNumber: '1234567890',
+          pdfUrl: '/fake-pdf-url',
+          statusUrl: '/fake-status-url',
+          ...submissionResponse,
+        },
+        timestamp: new Date('2024-05-05T12:00:00Z'),
+      },
+      data: {
+        fullName: { first: 'Jane', last: 'Doe' },
+        dob: '2000-01-01',
+        email: 'test@test.com',
+        [`view:${TOGGLE_KEY}`]: true,
+        ...formData,
+      },
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <ConfirmationPage2
+        route={{
+          formConfig,
+        }}
+      />
+    </Provider>,
+  );
+};
+
+describe('COE ConfirmationPage2', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders alert content and COE status action link', () => {
+    const { container } = initConfirmationPage();
+    const alert = container.querySelector('va-alert');
+    expect(alert).to.exist;
+    expect(alert).to.have.attribute('status', 'success');
+    expect(alert.textContent).to.contain(
+      'Request submission started on May 5, 2024',
+    );
+    expect(alert.textContent).to.contain('Your submission is in progress.');
+    expect(alert.textContent).to.contain(
+      'After we receive your request, we’ll review your information and notify you by email on how to get your COE.',
+    );
+  });
+
+  it('renders the print section without the extra default copy', () => {
+    const { container } = initConfirmationPage();
+    expect(container.textContent).to.contain('Print this confirmation page');
+    expect(container.textContent).to.contain(
+      'If you’d like to keep a copy of the information on this page, you can print it now.',
+    );
+    expect(container.textContent).to.not.contain(
+      'You won’t be able to access this page later.',
+    );
+  });
+
+  it('renders the status section and what to expect process list', () => {
+    const { container } = initConfirmationPage();
+    expect(container.textContent).to.contain('What to expect');
+  });
+
+  it('renders the What to expect process list headings', () => {
+    const { container } = initConfirmationPage();
+    const items = Array.from(
+      container.querySelectorAll('va-process-list-item'),
+    );
+
+    expect(items.length).to.be.at.least(3);
+    expect(
+      container.querySelector(
+        'va-process-list-item[header="We’ll confirm when we are reviewing your request"]',
+      ),
+    ).to.exist;
+    expect(
+      container.querySelector(
+        'va-process-list-item[header="We’ll let you know if we need additional documentation"]',
+      ),
+    ).to.exist;
+    expect(
+      container.querySelector(
+        'va-process-list-item[header="We’ll provide a decision"]',
+      ),
+    ).to.exist;
+  });
+});

--- a/src/applications/lgy/coe/form/tests/unit/containers/selectors/ConfirmationPageSelector.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/unit/containers/selectors/ConfirmationPageSelector.unit.spec.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { cleanup, render } from '@testing-library/react';
+import { shouldUseNewConfirmation } from '../../../../containers/selectors/ConfirmationPageSelector';
+import { TOGGLE_KEY } from '../../../../constants';
+
+const mockStore = state => createStore(() => state);
+
+describe('COE ConfirmationPageSelector', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('shouldUseNewConfirmation', () => {
+    it('returns false when formData is empty', () => {
+      expect(shouldUseNewConfirmation({})).to.equal(false);
+    });
+
+    it('returns false when the toggle is falsy', () => {
+      expect(
+        shouldUseNewConfirmation({
+          [`view:${TOGGLE_KEY}`]: false,
+        }),
+      ).to.equal(false);
+    });
+
+    it('returns true when the toggle is truthy', () => {
+      expect(
+        shouldUseNewConfirmation({
+          [`view:${TOGGLE_KEY}`]: true,
+        }),
+      ).to.equal(true);
+    });
+
+    it('handles null/undefined safely', () => {
+      expect(shouldUseNewConfirmation(null)).to.equal(false);
+      expect(shouldUseNewConfirmation(undefined)).to.equal(false);
+    });
+  });
+
+  describe('renders with stubbed branch components', () => {
+    const loadSelectorWithStubs = () => {
+      const legacyPath = require.resolve(
+        '../../../../containers/ConfirmationPage',
+      );
+      const newPath = require.resolve(
+        '../../../../containers/ConfirmationPage2',
+      );
+      const selectorPath = require.resolve(
+        '../../../../containers/selectors/ConfirmationPageSelector',
+      );
+
+      delete require.cache[legacyPath];
+      delete require.cache[newPath];
+      delete require.cache[selectorPath];
+
+      require.cache[legacyPath] = {
+        id: legacyPath,
+        filename: legacyPath,
+        loaded: true,
+        exports: {
+          __esModule: true,
+          default: () => <div data-testid="legacy-confirmation" />,
+        },
+      };
+
+      require.cache[newPath] = {
+        id: newPath,
+        filename: newPath,
+        loaded: true,
+        exports: {
+          __esModule: true,
+          default: () => <div data-testid="new-confirmation" />,
+        },
+      };
+      return require('../../../../containers/selectors/ConfirmationPageSelector')
+        .default;
+    };
+
+    it('renders legacy confirmation when toggle is off', () => {
+      const ConfirmationPageSelector = loadSelectorWithStubs();
+      const store = mockStore({
+        form: {
+          data: {},
+        },
+      });
+      const { queryByTestId } = render(
+        <Provider store={store}>
+          <ConfirmationPageSelector
+            route={{
+              formConfig: {},
+            }}
+          />
+        </Provider>,
+      );
+
+      expect(queryByTestId('legacy-confirmation')).to.exist;
+      expect(queryByTestId('new-confirmation')).to.not.exist;
+    });
+
+    it('renders new confirmation when toggle is on', () => {
+      const ConfirmationPageSelector = loadSelectorWithStubs();
+      const store = mockStore({
+        form: {
+          data: {
+            [`view:${TOGGLE_KEY}`]: true,
+          },
+        },
+      });
+      const { queryByTestId } = render(
+        <Provider store={store}>
+          <ConfirmationPageSelector
+            route={{
+              formConfig: {},
+            }}
+          />{' '}
+        </Provider>,
+      );
+
+      expect(queryByTestId('new-confirmation')).to.exist;
+      expect(queryByTestId('legacy-confirmation')).to.not.exist;
+    });
+  });
+});

--- a/src/applications/lgy/coe/form/tests/unit/containers/selectors/ConfirmationPageSelector.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/unit/containers/selectors/ConfirmationPageSelector.unit.spec.jsx
@@ -3,84 +3,73 @@ import { expect } from 'chai';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { cleanup, render } from '@testing-library/react';
-import { shouldUseNewConfirmation } from '../../../../containers/selectors/ConfirmationPageSelector';
-import { TOGGLE_KEY } from '../../../../constants';
 
 const mockStore = state => createStore(() => state);
+const loadSelectorWithStubs = ({ enabled = false, isLoading = false } = {}) => {
+  const legacyPath = require.resolve('../../../../containers/ConfirmationPage');
+  const newPath = require.resolve('../../../../containers/ConfirmationPage2');
+  const toggleHookPath = require.resolve(
+    '~/platform/utilities/feature-toggles/useFeatureToggle',
+  );
+  const selectorPath = require.resolve(
+    '../../../../containers/selectors/ConfirmationPageSelector',
+  );
+
+  delete require.cache[legacyPath];
+  delete require.cache[newPath];
+  delete require.cache[toggleHookPath];
+  delete require.cache[selectorPath];
+
+  require.cache[legacyPath] = {
+    id: legacyPath,
+    filename: legacyPath,
+    loaded: true,
+    exports: {
+      __esModule: true,
+      default: () => <div data-testid="legacy-confirmation" />,
+    },
+  };
+
+  require.cache[newPath] = {
+    id: newPath,
+    filename: newPath,
+    loaded: true,
+    exports: {
+      __esModule: true,
+      default: () => <div data-testid="new-confirmation" />,
+    },
+  };
+
+  require.cache[toggleHookPath] = {
+    id: toggleHookPath,
+    filename: toggleHookPath,
+    loaded: true,
+    exports: {
+      __esModule: true,
+      useFeatureToggle: () => ({
+        TOGGLE_NAMES: {
+          coeFormRebuildCveTeam: 'coeFormRebuildCveTeam',
+        },
+        useToggleValue: () => enabled,
+        useToggleLoadingValue: () => isLoading,
+      }),
+    },
+  };
+
+  return require('../../../../containers/selectors/ConfirmationPageSelector')
+    .default;
+};
 
 describe('COE ConfirmationPageSelector', () => {
   afterEach(() => {
     cleanup();
   });
 
-  describe('shouldUseNewConfirmation', () => {
-    it('returns false when formData is empty', () => {
-      expect(shouldUseNewConfirmation({})).to.equal(false);
-    });
-
-    it('returns false when the toggle is falsy', () => {
-      expect(
-        shouldUseNewConfirmation({
-          [`view:${TOGGLE_KEY}`]: false,
-        }),
-      ).to.equal(false);
-    });
-
-    it('returns true when the toggle is truthy', () => {
-      expect(
-        shouldUseNewConfirmation({
-          [`view:${TOGGLE_KEY}`]: true,
-        }),
-      ).to.equal(true);
-    });
-
-    it('handles null/undefined safely', () => {
-      expect(shouldUseNewConfirmation(null)).to.equal(false);
-      expect(shouldUseNewConfirmation(undefined)).to.equal(false);
-    });
-  });
-
   describe('renders with stubbed branch components', () => {
-    const loadSelectorWithStubs = () => {
-      const legacyPath = require.resolve(
-        '../../../../containers/ConfirmationPage',
-      );
-      const newPath = require.resolve(
-        '../../../../containers/ConfirmationPage2',
-      );
-      const selectorPath = require.resolve(
-        '../../../../containers/selectors/ConfirmationPageSelector',
-      );
-
-      delete require.cache[legacyPath];
-      delete require.cache[newPath];
-      delete require.cache[selectorPath];
-
-      require.cache[legacyPath] = {
-        id: legacyPath,
-        filename: legacyPath,
-        loaded: true,
-        exports: {
-          __esModule: true,
-          default: () => <div data-testid="legacy-confirmation" />,
-        },
-      };
-
-      require.cache[newPath] = {
-        id: newPath,
-        filename: newPath,
-        loaded: true,
-        exports: {
-          __esModule: true,
-          default: () => <div data-testid="new-confirmation" />,
-        },
-      };
-      return require('../../../../containers/selectors/ConfirmationPageSelector')
-        .default;
-    };
-
     it('renders legacy confirmation when toggle is off', () => {
-      const ConfirmationPageSelector = loadSelectorWithStubs();
+      const ConfirmationPageSelector = loadSelectorWithStubs({
+        enabled: false,
+      });
       const store = mockStore({
         form: {
           data: {},
@@ -101,12 +90,12 @@ describe('COE ConfirmationPageSelector', () => {
     });
 
     it('renders new confirmation when toggle is on', () => {
-      const ConfirmationPageSelector = loadSelectorWithStubs();
+      const ConfirmationPageSelector = loadSelectorWithStubs({
+        enabled: true,
+      });
       const store = mockStore({
         form: {
-          data: {
-            [`view:${TOGGLE_KEY}`]: true,
-          },
+          data: {},
         },
       });
       const { queryByTestId } = render(
@@ -115,12 +104,36 @@ describe('COE ConfirmationPageSelector', () => {
             route={{
               formConfig: {},
             }}
-          />{' '}
+          />
         </Provider>,
       );
 
       expect(queryByTestId('new-confirmation')).to.exist;
       expect(queryByTestId('legacy-confirmation')).to.not.exist;
+    });
+
+    it('renders loading indicator while toggle value is loading', () => {
+      const ConfirmationPageSelector = loadSelectorWithStubs({
+        isLoading: true,
+      });
+      const store = mockStore({
+        form: {
+          data: {},
+        },
+      });
+      const { container, queryByTestId } = render(
+        <Provider store={store}>
+          <ConfirmationPageSelector
+            route={{
+              formConfig: {},
+            }}
+          />
+        </Provider>,
+      );
+
+      expect(container.querySelector('va-loading-indicator')).to.exist;
+      expect(queryByTestId('legacy-confirmation')).to.not.exist;
+      expect(queryByTestId('new-confirmation')).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This is work for the CVE team.
- We own this form.

## Related issue(s)

- CVE ticket [# 2437](https://va.ghe.com/orgs/software/projects/135/views/2?sliceBy%5Bvalue%5D=JOHN-RODRIGUEZ8&pane=issue&itemId=275661&issue=software%7Cva-cve%7C2437)

## What areas of the site does it impact?

No other areas.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
