### PR TITLE
Updates to expense card and verbiage for labels to be more generic

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/careFacilityExpenses/careExpensesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/careFacilityExpenses/careExpensesPages.js
@@ -24,6 +24,7 @@ import {
   careFrequencyLabels,
 } from '../../../../utils/labels';
 import { transformDate } from '../../05-claim-information/helpers';
+import { formatCurrency } from '../../../../utils/helpers';
 
 function introDescription() {
   return (
@@ -144,15 +145,34 @@ export const options = {
     ),
     getItemName: item => item?.provider || 'Care provider',
     cardDescription: item => {
-      if (!item?.careDateRange) {
-        return 'Care dates not provided';
+      const hasStartDate = !!item?.careDateRange?.from;
+      const hasEndDate = !!item?.careDateRange?.to;
+      let dateLabel = null;
+
+      if (hasStartDate && hasEndDate) {
+        dateLabel = `${transformDate(
+          item.careDateRange.from,
+        )} - ${transformDate(item.careDateRange.to)}`;
+      } else if (hasStartDate) {
+        dateLabel = transformDate(item.careDateRange.from);
       }
-      if (item?.careDateRange?.from && item?.careDateRange?.to) {
-        return `${transformDate(item.careDateRange.from)} - ${transformDate(
-          item.careDateRange.to,
-        )}`;
-      }
-      return transformDate(item.careDateRange.from);
+
+      const frequencyLabel = careFrequencyLabels[(item?.paymentFrequency)];
+      const amountLabel = formatCurrency(item?.paymentAmount);
+
+      return (
+        <div>
+          {dateLabel && (
+            <span className="vads-u-display--block">{dateLabel}</span>
+          )}
+          {frequencyLabel && (
+            <span className="vads-u-display--block">{frequencyLabel}</span>
+          )}
+          {amountLabel && (
+            <span className="vads-u-display--block">{amountLabel}</span>
+          )}
+        </div>
+      );
     },
     summaryTitle: 'Review your care expenses',
     yesNoBlankReviewQuestion: 'Do you have another care expense to add?',

--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/careFacilityExpenses/careExpensesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/careFacilityExpenses/careExpensesPages.js
@@ -143,7 +143,8 @@ export const options = {
         />
       </div>
     ),
-    getItemName: item => item?.provider || 'Care provider',
+    getItemName: (item, index) =>
+      `Expense ${index + 1}: ${item?.provider || 'Care provider'}`,
     cardDescription: item => {
       const hasStartDate = !!item?.careDateRange?.from;
       const hasEndDate = !!item?.careDateRange?.to;

--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/medicalExpenses/medicalExpensesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/medicalExpenses/medicalExpensesPages.js
@@ -233,7 +233,7 @@ const purposeDatePage = {
 
 const frequencyCostPage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Frequency and cost of care'),
+    ...arrayBuilderItemSubsequentPageTitleUI('Frequency and cost of expense'),
     paymentFrequency: radioUI({
       title: 'How often are the payments?',
       labels: frequencyLabels,

--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/medicalExpenses/medicalExpensesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/medicalExpenses/medicalExpensesPages.js
@@ -19,6 +19,7 @@ import {
 } from '../../../../utils/labels';
 import { transformDate } from '../../05-claim-information/helpers';
 import { customTextSchema } from '../../../definitions';
+import { formatCurrency } from '../../../../utils/helpers';
 
 function introDescription() {
   return (
@@ -70,8 +71,8 @@ function introDescription() {
 /** @type {ArrayBuilderOptions} */
 export const options = {
   arrayPath: 'medicalExpenses',
-  nounSingular: 'medical expense',
-  nounPlural: 'medical expenses',
+  nounSingular: 'expense',
+  nounPlural: 'expenses',
   required: false,
   maxItems: 6,
   isItemIncomplete: item =>
@@ -113,7 +114,8 @@ export const options = {
         />
       </div>
     ),
-    getItemName: item => item?.paymentRecipient || 'Medical expense',
+    getItemName: (item, index) =>
+      `Expense ${index + 1}: ${item?.provider || 'No provider name'}`,
     cardDescription: item => (
       <div>
         <span className="vads-u-display--block">
@@ -122,6 +124,9 @@ export const options = {
         <span className="vads-u-display--block">
           {frequencyLabels[(item?.paymentFrequency)] ||
             'Frequency not provided'}
+        </span>
+        <span className="vads-u-display--block">
+          {formatCurrency(item?.paymentAmount) || 'Amount not provided'}
         </span>
       </div>
     ),
@@ -274,7 +279,7 @@ export const medicalExpensesPages = arrayBuilderPages(options, pageBuilder => ({
     schema: purposeDatePage.schema,
   }),
   medicalFrequencyCostPage: pageBuilder.itemPage({
-    title: 'Frequency and cost of care',
+    title: 'Frequency and cost of expense',
     path: 'financial-information/medical-expenses/:index/frequency-cost',
     uiSchema: frequencyCostPage.uiSchema,
     schema: frequencyCostPage.schema,

--- a/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/careExpensesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/careExpensesPages.unit.spec.jsx
@@ -230,18 +230,39 @@ describe('Care Expenses Pages', () => {
     const { text } = options;
     const completeItem = {
       careDateRange: { from: '2020-01-01', to: '2020-01-31' },
+      paymentFrequency: 'MONTHLY',
+      paymentAmount: 500,
     };
     const partialItem = {
       careDateRange: { from: '2020-01-01' },
+      paymentFrequency: 'ANNUALLY',
+      paymentAmount: 1200,
+    };
+    const noDateItem = {
+      paymentFrequency: 'MONTHLY',
+      paymentAmount: 250,
     };
     const incompleteItem = {};
 
-    expect(text.cardDescription(completeItem)).to.equal(
-      `01/01/2020 - 01/31/2020`,
+    const { getByText, queryByText, rerender, container } = render(
+      text.cardDescription(completeItem),
     );
-    expect(text.cardDescription(partialItem)).to.equal('01/01/2020');
-    expect(text.cardDescription(incompleteItem)).to.equal(
-      'Care dates not provided',
-    );
+    expect(getByText('01/01/2020 - 01/31/2020')).to.exist;
+    expect(getByText('Once a month')).to.exist;
+    expect(getByText('$500')).to.exist;
+
+    rerender(text.cardDescription(partialItem));
+    expect(getByText('01/01/2020')).to.exist;
+    expect(queryByText('01/01/2020 - 01/31/2020')).to.not.exist;
+    expect(getByText('Once a year')).to.exist;
+    expect(getByText('$1,200')).to.exist;
+
+    rerender(text.cardDescription(noDateItem));
+    expect(queryByText('01/01/2020')).to.not.exist;
+    expect(getByText('Once a month')).to.exist;
+    expect(getByText('$250')).to.exist;
+
+    rerender(text.cardDescription(incompleteItem));
+    expect(container.textContent.trim()).to.equal('');
   });
 });

--- a/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/careExpensesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/careExpensesPages.unit.spec.jsx
@@ -223,8 +223,10 @@ describe('Care Expenses Pages', () => {
     };
     const itemWithoutName = {};
 
-    expect(text.getItemName(itemWithName)).to.equal('John Doe');
-    expect(text.getItemName(itemWithoutName)).to.equal('Care provider');
+    expect(text.getItemName(itemWithName, 0)).to.equal('Expense 1: John Doe');
+    expect(text.getItemName(itemWithoutName, 1)).to.equal(
+      'Expense 2: Care provider',
+    );
   });
   it('should show the correct cardDescription output', () => {
     const { text } = options;

--- a/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/medicalExpensesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/medicalExpensesPages.unit.spec.jsx
@@ -113,11 +113,13 @@ describe('Medical Expenses Pages', () => {
 
   it('should show the correct getItemName output', () => {
     const { text } = options;
-    const itemWithName = { paymentRecipient: 'Dr. Smith' };
-    const itemWithoutName = {};
+    const itemWithName = { provider: 'Dr. Smith' };
+    const itemWithoutName = { provider: '' };
 
-    expect(text.getItemName(itemWithName)).to.equal('Dr. Smith');
-    expect(text.getItemName(itemWithoutName)).to.equal('Medical expense');
+    expect(text.getItemName(itemWithName, 0)).to.equal('Expense 1: Dr. Smith');
+    expect(text.getItemName(itemWithoutName, 0)).to.equal(
+      'Expense 1: No provider name',
+    );
   });
   it('should show the correct cardDescription output', () => {
     const { text } = options;

--- a/src/applications/survivors-benefits/utils/helpers.jsx
+++ b/src/applications/survivors-benefits/utils/helpers.jsx
@@ -17,7 +17,32 @@ export const isSameOrAfter = (date1, date2) => {
   return isAfter(date1, date2) || isEqual(date1, date2);
 };
 
-export const formatCurrency = num => `$${num.toLocaleString()}`;
+/**
+ * Formats a numeric currency value for display.
+ *
+ * - Whole dollar amounts are displayed without cents (e.g. 1000 -> '$1,000')
+ * - Amounts with cents are displayed with exactly 2 decimal places (e.g. 10.5 -> '$10.50')
+ * - null or undefined values return a fallback string
+ *
+ * @param {number|null|undefined} amount - The numeric currency value to format
+ * @returns {string|null} The formatted currency string (e.g. '$1,000' or '$10.50'),
+ *   or null if amount is null or undefined. Use || to provide a fallback:
+ *   `formatCurrency(item?.paymentAmount) || 'Amount not provided'`
+ *
+ * @example
+ * formatCurrency(1000)      // '$1,000'
+ * formatCurrency(10.5)      // '$10.50'
+ * formatCurrency(1234567.89) // '$1,234,567.89'
+ * formatCurrency(null)      // null
+ * formatCurrency(undefined) // null
+ */
+export const formatCurrency = amount => {
+  if (amount == null) return null;
+  return `$${Number(amount).toLocaleString('en-US', {
+    minimumFractionDigits: Number.isInteger(amount) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
 
 const warDates = [
   ['1916-05-09', '1917-04-05'], // Mexican Border Period (May 9, 1916 - April 5, 1917)


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated noun labels from "medical expense/expenses" to "expense/expenses" for generic reuse
- Changed `getItemName` to use `provider` with an indexed prefix (`Expense 1: ...`)
- Added formatted payment amount to `cardDescription` using an improved `formatCurrency` helper
- Improved `formatCurrency` in `helpers.jsx` to support commas, conditional cents, and null-safe returns
- Updated unit tests to match the new `getItemName` signature and output

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131527
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131528
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127457

## Testing done

- unit tests
- Some manual testing adding and editing medical expenses

## Screenshots

<img width="533" height="715" alt="Screenshot 2026-03-05 at 2 38 13 PM" src="https://github.com/user-attachments/assets/04d5e054-9435-457a-903c-a7bcf165dd3e" />

<img width="542" height="711" alt="Screenshot 2026-03-05 at 3 48 20 PM" src="https://github.com/user-attachments/assets/7a96a852-7dcf-4e48-8290-f6fb44ed472b" />

### Care Expenses
<img width="1890" height="4976" alt="image" src="https://github.com/user-attachments/assets/8be65100-ecae-43aa-b0b9-2ccb955466f3" />



## What areas of the site does it impact?

543EZ form -> medical expenses

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
