### PR TITLE
686c | Prevent exit form link when add flow is enabled

### DIFF
--- a/src/applications/dependents/686c-674/components/picklist/utils.js
+++ b/src/applications/dependents/686c-674/components/picklist/utils.js
@@ -335,6 +335,9 @@ export const pageDetails = {
  * @returns {boolean} - whether to show the exit link or continue button
  */
 export const showExitLink = ({ data = {}, index = 0 } = {}) => {
+  const isAddingDependents = data['view:addOrRemoveDependents']?.add === true;
+  if (isAddingDependents) return false;
+
   const selected = data[PICKLIST_DATA]?.filter(item => item.selected) || [];
   const list = data[PICKLIST_PATHS] || [];
   const exitPaths = list.filter(item => item.path.endsWith('-exit'));

--- a/src/applications/dependents/686c-674/tests/components/picklist/utils.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/components/picklist/utils.unit.spec.jsx
@@ -481,6 +481,29 @@ describe('showExitLink', () => {
     expect(showExitLink({ data, index: 3 })).to.be.false;
   });
 
+  it('should return false when add dependent is also selected', () => {
+    const data = {
+      'view:addOrRemoveDependents': { add: true, remove: true },
+      [PICKLIST_DATA]: [{ selected: false }, { selected: true }],
+      [PICKLIST_PATHS]: [{ path: 'test1-exit', index: 1 }],
+    };
+    expect(showExitLink({ data, index: 0 })).to.be.false;
+    expect(showExitLink({ data, index: 1 })).to.be.false;
+  });
+
+  it('should return false when only add dependent is selected', () => {
+    const data = {
+      'view:addOrRemoveDependents': { add: true },
+      [PICKLIST_DATA]: [{ selected: true }, { selected: true }],
+      [PICKLIST_PATHS]: [
+        { path: 'test1-exit', index: 0 },
+        { path: 'test2-exit', index: 1 },
+      ],
+    };
+    expect(showExitLink({ data, index: 0 })).to.be.false;
+    expect(showExitLink({ data, index: 1 })).to.be.false;
+  });
+
   it('should return true for a single exit page', () => {
     const data = {
       [PICKLIST_DATA]: [{ selected: false }, { selected: true }],


### PR DESCRIPTION


## Summary

- Prevent exit form link when add flow is enabled

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/135290

## Testing done

- unit tests added
- flow verified when add flow is enabled with mock api

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
