### PR TITLE
[5815] Prefill Pattern Design mismatches

### DIFF
--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -621,9 +621,8 @@ export const ContactInfoBase = ({
           id={`${contactInfoPageKey}Header`}
           className="vads-u-margin-top--3 vads-u-margin-bottom--0"
         >
-          {content.title}
+          Confirm the contact information we have on file for you
         </MainHeader>
-        {content.description}
         {!loggedIn && (
           <strong className="usa-input-error-message">
             You must be logged in to enable view and edit this page.

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -292,7 +292,7 @@ export const ContactInfoBase = ({
   let headerLevel = contactSectionHeadingLevel;
   if (!headerLevel) {
     if (isMinimalHeader) {
-      headerLevel = '3';
+      headerLevel = '2';
     } else if (onReviewPage) {
       headerLevel = '5';
     } else {

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -395,7 +395,9 @@ export const ContactInfoBase = ({
     return (
       <ContactInfoCard
         key={FIELD_NAMES.MAILING_ADDRESS}
-        error={missingRequiredAddress ? 'You must add your address' : ''}
+        error={
+          submitted && missingRequiredAddress ? 'You must add your address' : ''
+        }
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.MAILING_ADDRESS)}
         formKey={keys.address}
@@ -434,7 +436,9 @@ export const ContactInfoBase = ({
       <ContactInfoCard
         key={FIELD_NAMES.HOME_PHONE}
         error={
-          missingRequiredHomePhone ? 'You must add your home phone number' : ''
+          submitted && missingRequiredHomePhone
+            ? 'You must add your home phone number'
+            : ''
         }
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.HOME_PHONE)}
@@ -475,7 +479,7 @@ export const ContactInfoBase = ({
       <ContactInfoCard
         key={FIELD_NAMES.MOBILE_PHONE}
         error={
-          missingRequiredMobilePhone
+          submitted && missingRequiredMobilePhone
             ? 'You must add your mobile phone number'
             : ''
         }
@@ -515,7 +519,11 @@ export const ContactInfoBase = ({
     return (
       <ContactInfoCard
         key={FIELD_NAMES.EMAIL}
-        error={missingRequiredEmail ? 'You must add your email address' : ''}
+        error={
+          submitted && missingRequiredEmail
+            ? 'You must add your email address'
+            : ''
+        }
         contactPath={contactPath}
         required={requiredKeys.includes(FIELD_NAMES.EMAIL)}
         formKey={keys.email}

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -11,6 +11,7 @@ import {
   isLoggedIn,
 } from '@department-of-veterans-affairs/platform-user/selectors';
 import { generateMockUser } from 'platform/site-wide/user-nav/tests/mocks/user';
+import { isMinimalHeaderPath } from 'platform/forms-system/src/js/patterns/minimal-header';
 import AddressView from 'platform/user/profile/vap-svc/components/AddressField/AddressView';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import {
@@ -274,8 +275,30 @@ export const ContactInfoBase = ({
     [missingInfo, hasInitialized, testContinueAlert],
   );
 
-  const MainHeader = onReviewPage ? 'h4' : 'h3';
-  const headerLevel = contactSectionHeadingLevel || (onReviewPage ? '5' : '4');
+  const isMinimalHeader = isMinimalHeaderPath();
+
+  let MainHeader = 'h3';
+  if (onReviewPage) {
+    MainHeader = 'h4';
+  } else if (isMinimalHeader) {
+    MainHeader = 'h1';
+  }
+
+  const mainHeaderClass =
+    isMinimalHeader && !onReviewPage
+      ? 'vads-u-margin-top--3 vads-u-margin-bottom--0 vads-u-font-size--h2'
+      : 'vads-u-margin-top--3 vads-u-margin-bottom--0';
+
+  let headerLevel = contactSectionHeadingLevel;
+  if (!headerLevel) {
+    if (isMinimalHeader) {
+      headerLevel = '3';
+    } else if (onReviewPage) {
+      headerLevel = '5';
+    } else {
+      headerLevel = '4';
+    }
+  }
 
   // Helper function to render email addresses consistently
   const renderEmail = emailData => {
@@ -632,7 +655,7 @@ export const ContactInfoBase = ({
       <form onSubmit={handlers.onSubmit}>
         <MainHeader
           id={`${contactInfoPageKey}Header`}
-          className="vads-u-margin-top--3 vads-u-margin-bottom--0"
+          className={mainHeaderClass}
         >
           Confirm the contact information we have on file for you
         </MainHeader>

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -287,6 +287,11 @@ export const ContactInfoBase = ({
 
   // Render alerts above contact sections
   const renderContactAlerts = () => {
+    // Don't show success alerts if there are errors
+    if (submitted && (missingInfo.length > 0 || validationErrors.length > 0)) {
+      return null;
+    }
+
     const alerts = [];
 
     Object.entries(fieldConfig).forEach(([id, { text, key }]) => {

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -642,7 +642,7 @@ export const ContactInfoBase = ({
     <>
       {contentBeforeButtons}
       <FormNavButtons
-        goBack={handlers.onGoBack}
+        goBack={!isMinimalHeader && handlers.onGoBack}
         goForward={handlers.onGoForward}
       />
       {contentAfterButtons}

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/EditContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/EditContactInfo.jsx
@@ -106,8 +106,7 @@ export const BuildPageBase = ({
           {field !== 'MAILING_ADDRESS' && (
             <va-alert status="info" visible slim>
               <p className="vads-u-margin--0">
-                Any changes you make will also be reflected on your VA.gov
-                profile.
+                Any changes you make will also be reflected on your profile.
               </p>
             </va-alert>
           )}

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/EditContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/EditContactInfo.jsx
@@ -12,6 +12,7 @@ import {
 import { usePrevious } from 'platform/utilities/react-hooks';
 import { withRouter } from 'react-router';
 import { refreshProfile, sanitizeUrl } from 'platform/user/exportsFile';
+import { isMinimalHeaderPath } from 'platform/forms-system/src/js/patterns/minimal-header';
 import {
   ContactInfoFormAppConfigProvider,
   useContactInfoFormAppConfig,
@@ -33,6 +34,7 @@ export const BuildPageBase = ({
   const Heading = editContactInfoHeadingLevel || 'h3';
   const headerRef = useRef(null);
   const contactInfoFormAppConfig = useContactInfoFormAppConfig();
+  const isMinimalHeader = isMinimalHeaderPath();
 
   const modalState = useSelector(state => state?.vapService.modal);
   const prevModalState = usePrevious(modalState);
@@ -101,7 +103,12 @@ export const BuildPageBase = ({
         keys: router?.location?.state?.keys || { wrapper: 'contactInfo' },
       }}
     >
-      <div className="va-profile-wrapper" onSubmit={handlers.onSubmit}>
+      <div
+        className={`va-profile-wrapper${
+          isMinimalHeader ? ' hide-cancel-button' : ''
+        }`}
+        onSubmit={handlers.onSubmit}
+      >
         <InitializeVAPServiceID>
           {field !== 'MAILING_ADDRESS' && (
             <va-alert status="info" visible slim>

--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultCardHeader.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultCardHeader.jsx
@@ -4,7 +4,7 @@ import { isMinimalHeaderPath } from 'platform/forms-system/src/js/patterns/minim
 
 export const DefaultCardHeader = ({ level = '3' }) => {
   const isMinimalHeader = isMinimalHeaderPath();
-  const HeaderTag = isMinimalHeader ? 'h3' : `h4`;
+  const HeaderTag = isMinimalHeader ? 'h2' : `h4`;
   const cardHeaderLevel = isMinimalHeader ? '3' : level;
 
   return (

--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultCardHeader.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultCardHeader.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isMinimalHeaderPath } from 'platform/forms-system/src/js/patterns/minimal-header';
 
 export const DefaultCardHeader = ({ level = '3' }) => {
+  const isMinimalHeader = isMinimalHeaderPath();
+  const HeaderTag = isMinimalHeader ? 'h3' : `h4`;
+  const cardHeaderLevel = isMinimalHeader ? '3' : level;
+
   return (
-    <h4 className={`vads-u-margin-top--0 vads-u-font-size--h${level}`}>
+    <HeaderTag
+      className={`vads-u-margin-top--0 vads-u-font-size--h${cardHeaderLevel}`}
+    >
       Personal information
-    </h4>
+    </HeaderTag>
   );
 };
 

--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultHeader.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultHeader.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export const DefaultHeader = () => {
   return (
     <h3 className="vads-u-margin-bottom--3">
-      Confirm the personal information we have on file for you.
+      Confirm the personal information we have on file for you
     </h3>
   );
 };

--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultHeader.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/DefaultHeader.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import { isMinimalHeaderPath } from 'platform/forms-system/src/js/patterns/minimal-header';
 
 export const DefaultHeader = () => {
+  const isMinimalHeader = isMinimalHeaderPath();
+  const HeaderTag = isMinimalHeader ? 'h1' : 'h3';
+  const headerClass = isMinimalHeader
+    ? 'vads-u-margin-bottom--3 vads-u-font-size--h2'
+    : 'vads-u-margin-bottom--3';
+
   return (
-    <h3 className="vads-u-margin-bottom--3">
+    <HeaderTag className={headerClass}>
       Confirm the personal information we have on file for you
-    </h3>
+    </HeaderTag>
   );
 };

--- a/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/PersonalInformation/PersonalInformation.jsx
@@ -162,23 +162,27 @@ export const PersonalInformation = ({
                   className="dd-privacy-hidden"
                   data-dd-action-name="Veteran's name"
                 >
-                  <strong>Name: </strong>
-                  {first || last ? (
-                    `${first || ''} ${middle || ''} ${last || ''}`
-                  ) : (
-                    <span data-testid="name-not-available">Not available</span>
-                  )}
-                  {suffix ? `, ${suffix}` : null}
+                  {'Name: '}
+                  <strong>
+                    {first || last ? (
+                      `${first || ''} ${middle || ''} ${last || ''}`
+                    ) : (
+                      <span data-testid="name-not-available">
+                        Not available
+                      </span>
+                    )}
+                    {suffix ? `, ${suffix}` : null}
+                  </strong>
                 </dd>
               </div>
             )}
             {finalConfig.ssn?.show && (
               <div className="vads-u-margin-bottom--2">
-                <dt className="vads-u-display--inline-block vads-u-font-weight--bold vads-u-margin-right--0p5">
+                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5">
                   {getSSNTitle()}
                 </dt>
                 <dd
-                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans"
+                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans vads-u-font-weight--bold"
                   data-dd-action-name="Veteran's SSN"
                 >
                   {ssn ? (
@@ -191,11 +195,11 @@ export const PersonalInformation = ({
             )}
             {finalConfig.vaFileNumber?.show && (
               <div className="vads-u-margin-bottom--2">
-                <dt className="vads-u-display--inline-block vads-u-font-weight--bold vads-u-margin-right--0p5">
+                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5">
                   Last 4 digits of VA file number:
                 </dt>
                 <dd
-                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans"
+                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans vads-u-font-weight--bold"
                   data-dd-action-name="Veteran's VA file number"
                 >
                   {vaFileLastFour ? (
@@ -210,11 +214,11 @@ export const PersonalInformation = ({
             )}
             {finalConfig.dateOfBirth?.show && (
               <div className="vads-u-margin-bottom--2">
-                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5 vads-u-font-weight--bold">
+                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5">
                   Date of birth:
                 </dt>
                 <dd
-                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans"
+                  className="vads-u-display--inline-block dd-privacy-mask vads-u-font-family--sans vads-u-font-weight--bold"
                   data-dd-action-name="Veteran's date of birth"
                 >
                   {isValid(dobDateObj) ? (
@@ -227,11 +231,11 @@ export const PersonalInformation = ({
             )}
             {finalConfig.sex?.show && (
               <div className="vads-u-margin-bottom--2">
-                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5 vads-u-font-weight--bold">
+                <dt className="vads-u-display--inline-block vads-u-margin-right--0p5">
                   Sex:
                 </dt>
                 <dd
-                  className="vads-u-display--inline-block dd-privacy-hidden"
+                  className="vads-u-display--inline-block dd-privacy-hidden vads-u-font-weight--bold"
                   data-dd-action-name="Veteran's sex"
                 >
                   {gender ? (

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -776,3 +776,11 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
 .additional-input-container:has(> [error]) {
   margin-top: 24px;
 }
+
+/* Hide cancel button in contact info edit pages */
+.hide-cancel-button {
+  button[data-testid="cancel-edit-button"],
+  va-button[data-testid="cancel-edit-button"] {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR:
- updates the header levels of prefill pattern components when Minimal Header is also present in a form that uses prefill
- removes the 'Cancel' button from the edit contact info pages when Minimal Header is present
- removes the 'Back' button on the personal and contact info pages when Minimal Header is present
- updates the Error State behavior of Contact Info page, such that the error state activates only when the user clicks "Continue" while there is missing required info
- removes the Success alert when the user clicks "Continue" to prevent Success and Error alerts stacking on top of eachother

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5815

## Testing done

- Manual testing
- Unit tests
- E2e tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| **Before** | **After** |
| ------ | ----- |
|<img width="652" height="524" alt="image" src="https://github.com/user-attachments/assets/ad92a749-cf1c-4f8d-8bc0-1a803bf602b6" />|<img width="596" height="604" alt="image" src="https://github.com/user-attachments/assets/25514b37-ebed-42d2-94ed-3a133ac6587e" />|
|<img width="422" height="424" alt="Screenshot 2026-03-05 152106" src="https://github.com/user-attachments/assets/49ae78da-a702-481a-be53-a7a1ca5403da" />|<img width="433" height="429" alt="image" src="https://github.com/user-attachments/assets/1ddc2f4b-8e2d-4def-84c4-a2580199d7d5" />|
|<img width="608" height="604" alt="image" src="https://github.com/user-attachments/assets/b0266cc6-8d2e-42a6-aa2c-cf71b24ffd13" />|<img width="541" height="590" alt="image" src="https://github.com/user-attachments/assets/047858b9-389f-4513-8970-d0ba7a99520a" />|
|<img width="360" height="311" alt="image" src="https://github.com/user-attachments/assets/d2b33b12-fce5-4f81-84c1-d0f892a5783d" />|<img width="393" height="329" alt="image" src="https://github.com/user-attachments/assets/da52cec7-1aff-4db5-bd06-dcc7255ea988" />|
|<img width="590" height="370" alt="image" src="https://github.com/user-attachments/assets/544b7586-757f-41cc-9e32-1556b4787253" />|<img width="442" height="364" alt="image" src="https://github.com/user-attachments/assets/1c00318d-5743-4b50-867b-0226ff4b83ed" />|
|<img width="547" height="245" alt="image" src="https://github.com/user-attachments/assets/32396c73-54f6-4366-84fc-d3cf91cf922c" />|<img width="560" height="245" alt="image" src="https://github.com/user-attachments/assets/d070c95c-9aeb-4a73-bfaa-a28a891bcc29" />|
|<img width="641" height="852" alt="image" src="https://github.com/user-attachments/assets/019a9131-595f-4f8b-a742-812d9bd0be16" />|<img width="626" height="729" alt="image" src="https://github.com/user-attachments/assets/bb417b92-55c7-4343-9bf8-2a159028f59b" />|

## What areas of the site does it impact?

Prefill pattern in platform

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
