### PR TITLE
22-10278 fixes: e2e, personal info pattern

### DIFF
--- a/src/applications/edu-benefits/10278/config/form.js
+++ b/src/applications/edu-benefits/10278/config/form.js
@@ -1,7 +1,7 @@
 import footerContent from 'platform/forms/components/FormFooter';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import { VA_FORM_IDS } from 'platform/forms/constants';
-import { personalInformationPage } from 'platform/forms-system/src/js/components/PersonalInformation';
+import { profilePersonalInfoPage } from 'platform/forms-system/src/js/patterns/prefill/PersonalInformation';
 import { profileContactInfoPages } from 'platform/forms-system/src/js/patterns/prefill/ContactInfo';
 import { getContent } from 'platform/forms-system/src/js/utilities/data/profile';
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
@@ -100,7 +100,7 @@ const formConfig = {
     personalInformationChapter: {
       title: 'Your personal information',
       pages: {
-        ...personalInformationPage({
+        ...profilePersonalInfoPage({
           personalInfoConfig: {
             name: { show: true, required: true },
             ssn: { show: true, required: true },

--- a/src/applications/edu-benefits/10278/tests/e2e/10278-edu-benefits.cypress.spec.js
+++ b/src/applications/edu-benefits/10278/tests/e2e/10278-edu-benefits.cypress.spec.js
@@ -12,53 +12,46 @@ import manifest from '../../manifest.json';
 const testConfig = createTestConfig(
   {
     dataPrefix: 'data',
-    dataSets: ['authenticated-test', 'unauthenticated-test'],
+    dataSets: ['authenticated-test'],
     dataDir: path.join(__dirname, '..', 'fixtures', 'data'),
     pageHooks: {
       introduction: ({ afterHook }) => {
         afterHook(() => {
-          cy.get('@testData').then(({ userLoggedIn }) => {
-            // Grab corresponding start button/link based on authentication
-            if (userLoggedIn) {
-              cy.findAllByText(/^start/i, { selector: 'a[href="#start"]' })
-                .last()
-                .click({ force: true });
-            } else {
-              cy.get('.schemaform-start-button')
-                .first()
-                .click();
-            }
-          });
+          cy.get('va-link-action[href="#start"]')
+            .last()
+            .click({ force: true });
         });
       },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('@testData').then(({ userLoggedIn }) => {
-            if (userLoggedIn) {
-              cy.get('#inputField').type('John Doe', { force: true });
-            } else {
-              cy.get('#inputField').type('Not Authenticated', { force: true });
-            }
+          cy.get('@testData').then(data => {
+            const { claimantPersonalInformation } = data;
+            const { fullName } = claimantPersonalInformation;
+            const name = `${fullName.first} ${fullName.middle || ''} ${
+              fullName.last
+            }`.trim();
+            cy.get('va-statement-of-truth')
+              .shadow()
+              .get('#veteran-signature')
+              .shadow()
+              .get('input[name="veteran-signature"]')
+              .type(name);
+            cy.get('va-statement-of-truth')
+              .shadow()
+              .find('input[type="checkbox"]')
+              .check({ force: true });
+            cy.findByText(/submit/i, { selector: 'button' }).click();
           });
-          cy.get('#checkbox-element').check({ force: true });
-          cy.findByText(/Continue/i, { selector: 'button' }).click();
         });
       },
     },
     setupPerTest: () => {
-      cy.get('@testData').then(({ userLoggedIn }) => {
-        // Default endpoints to intercept
-        cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
-        cy.intercept('POST', formConfig.submitUrl, mockSubmit);
-        cy.intercept('PUT', '/v0/in_progress_forms/22-10278', sip);
-
-        // Tests the authenticated form path which requires login and prefill
-        if (userLoggedIn) {
-          cy.intercept('GET', '/v0/user', user);
-          cy.intercept('GET', '/v0/in_progress_forms/22-10278', prefilledForm);
-          cy.login(user);
-        }
-      });
+      cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+      cy.intercept('PUT', '/v0/in_progress_forms/22-10278', sip);
+      cy.intercept('GET', '/v0/user', user);
+      cy.intercept('GET', '/v0/in_progress_forms/22-10278', prefilledForm);
+      cy.login(user);
     },
     skip: Cypress.env('CI'), // Skip CI initially until content-build is merged
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR? 
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
-  remove unauth  path in e2e cypress test
- update personal info page to use pre-fill ready pattern 'profilePersonalInfoPage`

## Related issue(s)

NA

## Testing done
<img width="2074" height="430" alt="Screenshot 2026-03-06 at 1 48 43 PM" src="https://github.com/user-attachments/assets/9da2cf84-abe3-4aa1-a446-00d647f2de00" />

## Screenshots

NA

## What areas of the site does it impact?
edu-benefits/10278

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA