### PR TITLE
133024: Update Complex Claims review and confirmation pages for community care

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ConfirmationPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ConfirmationPage.jsx
@@ -123,7 +123,7 @@ const ConfirmationPage = () => {
               <ExpensesAccordion
                 expenses={expenses}
                 documents={documents}
-                headerLevel={2}
+                headerLevel={3}
               />
             </>
           )}

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpenseCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpenseCard.jsx
@@ -4,7 +4,10 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
 
-import { useFeatureToggle, TOGGLE_NAMES } from 'platform/utilities/feature-toggles';
+import {
+  useFeatureToggle,
+  TOGGLE_NAMES,
+} from 'platform/utilities/feature-toggles';
 
 import {
   setReviewPageAlert,
@@ -69,10 +72,11 @@ const ExpenseCard = ({ apptId, claimId, expense, address, showEditDelete }) => {
         className="expense-card"
         data-testid={`expense-card-${expense.id}`}
       >
-        { ccEnabled
-          ? <h3 className="vads-u-margin-top--1">{header}</h3>
-          : <h4 className="vads-u-margin-top--1">{header}</h4>
-        }
+        {ccEnabled ? (
+          <h3 className="vads-u-margin-top--1">{header}</h3>
+        ) : (
+          <h4 className="vads-u-margin-top--1">{header}</h4>
+        )}
         {isDeleting ? (
           <div className="vads-u-text-align--center vads-u-margin--5">
             <va-loading-indicator message="Deleting..." set-focus={false} />

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpenseCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpenseCard.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
 
+import { useFeatureToggle, TOGGLE_NAMES } from 'platform/utilities/feature-toggles';
+
 import {
   setReviewPageAlert,
   deleteExpenseDeleteDocument,
@@ -29,6 +31,9 @@ const ExpenseCard = ({ apptId, claimId, expense, address, showEditDelete }) => {
   const header = isMileage
     ? 'Mileage expense'
     : `${formatDate(expense.dateIncurred)}, ${currency(expense.costRequested)}`;
+
+  const { useToggleValue } = useFeatureToggle();
+  const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
   const handleDeleteExpenseAndDocument = async () => {
     setShowDeleteModal(false);
@@ -64,7 +69,10 @@ const ExpenseCard = ({ apptId, claimId, expense, address, showEditDelete }) => {
         className="expense-card"
         data-testid={`expense-card-${expense.id}`}
       >
-        <h4 className="vads-u-margin-top--1">{header}</h4>
+        { ccEnabled
+          ? <h3 className="vads-u-margin-top--1">{header}</h3>
+          : <h4 className="vads-u-margin-top--1">{header}</h4>
+        }
         {isDeleting ? (
           <div className="vads-u-text-align--center vads-u-margin--5">
             <va-loading-indicator message="Deleting..." set-focus={false} />

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpenseCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpenseCard.jsx
@@ -5,11 +5,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
 
 import {
-  useFeatureToggle,
-  TOGGLE_NAMES,
-} from 'platform/utilities/feature-toggles';
-
-import {
   setReviewPageAlert,
   deleteExpenseDeleteDocument,
   clearReviewPageAlert,
@@ -21,7 +16,14 @@ import { currency } from '../../../util/string-helpers';
 import ExpenseCardDetails from './ExpenseCardDetails';
 import DeleteExpenseModal from './DeleteExpenseModal';
 
-const ExpenseCard = ({ apptId, claimId, expense, address, showEditDelete }) => {
+const ExpenseCard = ({
+  apptId,
+  claimId,
+  expense,
+  address,
+  showEditDelete,
+  decreaseHeaderLevel,
+}) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const dispatch = useDispatch();
 
@@ -34,9 +36,6 @@ const ExpenseCard = ({ apptId, claimId, expense, address, showEditDelete }) => {
   const header = isMileage
     ? 'Mileage expense'
     : `${formatDate(expense.dateIncurred)}, ${currency(expense.costRequested)}`;
-
-  const { useToggleValue } = useFeatureToggle();
-  const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
   const handleDeleteExpenseAndDocument = async () => {
     setShowDeleteModal(false);
@@ -72,7 +71,7 @@ const ExpenseCard = ({ apptId, claimId, expense, address, showEditDelete }) => {
         className="expense-card"
         data-testid={`expense-card-${expense.id}`}
       >
-        {ccEnabled ? (
+        {decreaseHeaderLevel ? (
           <h3 className="vads-u-margin-top--1">{header}</h3>
         ) : (
           <h4 className="vads-u-margin-top--1">{header}</h4>
@@ -168,6 +167,7 @@ ExpenseCard.propTypes = {
   address: PropTypes.object,
   apptId: PropTypes.string,
   claimId: PropTypes.string,
+  decreaseHeaderLevel: PropTypes.bool,
   showEditDelete: PropTypes.bool,
 };
 

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpenseCardList.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpenseCardList.jsx
@@ -4,6 +4,10 @@ import { VaButton } from '@department-of-veterans-affairs/component-library/dist
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
+import {
+  useFeatureToggle,
+  TOGGLE_NAMES,
+} from 'platform/utilities/feature-toggles';
 
 import ExpenseCard from './ExpenseCard';
 import { getExpenseType } from '../../../util/complex-claims-helper';
@@ -21,6 +25,9 @@ const ExpenseCardList = ({
   const { apptId, claimId } = useParams();
   const address = useSelector(selectVAPResidentialAddress);
   const expenseFields = getExpenseType(type);
+
+  const { useToggleValue } = useFeatureToggle();
+  const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
   const onAddExpense = expenseRoute => {
     dispatch(setExpenseBackDestination('review'));
@@ -41,6 +48,7 @@ const ExpenseCardList = ({
           expense={expense}
           address={address}
           showEditDelete={showEditDelete}
+          decreaseHeaderLevel={ccEnabled && !showHeader}
         />
       ))}
 

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -32,7 +32,9 @@ const ExpensesAccordion = ({
   const proofOfAttendanceDocument = useMemo(
     () =>
       documents.find(d =>
-        d.filename?.startsWith(`${PROOF_OF_ATTENDANCE_FILENAME}.`),
+        d.filename
+          ?.toLowerCase()
+          .startsWith(`${PROOF_OF_ATTENDANCE_FILENAME}.`),
       ),
     [documents],
   );

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -59,25 +59,31 @@ const ExpensesAccordion = ({
   });
   const hasExpenses = expenseEntries.length > 0;
   const showProofOfAttendance =
-    ccEnabled &&
-    isAppointmentCC &&
-    !!proofOfAttendanceDocument &&
-    groupAccordionItemsByType;
+    ccEnabled && isAppointmentCC && !!proofOfAttendanceDocument;
 
   // No expenses case
-  if (!hasExpenses) {
-    return showProofOfAttendance ? (
-      <va-accordion open-single>
-        <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
-      </va-accordion>
-    ) : null;
+  if (!hasExpenses && !showProofOfAttendance) {
+    return null;
   }
+
+  const expensesAccordionTitle = showProofOfAttendance
+    ? 'Submitted expenses and files'
+    : 'Submitted expenses';
 
   return (
     <va-accordion open-single={!groupAccordionItemsByType}>
-      {showProofOfAttendance && (
-        <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
-      )}
+      {showProofOfAttendance &&
+        groupAccordionItemsByType && (
+          <va-accordion-item
+            key="proof-of-attendance"
+            header="Proof of attendance"
+            level={headerLevel}
+          >
+            <ProofOfAttendanceCard
+              filename={proofOfAttendanceDocument.filename}
+            />
+          </va-accordion-item>
+        )}
       {groupAccordionItemsByType ? (
         // Multiple accordion items (one per type)
         // Edit and Delete expense buttons show on the expense card
@@ -100,10 +106,22 @@ const ExpensesAccordion = ({
         // Single accordion item with grouped sections inside
         // Expense cards are organized by type and each type has a header that is displayed
         <va-accordion-item
-          header="Submitted expenses"
+          header={expensesAccordionTitle}
           bordered
           level={headerLevel}
         >
+          {showProofOfAttendance && (
+            <>
+              <h3 data-testid="proof-of-attendance-header">
+                Proof of attendance
+              </h3>
+              <ProofOfAttendanceCard
+                filename={proofOfAttendanceDocument.filename}
+                showEdit={false}
+                decreaseHeaderLevel
+              />
+            </>
+          )}
           {expenseEntries.map(([type, expensesList]) => (
             <ExpenseCardList
               key={type}

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -58,10 +58,15 @@ const ExpensesAccordion = ({
     return expenseTypeOrder.indexOf(a) - expenseTypeOrder.indexOf(b);
   });
   const hasExpenses = expenseEntries.length > 0;
+  const showProofOfAttendance =
+    ccEnabled &&
+    isAppointmentCC &&
+    !!proofOfAttendanceDocument &&
+    groupAccordionItemsByType;
 
   // No expenses case
   if (!hasExpenses) {
-    return ccEnabled && isAppointmentCC && !!proofOfAttendanceDocument ? (
+    return showProofOfAttendance ? (
       <va-accordion open-single>
         <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
       </va-accordion>
@@ -70,13 +75,9 @@ const ExpensesAccordion = ({
 
   return (
     <va-accordion open-single={!groupAccordionItemsByType}>
-      {ccEnabled &&
-        isAppointmentCC &&
-        !!proofOfAttendanceDocument && (
-          <ProofOfAttendanceCard
-            filename={proofOfAttendanceDocument.filename}
-          />
-        )}
+      {showProofOfAttendance && (
+        <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
+      )}
       {groupAccordionItemsByType ? (
         // Multiple accordion items (one per type)
         // Edit and Delete expense buttons show on the expense card

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -29,8 +29,8 @@ const ExpensesAccordion = ({
 
   const proofOfAttendanceDocument = useMemo(
     () =>
-      documents.find(
-        d => d.filename?.split('.')?.[0] === PROOF_OF_ATTENDANCE_FILENAME,
+      documents.find(d =>
+        d.filename?.startsWith(`${PROOF_OF_ATTENDANCE_FILENAME}.`),
       ),
     [documents],
   );

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom-v5-compat';
+import { useSelector } from 'react-redux';
 
 import {
   useFeatureToggle,
   TOGGLE_NAMES,
 } from 'platform/utilities/feature-toggles';
-import { useSelector } from 'react-redux';
 import ExpenseCardList from './ExpenseCardList';
 import { getExpenseType } from '../../../util/complex-claims-helper';
 import {
@@ -21,6 +22,7 @@ const ExpensesAccordion = ({
   groupAccordionItemsByType = false,
   headerLevel = 3,
 }) => {
+  const { apptId, claimId } = useParams();
   const { useToggleValue } = useFeatureToggle();
   const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
@@ -71,11 +73,13 @@ const ExpensesAccordion = ({
       {showProofOfAttendance &&
         groupAccordionItemsByType && (
           <va-accordion-item
-            key="proof-of-attendance"
+            key="proof-of-attendance-item"
             header="Proof of attendance"
             level={headerLevel}
           >
             <ProofOfAttendanceCard
+              apptId={apptId}
+              claimId={claimId}
               filename={proofOfAttendanceDocument.filename}
             />
           </va-accordion-item>
@@ -116,6 +120,8 @@ const ExpensesAccordion = ({
                 Proof of attendance
               </h3>
               <ProofOfAttendanceCard
+                apptId={apptId}
+                claimId={claimId}
                 filename={proofOfAttendanceDocument.filename}
                 showEdit={false}
                 decreaseHeaderLevel

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -1,25 +1,19 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
-import ExpenseCardList from './ExpenseCardList';
-import { getExpenseType } from '../../../util/complex-claims-helper';
-import { EXPENSE_TYPES, PROOF_OF_ATTENDANCE_FILENAME } from '../../../constants';
-import ProofOfAttendanceCard from './ProofOfAttendanceCard';
 import {
   useFeatureToggle,
   TOGGLE_NAMES,
 } from 'platform/utilities/feature-toggles';
-import { selectAppointment } from '../../../redux/selectors';
 import { useSelector } from 'react-redux';
-
-const findProofOfAttendanceDocument = documents =>
-  useMemo(
-    () =>
-      documents.find(
-        d => d.filename?.split('.')?.[0] === PROOF_OF_ATTENDANCE_FILENAME,
-      ),
-    [documents],
-  ) || { filename: 'proof-of-attendance.pdf' };
+import ExpenseCardList from './ExpenseCardList';
+import { getExpenseType } from '../../../util/complex-claims-helper';
+import {
+  EXPENSE_TYPES,
+  PROOF_OF_ATTENDANCE_FILENAME,
+} from '../../../constants';
+import ProofOfAttendanceCard from './ProofOfAttendanceCard';
+import { selectAppointment } from '../../../redux/selectors';
 
 const ExpensesAccordion = ({
   documents = [],
@@ -29,9 +23,17 @@ const ExpensesAccordion = ({
 }) => {
   const { useToggleValue } = useFeatureToggle();
   const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
+
   const appointment = useSelector(selectAppointment);
   const isAppointmentCC = appointment?.data?.isCC || true; // TODO: remove true
-  const proofOfAttendanceDocument = findProofOfAttendanceDocument(documents);
+
+  const proofOfAttendanceDocument = useMemo(
+    () =>
+      documents.find(
+        d => d.filename?.split('.')?.[0] === PROOF_OF_ATTENDANCE_FILENAME,
+      ),
+    [documents],
+  ) || { filename: 'proof-of-attendance.pdf' };
 
   // Group expenses by expenseType and attach their document
   const groupedExpenses = useMemo(
@@ -68,9 +70,13 @@ const ExpensesAccordion = ({
 
   return (
     <va-accordion open-single={!groupAccordionItemsByType}>
-      { ccEnabled && isAppointmentCC && !!proofOfAttendanceDocument && (
-        <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
-      )}
+      {ccEnabled &&
+        isAppointmentCC &&
+        !!proofOfAttendanceDocument && (
+          <ProofOfAttendanceCard
+            filename={proofOfAttendanceDocument.filename}
+          />
+        )}
       {groupAccordionItemsByType ? (
         // Multiple accordion items (one per type)
         // Edit and Delete expense buttons show on the expense card

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -3,7 +3,23 @@ import PropTypes from 'prop-types';
 
 import ExpenseCardList from './ExpenseCardList';
 import { getExpenseType } from '../../../util/complex-claims-helper';
-import { EXPENSE_TYPES } from '../../../constants';
+import { EXPENSE_TYPES, PROOF_OF_ATTENDANCE_FILENAME } from '../../../constants';
+import ProofOfAttendanceCard from './ProofOfAttendanceCard';
+import {
+  useFeatureToggle,
+  TOGGLE_NAMES,
+} from 'platform/utilities/feature-toggles';
+import { selectAppointment } from '../../../redux/selectors';
+import { useSelector } from 'react-redux';
+
+const findProofOfAttendanceDocument = documents =>
+  useMemo(
+    () =>
+      documents.find(
+        d => d.filename?.split('.')?.[0] === PROOF_OF_ATTENDANCE_FILENAME,
+      ),
+    [documents],
+  ) || { filename: 'proof-of-attendance.pdf' };
 
 const ExpensesAccordion = ({
   documents = [],
@@ -11,6 +27,12 @@ const ExpensesAccordion = ({
   groupAccordionItemsByType = false,
   headerLevel = 3,
 }) => {
+  const { useToggleValue } = useFeatureToggle();
+  const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
+  const appointment = useSelector(selectAppointment);
+  const isAppointmentCC = appointment?.data?.isCC || true; // TODO: remove true
+  const proofOfAttendanceDocument = findProofOfAttendanceDocument(documents);
+
   // Group expenses by expenseType and attach their document
   const groupedExpenses = useMemo(
     () => {
@@ -37,11 +59,18 @@ const ExpensesAccordion = ({
 
   // No expenses case
   if (!hasExpenses) {
-    return null;
+    return ccEnabled && isAppointmentCC && !!proofOfAttendanceDocument ? (
+      <va-accordion open-single>
+        <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
+      </va-accordion>
+    ) : null;
   }
 
   return (
     <va-accordion open-single={!groupAccordionItemsByType}>
+      { ccEnabled && isAppointmentCC && !!proofOfAttendanceDocument && (
+        <ProofOfAttendanceCard filename={proofOfAttendanceDocument.filename} />
+      )}
       {groupAccordionItemsByType ? (
         // Multiple accordion items (one per type)
         // Edit and Delete expense buttons show on the expense card

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -66,10 +66,6 @@ const ExpensesAccordion = ({
     return null;
   }
 
-  const expensesAccordionTitle = showProofOfAttendance
-    ? 'Submitted expenses and files'
-    : 'Submitted expenses';
-
   return (
     <va-accordion open-single={!groupAccordionItemsByType}>
       {showProofOfAttendance &&
@@ -106,7 +102,11 @@ const ExpensesAccordion = ({
         // Single accordion item with grouped sections inside
         // Expense cards are organized by type and each type has a header that is displayed
         <va-accordion-item
-          header={expensesAccordionTitle}
+          header={
+            showProofOfAttendance
+              ? 'Submitted expenses and files'
+              : 'Submitted expenses'
+          }
           bordered
           level={headerLevel}
         >

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensesAccordion.jsx
@@ -25,7 +25,7 @@ const ExpensesAccordion = ({
   const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
   const appointment = useSelector(selectAppointment);
-  const isAppointmentCC = appointment?.data?.isCC || true; // TODO: remove true
+  const isAppointmentCC = appointment?.data?.isCC;
 
   const proofOfAttendanceDocument = useMemo(
     () =>
@@ -33,7 +33,7 @@ const ExpensesAccordion = ({
         d => d.filename?.split('.')?.[0] === PROOF_OF_ATTENDANCE_FILENAME,
       ),
     [documents],
-  ) || { filename: 'proof-of-attendance.pdf' };
+  );
 
   // Group expenses by expenseType and attach their document
   const groupedExpenses = useMemo(

--- a/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
@@ -13,19 +13,20 @@ const ProofOfAttendanceCard = ({ filename }) => {
       <div className="vads-u-margin-top--2">
         <va-card
           className="expense-card"
-          data-testid={`proof-of-attendance-card`}
+          data-testid="proof-of-attendance-card"
         >
           <h3 className="vads-u-margin-top--1">File name</h3>
           <p>{filename}</p>
           <p>
-            <span className="vads-u-font-weight--bold">Note:</span> We've
-            changed your file name to "{PROOF_OF_ATTENDANCE_FILENAME}."
+            <span className="vads-u-font-weight--bold">Note:</span> We’ve
+            changed your file name to "{PROOF_OF_ATTENDANCE_FILENAME}
+            ."
           </p>
           <div className="review-button-row">
             <div className="review-edit-button">
               <Link
-                data-testid={`proof-of-attendance-edit-link`}
-                to={`/`} // TODO PoA: Go to proof of attendance page
+                data-testid="proof-of-attendance-edit-link"
+                to="/" // TODO: Go to proof of attendance edit page
               >
                 Edit
                 <va-icon

--- a/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom-v5-compat';
 import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../constants';
 
 const ProofOfAttendanceCard = ({
+  apptId,
+  claimId,
   filename,
   decreaseHeaderLevel = false,
   showEdit = true,
@@ -26,7 +28,7 @@ const ProofOfAttendanceCard = ({
             <div className="review-edit-button">
               <Link
                 data-testid="proof-of-attendance-edit-link"
-                to="/" // TODO: Go to proof of attendance edit page
+                to={`/file-new-claim/${apptId}/${claimId}/proof-of-attendance`}
               >
                 Edit
                 <va-icon
@@ -46,6 +48,8 @@ const ProofOfAttendanceCard = ({
 
 ProofOfAttendanceCard.propTypes = {
   filename: PropTypes.string.isRequired,
+  apptId: PropTypes.string,
+  claimId: PropTypes.string,
   decreaseHeaderLevel: PropTypes.bool,
   showEdit: PropTypes.bool,
 };

--- a/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
-import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../constants';
 
 const ProofOfAttendanceCard = ({
   apptId,
@@ -11,6 +10,7 @@ const ProofOfAttendanceCard = ({
   showEdit = true,
 }) => {
   const HeadingTag = decreaseHeaderLevel ? 'h4' : 'h3';
+  const filenameWithoutExtension = filename?.replace(/\.[^.]+$/, '');
 
   return (
     <div className="vads-u-margin-top--2">
@@ -19,7 +19,7 @@ const ProofOfAttendanceCard = ({
         <p>{filename}</p>
         <p>
           <span className="vads-u-font-weight--bold">Note:</span>
-          {` We’ve changed your file name to "${PROOF_OF_ATTENDANCE_FILENAME}."`}
+          {` We’ve changed your file name to "${filenameWithoutExtension}."`}
         </p>
         <div className="review-button-row">
           {showEdit && (

--- a/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
@@ -10,14 +10,12 @@ const ProofOfAttendanceCard = ({
   decreaseHeaderLevel = false,
   showEdit = true,
 }) => {
+  const HeadingTag = decreaseHeaderLevel ? 'h4' : 'h3';
+
   return (
     <div className="vads-u-margin-top--2">
       <va-card className="expense-card" data-testid="proof-of-attendance-card">
-        {decreaseHeaderLevel ? (
-          <h4 className="vads-u-margin-top--1">File name</h4>
-        ) : (
-          <h3 className="vads-u-margin-top--1">File name</h3>
-        )}
+        <HeadingTag className="vads-u-margin-top--1">File name</HeadingTag>
         <p>{filename}</p>
         <p>
           <span className="vads-u-font-weight--bold">Note:</span>

--- a/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom-v5-compat';
+import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../constants';
+
+const ProofOfAttendanceCard = ({ filename }) => {
+  return (
+    <va-accordion-item
+      key="proof-of-attendance"
+      header="Proof of attendance"
+      level={2}
+    >
+      <div className="vads-u-margin-top--2">
+        <va-card
+          className="expense-card"
+          data-testid={`proof-of-attendance-card`}
+        >
+          <h3 className="vads-u-margin-top--1">File name</h3>
+          <p>{filename}</p>
+          <p>
+            <span className="vads-u-font-weight--bold">Note:</span> We've
+            changed your file name to "{PROOF_OF_ATTENDANCE_FILENAME}."
+          </p>
+          <div className="review-button-row">
+            <div className="review-edit-button">
+              <Link
+                data-testid={`proof-of-attendance-edit-link`}
+                to={`/`} // TODO PoA: Go to proof of attendance page
+              >
+                Edit
+                <va-icon
+                  active
+                  icon="navigate_next"
+                  size={3}
+                  aria-hidden="true"
+                />
+              </Link>
+            </div>
+          </div>
+        </va-card>
+      </div>
+    </va-accordion-item>
+  );
+};
+
+ProofOfAttendanceCard.propTypes = {
+  filename: PropTypes.string.isRequired,
+};
+
+export default ProofOfAttendanceCard;

--- a/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ProofOfAttendanceCard.jsx
@@ -3,26 +3,26 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
 import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../constants';
 
-const ProofOfAttendanceCard = ({ filename }) => {
+const ProofOfAttendanceCard = ({
+  filename,
+  decreaseHeaderLevel = false,
+  showEdit = true,
+}) => {
   return (
-    <va-accordion-item
-      key="proof-of-attendance"
-      header="Proof of attendance"
-      level={2}
-    >
-      <div className="vads-u-margin-top--2">
-        <va-card
-          className="expense-card"
-          data-testid="proof-of-attendance-card"
-        >
+    <div className="vads-u-margin-top--2">
+      <va-card className="expense-card" data-testid="proof-of-attendance-card">
+        {decreaseHeaderLevel ? (
+          <h4 className="vads-u-margin-top--1">File name</h4>
+        ) : (
           <h3 className="vads-u-margin-top--1">File name</h3>
-          <p>{filename}</p>
-          <p>
-            <span className="vads-u-font-weight--bold">Note:</span> We’ve
-            changed your file name to "{PROOF_OF_ATTENDANCE_FILENAME}
-            ."
-          </p>
-          <div className="review-button-row">
+        )}
+        <p>{filename}</p>
+        <p>
+          <span className="vads-u-font-weight--bold">Note:</span>
+          {` We’ve changed your file name to "${PROOF_OF_ATTENDANCE_FILENAME}."`}
+        </p>
+        <div className="review-button-row">
+          {showEdit && (
             <div className="review-edit-button">
               <Link
                 data-testid="proof-of-attendance-edit-link"
@@ -37,15 +37,17 @@ const ProofOfAttendanceCard = ({ filename }) => {
                 />
               </Link>
             </div>
-          </div>
-        </va-card>
-      </div>
-    </va-accordion-item>
+          )}
+        </div>
+      </va-card>
+    </div>
   );
 };
 
 ProofOfAttendanceCard.propTypes = {
   filename: PropTypes.string.isRequired,
+  decreaseHeaderLevel: PropTypes.bool,
+  showEdit: PropTypes.bool,
 };
 
 export default ProofOfAttendanceCard;

--- a/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
@@ -4,7 +4,10 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-import { useFeatureToggle, TOGGLE_NAMES } from 'platform/utilities/feature-toggles';
+import {
+  useFeatureToggle,
+  TOGGLE_NAMES,
+} from 'platform/utilities/feature-toggles';
 import { focusElement } from 'platform/utilities/ui/focus';
 import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import ReviewPageAlert from './ReviewPageAlert';
@@ -154,7 +157,7 @@ const ReviewPage = () => {
             accept the travel agreement and submit your claim. Make sure to file
             your claim within 30 days of your appointment.
           </p>
-          { !ccEnabled && <h2>Expense types</h2> }
+          {!ccEnabled && <h2>Expense types</h2>}
           <ExpensesAccordion
             expenses={expenses}
             documents={documents}

--- a/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ReviewPage.jsx
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
+import { useFeatureToggle, TOGGLE_NAMES } from 'platform/utilities/feature-toggles';
 import { focusElement } from 'platform/utilities/ui/focus';
 import useSetPageTitle from '../../../hooks/useSetPageTitle';
 import ReviewPageAlert from './ReviewPageAlert';
@@ -31,6 +32,9 @@ const ReviewPage = () => {
   const expenses = useSelector(selectAllExpenses) ?? [];
   const documents = useSelector(selectAllDocuments) ?? [];
   const alertMessage = useSelector(selectReviewPageAlert);
+
+  const { useToggleValue } = useFeatureToggle();
+  const ccEnabled = useToggleValue(TOGGLE_NAMES.travelPayEnableCommunityCare);
 
   const title = 'Your unsubmitted expenses';
 
@@ -150,12 +154,12 @@ const ReviewPage = () => {
             accept the travel agreement and submit your claim. Make sure to file
             your claim within 30 days of your appointment.
           </p>
-          <h2>Expense types</h2>
+          { !ccEnabled && <h2>Expense types</h2> }
           <ExpensesAccordion
             expenses={expenses}
             documents={documents}
             groupAccordionItemsByType
-            headerLevel={3}
+            headerLevel={ccEnabled ? 2 : 3}
           />
           <div className="vads-u-margin-top--3">
             <va-card data-testid="summary-box" background>

--- a/src/applications/travel-pay/constants.js
+++ b/src/applications/travel-pay/constants.js
@@ -300,4 +300,3 @@ export const ACCEPTED_FILE_TYPES = Object.freeze([
 ]);
 
 export const PROOF_OF_ATTENDANCE_FILENAME = 'proof-of-attendance';
-

--- a/src/applications/travel-pay/constants.js
+++ b/src/applications/travel-pay/constants.js
@@ -298,3 +298,6 @@ export const ACCEPTED_FILE_TYPES = Object.freeze([
   '.tif',
   '.tiff',
 ]);
+
+export const PROOF_OF_ATTENDANCE_FILENAME = 'proof-of-attendance';
+

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpenseCard.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpenseCard.unit.spec.jsx
@@ -76,7 +76,7 @@ describe('ExpenseCard', () => {
   // Helper to render the component with router + store
   const renderExpenseCard = (
     expense = defaultMileageExpense,
-    showEditDelete = true,
+    { showEditDelete = true, decreaseHeaderLevel = false } = {},
   ) =>
     renderWithStoreAndRouter(
       <MemoryRouter initialEntries={['/review']}>
@@ -84,6 +84,7 @@ describe('ExpenseCard', () => {
           expense={expense}
           address={expense.address}
           showEditDelete={showEditDelete}
+          decreaseHeaderLevel={decreaseHeaderLevel}
         />
       </MemoryRouter>,
       { initialState: getData(), reducers: reducer },
@@ -225,7 +226,7 @@ describe('ExpenseCard', () => {
   it('renders mileage component with no edit button, delete button or delete modal', () => {
     const { getByText, container, queryByTestId } = renderExpenseCard(
       defaultMileageExpense,
-      false,
+      { showEditDelete: false },
     );
 
     expect(getByText('Mileage expense')).to.exist;
@@ -244,6 +245,22 @@ describe('ExpenseCard', () => {
 
     // Delete modal does not exist
     expect(queryByTestId('delete-expense-modal')).to.not.exist;
+  });
+
+  it('renders h4 header by default', () => {
+    const { container } = renderExpenseCard();
+    const h4 = container.querySelector('h4');
+    expect(h4).to.exist;
+    expect(h4.textContent).to.equal('Mileage expense');
+  });
+
+  it('renders h3 header when decreaseHeaderLevel is true', () => {
+    const { container } = renderExpenseCard(defaultMileageExpense, {
+      decreaseHeaderLevel: true,
+    });
+    const h3 = container.querySelector('h3');
+    expect(h3).to.exist;
+    expect(h3.textContent).to.equal('Mileage expense');
   });
 
   it('dispatches setReviewPageAlert when deleting expense fails', async () => {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpenseCardList.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpenseCardList.unit.spec.jsx
@@ -180,4 +180,45 @@ describe('Complex Claims - <ExpenseCardList />', () => {
       `/file-new-claim/${apptId}/${claimId}/parking`,
     );
   });
+
+  describe('decreaseHeaderLevel prop on ExpenseCard', () => {
+    const getCCState = (ccEnabled = true) => ({
+      ...initialState,
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        travel_pay_enable_community_care: ccEnabled,
+      },
+    });
+
+    it('decreases the header level when ccEnabled and not showing the header', () => {
+      const { container } = renderList(
+        { type: 'Parking', expensesList, showHeader: false },
+        getCCState(true),
+      );
+
+      const h3 = container.querySelector('h3');
+      expect(h3).to.exist;
+      expect(container.querySelector('h4')).to.not.exist;
+    });
+
+    it('does not decrease the header level when ccEnabled but showing the header', () => {
+      const { container } = renderList(
+        { type: 'Parking', expensesList, showHeader: true },
+        getCCState(true),
+      );
+
+      const h4 = container.querySelector('h4');
+      expect(h4).to.exist;
+    });
+
+    it('does not decrease the header level when ccEnabled is false', () => {
+      const { container } = renderList(
+        { type: 'Parking', expensesList, showHeader: false },
+        getCCState(false),
+      );
+
+      const h4 = container.querySelector('h4');
+      expect(h4).to.exist;
+    });
+  });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
@@ -307,103 +307,149 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
       },
     ];
 
-    it('renders ProofOfAttendanceCard when CC is enabled, appointment is CC, document exists, and groupAccordionItemsByType is true', () => {
-      const { getByText } = renderAccordion(
-        {
-          expenses: [],
-          documents: documentsWithPOA,
-          groupAccordionItemsByType: true,
-        },
-        getCommunityCareState(),
-      );
+    describe('Proof of attendance card', () => {
+      it('does not render when CC is disabled', () => {
+        renderAccordion(
+          {
+            expenses: [],
+            documents: documentsWithPOA,
+            groupAccordionItemsByType: true,
+          },
+          getCommunityCareState({ ccEnabled: false }),
+        );
 
-      expect(document.querySelector('va-accordion')).to.exist;
-      expect(getByText('proof-of-attendance.pdf')).to.exist;
+        expect(document.querySelector('va-accordion')).to.not.exist;
+      });
+
+      it('does not render when appointment is not CC', () => {
+        renderAccordion(
+          {
+            expenses: [],
+            documents: documentsWithPOA,
+            groupAccordionItemsByType: true,
+          },
+          getCommunityCareState({ isAppointmentCC: false }),
+        );
+
+        expect(document.querySelector('va-accordion')).to.not.exist;
+      });
+
+      it('does not render when proof of attendance document does not exist', () => {
+        renderAccordion(
+          { expenses: [], documents, groupAccordionItemsByType: true },
+          getCommunityCareState(),
+        );
+
+        expect(document.querySelector('va-accordion')).to.not.exist;
+      });
+
+      it('does not render when document filename does not match POA constant', () => {
+        const documentsWithWrongName = [
+          {
+            documentId: 'doc-wrong',
+            filename: 'some-other-document.pdf',
+            mimetype: 'application/pdf',
+          },
+        ];
+        renderAccordion(
+          {
+            expenses: [],
+            documents: documentsWithWrongName,
+            groupAccordionItemsByType: true,
+          },
+          getCommunityCareState(),
+        );
+
+        expect(document.querySelector('va-accordion')).to.not.exist;
+      });
+
+      it('renders as separate accordion item when groupAccordionItemsByType is true', () => {
+        const { getByText } = renderAccordion(
+          {
+            expenses: [],
+            documents: documentsWithPOA,
+            groupAccordionItemsByType: true,
+          },
+          getCommunityCareState(),
+        );
+
+        const poaAccordionItem = document.querySelector(
+          'va-accordion-item[header="Proof of attendance"]',
+        );
+        expect(poaAccordionItem).to.exist;
+        expect(getByText('proof-of-attendance.pdf')).to.exist;
+      });
+
+      it('renders inside "Submitted expenses and files" accordion item when groupAccordionItemsByType is false', () => {
+        const { getByText, getAllByTestId } = renderAccordion(
+          {
+            expenses,
+            documents: documentsWithPOA,
+            groupAccordionItemsByType: false,
+          },
+          getCommunityCareState(),
+        );
+
+        const item = document.querySelector(
+          'va-accordion-item[header="Submitted expenses and files"]',
+        );
+        expect(item).to.exist;
+
+        const headers = getAllByTestId('proof-of-attendance-header');
+        expect(headers[0].textContent).to.equal('Proof of attendance');
+        expect(getByText('proof-of-attendance.pdf')).to.exist;
+      });
+
+      it('renders only when no expenses but CC conditions are met', () => {
+        const { getByText, queryByText } = renderAccordion(
+          {
+            expenses: [],
+            documents: documentsWithPOA,
+            groupAccordionItemsByType: true,
+          },
+          getCommunityCareState(),
+        );
+
+        expect(document.querySelector('va-accordion')).to.exist;
+        expect(getByText('proof-of-attendance.pdf')).to.exist;
+
+        expect(queryByText('Mileage')).to.not.exist;
+        expect(queryByText('Parking')).to.not.exist;
+      });
     });
 
-    it('does not render ProofOfAttendanceCard when CC is disabled', () => {
-      renderAccordion(
-        {
-          expenses: [],
-          documents: documentsWithPOA,
-          groupAccordionItemsByType: true,
-        },
-        getCommunityCareState({ ccEnabled: false }),
-      );
+    describe('accordion item title', () => {
+      it('is "Submitted expenses and files" when showing POA', () => {
+        renderAccordion(
+          {
+            expenses,
+            documents: documentsWithPOA,
+            groupAccordionItemsByType: false,
+          },
+          getCommunityCareState(),
+        );
 
-      expect(document.querySelector('va-accordion')).to.not.exist;
-    });
+        const item = document.querySelector(
+          'va-accordion-item[header="Submitted expenses and files"]',
+        );
+        expect(item).to.exist;
+      });
 
-    it('does not render ProofOfAttendanceCard when appointment is not CC', () => {
-      renderAccordion(
-        {
-          expenses: [],
-          documents: documentsWithPOA,
-          groupAccordionItemsByType: true,
-        },
-        getCommunityCareState({ isAppointmentCC: false }),
-      );
+      it('is "Submitted expenses" when not showing POA', () => {
+        renderAccordion(
+          {
+            expenses,
+            documents,
+            groupAccordionItemsByType: false,
+          },
+          getCommunityCareState({ ccEnabled: false }),
+        );
 
-      expect(document.querySelector('va-accordion')).to.not.exist;
-    });
-
-    it('does not render ProofOfAttendanceCard when proof of attendance document does not exist', () => {
-      renderAccordion(
-        { expenses: [], documents, groupAccordionItemsByType: true },
-        getCommunityCareState(),
-      );
-
-      expect(document.querySelector('va-accordion')).to.not.exist;
-    });
-
-    it('does not render ProofOfAttendanceCard when groupAccordionItemsByType is false', () => {
-      renderAccordion(
-        {
-          expenses: [],
-          documents: documentsWithPOA,
-          groupAccordionItemsByType: false,
-        },
-        getCommunityCareState(),
-      );
-
-      expect(document.querySelector('va-accordion')).to.not.exist;
-    });
-
-    it('renders only ProofOfAttendanceCard accordion when no expenses but CC conditions are met', () => {
-      const { getByText, queryByText } = renderAccordion(
-        {
-          expenses: [],
-          documents: documentsWithPOA,
-          groupAccordionItemsByType: true,
-        },
-        getCommunityCareState(),
-      );
-
-      expect(document.querySelector('va-accordion')).to.exist;
-      expect(getByText('proof-of-attendance.pdf')).to.exist;
-
-      expect(queryByText('Mileage')).to.not.exist;
-      expect(queryByText('Parking')).to.not.exist;
-    });
-
-    it('does not render ProofOfAttendanceCard when there is no properly named proof-of-attendance document', () => {
-      const documentsWithWrongName = [
-        {
-          documentId: 'doc-wrong',
-          filename: 'some-other-document.pdf',
-          mimetype: 'application/pdf',
-        },
-      ];
-      renderAccordion(
-        {
-          expenses: [],
-          documents: documentsWithWrongName,
-          groupAccordionItemsByType: true,
-        },
-        getCommunityCareState(),
-      );
-
-      expect(document.querySelector('va-accordion')).to.not.exist;
+        const item = document.querySelector(
+          'va-accordion-item[header="Submitted expenses"]',
+        );
+        expect(item).to.exist;
+      });
     });
   });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
@@ -275,4 +275,83 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
 
     expect(headerTexts).to.include.members(['Mileage', 'Parking']);
   });
+
+  describe('Community Care (CC) - Proof of Attendance', () => {
+    const getCommunityCareState = ({
+      ccEnabled = true,
+      isAppointmentCC = true,
+    } = {}) => ({
+      ...initialState,
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        travel_pay_enable_community_care: ccEnabled,
+      },
+      travelPay: {
+        ...initialState.travelPay,
+        appointment: {
+          ...initialState.travelPay.appointment,
+          data: {
+            ...initialState.travelPay.appointment.data,
+            isCC: isAppointmentCC,
+          },
+        },
+      },
+    });
+
+    const documentsWithPOA = [
+      ...documents,
+      {
+        documentId: 'doc-poa',
+        filename: 'proof-of-attendance.pdf',
+        mimetype: 'application/pdf',
+      },
+    ];
+
+    it('renders ProofOfAttendanceCard when CC is enabled, appointment is CC, and document exists', () => {
+      const { getByText } = renderAccordion(
+        { expenses: [], documents: documentsWithPOA },
+        getCommunityCareState(),
+      );
+
+      expect(document.querySelector('va-accordion')).to.exist;
+      expect(getByText('proof-of-attendance.pdf')).to.exist;
+    });
+
+    it('does not render ProofOfAttendanceCard when CC is disabled', () => {
+      renderAccordion(
+        { expenses: [], documents: documentsWithPOA },
+        getCommunityCareState({ ccEnabled: false }),
+      );
+
+      expect(document.querySelector('va-accordion')).to.not.exist;
+    });
+
+    it('does not render ProofOfAttendanceCard when appointment is not CC', () => {
+      renderAccordion(
+        { expenses: [], documents: documentsWithPOA },
+        getCommunityCareState({ isAppointmentCC: false }),
+      );
+
+      expect(document.querySelector('va-accordion')).to.not.exist;
+    });
+
+    it('does not render ProofOfAttendanceCard when proof of attendance document does not exist', () => {
+      renderAccordion({ expenses: [], documents }, getCommunityCareState());
+
+      expect(document.querySelector('va-accordion')).to.not.exist;
+    });
+
+    it('renders only ProofOfAttendanceCard accordion when no expenses but CC conditions are met', () => {
+      const { getByText, queryByText } = renderAccordion(
+        { expenses: [], documents: documentsWithPOA },
+        getCommunityCareState(),
+      );
+
+      expect(document.querySelector('va-accordion')).to.exist;
+      expect(getByText('proof-of-attendance.pdf')).to.exist;
+
+      expect(queryByText('Mileage')).to.not.exist;
+      expect(queryByText('Parking')).to.not.exist;
+    });
+  });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
@@ -353,5 +353,21 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
       expect(queryByText('Mileage')).to.not.exist;
       expect(queryByText('Parking')).to.not.exist;
     });
+
+    it('does not render ProofOfAttendanceCard when there is no properly named proof-of-attendance document', () => {
+      const documentsWithWrongName = [
+        {
+          documentId: 'doc-wrong',
+          filename: 'some-other-document.pdf',
+          mimetype: 'application/pdf',
+        },
+      ];
+      renderAccordion(
+        { expenses: [], documents: documentsWithWrongName },
+        getCommunityCareState(),
+      );
+
+      expect(document.querySelector('va-accordion')).to.not.exist;
+    });
   });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensesAccordion.unit.spec.jsx
@@ -307,9 +307,13 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
       },
     ];
 
-    it('renders ProofOfAttendanceCard when CC is enabled, appointment is CC, and document exists', () => {
+    it('renders ProofOfAttendanceCard when CC is enabled, appointment is CC, document exists, and groupAccordionItemsByType is true', () => {
       const { getByText } = renderAccordion(
-        { expenses: [], documents: documentsWithPOA },
+        {
+          expenses: [],
+          documents: documentsWithPOA,
+          groupAccordionItemsByType: true,
+        },
         getCommunityCareState(),
       );
 
@@ -319,7 +323,11 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
 
     it('does not render ProofOfAttendanceCard when CC is disabled', () => {
       renderAccordion(
-        { expenses: [], documents: documentsWithPOA },
+        {
+          expenses: [],
+          documents: documentsWithPOA,
+          groupAccordionItemsByType: true,
+        },
         getCommunityCareState({ ccEnabled: false }),
       );
 
@@ -328,7 +336,11 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
 
     it('does not render ProofOfAttendanceCard when appointment is not CC', () => {
       renderAccordion(
-        { expenses: [], documents: documentsWithPOA },
+        {
+          expenses: [],
+          documents: documentsWithPOA,
+          groupAccordionItemsByType: true,
+        },
         getCommunityCareState({ isAppointmentCC: false }),
       );
 
@@ -336,14 +348,34 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
     });
 
     it('does not render ProofOfAttendanceCard when proof of attendance document does not exist', () => {
-      renderAccordion({ expenses: [], documents }, getCommunityCareState());
+      renderAccordion(
+        { expenses: [], documents, groupAccordionItemsByType: true },
+        getCommunityCareState(),
+      );
+
+      expect(document.querySelector('va-accordion')).to.not.exist;
+    });
+
+    it('does not render ProofOfAttendanceCard when groupAccordionItemsByType is false', () => {
+      renderAccordion(
+        {
+          expenses: [],
+          documents: documentsWithPOA,
+          groupAccordionItemsByType: false,
+        },
+        getCommunityCareState(),
+      );
 
       expect(document.querySelector('va-accordion')).to.not.exist;
     });
 
     it('renders only ProofOfAttendanceCard accordion when no expenses but CC conditions are met', () => {
       const { getByText, queryByText } = renderAccordion(
-        { expenses: [], documents: documentsWithPOA },
+        {
+          expenses: [],
+          documents: documentsWithPOA,
+          groupAccordionItemsByType: true,
+        },
         getCommunityCareState(),
       );
 
@@ -363,7 +395,11 @@ describe('Complex Claims - <ExpensesAccordion />', () => {
         },
       ];
       renderAccordion(
-        { expenses: [], documents: documentsWithWrongName },
+        {
+          expenses: [],
+          documents: documentsWithWrongName,
+          groupAccordionItemsByType: true,
+        },
         getCommunityCareState(),
       );
 

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
@@ -9,7 +9,12 @@ describe('ProofOfAttendanceCard', () => {
   const renderCard = (props = {}) => {
     return render(
       <MemoryRouter>
-        <ProofOfAttendanceCard filename="test-file.pdf" {...props} />
+        <ProofOfAttendanceCard
+          filename="test-file.pdf"
+          apptId="12345"
+          claimId="45678"
+          {...props}
+        />
       </MemoryRouter>,
     );
   };
@@ -45,12 +50,12 @@ describe('ProofOfAttendanceCard', () => {
     expect(getByText('Edit')).to.exist;
   });
 
-  // TODO: Update this test when the proof of attendance page is implemented.
-  // This currently points to '/' as a placeholder.
-  it('Edit link points to placeholder URL', () => {
+  it('Edit link points to the correct URL to edit the POA file', () => {
     const { getByTestId } = renderCard();
     const editLink = getByTestId('proof-of-attendance-edit-link');
-    expect(editLink.getAttribute('href')).to.eq('/');
+    expect(editLink.getAttribute('href')).to.eq(
+      '/file-new-claim/12345/45678/proof-of-attendance',
+    );
   });
 
   it('renders the va-card', () => {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
@@ -6,23 +6,27 @@ import ProofOfAttendanceCard from '../../../../components/complex-claims/pages/P
 import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../../constants';
 
 describe('ProofOfAttendanceCard', () => {
-  const renderCard = () => {
+  const renderCard = (props = {}) => {
     return render(
       <MemoryRouter>
-        <va-accordion>
-          <ProofOfAttendanceCard filename="test-file.pdf" />
-        </va-accordion>
+        <ProofOfAttendanceCard filename="test-file.pdf" {...props} />
       </MemoryRouter>,
     );
   };
 
-  it('renders the accordion item with correct header', () => {
+  it('renders h3 header by default', () => {
     const { container } = renderCard();
-    const accordionItem = container.querySelector('va-accordion-item');
-    expect(accordionItem).to.exist;
-    expect(accordionItem.getAttribute('header')).to.equal(
-      'Proof of attendance',
-    );
+    const h3 = container.querySelector('h3');
+    expect(h3).to.exist;
+    expect(h3.textContent).to.equal('File name');
+  });
+
+  it('renders h4 header when decreaseHeaderLevel is true', () => {
+    const { container } = renderCard({ decreaseHeaderLevel: true });
+    const h4 = container.querySelector('h4');
+    expect(h4).to.exist;
+    expect(h4.textContent).to.equal('File name');
+    expect(container.querySelector('h3')).to.not.exist;
   });
 
   it('renders the filename', () => {
@@ -31,13 +35,9 @@ describe('ProofOfAttendanceCard', () => {
   });
 
   it('renders the note about filename change', () => {
-    const { getByText } = renderCard();
-    expect(
-      getByText(
-        `We've changed your file name to "${PROOF_OF_ATTENDANCE_FILENAME}."`,
-        { exact: false },
-      ),
-    ).to.exist;
+    const { container } = renderCard();
+    expect(container.textContent).to.include('changed your file name to');
+    expect(container.textContent).to.include(PROOF_OF_ATTENDANCE_FILENAME);
   });
 
   it('renders the Edit link', () => {
@@ -56,5 +56,11 @@ describe('ProofOfAttendanceCard', () => {
   it('renders the va-card', () => {
     const { getByTestId } = renderCard();
     expect(getByTestId('proof-of-attendance-card')).to.exist;
+  });
+
+  it('does not render Edit link when showEdit is false', () => {
+    const { queryByText, queryByTestId } = renderCard({ showEdit: false });
+    expect(queryByText('Edit')).to.not.exist;
+    expect(queryByTestId('proof-of-attendance-edit-link')).to.not.exist;
   });
 });

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom-v5-compat';
 import ProofOfAttendanceCard from '../../../../components/complex-claims/pages/ProofOfAttendanceCard';
-import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../../constants';
 
 describe('ProofOfAttendanceCard', () => {
   const renderCard = (props = {}) => {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
+import ProofOfAttendanceCard from '../../../../components/complex-claims/pages/ProofOfAttendanceCard';
+import { PROOF_OF_ATTENDANCE_FILENAME } from '../../../../constants';
+
+describe('ProofOfAttendanceCard', () => {
+  const renderCard = () => {
+    return render(
+      <MemoryRouter>
+        <va-accordion>
+          <ProofOfAttendanceCard filename="test-file.pdf" />
+        </va-accordion>
+      </MemoryRouter>,
+    );
+  };
+
+  it('renders the accordion item with correct header', () => {
+    const { container } = renderCard();
+    const accordionItem = container.querySelector('va-accordion-item');
+    expect(accordionItem).to.exist;
+    expect(accordionItem.getAttribute('header')).to.equal(
+      'Proof of attendance',
+    );
+  });
+
+  it('renders the filename', () => {
+    const { getByText } = renderCard();
+    expect(getByText('test-file.pdf')).to.exist;
+  });
+
+  it('renders the note about filename change', () => {
+    const { getByText } = renderCard();
+    expect(
+      getByText(
+        `We've changed your file name to "${PROOF_OF_ATTENDANCE_FILENAME}."`,
+        { exact: false },
+      ),
+    ).to.exist;
+  });
+
+  it('renders the Edit link', () => {
+    const { getByText } = renderCard();
+    expect(getByText('Edit')).to.exist;
+  });
+
+  // TODO: Update this test when the proof of attendance page is implemented.
+  // This currently points to '/' as a placeholder.
+  it('Edit link points to placeholder URL', () => {
+    const { getByTestId } = renderCard();
+    const editLink = getByTestId('proof-of-attendance-edit-link');
+    expect(editLink.getAttribute('href')).to.eq('/');
+  });
+
+  it('renders the va-card', () => {
+    const { getByTestId } = renderCard();
+    expect(getByTestId('proof-of-attendance-card')).to.exist;
+  });
+});

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ProofOfAttendanceCard.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('ProofOfAttendanceCard', () => {
   it('renders the note about filename change', () => {
     const { container } = renderCard();
     expect(container.textContent).to.include('changed your file name to');
-    expect(container.textContent).to.include(PROOF_OF_ATTENDANCE_FILENAME);
+    expect(container.textContent).to.include('test-file');
   });
 
   it('renders the Edit link', () => {

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ReviewPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ReviewPage.unit.spec.jsx
@@ -549,4 +549,102 @@ describe('Travel Pay – ReviewPage', () => {
       expect(getByTestId('alert-display').textContent).to.equal('no-alert');
     });
   });
+
+  describe('Community Care (CC)', () => {
+    const getCommunityCareState = ({ ccEnabled = true } = {}) => ({
+      ...getData(),
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        travel_pay_enable_community_care: ccEnabled,
+      },
+    });
+
+    it('does not render "Expense types" heading when CC is enabled', () => {
+      const { queryByRole } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[`/file-new-claim/${apptId}/${claimId}/review`]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<ReviewPage />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState: getCommunityCareState(),
+          reducers: reducer,
+        },
+      );
+
+      expect(queryByRole('heading', { name: 'Expense types' })).to.not.exist;
+    });
+
+    it('renders "Expense types" heading when CC is disabled', () => {
+      const { getByRole } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[`/file-new-claim/${apptId}/${claimId}/review`]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<ReviewPage />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState: getCommunityCareState({ ccEnabled: false }),
+          reducers: reducer,
+        },
+      );
+
+      expect(getByRole('heading', { name: 'Expense types' })).to.exist;
+    });
+
+    it('passes headerLevel 2 to ExpensesAccordion when CC is enabled', () => {
+      const { container } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[`/file-new-claim/${apptId}/${claimId}/review`]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<ReviewPage />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState: getCommunityCareState(),
+          reducers: reducer,
+        },
+      );
+
+      const accordionItems = container.querySelectorAll('va-accordion-item');
+      expect(accordionItems.length).to.be.greaterThan(0);
+      expect(accordionItems[0].getAttribute('level')).to.equal('2');
+    });
+
+    it('passes headerLevel 3 to ExpensesAccordion when CC is disabled', () => {
+      const { container } = renderWithStoreAndRouter(
+        <MemoryRouter
+          initialEntries={[`/file-new-claim/${apptId}/${claimId}/review`]}
+        >
+          <Routes>
+            <Route
+              path="/file-new-claim/:apptId/:claimId/review"
+              element={<ReviewPage />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        {
+          initialState: getCommunityCareState({ ccEnabled: false }),
+          reducers: reducer,
+        },
+      );
+
+      const accordionItems = container.querySelectorAll('va-accordion-item');
+      expect(accordionItems.length).to.be.greaterThan(0);
+      expect(accordionItems[0].getAttribute('level')).to.equal('3');
+    });
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR adds the following changes to the Complex Claims review page for Community Care:
- Heading level changes
- Removes the "Expense types" header
- Adds a `Proof of attendance` card to the top of the expense list. It renders either as a separate accordion (Review page) or within the expense accordion (Confirmation page).

**Note**
The community care feature is a work in progress and therefore some placeholder functionality is in this PR such as:
- We may change how we select/get the "proof of attendance" document. The assumption now is it's in the documents list in redux. 
- The `Edit` link target on the PoA Card isn't correct - we will change once the page exists.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/133042
https://github.com/department-of-veterans-affairs/va.gov-team/issues/133061

## Testing done
- Updated unit tests for the review page and expense accordion. Added new test file for the proof of attendance card.
- Manual testing using local mock data

## Screenshots

**REVIEW PAGE - BEFORE**
<img width="970" height="620" alt="image" src="https://github.com/user-attachments/assets/c1bd41e2-a858-4f8e-a9a6-383a1cc63571" />

**REVIEW PAGE - AFTER (when CC is ON and appointment is CC)**
<img width="972" height="680" alt="image" src="https://github.com/user-attachments/assets/44b86e56-97db-4b97-a7b7-92ee989bdcb9" />

**CONFIRMATION PAGE - BEFORE**
<img width="971" height="647" alt="image" src="https://github.com/user-attachments/assets/9f7fe37d-1446-464f-92ab-836956decdb6" />

**CONFIRMATION PAGE - AFTER (when CC is ON and appointment is CC)**
<img width="972" height="647" alt="image" src="https://github.com/user-attachments/assets/58a1b5f3-3c09-494a-97db-50cfc9da94d6" />


## What areas of the site does it impact?
Travel pay complex claims

## Acceptance criteria
**General**
- [ ] Should render the Proof of Attendance accordion item if:
       - Community Care FF is ON
       - AND The appointment is a Community Care appointment
       - AND There is a document with the filename `proof-of-attendance`. The extension does not matter.
- [ ] Should NOT render the Proof of Attendance accordion item if any of the above are false.
- [ ] Should render the Proof of Attendance card even if there are no other expenses
- [ ] Should render the correct heading levels (based on the Figma mock) when the FF is ON
- [ ] Should NOT render the `Expense types` heading that was previous there when the FF is ON.
- [ ] Expand All / Collapse All should expand and collapse the Proof of Attendance item along with the other expense card items.

**Review page specific**
- [ ] Should render the Proof of attendance card in a separate accordion.

**Confirmation page specific**
- [ ] Should render the Proof of attendance card within the same expenses accordion on the Confirmation page.
- [ ] Should show the accordion title of "Submitted expenses and files" if there is a POA file, and "Submitted expenses" if there is no PoA file.
- [ ] Should NOT have an "Edit" button on the PoA card.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
