### PR TITLE
Remove va_online_scheduling_recent_locations_filter feature toggle

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
@@ -25,10 +25,7 @@ import {
   hideEligibilityModal,
 } from '../../redux/actions';
 import { getPageTitle } from '../../newAppointmentFlow';
-import {
-  selectFeatureRecentLocationsFilter,
-  selectFeatureRemoveFacilityConfigCheck,
-} from '../../../redux/selectors';
+import { selectFeatureRemoveFacilityConfigCheck } from '../../../redux/selectors';
 
 const initialSchema = {
   type: 'object',
@@ -45,9 +42,6 @@ const pageKey = 'vaFacilityV2';
 
 export default function VAFacilityPageV2() {
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
-  const featureRecentLocationsFilter = useSelector(state =>
-    selectFeatureRecentLocationsFilter(state),
-  );
 
   const history = useHistory();
   const dispatch = useDispatch();
@@ -75,33 +69,21 @@ export default function VAFacilityPageV2() {
     selectFeatureRemoveFacilityConfigCheck,
   );
 
-  const sortOptions = useMemo(
-    () => {
-      const options = [
-        {
-          value: 'distanceFromResidentialAddress',
-          label: 'Closest to your home',
-        },
-        {
-          value: 'distanceFromCurrentLocation',
-          label: 'Closest to your current location',
-        },
-        { value: 'alphabetical', label: 'Alphabetically' },
-      ];
-      if (featureRecentLocationsFilter) {
-        // Add recentLocations to the top of the list
-        return [
-          {
-            value: 'recentLocations',
-            label: 'By recent locations',
-          },
-          ...options,
-        ];
-      }
-      return options;
+  const sortOptions = [
+    {
+      value: 'recentLocations',
+      label: 'By recent locations',
     },
-    [featureRecentLocationsFilter],
-  );
+    {
+      value: 'distanceFromResidentialAddress',
+      label: 'Closest to your home',
+    },
+    {
+      value: 'distanceFromCurrentLocation',
+      label: 'Closest to your current location',
+    },
+    { value: 'alphabetical', label: 'Alphabetically' },
+  ];
 
   const uiSchema = {
     vaFacility: {
@@ -117,8 +99,7 @@ export default function VAFacilityPageV2() {
   const loadingFacilities =
     childFacilitiesStatus === FETCH_STATUS.loading ||
     childFacilitiesStatus === FETCH_STATUS.notStarted ||
-    (featureRecentLocationsFilter &&
-      fetchRecentLocationStatus === FETCH_STATUS.loading);
+    fetchRecentLocationStatus === FETCH_STATUS.loading;
 
   const isLoading =
     loadingFacilities || (singleValidVALocation && loadingEligibility);

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -18,7 +18,6 @@ import {
   selectFeatureCommunityCare,
   selectFeatureDirectScheduling,
   selectFeatureMentalHealthHistoryFiltering,
-  selectFeatureRecentLocationsFilter,
   selectFeatureRemoveFacilityConfigCheck,
   selectFeatureUseBrowserTimezone,
   selectRegisteredCernerFacilityIds,
@@ -468,7 +467,6 @@ export function openFacilityPageV2(page, uiSchema, schema) {
       const { newAppointment } = state;
       const typeOfCare = getTypeOfCare(newAppointment.data);
       const typeOfCareId = typeOfCare?.id;
-      const useRecentLocations = selectFeatureRecentLocationsFilter(state);
       const siteIds = selectSystemIds(state);
       const cernerSiteIds = selectRegisteredCernerFacilityIds(state);
       let facilities = getTypeOfCareFacilities(state);
@@ -482,22 +480,13 @@ export function openFacilityPageV2(page, uiSchema, schema) {
 
       // Fetch facilities that support this type of care
       if (!facilities) {
-        if (useRecentLocations) {
-          facilities = await fetchRecentLocations(
-            dispatch,
-            siteIds,
-            removeFacilityConfigCheck,
-            featureUseVpg,
-          );
-          recordItemsRetrieved('recent-locations', facilities?.length || 0);
-        } else {
-          facilities = await getLocationsByTypeOfCareAndSiteIds({
-            siteIds,
-            removeFacilityConfigCheck,
-            useVpg: featureUseVpg,
-          });
-          recordItemsRetrieved('available_facilities', facilities?.length);
-        }
+        facilities = await fetchRecentLocations(
+          dispatch,
+          siteIds,
+          removeFacilityConfigCheck,
+          featureUseVpg,
+        );
+        recordItemsRetrieved('recent-locations', facilities?.length || 0);
       }
 
       dispatch({
@@ -508,7 +497,6 @@ export function openFacilityPageV2(page, uiSchema, schema) {
         uiSchema,
         cernerSiteIds,
         address: selectVAPResidentialAddress(state),
-        featureRecentLocationsFilter: useRecentLocations,
         removeFacilityConfigCheck,
       });
 

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -343,17 +343,12 @@ export default function formReducer(state = initialState, action) {
       const { removeFacilityConfigCheck } = action;
       let newData = state.data;
       let { facilities } = action;
-      const {
-        typeOfCareId,
-        featureRecentLocationsFilter,
-        address,
-        cernerSiteIds,
-      } = action;
+      const { typeOfCareId, address, cernerSiteIds } = action;
       const hasResidentialCoordinates =
         !!address?.latitude && !!address?.longitude;
 
       let sortMethod = FACILITY_SORT_METHODS.alphabetical;
-      if (featureRecentLocationsFilter && facilities?.length) {
+      if (facilities?.length) {
         sortMethod = FACILITY_SORT_METHODS.recentLocations;
       } else if (hasResidentialCoordinates) {
         sortMethod = FACILITY_SORT_METHODS.distanceFromResidential;

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -76,9 +76,6 @@ export const selectFeatureCommunityCareCancellations = state =>
 
 export const selectFilterData = state => toggleValues(state).vaOnlineFilterData;
 
-export const selectFeatureRecentLocationsFilter = state =>
-  toggleValues(state).vaOnlineSchedulingRecentLocationsFilter;
-
 export const selectFeatureRemovePodiatry = state =>
   toggleValues(state).vaOnlineSchedulingRemovePodiatry;
 

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -8,7 +8,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingCCDirectScheduling', value: true },
   { name: 'vaOnlineSchedulingCCDirectSchedulingChiropractic', value: true },
   { name: 'vaOnlineSchedulingCommunityCareCancellations', value: true },
-  { name: 'vaOnlineSchedulingRecentLocationsFilter', value: true },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
   { name: 'edu_section_103', value: true },
   { name: 'gibctEybBottomSheet', value: true },

--- a/src/applications/vaos/tests/mocks/mockApis.js
+++ b/src/applications/vaos/tests/mocks/mockApis.js
@@ -375,14 +375,18 @@ export function mockFacilitiesApi({
   }/vaos/v2/facilities?children=${children}&${idList
     .map(id => `ids[]=${id}`)
     .join('&')}`;
+  const url = `${baseUrl}&sort_by=recentLocations`;
 
+  // mock both the baseURL and the url with recent locations for testing
   if (responseCode === 200) {
     setFetchJSONResponse(global.fetch.withArgs(baseUrl), { data });
+    setFetchJSONResponse(global.fetch.withArgs(url), { data });
   } else {
     setFetchJSONFailure(global.fetch.withArgs(baseUrl), { errors: [] });
+    setFetchJSONFailure(global.fetch.withArgs(url), { errors: [] });
   }
 
-  return baseUrl;
+  return url;
 }
 
 /**

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -351,7 +351,6 @@
   "vaOnlineSchedulingCommunityCare": "va_online_scheduling_community_care",
   "vaOnlineSchedulingCommunityCareCancellations": "va_online_scheduling_community_care_cancellations",
   "vaOnlineSchedulingDirect": "va_online_scheduling_direct",
-  "vaOnlineSchedulingRecentLocationsFilter": "va_online_scheduling_recent_locations_filter",
   "vaOnlineSchedulingRequests": "va_online_scheduling_requests",
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
   "vaOnlineSchedulingMentalHealthHistoryFiltering": "va_online_scheduling_mental_health_history_filtering",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removing fully released feature toggle `va_online_scheduling_recent_locations_filter`
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114893

## Testing done

- Tested locally and updated unit tests.

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
