### PR TITLE
Add screenshot capability

### DIFF
--- a/src/applications/vass/README.md
+++ b/src/applications/vass/README.md
@@ -25,7 +25,82 @@ yarn test:unit --app-folder vass --log-level all
 
 # E2E tests
 yarn cy:open
-yarn cy:run --spec "src/applications/vass/tests/e2e/vass.cypress.spec.js"
+yarn cy:run --spec "src/applications/vass/tests/e2e/**/*.cypress.spec.js"
+```
+
+### Screenshots
+
+Screenshots are disabled by default during test runs to speed up regular e2e testing. To capture screenshots, pass the `--env screenshots=vass` flag:
+
+```bash
+yarn cy:run --env screenshots=vass --spec "src/applications/vass/tests/e2e/**/*.cypress.spec.js"
+```
+
+After the command completes, screenshots are saved to the `cypress/screenshots` folder at the root of the project. Each Cypress test file gets its own subfolder containing all screenshots from that file:
+
+```
+cypress/screenshots/
+├── happy-path.cypress.spec.js/
+│   ├── vass_schedule_verifyIdentity.png
+│   ├── vass_schedule_enterOTP.png
+│   ├── vass_schedule_dateTimeSelection.png
+│   ├── vass_schedule_topicSelection.png
+│   ├── vass_schedule_review.png
+│   ├── vass_schedule_confirmation.png
+│   ├── vass_schedule_dateTimeSelection_firstSlotSelected.png
+│   ├── vass_schedule_review_beforeDateTimeChange.png
+│   ├── vass_schedule_dateTimeSelection_secondSlotSelected.png
+│   ├── vass_schedule_review_afterDateTimeChange.png
+│   ├── vass_schedule_confirmation_changedDateTime.png
+│   ├── vass_schedule_review_beforeTopicChange.png
+│   ├── vass_schedule_topicSelection_changingTopic.png
+│   ├── vass_schedule_review_afterTopicChange.png
+│   ├── vass_schedule_confirmation_changedTopic.png
+│   ├── vass_cancel_cancelAppointmentPage.png
+│   ├── vass_cancel_cancelConfirmation.png
+│   ├── vass_cancel_verifyIdentity_cancellationLink.png
+│   ├── vass_cancel_enterOTP_cancellationLink.png
+│   ├── vass_cancel_cancelAppointmentPage_fromLink.png
+│   ├── vass_cancel_cancelConfirmation_fromLink.png
+│   ├── vass_alreadyScheduled_page.png
+│   ├── vass_alreadyScheduled_cancelAppointmentPage.png
+│   └── vass_alreadyScheduled_cancelConfirmation.png
+└── error-path.cypress.spec.js/
+    ├── vass_error_verify_invalidCredentials.png
+    ├── vass_error_verify_3FailedAttempts.png
+    ├── vass_error_verify_rateLimited.png
+    ├── vass_error_verify_serverError500.png
+    ├── vass_error_verify_serviceUnavailable503.png
+    ├── vass_error_verify_emptyLastName.png
+    ├── vass_error_verify_emptyDateOfBirth.png
+    ├── vass_error_otp_invalidCode.png
+    ├── vass_error_otp_lastAttempt.png
+    ├── vass_error_otp_accountLocked.png
+    ├── vass_error_otp_expired.png
+    ├── vass_error_otp_serverError500.png
+    ├── vass_error_otp_serviceUnavailable503.png
+    ├── vass_error_otp_emptyInput.png
+    ├── vass_error_otp_nonNumericInput.png
+    ├── vass_error_otp_tooShort.png
+    ├── vass_error_availability_notWithinCohort.png
+    ├── vass_error_availability_alreadyBooked.png
+    ├── vass_error_availability_noSlots.png
+    ├── vass_error_availability_serverError500.png
+    ├── vass_error_availability_serviceUnavailable503.png
+    ├── vass_error_topics_serverError500.png
+    ├── vass_error_topics_serviceUnavailable503.png
+    ├── vass_error_create_saveFailed.png
+    ├── vass_error_create_serverError500.png
+    ├── vass_error_create_serviceUnavailable503.png
+    ├── vass_error_details_notFound.png
+    ├── vass_error_details_serverError500.png
+    ├── vass_error_details_serviceUnavailable503.png
+    ├── vass_error_cancel_failed.png
+    ├── vass_error_cancel_appointmentNotFound.png
+    ├── vass_error_cancel_cancellationNotFound.png
+    ├── vass_error_cancel_serverError500.png
+    ├── vass_error_cancel_serviceUnavailable503.png
+    └── vass_error_navigation_noUuid.png
 ```
 
 ## Mock UUIDs

--- a/src/applications/vass/components/ErrorAlert.jsx
+++ b/src/applications/vass/components/ErrorAlert.jsx
@@ -10,6 +10,7 @@ const ErrorAlert = ({ flowType = FLOW_TYPES.SCHEDULE }) => {
   return (
     <va-alert
       status="error"
+      visible
       class="vads-u-margin-top--4"
       data-testid="api-error-alert"
     >

--- a/src/applications/vass/components/VerificationErrorAlert.jsx
+++ b/src/applications/vass/components/VerificationErrorAlert.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const VerificationErrorAlert = ({ message }) => {
+  return (
+    <va-alert
+      data-testid="verification-error-alert"
+      class="vads-u-margin-top--4"
+      status="error"
+      visible
+      slim
+    >
+      <p className="vads-u-margin-y--0">{message}</p>
+    </va-alert>
+  );
+};
+
+export default VerificationErrorAlert;
+
+VerificationErrorAlert.propTypes = {
+  message: PropTypes.string.isRequired,
+};

--- a/src/applications/vass/components/VerificationErrorAlert.unit.spec.jsx
+++ b/src/applications/vass/components/VerificationErrorAlert.unit.spec.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import VerificationErrorAlert from './VerificationErrorAlert';
+
+describe('VASS Component: VerificationErrorAlert', () => {
+  it('should render the verification error alert with correct structure', () => {
+    const message = 'Test verification error message';
+    const { getByTestId } = render(
+      <VerificationErrorAlert message={message} />,
+    );
+
+    const alert = getByTestId('verification-error-alert');
+    expect(alert).to.exist;
+    expect(alert.getAttribute('status')).to.equal('error');
+    expect(alert.getAttribute('class')).to.contain('vads-u-margin-top--4');
+  });
+
+  it('should display the provided error message', () => {
+    const message =
+      'The one-time verification code you entered doesn\u2019t match the one we sent you.';
+    const { getByTestId } = render(
+      <VerificationErrorAlert message={message} />,
+    );
+
+    const alert = getByTestId('verification-error-alert');
+    expect(alert.textContent).to.contain(message);
+  });
+
+  it('should render the message inside a paragraph element', () => {
+    const message = 'Account locked error message';
+    const { getByTestId } = render(
+      <VerificationErrorAlert message={message} />,
+    );
+
+    const paragraph = getByTestId('verification-error-alert').querySelector(
+      'p',
+    );
+    expect(paragraph).to.exist;
+    expect(paragraph.textContent).to.equal(message);
+    expect(paragraph.className).to.contain('vads-u-margin-y--0');
+  });
+});

--- a/src/applications/vass/layout/Wrapper.jsx
+++ b/src/applications/vass/layout/Wrapper.jsx
@@ -9,6 +9,7 @@ import { focusElement } from 'platform/utilities/ui';
 
 import NeedHelp from '../components/NeedHelp';
 import ErrorAlert from '../components/ErrorAlert';
+import VerificationErrorAlert from '../components/VerificationErrorAlert';
 import { FLOW_TYPES } from '../utils/constants';
 
 // TODO: Maybe combine errorAlert and verificationError into a single prop
@@ -17,15 +18,7 @@ const getContent = (errorAlert, verificationError, children, flowType) => {
     return <ErrorAlert flowType={flowType} />;
   }
   if (verificationError) {
-    return (
-      <va-alert
-        data-testid="verification-error-alert"
-        class="vads-u-margin-top--4"
-        status="error"
-      >
-        {verificationError}
-      </va-alert>
-    );
+    return <VerificationErrorAlert message={verificationError} />;
   }
   return children;
 };

--- a/src/applications/vass/pages/EnterOTP.jsx
+++ b/src/applications/vass/pages/EnterOTP.jsx
@@ -29,6 +29,8 @@ const getErrorMessage = (errorCode, attemptsRemaining = 0) => {
   switch (errorCode) {
     case OTP_ERROR_CODES.ACCOUNT_LOCKED:
       return 'The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes. Check your email and select the link to schedule a call.';
+    case OTP_ERROR_CODES.OTP_EXPIRED:
+      return 'The one-time verification code you entered has expired. Select the link in your email to get a new code and schedule a call.';
     case OTP_ERROR_CODES.INVALID_OTP:
       if (attemptsRemaining === 1) {
         return 'The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again.';

--- a/src/applications/vass/pages/EnterOTP.unit.spec.jsx
+++ b/src/applications/vass/pages/EnterOTP.unit.spec.jsx
@@ -19,6 +19,7 @@ import { FLOW_TYPES, URLS, VASS_PHONE_NUMBER } from '../utils/constants';
 import {
   createOTPInvalidError,
   createOTPAccountLockedError,
+  createOTPExpiredError,
   createAppointmentAlreadyBookedError,
   createVassApiError,
   createNotWithinCohortError,
@@ -237,6 +238,21 @@ describe('VASS Component: EnterOTP', () => {
         expect(errorAlert).to.exist;
         expect(errorAlert.textContent).to.match(
           /The one-time verification code you entered doesn’t match the one we sent you. You can try again in 15 minutes./i,
+        );
+      });
+    });
+
+    it('should display expired OTP error message', async () => {
+      setFetchJSONFailure(global.fetch.onCall(0), createOTPExpiredError());
+      const { container, getByTestId } = renderComponent();
+      inputVaTextInput(container, '123456', 'va-text-input[name="otp"]');
+      const continueButton = getByTestId('continue-button');
+      continueButton.click();
+      await waitFor(() => {
+        const errorAlert = getByTestId('enter-otp-error-alert');
+        expect(errorAlert).to.exist;
+        expect(errorAlert.textContent).to.match(
+          /The one-time verification code you entered has expired. Select the link in your email to get a new code and schedule a call./i,
         );
       });
     });

--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -14,6 +14,7 @@ import {
   mockAppointmentDetailsApi,
   mockCancelAppointmentApi,
   patchCookiesForCI,
+  saveScreenshot,
 } from './vass-e2e-helpers';
 import MockRequestOtpResponse from '../fixtures/MockRequestOtpResponse';
 import MockAuthenticateOtpResponse from '../fixtures/MockAuthenticateOtpResponse';
@@ -59,6 +60,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:request-otp');
 
           VerifyPageObject.assertInvalidCredentialsErrorAlert();
+          saveScreenshot('vass_error_verify_invalidCredentials');
         });
 
         it('should display a verification error alert after 3 failed attempts', () => {
@@ -78,6 +80,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertInvalidVerificationErrorAlert({
             exist: true,
           });
+          saveScreenshot('vass_error_verify_3FailedAttempts');
         });
       });
 
@@ -103,6 +106,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertInvalidVerificationErrorAlert({
             exist: true,
           });
+          saveScreenshot('vass_error_verify_rateLimited');
         });
       });
 
@@ -126,6 +130,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:request-otp');
 
           VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+          saveScreenshot('vass_error_verify_serverError500');
         });
       });
 
@@ -149,6 +154,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:request-otp');
 
           VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+          saveScreenshot('vass_error_verify_serviceUnavailable503');
         });
       });
     });
@@ -167,6 +173,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.clickSubmit();
 
           VerifyPageObject.assertLastNameError('Please enter your last name');
+          saveScreenshot('vass_error_verify_emptyLastName');
         });
       });
 
@@ -181,6 +188,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertDateOfBirthError(
             'Please enter your date of birth',
           );
+          saveScreenshot('vass_error_verify_emptyDateOfBirth');
         });
       });
     });
@@ -217,6 +225,7 @@ describe('VASS Error Paths', () => {
             containsText:
               'The one-time verification code you entered doesn’t match the one we sent you. Check your email and try again.',
           });
+          saveScreenshot('vass_error_otp_invalidCode');
         });
 
         it('should display an invalid OTP error when the user has 1 remaining attempt', () => {
@@ -238,6 +247,7 @@ describe('VASS Error Paths', () => {
             containsText:
               'The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again.',
           });
+          saveScreenshot('vass_error_otp_lastAttempt');
         });
       });
 
@@ -259,6 +269,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertVerificationErrorPage();
+          saveScreenshot('vass_error_otp_accountLocked');
         });
       });
 
@@ -280,6 +291,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertOTPErrorAlert({ exist: true });
+          saveScreenshot('vass_error_otp_expired');
         });
       });
 
@@ -301,6 +313,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertWrapperErrorAlert({ exist: true });
+          saveScreenshot('vass_error_otp_serverError500');
         });
       });
 
@@ -322,6 +335,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertWrapperErrorAlert({ exist: true });
+          saveScreenshot('vass_error_otp_serviceUnavailable503');
         });
       });
     });
@@ -337,6 +351,7 @@ describe('VASS Error Paths', () => {
           EnterOTPPageObject.assertOTPError(
             'Please enter your one-time verification code',
           );
+          saveScreenshot('vass_error_otp_emptyInput');
         });
       });
 
@@ -352,6 +367,7 @@ describe('VASS Error Paths', () => {
             EnterOTPPageObject.assertOTPError(
               'Your verification code should only contain numbers',
             );
+            saveScreenshot('vass_error_otp_nonNumericInput');
           });
         });
 
@@ -366,6 +382,7 @@ describe('VASS Error Paths', () => {
             EnterOTPPageObject.assertOTPError(
               'Your verification code should be 6 digits',
             );
+            saveScreenshot('vass_error_otp_tooShort');
           });
         });
       });
@@ -402,6 +419,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_availability_notWithinCohort');
       });
     });
 
@@ -429,6 +447,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         AlreadyScheduledPageObject.assertAlreadyScheduledPage();
+        saveScreenshot('vass_error_availability_alreadyBooked');
       });
     });
 
@@ -446,6 +465,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_availability_noSlots');
       });
     });
 
@@ -463,6 +483,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_availability_serverError500');
       });
     });
 
@@ -480,6 +501,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_availability_serviceUnavailable503');
       });
     });
   });
@@ -519,6 +541,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_topics_serverError500');
       });
     });
 
@@ -536,6 +559,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_topics_serviceUnavailable503');
       });
     });
   });
@@ -578,6 +602,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_create_saveFailed');
       });
     });
 
@@ -595,6 +620,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_create_serverError500');
       });
     });
 
@@ -612,6 +638,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_create_serviceUnavailable503');
       });
     });
   });
@@ -655,6 +682,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_details_notFound');
       });
     });
 
@@ -672,6 +700,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_details_serverError500');
       });
     });
 
@@ -689,6 +718,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_details_serviceUnavailable503');
       });
     });
   });
@@ -749,6 +779,7 @@ describe('VASS Error Paths', () => {
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        saveScreenshot('vass_error_cancel_failed');
       });
     });
 
@@ -770,6 +801,7 @@ describe('VASS Error Paths', () => {
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        saveScreenshot('vass_error_cancel_appointmentNotFound');
       });
     });
 
@@ -792,6 +824,7 @@ describe('VASS Error Paths', () => {
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        saveScreenshot('vass_error_cancel_cancellationNotFound');
       });
     });
 
@@ -814,6 +847,7 @@ describe('VASS Error Paths', () => {
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        saveScreenshot('vass_error_cancel_serverError500');
       });
     });
 
@@ -836,6 +870,7 @@ describe('VASS Error Paths', () => {
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        saveScreenshot('vass_error_cancel_serviceUnavailable503');
       });
     });
   });
@@ -884,6 +919,7 @@ describe('VASS Error Paths', () => {
         cy.injectAxeThenAxeCheck();
 
         VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+        saveScreenshot('vass_error_navigation_noUuid');
       });
     });
   });

--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -4,6 +4,7 @@ import DateTimeSelectionPageObject from './page-objects/DateTimeSelectionPageObj
 import TopicSelectionPageObject from './page-objects/TopicSelectionPageObject';
 import ReviewPageObject from './page-objects/ReviewPageObject';
 import CancelAppointmentPageObject from './page-objects/CancelAppointmentPageObject';
+import ConfirmationPageObject from './page-objects/ConfirmationPageObject';
 import AlreadyScheduledPageObject from './page-objects/AlreadyScheduledPageObject';
 import {
   mockRequestOtpApi,
@@ -290,7 +291,11 @@ describe('VASS Error Paths', () => {
 
           cy.wait('@vass:post:authenticate-otp');
 
-          EnterOTPPageObject.assertOTPErrorAlert({ exist: true });
+          EnterOTPPageObject.assertOTPErrorAlert({
+            exist: true,
+            containsText:
+              'The one-time verification code you entered has expired. Select the link in your email to get a new code and schedule a call.',
+          });
           saveScreenshot('vass_error_otp_expired');
         });
       });
@@ -920,6 +925,58 @@ describe('VASS Error Paths', () => {
 
         VerifyPageObject.assertWrapperErrorAlert({ exist: true });
         saveScreenshot('vass_error_navigation_noUuid');
+      });
+    });
+
+    describe('when the user decides not to cancel the appointment', () => {
+      const appointmentId = 'abcdef123456';
+      beforeEach(() => {
+        mockRequestOtpApi();
+        const authenticateOtpResponse = new MockAuthenticateOtpResponse({
+          token: createMockJwt(uuid, expiresIn),
+          expiresIn,
+        }).toJSON();
+        mockAuthenticateOtpApi({
+          response: authenticateOtpResponse,
+          responseCode: 200,
+        });
+        mockAppointmentAvailabilityApi({
+          response: new MockAppointmentAvailabilityResponse({
+            appointmentId,
+            availableSlots: MockAppointmentAvailabilityResponse.createSlots(),
+          }).toJSON(),
+          responseCode: 200,
+        });
+        mockAppointmentDetailsApi({
+          response: new MockAppointmentDetailsResponse({
+            appointmentId,
+          }).toJSON(),
+          responseCode: 200,
+        });
+
+        cy.visit(
+          `/service-member/benefits/solid-start/schedule?uuid=${uuid}&cancel=true`,
+        );
+        VerifyPageObject.fillAndSubmitForm();
+        cy.wait('@vass:post:request-otp');
+      });
+
+      it('should navigate to the appointment details page', () => {
+        EnterOTPPageObject.fillAndSubmitOTP();
+        cy.wait('@vass:post:authenticate-otp');
+        cy.wait('@vass:get:appointment-availability');
+        cy.wait('@vass:get:appointment-details');
+
+        CancelAppointmentPageObject.assertCancelAppointmentPage();
+        cy.injectAxeThenAxeCheck();
+
+        CancelAppointmentPageObject.clickNoDontCancel();
+
+        ConfirmationPageObject.assertDetailsOnlyPage({
+          agentName: 'Agent Smith',
+        });
+        cy.injectAxeThenAxeCheck();
+        saveScreenshot('vass_error_navigation_noCancelAppointment');
       });
     });
   });

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -12,6 +12,7 @@ import {
   mockAppointmentDetailsApi,
   mockCancelAppointmentApi,
   patchCookiesForCI,
+  saveScreenshot,
 } from './vass-e2e-helpers';
 import MockAppointmentAvailabilityResponse from '../fixtures/MockAppointmentAvailabilityResponse';
 import MockAppointmentDetailsResponse from '../fixtures/MockAppointmentDetailsResponse';
@@ -64,30 +65,34 @@ describe('VASS Schedule Appointment', () => {
 
     it('should schedule an appointment', () => {
       VerifyPageObject.assertVerifyPage();
-
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_schedule_verifyIdentity');
 
       VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       EnterOTPPageObject.assertEnterOTPPage();
-
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_schedule_enterOTP');
+
       EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-availability');
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_schedule_dateTimeSelection');
       DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
 
       cy.wait('@vass:get:topics');
       cy.injectAxeThenAxeCheck();
       TopicSelectionPageObject.assertTopicSelectionPage();
+      saveScreenshot('vass_schedule_topicSelection');
       TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
 
       ReviewPageObject.assertReviewPage();
       cy.injectAxeThenAxeCheck();
       ReviewPageObject.assertTopicDescription('General VA benefits');
+      saveScreenshot('vass_schedule_review');
       ReviewPageObject.clickConfirmAppointment();
 
       cy.wait('@vass:post:appointment');
@@ -99,6 +104,7 @@ describe('VASS Schedule Appointment', () => {
         topics: ['General VA benefits'],
       });
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_schedule_confirmation');
       ConfirmationPageObject.assertAddToCalendarButton();
       ConfirmationPageObject.assertPrintFunctionality();
     });
@@ -161,6 +167,7 @@ describe('VASS Schedule Appointment', () => {
       // Select first slot (index 0) in a consistent manner
       DateTimeSelectionPageObject.selectFirstAvailableDate();
       DateTimeSelectionPageObject.selectTimeSlotByIndex(0);
+      saveScreenshot('vass_schedule_dateTimeSelection_firstSlotSelected');
       DateTimeSelectionPageObject.clickContinue();
 
       cy.wait('@vass:get:topics');
@@ -173,12 +180,14 @@ describe('VASS Schedule Appointment', () => {
       ReviewPageObject.assertTopicDescription(topic);
       ReviewPageObject.assertDateTimeDescriptionContains(expectedDate);
       ReviewPageObject.assertDateTimeDescriptionContains(expectedTime1);
+      saveScreenshot('vass_schedule_review_beforeDateTimeChange');
 
       // Change date/time: go back and select the second slot
       ReviewPageObject.clickEditDateTime();
       DateTimeSelectionPageObject.assertDateTimeSelectionPage();
       DateTimeSelectionPageObject.selectFirstAvailableDate();
       DateTimeSelectionPageObject.selectTimeSlotByIndex(1);
+      saveScreenshot('vass_schedule_dateTimeSelection_secondSlotSelected');
       DateTimeSelectionPageObject.clickContinue();
 
       TopicSelectionPageObject.assertTopicSelectionPage();
@@ -187,6 +196,7 @@ describe('VASS Schedule Appointment', () => {
       ReviewPageObject.assertReviewPage();
       ReviewPageObject.assertDateTimeDescriptionContains(expectedDate);
       ReviewPageObject.assertDateTimeDescriptionContains(expectedTime2);
+      saveScreenshot('vass_schedule_review_afterDateTimeChange');
       ReviewPageObject.clickConfirmAppointment();
 
       cy.wait('@vass:post:appointment');
@@ -200,6 +210,7 @@ describe('VASS Schedule Appointment', () => {
       ConfirmationPageObject.assertWhenSectionContainsDateTime(expectedDate);
       ConfirmationPageObject.assertWhenSectionContainsDateTime(expectedTime2);
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_schedule_confirmation_changedDateTime');
     });
 
     it('should allow the user to change the topic', () => {
@@ -228,6 +239,7 @@ describe('VASS Schedule Appointment', () => {
       ReviewPageObject.assertReviewPage();
       cy.injectAxeThenAxeCheck();
       ReviewPageObject.assertTopicDescription(firstTopic);
+      saveScreenshot('vass_schedule_review_beforeTopicChange');
 
       // Change topic: go back, unselect first and select second
       ReviewPageObject.clickEditTopic();
@@ -235,10 +247,12 @@ describe('VASS Schedule Appointment', () => {
       TopicSelectionPageObject.unselectTopicByTestId(
         'topic-checkbox-general-va-benefits',
       );
+      saveScreenshot('vass_schedule_topicSelection_changingTopic');
       TopicSelectionPageObject.selectTopicAndContinue(secondTopic);
 
       ReviewPageObject.assertReviewPage();
       ReviewPageObject.assertTopicDescription(secondTopic);
+      saveScreenshot('vass_schedule_review_afterTopicChange');
       ReviewPageObject.clickConfirmAppointment();
 
       cy.wait('@vass:post:appointment');
@@ -250,6 +264,7 @@ describe('VASS Schedule Appointment', () => {
         topics: [secondTopic],
       });
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_schedule_confirmation_changedTopic');
     });
   });
 
@@ -317,6 +332,7 @@ describe('VASS Schedule Appointment', () => {
         agentName: 'Agent Smith',
       });
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_cancel_cancelAppointmentPage');
 
       CancelAppointmentPageObject.clickYesCancelAppointment();
       cy.wait('@vass:post:cancel-appointment');
@@ -325,6 +341,7 @@ describe('VASS Schedule Appointment', () => {
         agentName: 'Agent Smith',
       });
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_cancel_cancelConfirmation');
     });
 
     it('should cancel an appointment from a cancelation link', () => {
@@ -334,12 +351,14 @@ describe('VASS Schedule Appointment', () => {
 
       VerifyPageObject.assertVerifyPage({ cancellationFlow: true });
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_cancel_verifyIdentity_cancellationLink');
       VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
       cy.injectAxeThenAxeCheck();
       EnterOTPPageObject.assertEnterOTPPage({ cancellationFlow: true });
       EnterOTPPageObject.assertSuccessAlertContainsEmail('s****@email.com');
+      saveScreenshot('vass_cancel_enterOTP_cancellationLink');
       EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-details');
@@ -348,6 +367,7 @@ describe('VASS Schedule Appointment', () => {
       CancelAppointmentPageObject.assertCancelAppointmentPage({
         agentName: 'Agent Smith',
       });
+      saveScreenshot('vass_cancel_cancelAppointmentPage_fromLink');
 
       CancelAppointmentPageObject.clickYesCancelAppointment();
       cy.wait('@vass:post:cancel-appointment');
@@ -356,6 +376,7 @@ describe('VASS Schedule Appointment', () => {
         agentName: 'Agent Smith',
       });
       cy.injectAxeThenAxeCheck();
+      saveScreenshot('vass_cancel_cancelConfirmation_fromLink');
     });
   });
 
@@ -408,6 +429,7 @@ describe('VASS Schedule Appointment', () => {
 
         AlreadyScheduledPageObject.assertAlreadyScheduledPage();
         cy.injectAxeThenAxeCheck();
+        saveScreenshot('vass_alreadyScheduled_page');
       });
 
       it('should allow the user to cancel', () => {
@@ -433,6 +455,7 @@ describe('VASS Schedule Appointment', () => {
           agentName: 'Agent Smith',
         });
         cy.injectAxeThenAxeCheck();
+        saveScreenshot('vass_alreadyScheduled_cancelAppointmentPage');
 
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');
@@ -441,6 +464,7 @@ describe('VASS Schedule Appointment', () => {
           agentName: 'Agent Smith',
         });
         cy.injectAxeThenAxeCheck();
+        saveScreenshot('vass_alreadyScheduled_cancelConfirmation');
       });
     });
   });

--- a/src/applications/vass/tests/e2e/page-objects/ConfirmationPageObject.js
+++ b/src/applications/vass/tests/e2e/page-objects/ConfirmationPageObject.js
@@ -89,9 +89,11 @@ export class ConfirmationPageObject extends PageObject {
 
     // How to join section with phone number
     this.assertElement('how-to-join-section');
-    cy.findByTestId('solid-start-telephone')
-      .should('exist')
-      .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+    cy.findByTestId('appointment-card').within(() => {
+      cy.findByTestId('solid-start-telephone')
+        .should('exist')
+        .and('have.attr', 'contact', VASS_PHONE_NUMBER);
+    });
 
     // When section
     this.assertElement('when-section');

--- a/src/applications/vass/tests/e2e/vass-e2e-helpers.js
+++ b/src/applications/vass/tests/e2e/vass-e2e-helpers.js
@@ -291,3 +291,99 @@ export function mockCancelAppointmentApi({
     },
   ).as('vass:post:cancel-appointment');
 }
+
+/**
+ * Selector for the main scrollable container element.
+ * Used to manipulate scroll behavior for full-page screenshots.
+ */
+const SCROLLER = 'body';
+
+/**
+ * Expands the scroll container to its full content height before taking a screenshot.
+ *
+ * By default, Cypress screenshots only capture the visible viewport. This function
+ * temporarily modifies the scroll container's styles to make all content visible
+ * by setting the height to the full scroll height and removing overflow constraints.
+ *
+ * The original styles are saved to a Cypress alias (`scrollerPrevStyles`) so they
+ * can be restored after the screenshot is taken.
+ *
+ * @private
+ */
+function expandScrollerForShot() {
+  cy.get(SCROLLER).then($el => {
+    const el = $el[0];
+    const prev = {
+      height: el.style.height,
+      overflow: el.style.overflow,
+      maxHeight: el.style.maxHeight,
+    };
+
+    el.style.height = `${el.scrollHeight}px`;
+    el.style.maxHeight = 'none';
+    el.style.overflow = 'visible';
+
+    cy.wrap(prev, { log: false }).as('scrollerPrevStyles');
+  });
+}
+
+/**
+ * Restores the scroll container's original styles after a screenshot is taken.
+ *
+ * This function retrieves the previously saved styles from the `scrollerPrevStyles`
+ * Cypress alias and applies them back to the scroll container, returning the page
+ * to its normal scrollable state.
+ *
+ * @private
+ */
+function restoreScrollerAfterShot() {
+  cy.get('@scrollerPrevStyles').then(prev => {
+    cy.get(SCROLLER).then($el => {
+      const el = $el[0];
+      el.style.height = prev.height;
+      el.style.maxHeight = prev.maxHeight;
+      el.style.overflow = prev.overflow;
+    });
+  });
+}
+
+/**
+ * Saves a screenshot of the current page.
+ *
+ * Screenshots are disabled by default. Pass `--env screenshots=vass` to enable them.
+ * Use `--env screenshots=all` to capture screenshots for all apps.
+ *
+ * @param {string} name - The name of the screenshot. Must be in the format of 'appName_featureName'.
+ * @param {Object} [options] - The options for the screenshot.
+ * @param {string} [options.overwrite=true] - Whether to overwrite the screenshot if it already exists.
+ * @param {string} [options.capture='fullPage'] - The capture mode for the screenshot.
+ */
+export function saveScreenshot(
+  name,
+  options = { overwrite: true, capture: 'fullPage' },
+) {
+  const screenshotOptions = Cypress.env('screenshots');
+  if (!screenshotOptions) {
+    return;
+  }
+
+  const optionsSet = new Set(screenshotOptions.split(','));
+
+  const [appName, featureName] = name.split('_');
+
+  if (
+    !optionsSet.has(appName) &&
+    !optionsSet.has(featureName) &&
+    screenshotOptions !== 'all'
+  ) {
+    return;
+  }
+
+  if (options.capture === 'fullPage') {
+    expandScrollerForShot();
+  }
+  cy.screenshot(name, options);
+  if (options.capture === 'fullPage') {
+    restoreScrollerAfterShot();
+  }
+}

--- a/src/applications/vass/utils/mock-helpers.unit.spec.jsx
+++ b/src/applications/vass/utils/mock-helpers.unit.spec.jsx
@@ -1,5 +1,14 @@
 import { expect } from 'chai';
+import { format } from 'date-fns';
+import { zonedTimeToUtc } from 'date-fns-tz';
 import { generateSlots } from './mock-helpers';
+
+const TZ_PT = 'America/Los_Angeles';
+
+const getExpectedPacific8amUtc = utcDateString => {
+  const dateStr = format(new Date(utcDateString), 'yyyy-MM-dd');
+  return zonedTimeToUtc(`${dateStr}T08:00:00`, TZ_PT);
+};
 
 describe('generateSlots', () => {
   it('should generate default 14 days of slots with 12 slots per day', () => {
@@ -30,11 +39,13 @@ describe('generateSlots', () => {
     expect(durationMinutes).to.equal(30);
   });
 
-  it('should start at 16:00 UTC or 8:00 PST', () => {
+  it('should start at 8:00 AM Pacific', () => {
     const slots = generateSlots(7, 1);
 
     const firstSlotStart = new Date(slots[0].dtStartUtc);
-    expect(firstSlotStart.getUTCHours()).to.equal(16); // 16:00 UTC
+    const expected8amUtc = getExpectedPacific8amUtc(slots[0].dtStartUtc);
+
+    expect(firstSlotStart.getUTCHours()).to.equal(expected8amUtc.getUTCHours());
     expect(firstSlotStart.getUTCMinutes()).to.equal(0);
   });
 
@@ -42,14 +53,18 @@ describe('generateSlots', () => {
     const slots = generateSlots(7, 3);
 
     const firstDay = slots.slice(0, 3);
+    const expected8amUtc = getExpectedPacific8amUtc(firstDay[0].dtStartUtc);
+    const startHour = expected8amUtc.getUTCHours();
 
-    expect(new Date(firstDay[0].dtStartUtc).getUTCHours()).to.equal(16);
+    expect(new Date(firstDay[0].dtStartUtc).getUTCHours()).to.equal(startHour);
     expect(new Date(firstDay[0].dtStartUtc).getUTCMinutes()).to.equal(0);
 
-    expect(new Date(firstDay[1].dtStartUtc).getUTCHours()).to.equal(16);
+    expect(new Date(firstDay[1].dtStartUtc).getUTCHours()).to.equal(startHour);
     expect(new Date(firstDay[1].dtStartUtc).getUTCMinutes()).to.equal(30);
 
-    expect(new Date(firstDay[2].dtStartUtc).getUTCHours()).to.equal(17);
+    expect(new Date(firstDay[2].dtStartUtc).getUTCHours()).to.equal(
+      startHour + 1,
+    );
     expect(new Date(firstDay[2].dtStartUtc).getUTCMinutes()).to.equal(0);
   });
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they
  cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

  ## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:
  Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as
  the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - Add opt-in screenshot capture to VASS Cypress e2e tests via a new `saveScreenshot` helper function in
  `vass-e2e-helpers.js`. Screenshots are disabled by default and enabled with `--env screenshots=vass`.
  - The helper expands the scroll container to full content height before capture (full-page screenshots) and restores
  original styles afterward.
  - 23 screenshot calls added to `happy-path.cypress.spec.js` covering: identity verification, OTP entry, date/time selection,
   topic selection, review, confirmation, and edit flows (change date/time, change topic), cancellation flows, and
  already-scheduled flows.
  - 35 screenshot calls added to `error-path.cypress.spec.js` covering: verify errors, OTP errors, availability errors, topic
  errors, create errors, details errors, cancel errors, and navigation errors.
  - README updated with screenshot documentation (CLI flag usage, output directory structure, full list of generated
  filenames) and updated e2e spec glob pattern from single file to `**/*.cypress.spec.js`.
  - VASS team owns this code.

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#135413

  ## Testing done

  - **Previous behavior:** VASS e2e tests had no screenshot capture capability. There was no way to generate visual
  documentation of UI states from the test suite.
  - **Steps to verify:**
    1. Run tests without the flag: `yarn cy:run --spec "src/applications/vass/tests/e2e/**/*.cypress.spec.js"` — confirm no
  screenshots are generated in `cypress/screenshots/`.
    2. Run tests with the flag: `yarn cy:run --env screenshots=vass --spec
  "src/applications/vass/tests/e2e/**/*.cypress.spec.js"` — confirm screenshots are saved to `cypress/screenshots/` with the
  expected folder structure and filenames as documented in the README.
    3. Verify screenshots are full-page (not viewport-clipped) by inspecting the output images.
  - **Tests updated:** No new unit/integration tests added. The screenshot functionality is exercised as part of the existing
  e2e test runs when the flag is enabled. The `saveScreenshot` helper is a no-op when the flag is absent, so existing test
  behavior is unchanged.

  ## Screenshots

  N/A — no UI changes. This PR adds test infrastructure for capturing screenshots, not visual changes to the application.

  ## What areas of the site does it impact?

  This change is scoped entirely to `src/applications/vass/tests/e2e/` and `src/applications/vass/README.md`. No production
  application code, shared platform code, or other applications are affected.

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
  - [x] Linting warnings have been addressed
  - [x] Documentation has been updated (README.md updated with screenshot usage docs)
  - [ ] Screenshot of the developed feature is added
  - [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessi
  bility-staging-review) has been performed

  ### Error Handling

  - [ ] Browser console contains no warnings or errors.
  - [ ] Events are being sent to the appropriate logging solution
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

  ### Authentication

  - [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

  ## Requested Feedback

  - The `saveScreenshot` helper uses DOM style manipulation (`expandScrollerForShot` / `restoreScrollerAfterShot`) to capture
  full-page screenshots. Please review the approach of temporarily modifying `body` styles (height, overflow, maxHeight) to
  ensure it doesn't interfere with test assertions or cause flakiness.
  - The filtering logic in `saveScreenshot` splits the screenshot name on `_` to extract app and feature names. Confirm this
  naming convention (`appName_featureName_detail`) is clear and sustainable.