### PR TITLE
Remove browser timezone fallback feature toggle

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentDateTime.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentDateTime.jsx
@@ -1,10 +1,8 @@
 import { formatInTimeZone } from 'date-fns-tz';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { getAppointmentTimezone } from '../../services/appointment';
 import { DATE_FORMATS } from '../../utils/constants';
-import { selectFeatureUseBrowserTimezone } from '../../redux/selectors';
 
 export function AppointmentDate({
   date,
@@ -29,16 +27,9 @@ export function AppointmentTime({
   timezone,
   format = 'h:mm aaaa',
 }) {
-  const featureUseBrowserTimezone = useSelector(
-    selectFeatureUseBrowserTimezone,
-  );
-
   if (!appointment) return null;
 
-  const { abbreviation, description } = getAppointmentTimezone(
-    appointment,
-    featureUseBrowserTimezone,
-  );
+  const { abbreviation, description } = getAppointmentTimezone(appointment);
   return (
     <>
       <span data-dd-privacy="mask" data-testid="appointment-time">

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
@@ -18,7 +18,6 @@ import {
   selectStartDate,
   selectTimeZoneAbbr,
 } from '../../redux/selectors';
-import { selectFeatureUseBrowserTimezone } from '../../../redux/selectors';
 
 export default function AppointmentColumnLayout({
   data,
@@ -26,9 +25,6 @@ export default function AppointmentColumnLayout({
   grouped,
   link,
 }) {
-  const featureUseBrowserTimezone = useSelector(
-    selectFeatureUseBrowserTimezone,
-  );
   const appointmentLocality = useSelector(() =>
     selectAppointmentLocality(data),
   );
@@ -37,9 +33,7 @@ export default function AppointmentColumnLayout({
   const modalityText = useSelector(() => selectModalityText(data));
   const modalityIcon = useSelector(() => selectModalityIcon(data));
   const startDate = useSelector(() => selectStartDate(data));
-  const timezoneAbbr = useSelector(() =>
-    selectTimeZoneAbbr(data, featureUseBrowserTimezone),
-  );
+  const timezoneAbbr = useSelector(() => selectTimeZoneAbbr(data));
 
   const dateAriaLabel = useSelector(() => selectApptDateAriaText(data));
   const detailAriaLabel = useSelector(() =>

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.jsx
@@ -26,7 +26,6 @@ import {
   selectIsPast,
 } from '../../redux/selectors';
 import DetailsVA from './DetailsVA';
-import { selectFeatureUseBrowserTimezone } from '../../../redux/selectors';
 
 export default function UpcomingAppointmentsDetailsPage() {
   const dispatch = useDispatch();
@@ -39,9 +38,6 @@ export default function UpcomingAppointmentsDetailsPage() {
   } = useSelector(
     state => getConfirmedAppointmentDetailsInfo(state, id),
     shallowEqual,
-  );
-  const featureUseBrowserTimezone = useSelector(
-    selectFeatureUseBrowserTimezone,
   );
   const isInPerson = isInPersonVisit(appointment);
   const isPast = selectIsPast(appointment);
@@ -60,7 +56,7 @@ export default function UpcomingAppointmentsDetailsPage() {
         dispatch(closeCancelAppointment());
       };
     },
-    [id, dispatch, appointmentTypePrefix, featureUseBrowserTimezone],
+    [id, dispatch, appointmentTypePrefix],
   );
 
   useEffect(

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -4,7 +4,6 @@ import { selectPatientFacilities } from '@department-of-veterans-affairs/platfor
 import * as Sentry from '@sentry/browser';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureUseBrowserTimezone,
   selectSystemIds,
   selectFeatureUseVpg,
   selectFeatureAddOhAvs,
@@ -94,7 +93,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
     const patientFacilities = selectPatientFacilities(state);
-    const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
 
     const includeEPS = getIsInPilotUserStations(
       featureCCDirectScheduling,
@@ -132,7 +130,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
           startDate, // Start 30 days in the past for canceled appointments
           endDate,
           includeEPS,
-          featureUseBrowserTimezone,
         }),
       ];
       if (includeRequests) {
@@ -147,7 +144,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             startDate: requestStartDate, // Start 120 days in the past for requests
             endDate: requestEndDate, // End 1 day in the future for requests
             includeEPS,
-            featureUseBrowserTimezone,
           })
             .then(requests => {
               dispatch({
@@ -252,7 +248,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
       featureCCDirectScheduling,
       patientFacilities || [],
     );
-    const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
 
     dispatch({
       type: FETCH_PAST_APPOINTMENTS,
@@ -270,7 +265,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
         avs: true,
         fetchClaimStatus: true,
         includeEPS,
-        featureUseBrowserTimezone,
       });
       const appointments = results.filter(appt => !appt.hasOwnProperty('meta'));
       const backendServiceFailures =
@@ -326,7 +320,6 @@ export function fetchRequestDetails(id) {
       ]);
       let facilityId = getVAAppointmentLocationId(request);
       let facility = state.appointments.facilityData?.[facilityId];
-      const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
 
       if (!request || (facilityId && !facility)) {
         dispatch({
@@ -337,7 +330,6 @@ export function fetchRequestDetails(id) {
       if (!request) {
         request = await fetchRequestById({
           id,
-          featureUseBrowserTimezone,
         });
         facilityId = getVAAppointmentLocationId(request);
         facility = state.appointments.facilityData?.[facilityId];
@@ -371,7 +363,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
       const addOhAvs = selectFeatureAddOhAvs(state);
 
       let appointment = selectAppointmentById(state, id, [
@@ -402,7 +393,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         appointment = await fetchBookedAppointment({
           id,
           type,
-          featureUseBrowserTimezone,
         });
       }
 
@@ -474,7 +464,6 @@ export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
     const state = getState();
     const appointment = state.appointments.appointmentToCancel;
-    const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
 
     try {
       dispatch({
@@ -483,7 +472,6 @@ export function confirmCancelAppointment() {
 
       const updatedAppointment = await cancelAppointment({
         appointment,
-        featureUseBrowserTimezone,
       });
 
       dispatch({

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -245,11 +245,8 @@ export function selectIsPhone(appointment) {
   return appointment?.vaos?.isPhoneAppointment;
 }
 
-export function selectTimeZoneAbbr(appointment, isUseBrowserTimezone) {
-  const { abbreviation } = getAppointmentTimezone(
-    appointment,
-    isUseBrowserTimezone,
-  );
+export function selectTimeZoneAbbr(appointment) {
+  const { abbreviation } = getAppointmentTimezone(appointment);
   return abbreviation;
 }
 

--- a/src/applications/vaos/covid-19-vaccine/components/SecondDosePage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/SecondDosePage.jsx
@@ -12,7 +12,6 @@ import {
 } from '../flow';
 import { getTimezoneByFacilityId } from '../../utils/timezone';
 import { DATE_FORMATS } from '../../utils/constants';
-import { selectFeatureUseBrowserTimezone } from '../../redux/selectors';
 
 const pageKey = 'secondDosePage';
 const pageTitle = 'When to plan for a second dose';
@@ -23,18 +22,12 @@ export default function SecondDosePage() {
     shallowEqual,
   );
   const pageChangeInProgress = useSelector(selectPageChangeInProgress);
-  const featureUseBrowserTimezone = useSelector(
-    selectFeatureUseBrowserTimezone,
-  );
 
   const history = useHistory();
   const dispatch = useDispatch();
   const { date1, vaFacility } = data;
   const selectedDate = parseISO(date1[0]);
-  const timezone = getTimezoneByFacilityId(
-    vaFacility,
-    featureUseBrowserTimezone,
-  );
+  const timezone = getTimezoneByFacilityId(vaFacility);
 
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -6,11 +6,7 @@ import {
   selectVAPResidentialAddress,
 } from '@department-of-veterans-affairs/platform-user/exports';
 import { format, isAfter, isDate, parseISO, startOfMinute } from 'date-fns';
-import {
-  selectFeatureUseBrowserTimezone,
-  selectSystemIds,
-  selectFeatureUseVpg,
-} from '../../redux/selectors';
+import { selectSystemIds, selectFeatureUseVpg } from '../../redux/selectors';
 import {
   STARTED_NEW_APPOINTMENT_FLOW,
   VACCINE_FORM_SUBMIT_SUCCEEDED,
@@ -390,9 +386,6 @@ export function prefillContactInfo() {
 
 export function confirmAppointment(history) {
   return async (dispatch, getState) => {
-    const state = getState();
-    const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
-
     dispatch({
       type: FORM_SUBMIT,
     });
@@ -410,7 +403,6 @@ export function confirmAppointment(history) {
     try {
       const appointment = await createAppointment({
         appointment: transformFormToVAOSAppointment(getState()),
-        featureUseBrowserTimezone,
       });
 
       const data = selectCovid19VaccineFormData(getState());

--- a/src/applications/vaos/new-appointment/components/ReviewPage/AppointmentDate.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/AppointmentDate.jsx
@@ -1,13 +1,11 @@
 import { formatInTimeZone } from 'date-fns-tz';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { DATE_FORMATS } from '../../../utils/constants';
 import {
   getTimezoneAbbrByFacilityId,
   getTimezoneByFacilityId,
 } from '../../../utils/timezone';
-import { selectFeatureUseBrowserTimezone } from '../../../redux/selectors';
 
 export default function AppointmentDate({
   classes,
@@ -16,18 +14,9 @@ export default function AppointmentDate({
   level = 3,
   directSchedule = false,
 }) {
-  const featureUseBrowserTimezone = useSelector(
-    selectFeatureUseBrowserTimezone,
-  );
   const Heading = `h${level}`;
-  const timezone = getTimezoneByFacilityId(
-    facilityId,
-    featureUseBrowserTimezone,
-  );
-  const timezoneAbbr = getTimezoneAbbrByFacilityId(
-    facilityId,
-    featureUseBrowserTimezone,
-  );
+  const timezone = getTimezoneByFacilityId(facilityId);
+  const timezoneAbbr = getTimezoneAbbrByFacilityId(facilityId);
 
   if (directSchedule) {
     return (

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -24,7 +24,6 @@ import useFormState from '../../../hooks/useFormState';
 import { getLongTermAppointmentHistoryV2 } from '../../../services/appointment';
 import { getPageTitle } from '../../newAppointmentFlow';
 import AppointmentsRadioWidget from '../AppointmentsRadioWidget';
-import { selectFeatureUseBrowserTimezone } from '../../../redux/selectors';
 
 const pageKey = 'typeOfCare';
 
@@ -42,9 +41,6 @@ export default function TypeOfCarePage() {
     removePodiatry,
     showPodiatryApptUnavailableModal,
   } = useSelector(selectTypeOfCarePage, shallowEqual);
-  const featureUseBrowserTimezone = useSelector(
-    selectFeatureUseBrowserTimezone,
-  );
 
   const history = useHistory();
   const showUpdateAddressAlert = useMemo(
@@ -144,7 +140,7 @@ export default function TypeOfCarePage() {
             // This could get called multiple times, but the function is memoized
             // and returns the previous promise if it eixsts
             if (showDirectScheduling) {
-              getLongTermAppointmentHistoryV2(featureUseBrowserTimezone);
+              getLongTermAppointmentHistoryV2();
             }
 
             setData(newData);

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -19,7 +19,6 @@ import {
   selectFeatureDirectScheduling,
   selectFeatureMentalHealthHistoryFiltering,
   selectFeatureRemoveFacilityConfigCheck,
-  selectFeatureUseBrowserTimezone,
   selectRegisteredCernerFacilityIds,
   selectSystemIds,
   selectFeatureUseVpg,
@@ -342,7 +341,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
     const featurePastVisitMHFilter = selectFeatureMentalHealthHistoryFiltering(
       state,
     );
-    const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
 
     const removeFacilityConfigCheck = selectFeatureRemoveFacilityConfigCheck(
       state,
@@ -365,7 +363,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
             directSchedulingEnabled,
             isCerner: true,
             removeFacilityConfigCheck,
-            featureUseBrowserTimezone,
           });
 
           dispatch({
@@ -400,7 +397,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
           directSchedulingEnabled,
           featurePastVisitMHFilter,
           removeFacilityConfigCheck,
-          featureUseBrowserTimezone,
         });
         if (showModal) {
           recordEvent({
@@ -868,7 +864,6 @@ export function submitAppointmentOrRequest(history) {
     const newAppointment = getNewAppointment(state);
     const data = newAppointment?.data;
     const typeOfCare = getTypeOfCare(getFormData(state))?.name;
-    const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
     const useVpg = selectFeatureUseVpg(state);
     const selectedEhr = selectAppointmentEhr(state);
 
@@ -893,7 +888,6 @@ export function submitAppointmentOrRequest(history) {
         let appointment = null;
         appointment = await createAppointment({
           appointment: transformFormToVAOSAppointment(getState(), useVpg),
-          featureUseBrowserTimezone,
         });
 
         dispatch({
@@ -981,7 +975,6 @@ export function submitAppointmentOrRequest(history) {
 
         const requestData = await createAppointment({
           appointment: requestBody,
-          featureUseBrowserTimezone,
         });
 
         dispatch({

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -6,10 +6,7 @@ import { getIsInPilotUserStations } from '../referral-appointments/utils/pilot';
 import { getAppointmentRequests } from '../services/appointment';
 import { GA_PREFIX } from '../utils/constants';
 import { captureError } from '../utils/error';
-import {
-  selectFeatureCCDirectScheduling,
-  selectFeatureUseBrowserTimezone,
-} from './selectors';
+import { selectFeatureCCDirectScheduling } from './selectors';
 
 export const FETCH_FACILITY_LIST_DATA_SUCCEEDED =
   'vaos/FETCH_FACILITY_LIST_DATA_SUCCEEDED';
@@ -43,7 +40,6 @@ export function fetchPendingAppointments() {
       const state = getState();
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
       const patientFacilities = selectPatientFacilities(state);
-      const featureUseBrowserTimezone = selectFeatureUseBrowserTimezone(state);
       const includeEPS = getIsInPilotUserStations(
         featureCCDirectScheduling,
         patientFacilities || [],
@@ -53,7 +49,6 @@ export function fetchPendingAppointments() {
         startDate: subDays(new Date(), 120),
         endDate: addDays(new Date(), 2),
         includeEPS,
-        featureUseBrowserTimezone,
       });
 
       const data = pendingAppointments?.filter(

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -118,8 +118,5 @@ export const selectFeatureAddOhAvs = state =>
 export const selectFeatureRemoveFacilityConfigCheck = state =>
   toggleValues(state).vaOnlineSchedulingRemoveFacilityConfigCheck;
 
-export const selectFeatureUseBrowserTimezone = state =>
-  toggleValues(state).vaOnlineSchedulingUseBrowserTimezone;
-
 export const selectFeatureUseVpg = state =>
   toggleValues(state).vaOnlineSchedulingUseVpg;

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -67,7 +67,6 @@ function apptRequestSort(a, b) {
  * @param {Date} params.endDate Date in YYYY-MM-DD format
  * @param {Boolean} params.fetchClaimStatus Boolean to fetch travel claim data
  * @param {Boolean} params.includeEPS Boolean to include EPS appointments
- * @param {boolean?} params.featureUseBrowserTimezone Feature flag. Default = false.
  * @returns {Promise <Object>[]} A FHIR searchset of booked Appointment resources
  */
 export async function fetchAppointments({
@@ -76,7 +75,6 @@ export async function fetchAppointments({
   avs = false,
   fetchClaimStatus = false,
   includeEPS = false,
-  featureUseBrowserTimezone = false,
 }) {
   try {
     const appointments = [];
@@ -97,15 +95,9 @@ export async function fetchAppointments({
       );
     });
 
-    appointments.push(
-      ...transformVAOSAppointments(
-        filteredAppointments,
-        featureUseBrowserTimezone,
-      ),
-      {
-        meta: allAppointments.backendSystemFailures,
-      },
-    );
+    appointments.push(...transformVAOSAppointments(filteredAppointments), {
+      meta: allAppointments.backendSystemFailures,
+    });
 
     return appointments;
   } catch (e) {
@@ -126,14 +118,12 @@ export async function fetchAppointments({
  * @param {Date} params.startDate Date in YYYY-MM-DD format
  * @param {Date} params.endDate Date in YYYY-MM-DD format
  * @param {Boolean} params.includeEPS Boolean to include EPS appointments
- * @param {boolean?} params.featureUseBrowserTimezone Feature flag. Default = false.
  * @returns {Promise Appointment[]} A FHIR searchset of pending Appointment resources
  */
 export async function getAppointmentRequests({
   startDate,
   endDate,
   includeEPS = false,
-  featureUseBrowserTimezone,
 }) {
   try {
     const appointments = await getAppointments({
@@ -141,7 +131,6 @@ export async function getAppointmentRequests({
       endDate,
       statuses: ['proposed', 'cancelled'],
       includeEPS,
-      featureUseBrowserTimezone,
     });
 
     const requestsWithoutAppointments = appointments.data.filter(appt => {
@@ -153,7 +142,6 @@ export async function getAppointmentRequests({
 
     const transformRequests = transformVAOSAppointments(
       requestsWithoutAppointments,
-      featureUseBrowserTimezone,
     );
 
     transformRequests.push({
@@ -177,17 +165,13 @@ export async function getAppointmentRequests({
  * @async
  * @param {Object} params
  * @param {string} params.id Appointment request id
- * @param {boolean?} params.featureUseBrowserTimezone Feature flag. Default = false.
  * @returns {Promise<Object>} An Appointment object for the given request id
  */
-export async function fetchRequestById({
-  id,
-  featureUseBrowserTimezone = false,
-}) {
+export async function fetchRequestById({ id }) {
   try {
     const appointment = await getAppointment(id);
 
-    return transformVAOSAppointment(appointment, featureUseBrowserTimezone);
+    return transformVAOSAppointment(appointment);
   } catch (e) {
     if (e.errors) {
       throw mapToFHIRErrors(e.errors);
@@ -211,11 +195,10 @@ export async function fetchBookedAppointment({
   id,
   avs = true,
   fetchClaimStatus = true,
-  featureUseBrowserTimezone = false,
 }) {
   try {
     const appointment = await getAppointment(id, avs, fetchClaimStatus);
-    return transformVAOSAppointment(appointment, featureUseBrowserTimezone);
+    return transformVAOSAppointment(appointment);
   } catch (e) {
     if (e.errors) {
       throw mapToFHIRErrors(e.errors);
@@ -454,16 +437,12 @@ export function groupAppointmentsByMonth(appointments) {
  * @export
  * @param {Object} params
  * @param {VAOSAppointment} params.appointment The appointment to send
- * @param {boolean?} params.featureUseBrowserTimezone Feature flag. Default = false.
  * @returns {Promise<Object>} The created appointment
  */
-export async function createAppointment({
-  appointment,
-  featureUseBrowserTimezone = false,
-}) {
+export async function createAppointment({ appointment }) {
   const result = await postAppointment(appointment);
 
-  return transformVAOSAppointment(result, featureUseBrowserTimezone);
+  return transformVAOSAppointment(result);
 }
 
 const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
@@ -474,13 +453,9 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  * @export
  * @param {Object} params
  * @param {Appointment} params.appointment The appointment to cancel
- * @param {boolean?} params.featureUseBrowserTimezone Feature flag. Default = false.
  * @returns {Promise<Object>} Returns either null or the updated appointment data
  */
-export async function cancelAppointment({
-  appointment,
-  featureUseBrowserTimezone = false,
-}) {
+export async function cancelAppointment({ appointment }) {
   const additionalEventData = {
     appointmentType:
       appointment.status === APPOINTMENT_STATUS.proposed
@@ -505,10 +480,7 @@ export async function cancelAppointment({
     });
     resetDataLayer();
 
-    return transformVAOSAppointment(
-      updatedAppointment,
-      featureUseBrowserTimezone,
-    );
+    return transformVAOSAppointment(updatedAppointment);
   } catch (e) {
     captureError(e, true);
     recordEvent({
@@ -654,10 +626,7 @@ export function getCalendarData({ appointment, facility }) {
  *   - abbreviation: The timezone abbreviation (e.g. ET)
  *   - description: The written out description (e.g. Eastern time)
  */
-export function getAppointmentTimezone(
-  appointment,
-  isUseBrowserTimezone = false,
-) {
+export function getAppointmentTimezone(appointment) {
   // Appointments with timezone included in api
   if (appointment?.timezone) {
     const abbreviation = getTimezoneAbbrFromApi(appointment);
@@ -672,10 +641,7 @@ export function getAppointmentTimezone(
   if (appointment?.location?.vistaId) {
     const locationId =
       appointment?.location.stationId || appointment?.location.vistaId;
-    const abbreviation = getTimezoneAbbrByFacilityId(
-      locationId,
-      isUseBrowserTimezone,
-    );
+    const abbreviation = getTimezoneAbbrByFacilityId(locationId);
 
     return {
       abbreviation,
@@ -695,14 +661,13 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
   const batch = [];
   let promise = null;
 
-  return (featureUseBrowserTimezone = false) => {
+  return () => {
     if (!promise || navigator.userAgent === 'node.js') {
       // Creating an array of start and end dates for each chunk
       const ranges = Array.from(Array(chunks).keys()).map(i => {
         return {
           start: subYears(startOfDay(new Date()), i + 1),
           end: subYears(startOfDay(new Date()), i),
-          featureUseBrowserTimezone,
         };
       });
 
@@ -721,7 +686,6 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
         const p1 = await fetchAppointments({
           startDate: curr.start,
           endDate: curr.end,
-          featureUseBrowserTimezone,
         });
         batch.push(p1);
         return Promise.resolve([...batch].flat());

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -52,7 +52,7 @@ function getAtlasLocation(appt) {
   };
 }
 
-export function getAppointmentTimezone(appt, featureUseBrowserTimezone) {
+export function getAppointmentTimezone(appt) {
   let timezone = appt.location?.attributes?.timezone?.timeZoneId;
   // GMT/UTC is not a proper timeZoneId - only occurs when facility lat/long is 0,0 (Unset)
   // and LH resolves that to GMT. "GMT" is the IANA timezone (which LH uses) and UTC is just an alias.
@@ -61,16 +61,10 @@ export function getAppointmentTimezone(appt, featureUseBrowserTimezone) {
     timezone = null;
   }
 
-  return (
-    timezone ||
-    getTimezoneByFacilityId(appt.locationId, featureUseBrowserTimezone)
-  );
+  return timezone || getTimezoneByFacilityId(appt.locationId);
 }
 
-export function transformVAOSAppointment(
-  appt,
-  featureUseBrowserTimezone = false,
-) {
+export function transformVAOSAppointment(appt) {
   const appointmentType = getAppointmentType(appt);
   const isCC = appt.kind === 'cc';
   const isPast = appt.past;
@@ -90,7 +84,7 @@ export function transformVAOSAppointment(
     isCompAndPen || isCovid || appt.modality === 'vaInPerson';
 
   const isCancellable = appt.cancellable;
-  const appointmentTZ = getAppointmentTimezone(appt, featureUseBrowserTimezone);
+  const appointmentTZ = getAppointmentTimezone(appt);
 
   let videoData = { isVideo };
   if (isVideo) {
@@ -234,8 +228,6 @@ export function transformVAOSAppointment(
   };
 }
 
-export function transformVAOSAppointments(appts, featureUseBrowserTimezone) {
-  return appts.map(appt =>
-    transformVAOSAppointment(appt, featureUseBrowserTimezone),
-  );
+export function transformVAOSAppointments(appts) {
+  return appts.map(appt => transformVAOSAppointment(appt));
 }

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -120,23 +120,6 @@ describe('getAppointmentTimezone util', () => {
     expect(getTimezoneByFacilityIdStub.calledWith('999')).to.be.true;
   });
 
-  it('should pass featureUseBrowserTimezone to getTimezoneByFacilityId', () => {
-    const appointment = {
-      locationId: '555',
-      location: {
-        attributes: {
-          timezone: {
-            timeZoneId: 'UTC',
-          },
-        },
-      },
-    };
-
-    const result = getAppointmentTimezone(appointment, true);
-    expect(result).to.equal('America/Chicago');
-    expect(getTimezoneByFacilityIdStub.calledWith('555', true)).to.be.true;
-  });
-
   it('should handle missing location attribute gracefully', () => {
     const appointment = {
       locationId: '111',

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -21,6 +21,5 @@ module.exports = [
   },
   { name: 'vaOnlineSchedulingAddOhAvs', value: true },
   { name: 'vaOnlineSchedulingRemoveFacilityConfigCheck', value: true },
-  { name: 'vaOnlineSchedulingUseBrowserTimezone', value: true },
   { name: 'vaOnlineSchedulingUseVpg', value: true },
 ];

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -337,7 +337,6 @@ export async function fetchFlowEligibilityAndClinics({
   featurePastVisitMHFilter = false,
   isCerner = false,
   removeFacilityConfigCheck = false,
-  featureUseBrowserTimezone,
 }) {
   // Helper to avoid confusion
   const keepFacilityConfigCheck = !removeFacilityConfigCheck;
@@ -381,9 +380,9 @@ export async function fetchFlowEligibilityAndClinics({
       typeOfCare,
     }).catch(createErrorHandler('direct-available-clinics-error'));
 
-    additionalApiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
-      featureUseBrowserTimezone,
-    ).catch(createErrorHandler('direct-no-matching-past-clinics-error'));
+    additionalApiCalls.pastAppointments = getLongTermAppointmentHistoryV2().catch(
+      createErrorHandler('direct-no-matching-past-clinics-error'),
+    );
   }
 
   // Wait for additional API calls to finish

--- a/src/applications/vaos/utils/timezone.js
+++ b/src/applications/vaos/utils/timezone.js
@@ -63,20 +63,14 @@ export function mapGmtToAbbreviation(abbreviation) {
  *
  * @export
  * @param {string} id - Facility id
- * @param {boolean} isUseBrowserTimezone - Flag to determine if browser timezone
- * should be used when facility id is not found.
  * @returns IANA Timezone name Example: 'America/Chicago' or browsers timezone which
  * could be GMT.
  */
-export function getTimezoneByFacilityId(id, isUseBrowserTimezone = false) {
+export function getTimezoneByFacilityId(id) {
   if (!id) {
-    if (isUseBrowserTimezone) {
-      return mapGmtToAbbreviation(
-        Intl.DateTimeFormat().resolvedOptions().timeZone,
-      );
-    }
-
-    return null;
+    return mapGmtToAbbreviation(
+      Intl.DateTimeFormat().resolvedOptions().timeZone,
+    );
   }
 
   // Check 3 digit facility/location ids
@@ -86,7 +80,7 @@ export function getTimezoneByFacilityId(id, isUseBrowserTimezone = false) {
 
   // Check 5 digit facility/location ids
   const timezone = timezones[id.substring(0, 3)];
-  if (isUseBrowserTimezone && !timezone) {
+  if (!timezone) {
     // Default to browser timezone
     return mapGmtToAbbreviation(
       Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -151,25 +145,18 @@ export function getTimezoneDescByTimeZoneString(timezone) {
  *
  * @export
  * @param {string} id - Facility id
- * @param {boolean} isUseBrowserTimezone - Flag to determine if browser timezone
- * should be used when facility id is not found.
  * @returns Timezone abbreviation with daylight savings stripped. Example: 'CT'
  */
-export function getTimezoneAbbrByFacilityId(id, isUseBrowserTimezone = false) {
-  const matchingZone = getTimezoneByFacilityId(id, isUseBrowserTimezone);
+export function getTimezoneAbbrByFacilityId(id) {
+  const matchingZone = getTimezoneByFacilityId(id);
 
   // If using browser timezone and we received a GMT value, return it directly
-  if (isUseBrowserTimezone && matchingZone?.startsWith('GMT'))
-    return matchingZone;
+  if (matchingZone?.startsWith('GMT')) return matchingZone;
 
   // If no matching zone was found and we're allowed to use the browser timezone,
   // derive an abbreviation from the browser and strip DST
-  if (isUseBrowserTimezone && !matchingZone) {
-    return stripDST(mapGmtToAbbreviation(format(new Date(), 'z')));
-  }
-
   if (!matchingZone) {
-    return null;
+    return stripDST(mapGmtToAbbreviation(format(new Date(), 'z')));
   }
 
   let abbreviation = formatInTimeZone(new Date(), matchingZone, 'z');
@@ -188,12 +175,10 @@ export function getTimezoneAbbrByFacilityId(id, isUseBrowserTimezone = false) {
  *
  * @export
  * @param {string} id - Facility id
- * @param {boolean} isUseBrowserTimezone - Flag to determine if browser timezone
- * should be used when facility id is not found.
  * @returns Timezone description Example: Central time (CT)
  */
-export function getTimezoneDescByFacilityId(id, isUseBrowserTimezone = false) {
-  const abbreviation = getTimezoneAbbrByFacilityId(id, isUseBrowserTimezone);
+export function getTimezoneDescByFacilityId(id) {
+  const abbreviation = getTimezoneAbbrByFacilityId(id);
   const label = TIMEZONE_LABELS[abbreviation];
 
   if (label) {

--- a/src/applications/vaos/utils/timezone.unit.spec.jsx
+++ b/src/applications/vaos/utils/timezone.unit.spec.jsx
@@ -132,11 +132,10 @@ describe('VAOS Utils: timezone', () => {
     it('should return the correct description', () => {
       expect(getTimezoneDescByFacilityId('4022')).to.equal('Eastern time (ET)');
     });
-    it('should return null', () => {
-      expect(getTimezoneDescByFacilityId('0402')).to.be.null;
-    });
-    it('should return the timezone for users current location for bad facility id', () => {
-      expect(getTimezoneDescByFacilityId(null, true)).not.be.null;
+    it('should return the timezone for users current location for unknown or null facility id', () => {
+      expect(getTimezoneDescByFacilityId(null)).not.to.be.null;
+      expect(getTimezoneDescByFacilityId(undefined)).not.to.be.null;
+      expect(getTimezoneDescByFacilityId('unknown')).not.to.be.null;
     });
   });
 
@@ -227,12 +226,7 @@ describe('VAOS Utils: timezone', () => {
       expect(getTimezoneByFacilityId('672GA')).to.equal('America/St_Thomas');
     });
 
-    it('should return null for an unknown id', () => {
-      expect(getTimezoneByFacilityId(null)).to.be.null;
-      expect(getTimezoneByFacilityId(undefined)).to.be.null;
-    });
-
-    it('should return the timezone for users current location for bad facility id', () => {
+    it('should return the timezone for users current location for unknown or bad facility id', () => {
       const stub = Sinon.stub(Intl, 'DateTimeFormat');
       stub.returns({
         resolvedOptions() {
@@ -240,7 +234,9 @@ describe('VAOS Utils: timezone', () => {
         },
       });
 
-      expect(getTimezoneByFacilityId(null, true)).to.equal('America/Chicago');
+      expect(getTimezoneByFacilityId(null)).to.equal('America/Chicago');
+      expect(getTimezoneByFacilityId(undefined)).to.equal('America/Chicago');
+      expect(getTimezoneByFacilityId('unknown')).to.equal('America/Chicago');
       stub.restore();
     });
   });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -357,7 +357,6 @@
   "vaOnlineSchedulingAddSubstanceUseDisorder": "va_online_scheduling_add_substance_use_disorder",
   "vaOnlineSchedulingAddOhAvs": "va_online_scheduling_add_OH_avs",
   "vaOnlineSchedulingRemoveFacilityConfigCheck": "va_online_scheduling_remove_facility_config_check",
-  "vaOnlineSchedulingUseBrowserTimezone": "va_online_scheduling_use_browser_timezone",
   "vaOnlineSchedulingAddPrimaryCareMentalHealthInitiative": "va_online_scheduling_add_primary_care_mental_health_initiative",
   "vaOnlineSchedulingUseVpg": "va_online_scheduling_use_vpg",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removing fully released feature toggle `va_online_scheduling_use_browser_timezone`
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123630

## Testing done

- Tested locally and updated unit tests.

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
