### PR TITLE
Fully enables all types of of care for OH on staging

### DIFF
--- a/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
+++ b/src/applications/vaos/new-appointment/hooks/useOHScheduling.js
@@ -4,6 +4,9 @@ import { getFormData, getTypeOfCare } from '../redux/selectors';
 import { selectFeatureUseVpg } from '../../redux/selectors';
 import { OH_ENABLED_TYPES_OF_CARE } from '../../utils/constants';
 
+// There is additional logic in src/applications/vaos/new-appointment/newAppointmentFlow.js
+// When the hook is updated, this should be updated too. It's temporary, so speed was chosen
+// over elegance
 export function useOHScheduling() {
   const featureUseVpg = useSelector(selectFeatureUseVpg);
   const data = useSelector(getFormData);

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -93,9 +93,10 @@ async function vaFacilityNext(state, dispatch) {
   // This duplicates behavior used in the src/applications/vaos/new-appointment/hooks/useOHScheduling.js
   // hook. When the hook is updated, this should be updated too. It's temporary, so speed was chosen
   // over elegance
-  const typeOfCareEnabled = OH_ENABLED_TYPES_OF_CARE.includes(
-    environment.isStaging() || getTypeOfCare(state.newAppointment.data)?.idV2,
-  );
+
+  const typeOfCareId = getTypeOfCare(state.newAppointment.data)?.idV2;
+  const typeOfCareEnabled =
+    environment.isStaging() || OH_ENABLED_TYPES_OF_CARE.includes(typeOfCareId);
 
   const ehr = isCerner ? APPOINTMENT_SYSTEM.cerner : APPOINTMENT_SYSTEM.vista;
   dispatch(updateFacilityEhr(ehr));

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-shadow */
+import environment from 'platform/utilities/environment';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import {
   selectFeatureUseVpg,
@@ -89,8 +90,11 @@ async function vaFacilityNext(state, dispatch) {
   const isCerner = isCernerLocation(location?.id, cernerSiteIds);
   const featureUseVpg = selectFeatureUseVpg(state);
 
+  // This duplicates behavior used in the src/applications/vaos/new-appointment/hooks/useOHScheduling.js
+  // hook. When the hook is updated, this should be updated too. It's temporary, so speed was chosen
+  // over elegance
   const typeOfCareEnabled = OH_ENABLED_TYPES_OF_CARE.includes(
-    getTypeOfCare(state.newAppointment.data)?.idV2,
+    environment.isStaging() || getTypeOfCare(state.newAppointment.data)?.idV2,
   );
 
   const ehr = isCerner ? APPOINTMENT_SYSTEM.cerner : APPOINTMENT_SYSTEM.vista;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This adds the logic contained in the `src/applications/vaos/new-appointment/hooks/useOHScheduling.js` hook to the `src/applications/vaos/new-appointment/newAppointmentFlow.js`. Any place that the `OH_ENABLED_TYPES_OF_CARE` constant is used, we need to check for whether or not the environment is staging.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/134428

## Testing done
- Local testing

## What areas of the site does it impact?

New appointment flow within VAOS only in the staging environment.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


