### PR TITLE
Fix typo on ITF confirmation page

### DIFF
--- a/src/applications/representative-form-upload/components/ConfirmationPageViewITF.jsx
+++ b/src/applications/representative-form-upload/components/ConfirmationPageViewITF.jsx
@@ -71,7 +71,7 @@ export const ConfirmationPageViewITF = ({
           </li>
           <li>
             <p>
-              <strong>TF Date:</strong>
+              <strong>ITF Date:</strong>
             </p>
             <p role="text">{formattedSubmitDate} (Expires in 365 days)</p>
           </li>


### PR DESCRIPTION
## Summary

- Fixes a typo on the ITF confirmation page ("TF Date" --> "ITF Date")

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/135182

## Screenshots
Before:
<img width="659" height="148" alt="Screenshot 2026-03-06 at 9 53 12 AM" src="https://github.com/user-attachments/assets/6944f555-05a0-489a-8097-7c1099ca9d40" />
