### PR TITLE
CST 135300 Remove redundant scroll-to-top from claims list page

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -83,15 +83,6 @@ class YourClaimsPageV2 extends React.Component {
     focusElement('h1');
   }
 
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.location.pathname !== this.props.location.pathname ||
-      prevProps.location.search !== this.props.location.search
-    ) {
-      window.scrollTo(0, 0);
-    }
-  }
-
   static getDerivedStateFromProps(nextProps, prevState) {
     const newPage = YourClaimsPageV2.getPageFromURL(nextProps);
 


### PR DESCRIPTION
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- **Bug:** Page scrolls/jumps when switching claim filters (All/Active/Closed) after using pagination
- **Root cause:** `componentDidUpdate` in `YourClaimsPageV2` called `window.scrollTo(0, 0)` on any URL change (pathname or query params). When switching filters, `handleFilterChange` navigates to clear `?page=X`, triggering the scroll-to-top
- **Why this is dead code:** This component is a leaf route (`path="your-claims"`) — pathname changes unmount it entirely, so the pathname check never fires. Pagination scroll is already handled by `setPageFocus('#pagination-info')` in `changePage`, which scrolls to the "Showing X of Y records" element. The `componentDidUpdate` scroll was redundant and only caused harm for filter changes
- **Fix:** Remove the entire `componentDidUpdate` method
- Benefits Management Tools, Team 1 (Mavericks) owns this component

## Related issue(s)

department-of-veterans-affairs/va.gov-team#135300

## Testing done

- Verified all 28 existing unit tests pass
- **Old behavior:** After paginating to page 2+, clicking a filter button (e.g., "Closed") causes the page to jump/scroll to the top
- **New behavior:** Switching filters no longer causes a scroll jump. Pagination continues to scroll/focus to the "Showing X of Y records" element as before
- **Steps to verify:**
  1. Sign in as user 54, go to staging claims list
  2. Click page 2 in pagination — observe scroll to "Showing X of Y records" (unchanged)
  3. Shift+Tab to "Closed" filter, press Enter — page should NOT jump
  4. Click between filters — no scroll jump

## Screenshots

### `cst_claims_list_filter` Feature Flag Off

#### Before
https://github.com/user-attachments/assets/482880e7-db1c-4d81-b994-7235a164729c

#### After
https://github.com/user-attachments/assets/4cab79b7-5fa7-4ef3-9052-92a9d3a33a5d


### `cst_claims_list_filter` Feature Flag On

#### Before
https://github.com/user-attachments/assets/c120328a-4a09-4ca7-968d-874b8470d570

#### After
https://github.com/user-attachments/assets/9e878cd7-7604-4a62-ace4-06525b348c8c

## What areas of the site does it impact?

Claims Status Tool claims list page (`/track-claims/your-claims/`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This was a single method removal — `componentDidUpdate` was dead code on this leaf route. Pagination scroll behavior is preserved via `setPageFocus('#pagination-info')` in `changePage`. The scroll-to-top pattern is common across the monorepo but only needed on layout/parent routes, not leaf routes like this one.