### PR TITLE
134622 implement vads radio button component in pow section

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -1,6 +1,7 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import VaCheckboxGroupField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
+import { yesNoUI } from 'platform/forms-system/src/js/web-component-patterns/yesNoPattern';
 import PeriodOfConfinement from '../components/PeriodOfConfinement';
 import { claimingNew } from '../utils';
 import { formatDate } from '../utils/dates/formatting';
@@ -21,10 +22,7 @@ const itemAriaLabel = data =>
 
 export const uiSchema = {
   'ui:title': 'Prisoner of War (POW)',
-  'view:powStatus': {
-    'ui:title': 'Have you ever been a POW?',
-    'ui:widget': 'yesNo',
-  },
+  'view:powStatus': yesNoUI('Have you ever been a POW?'),
   'view:isPow': {
     'ui:options': {
       expandUnder: 'view:powStatus',

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -4,12 +4,22 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   fillDate,
-  selectRadio,
 } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
+
+const selectPowStatus = (form, value = 'Y') => {
+  const powStatusRadio = form.getDOMNode().querySelector('va-radio');
+
+  // Keep compatibility with environments where querySelector is patched/mocked.
+  if (powStatusRadio?.__events?.vaValueChange) {
+    powStatusRadio.__events.vaValueChange({ detail: { value } });
+  }
+
+  form.update();
+};
 
 describe('Prisoner of war info', () => {
   const {
@@ -33,7 +43,8 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(2);
+    expect(form.find('va-radio').length).to.equal(1);
+    expect(form.find('va-radio-option').length).to.equal(2);
     form.unmount();
   });
 
@@ -47,9 +58,9 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    selectRadio(form, 'root_view:powStatus', 'Y');
+    selectPowStatus(form, 'Y');
 
-    expect(form.find('input').length).to.equal(4);
+    expect(form.find('input').length).to.equal(2);
     expect(form.find('select').length).to.equal(4);
     form.unmount();
   });
@@ -67,7 +78,7 @@ describe('Prisoner of war info', () => {
     );
     await waitFor(() => {
       form.find('form').simulate('submit');
-      expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
+      expect(form.getDOMNode().querySelector('va-radio').error).to.not.be.null;
       expect(onSubmit.called).to.be.false;
     });
     form.unmount();
@@ -83,7 +94,7 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    selectRadio(form, 'root_view:powStatus', 'Y');
+    selectPowStatus(form, 'Y');
     fillDate(form, 'root_view:isPow_confinements_0_from', '2010-05-05');
     fillDate(form, 'root_view:isPow_confinements_0_to', '2011-05-05');
 
@@ -110,7 +121,7 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    selectRadio(form, 'root_view:powStatus', 'Y');
+    selectPowStatus(form, 'Y');
     fillDate(form, 'root_view:isPow_confinements_0_from', '2010-05-05');
     fillDate(form, 'root_view:isPow_confinements_0_to', '2011-05-05');
 
@@ -133,7 +144,7 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    selectRadio(form, 'root_view:powStatus', 'Y');
+    selectPowStatus(form, 'Y');
     expect(form.find('va-checkbox').length).to.equal(2);
     expect(form.find('va-checkbox[label="ASHD"]')).to.exist;
     expect(form.find('va-checkbox[label="Scars"]')).to.exist;
@@ -150,7 +161,7 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    selectRadio(form, 'root_view:powStatus', 'Y');
+    selectPowStatus(form, 'Y');
     expect(form.find('input[type="checkbox"]').length).to.equal(0);
     const output = form.render().text();
     expect(output).to.not.contain(
@@ -171,7 +182,7 @@ describe('Prisoner of war info', () => {
       />,
     );
 
-    selectRadio(form, 'root_view:powStatus', 'Y');
+    selectPowStatus(form, 'Y');
     fillDate(form, 'root_view:isPow_confinements_0_from', '2010-05-05');
     fillDate(form, 'root_view:isPow_confinements_0_to', '2014-05-05'); // After service period
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -83,7 +83,9 @@ describe('Prisoner of war info', () => {
     );
     await waitFor(() => {
       form.find('form').simulate('submit');
-      expect(form.getDOMNode().querySelector('va-radio').error).to.not.be.null;
+      const radio = form.getDOMNode().querySelector('va-radio');
+      expect(radio.error).to.exist;
+      expect(radio.error).to.have.length.above(0);
       expect(onSubmit.called).to.be.false;
     });
     form.unmount();

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -13,10 +13,13 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 const selectPowStatus = (form, value = 'Y') => {
   const powStatusRadio = form.getDOMNode().querySelector('va-radio');
 
-  // Keep compatibility with environments where querySelector is patched/mocked.
-  if (powStatusRadio?.__events?.vaValueChange) {
-    powStatusRadio.__events.vaValueChange({ detail: { value } });
-  }
+  powStatusRadio.dispatchEvent(
+    new CustomEvent('vaValueChange', {
+      detail: { value },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 
   form.update();
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -11,7 +11,9 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 const selectPowStatus = (form, value = 'Y') => {
-  const powStatusRadio = form.getDOMNode().querySelector('va-radio');
+  const powStatusRadio = form
+    .getDOMNode()
+    .querySelector('va-radio[name="root_view:powStatus"]');
 
   powStatusRadio.dispatchEvent(
     new CustomEvent('vaValueChange', {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR fixes a staging review finding by replacing a "radio button imposter" (non-standard radio control) with the proper VADS radio button component in the Prisoner of War (POW) section of the 21-526EZ disability claim form.

**Changes made:**
- Replaced `'ui:widget': 'yesNo'` pattern with the VADS `yesNoUI` helper function
- Imported `yesNoUI` from `platform/forms-system/src/js/web-component-patterns/yesNoPattern`
- Updated unit tests to work with the new `va-radio` web component

**Team:** Disability Benefits, Conditions Team

**Why this solution:** The old `'ui:widget': 'yesNo'` creates a non-standard radio control that doesn't meet VA.gov Experience Standards for consistency and accessibility. The `yesNoUI` pattern uses the proper VADS `YesNoField` web component, ensuring compliance with VA Design System standards and improving accessibility for Veterans.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134622
- Parent issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/123205

## Testing done

**Old behavior:**
The "Have you ever been a POW?" question used a radio button imposter (non-VADS component) that rendered as standard HTML radio inputs without proper VADS styling and behavior.

**Steps to verify:**
1. Navigate to the 526EZ form locally
2. Progress to the POW section (`/disability/file-disability-claim-form-21-526ez/pow`)
3. Verify the "Have you ever been a POW?" question renders as a proper `va-radio` web component with two options (Yes/No)
4. Select "Yes" and verify the confinement date fields expand correctly
5. Submit the form and verify validation works as expected
6. Run unit tests: `yarn test:unit src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx`

**Tests completed:**
- All 8 unit tests passing for the POW page
- ESLint passes with no errors
- Prettier formatting passes
- Manual verification that the component renders and behaves correctly
- Verified expandUnder functionality still works for confinement fields
- Verified form submission and validation work as expected

## Screenshots

| Before | After |
| --- | --- | 
| <img width="617" height="229" alt="Screenshot 2026-03-06 at 10 08 31 AM" src="https://github.com/user-attachments/assets/eca4aa01-4c75-40f0-bc99-e8577f51ad20" /> | <img width="491" height="239" alt="Screenshot 2026-03-06 at 10 08 43 AM" src="https://github.com/user-attachments/assets/146eab57-a5c5-418b-a370-c4a4090b461c" /> | 

## What areas of the site does it impact?

This change only impacts the Prisoner of War (POW) section of the 21-526EZ disability claim form at `/disability/file-disability-claim-form-21-526ez/pow`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (no documentation needed for this change)
- [x] Screenshot of the developed feature is added (not applicable - component replacement with same visual appearance)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (using VADS component improves accessibility)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (existing monitoring for 526EZ form applies)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user