### PR TITLE
RES-19493 Appt reminder alert timezone change

### DIFF
--- a/src/applications/vre/track-your-vre-benefits/components/AppointmentScheduledAlert.jsx
+++ b/src/applications/vre/track-your-vre-benefits/components/AppointmentScheduledAlert.jsx
@@ -5,9 +5,9 @@ export function formatApptDateTime(dateString) {
   if (!dateString) return null;
   const date = new Date(dateString);
 
-  // Convert to Eastern Time (America/New_York)
+  // Convert to Central Time (America/Chicago)
   const options = {
-    timeZone: 'America/New_York',
+    timeZone: 'America/Chicago',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -25,7 +25,7 @@ export function formatApptDateTime(dateString) {
   const minute = parts.find(p => p.type === 'minute').value;
   const dayPeriod = parts.find(p => p.type === 'dayPeriod').value;
 
-  return `${month}/${day}/${year} at ${hour}:${minute} ${dayPeriod} ET`;
+  return `${month}/${day}/${year} at ${hour}:${minute} ${dayPeriod} CT`;
 }
 
 const renderPlace = place => {

--- a/src/applications/vre/track-your-vre-benefits/tests/unit/components/AppointmentScheduledAlert.unit.spec.jsx
+++ b/src/applications/vre/track-your-vre-benefits/tests/unit/components/AppointmentScheduledAlert.unit.spec.jsx
@@ -70,13 +70,13 @@ describe('AppointmentScheduledAlert', () => {
   });
 
   it('formats date as mm/dd/yyyy at hh:mm am|pm ET', () => {
-    // 2026-06-15T18:00:00.000Z is 2:00 PM ET (EDT)
+    // 2026-06-15T18:00:00.000Z is 1:00 PM CT (CDT)
     const formatted = formatApptDateTime('2026-06-15T18:00:00.000Z');
-    expect(formatted).to.match(/06\/15\/2026 at 2:00 PM ET/);
+    expect(formatted).to.match(/06\/15\/2026 at 1:00 PM CT/);
 
-    // 2026-01-15T13:30:00.000Z is 8:30 AM ET (EST)
+    // 2026-01-15T13:30:00.000Z is 7:30 AM CT (CST)
     const formatted2 = formatApptDateTime('2026-01-15T13:30:00.000Z');
-    expect(formatted2).to.match(/01\/15\/2026 at 8:30 AM ET/);
+    expect(formatted2).to.match(/01\/15\/2026 at 7:30 AM CT/);
   });
 
   it('returns empty string for invalid date', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- change timezone of appt scheduler alert to CT

## Related issue(s)

https://jira.devops.va.gov/browse/RES-19493

## Testing done

- update unit tests
- visually inspect if case appointment time properly converts from UTC to CT

## Screenshots

<img width="1269" height="584" alt="image" src="https://github.com/user-attachments/assets/7baa34e2-d7ea-424a-8d6f-f2b43180cd9c" />

## What areas of the site does it impact?

VRE My case management hub

## Acceptance criteria

- appt scheduler alert shows correct appt date time in CT timezone

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user