### PR TITLE
Fix facility sort by recent locations after choosing another option

### DIFF
--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -531,7 +531,7 @@ export default function formReducer(state = initialState, action) {
       }
 
       if (sortMethod === FACILITY_SORT_METHODS.alphabetical) {
-        sortedFacilities = facilities.sort((a, b) =>
+        sortedFacilities = facilities.toSorted((a, b) =>
           a.name.localeCompare(b.name),
         );
       } else if (
@@ -539,7 +539,7 @@ export default function formReducer(state = initialState, action) {
         (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation &&
           location)
       ) {
-        sortedFacilities = facilities.sort(
+        sortedFacilities = facilities.toSorted(
           (a, b) => a.legacyVAR[sortMethod] - b.legacyVAR[sortMethod],
         );
       } else {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We were using the `.sort()` function which sorts the array in place. This overrides the original facilities order (which is sorted by recent locations) so we can no longer sort by recent locations after choosing another option. To fix this, we should use the non-mutating `.toSorted()` function.
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134591

## Testing done

- Tested locally

## Screenshots

To repro:
1. Visit the choose a facility page
2. Choose another sort option (e.g. alphabetical)
3. Choose sort by recent again

|         | Initial (sort by recent) | After choosing sort by alpha | After choosing sort by recent again (should be the same as the first) |
| ------- | ------ | ----- | ----- |
| Before  |   <img width="687" height="891" alt="image" src="https://github.com/user-attachments/assets/5c127b3c-cfcc-4469-899e-3b3e2ae2d40c" />    |  <img width="640" height="889" alt="image" src="https://github.com/user-attachments/assets/30bd6271-4d00-4a96-be41-08cc015117e2" />    | <img width="635" height="893" alt="image" src="https://github.com/user-attachments/assets/64178758-bf8b-42db-bd9a-4f6626c7dc8b" /> |
| After |   <img width="685" height="891" alt="image" src="https://github.com/user-attachments/assets/e8368496-919c-4030-9645-90a8a1176720" />    |   <img width="664" height="890" alt="image" src="https://github.com/user-attachments/assets/ddc9d985-f613-4f35-ad6a-8a3e1210c13b" />   | <img width="656" height="898" alt="image" src="https://github.com/user-attachments/assets/b265e29c-8c25-4ad5-86f5-9acdda416a57" /> |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
