### PR TITLE
update datadog events to send single facility ids opposed to an array

### DIFF
--- a/src/applications/mhv-medications/components/shared/OracleHealthTransitionAlerts.jsx
+++ b/src/applications/mhv-medications/components/shared/OracleHealthTransitionAlerts.jsx
@@ -53,15 +53,17 @@ export const OracleHealthT3Alert = ({
         blockedFacilityIds.length &&
         relevantMigration?.phases
       ) {
-        datadogRum.addAction(
-          dataDogActionNames.oracleHealthTransition
-            .T3_REFILL_BLOCKED_ALERT_DISPLAYED,
-          {
-            facilityId: blockedFacilityIds,
-            phase: relevantMigration?.phases?.current,
-            blockedPrescriptionCount: blockedPrescriptions.length,
-          },
-        );
+        blockedFacilityIds.forEach(id => {
+          datadogRum.addAction(
+            dataDogActionNames.oracleHealthTransition
+              .T3_REFILL_BLOCKED_ALERT_DISPLAYED,
+            {
+              facilityId: id,
+              phase: relevantMigration?.phases?.current,
+              blockedPrescriptionCount: blockedPrescriptions.length,
+            },
+          );
+        });
       }
     },
     [

--- a/src/applications/mhv-medications/hooks/useOracleHealthAlertTracking.js
+++ b/src/applications/mhv-medications/hooks/useOracleHealthAlertTracking.js
@@ -41,9 +41,11 @@ const useOracleHealthAlertTracking = ({
             migration =>
               migration.facilities?.map(f => String(f.facilityId)) || [],
           );
-          datadogRum.addAction(warningActionName, {
-            facilityId: facilityIds,
-            phase: warningMigrations[0].phases.current,
+          facilityIds.forEach(id => {
+            datadogRum.addAction(warningActionName, {
+              facilityId: id,
+              phase: warningMigrations[0].phases.current,
+            });
           });
         }
       }
@@ -67,9 +69,11 @@ const useOracleHealthAlertTracking = ({
             migration =>
               migration.facilities?.map(f => String(f.facilityId)) || [],
           );
-          datadogRum.addAction(errorActionName, {
-            facilityId: facilityIds,
-            phase: errorMigrations[0].phases.current,
+          facilityIds.forEach(id => {
+            datadogRum.addAction(errorActionName, {
+              facilityId: id,
+              phase: errorMigrations[0].phases.current,
+            });
           });
         }
       }

--- a/src/applications/mhv-medications/tests/components/shared/OracleHealthTransitionAlerts.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/OracleHealthTransitionAlerts.unit.spec.jsx
@@ -229,21 +229,24 @@ describe('OracleHealthTransitionAlerts', () => {
             expect(addActionSpy.callCount).to.be.greaterThan(0);
           });
 
-          const call = addActionSpy
+          const calls = addActionSpy
             .getCalls()
-            .find(
+            .filter(
               c =>
                 c.args[0] ===
                 dataDogActionNames.oracleHealthTransition
                   .T3_REFILL_BLOCKED_ALERT_DISPLAYED,
             );
-          expect(call).to.exist;
-          expect(call.args[1]).to.have.property('facilityId');
-          expect(call.args[1]).to.have.property('phase', 'p4');
-          expect(call.args[1]).to.have.property(
-            'blockedPrescriptionCount',
-            blockedPrescriptions.length,
-          );
+          expect(calls.length).to.be.greaterThan(0);
+          calls.forEach(call => {
+            expect(call.args[1]).to.have.property('facilityId');
+            expect(call.args[1].facilityId).to.be.a('string');
+            expect(call.args[1]).to.have.property('phase', 'p4');
+            expect(call.args[1]).to.have.property(
+              'blockedPrescriptionCount',
+              blockedPrescriptions.length,
+            );
+          });
         });
 
         it('calls datadogRum.addAction with T3_BLOCKED_RX_LINK_CLICK when a blocked prescription link is clicked', () => {

--- a/src/applications/mhv-medications/tests/hooks/useOracleHealthAlertTracking.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/hooks/useOracleHealthAlertTracking.unit.spec.jsx
@@ -400,8 +400,11 @@ describe('useOracleHealthAlertTracking', () => {
               dataDogActionNames.oracleHealthTransition
                 .T45_WARNING_ALERT_DISPLAYED,
           );
-        expect(warningCalls).to.have.length(1);
-        expect(warningCalls[0].args[1]).to.have.property('phase', 'p1');
+        expect(warningCalls).to.have.length(4);
+        warningCalls.forEach(call => {
+          expect(call.args[1]).to.have.property('phase', 'p1');
+          expect(call.args[1].facilityId).to.be.a('string');
+        });
       });
     });
   });
@@ -430,7 +433,7 @@ describe('useOracleHealthAlertTracking', () => {
   });
 
   describe('facility ID extraction', () => {
-    it('includes all facility IDs from matching migrations as strings', async () => {
+    it('fires one action per facility ID as a string', async () => {
       const mockStore = createMockStore();
       const wrapper = createTestWrapper(mockStore);
 
@@ -439,21 +442,23 @@ describe('useOracleHealthAlertTracking', () => {
       });
 
       await waitFor(() => {
-        const errorCall = addActionSpy
+        const errorCalls = addActionSpy
           .getCalls()
-          .find(
+          .filter(
             call =>
               call.args[0] ===
               dataDogActionNames.oracleHealthTransition
                 .T3_ERROR_ALERT_DISPLAYED,
           );
-        expect(errorCall).to.exist;
-        const { facilityId } = errorCall.args[1];
-        expect(facilityId).to.be.an('array');
-        expect(facilityId).to.include('506');
-        expect(facilityId).to.include('515');
-        expect(facilityId).to.include('553');
-        expect(facilityId).to.include('585');
+        expect(errorCalls).to.have.length(4);
+        const facilityIds = errorCalls.map(call => call.args[1].facilityId);
+        expect(facilityIds).to.include('506');
+        expect(facilityIds).to.include('515');
+        expect(facilityIds).to.include('553');
+        expect(facilityIds).to.include('585');
+        errorCalls.forEach(call => {
+          expect(call.args[1].facilityId).to.be.a('string');
+        });
       });
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request updates how facility IDs are tracked and reported in Datadog actions for Oracle Health transition alerts. Instead of sending an array of facility IDs in a single action, the code now sends one action per facility ID, ensuring more granular tracking. Associated tests have been updated to validate this new behavior.

**Tracking and Reporting Improvements:**

* Changed the logic in `OracleHealthTransitionAlerts.jsx` and `useOracleHealthAlertTracking.js` to send a separate Datadog action for each facility ID, rather than sending all IDs together in one action. 


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133128

## Testing done

* Updated unit tests in `OracleHealthTransitionAlerts.unit.spec.jsx` to verify that a separate action is fired for each facility ID and that each ID is a string.
* Modified tests in `useOracleHealthAlertTracking.unit.spec.jsx` to check that the correct number of actions are fired and that facility IDs are strings, not arrays. 

## What areas of the site does it impact?

* Medications Datadog monitoring

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
