### PR TITLE
[ARC/129841] Update 686c, 526ez to use submissionErrorLink config

### DIFF
--- a/src/applications/representative-form-upload/config/form-21-0966.jsx
+++ b/src/applications/representative-form-upload/config/form-21-0966.jsx
@@ -20,7 +20,7 @@ import ITFStatusLoadingIndicatorPage from '../components/ITFStatusLoadingIndicat
 import ITF403Error from '../components/ITF403Error';
 import ITF500Error from '../components/ITF500Error';
 import ITFExistingClaim from '../components/ITFExistingClaim';
-import ITFSubmissionErrorLink from './ITFSubmissionErrorLink';
+import SubmissionErrorLink from './submissionErrorLink';
 
 const form210966 = (pathname = null) => {
   const { subTitle, formNumber } = getFormContent(pathname);
@@ -53,7 +53,7 @@ const form210966 = (pathname = null) => {
     prefillEnabled: false,
     transformForSubmit: itfTransformForSubmit,
     submissionError: ITFSubmissionError,
-    submissionErrorLink: ITFSubmissionErrorLink,
+    submissionErrorLink: SubmissionErrorLink,
     defaultDefinitions: {},
     additionalRoutes: [
       {

--- a/src/applications/representative-form-upload/config/form-21-526-ez.jsx
+++ b/src/applications/representative-form-upload/config/form-21-526-ez.jsx
@@ -9,6 +9,7 @@ import { transformForSubmit } from './submit-transformer';
 import { getMockData, scrollAndFocusTarget, getFormContent } from '../helpers';
 import { CustomTopContent } from '../pages/helpers';
 import submissionError from './submissionError';
+import SubmissionErrorLink from './submissionErrorLink';
 
 const form21526Ez = (pathname = null) => {
   const { subTitle, formNumber } = getFormContent(pathname);
@@ -42,6 +43,7 @@ const form21526Ez = (pathname = null) => {
     prefillEnabled: false,
     transformForSubmit,
     submissionError,
+    submissionErrorLink: SubmissionErrorLink,
     defaultDefinitions: {},
     title: `Submit VA Form ${formNumber}`,
     subTitle,

--- a/src/applications/representative-form-upload/config/form-21-686-c.jsx
+++ b/src/applications/representative-form-upload/config/form-21-686-c.jsx
@@ -11,6 +11,7 @@ import { transformForSubmit } from './submit-transformer';
 import { getMockData, scrollAndFocusTarget, getFormContent } from '../helpers';
 import { CustomTopContent } from '../pages/helpers';
 import submissionError from './submissionError';
+import SubmissionErrorLink from './submissionErrorLink';
 
 const form21686C = (pathname = null) => {
   const { subTitle, formNumber } = getFormContent(pathname);
@@ -40,6 +41,7 @@ const form21686C = (pathname = null) => {
     prefillEnabled: false,
     transformForSubmit,
     submissionError,
+    submissionErrorLink: SubmissionErrorLink,
     defaultDefinitions: {},
     title: `Submit VA Form ${formNumber}`,
     subTitle,

--- a/src/applications/representative-form-upload/config/submissionError.js
+++ b/src/applications/representative-form-upload/config/submissionError.js
@@ -92,14 +92,6 @@ const SubmissionError = () => {
         . If you’re sure that representation is already established, try
         submitting the form again later.
       </p>
-      <p>
-        <a
-          className="vads-c-action-link--green"
-          href="/representative/submissions"
-        >
-          Go back to submissions page
-        </a>
-      </p>
     </va-alert>
   );
 };

--- a/src/applications/representative-form-upload/config/submissionErrorLink.jsx
+++ b/src/applications/representative-form-upload/config/submissionErrorLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ITFSubmissionErrorLink = () => {
+const SubmissionErrorLink = () => {
   return (
     <va-link-action
       type="primary"
@@ -11,4 +11,4 @@ const ITFSubmissionErrorLink = () => {
   );
 };
 
-export default ITFSubmissionErrorLink;
+export default SubmissionErrorLink;

--- a/src/applications/representative-form-upload/tests/unit/config/submissionError.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/config/submissionError.unit.spec.jsx
@@ -50,13 +50,6 @@ describe('<SubmissionError />', () => {
       expect(
         wrapper
           .find(
-            'a.vads-c-action-link--green[href="/representative/submissions"]',
-          )
-          .exists(),
-      ).to.be.true;
-      expect(
-        wrapper
-          .find(
             'a[href="https://www.va.gov/get-help-from-accredited-representative/appoint-rep/introduction/"]',
           )
           .exists(),


### PR DESCRIPTION
## Summary

- Update 686c and 526ez to use the new `submissionErrorLink` config created from ITF and prevent an additional "Go back to VA.gov" link from being rendered.
- Move action link outside of 686c and 526ez to match ITF implementation.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129841
- [Additional "Return to VA.gov" link on 686c and 526ez identified in OCTO Slack](https://dsva.slack.com/archives/C05SUUM4GAW/p1772742859001249?thread_ts=1772740933.380949&cid=C05SUUM4GAW)

## Testing done

- Tested both forms locally on MacOS/Chrome

## Screenshots

Before:
<img width="2492" height="2792" alt="image" src="https://github.com/user-attachments/assets/d0afc742-ddde-467d-b60b-7813a9bcd9c7" />

After:
<img width="680" height="952" alt="Screenshot 2026-03-05 at 4 13 56 PM" src="https://github.com/user-attachments/assets/e7f11328-54d5-47c5-b19f-1d45b2f73bdd" />
