### PR TITLE
[Ask VA] Add inbox-sorting feature

### DIFF
--- a/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
@@ -17,9 +17,10 @@ import { filterAndSort } from '../../utils/inbox';
 
 /**
  * @typedef {Object} Props
+ * @property {('business' | 'personal')[]} inquiryTypes
  * @property {string[]} categoryOptions
  * @property {string[]} statusOptions
- * @property {{ business: Inquiry[], personal: Inquiry[] }} inquiries
+ * @property {Inquiry[]} inquiries
  */
 
 /**
@@ -27,18 +28,19 @@ import { filterAndSort } from '../../utils/inbox';
  */
 export default function InboxLayoutNew({
   inquiries,
+  inquiryTypes,
   categoryOptions,
   statusOptions,
 }) {
-  const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
-  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
+  const [pendingCategoriesFilter, setPendingCategoriesFilter] = useState('All');
+  const [pendingStatusesFilter, setPendingStatusesFilter] = useState('All');
   const [pendingQuery, setPendingQuery] = useState('');
   const [sortOrder, setSortOrder] = useState(
     filterAndSort.sortOptions.lastUpdate.newest,
   );
   const [filters, setFilters] = useState({
-    status: 'All',
-    category: 'All',
+    statuses: ['All'],
+    categories: ['All'],
     query: '',
   });
 
@@ -47,7 +49,7 @@ export default function InboxLayoutNew({
       <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
         Your questions
       </h2>
-      {inquiries.personal.length || inquiries.business.length ? (
+      {inquiryTypes.length ? (
         <>
           <div className="filter-container">
             <div className="search-container">
@@ -65,9 +67,9 @@ export default function InboxLayoutNew({
                 hint={null}
                 label="Filter by status"
                 name="status"
-                value={pendingStatusFilter}
+                value={pendingStatusesFilter}
                 onVaSelect={event => {
-                  setPendingStatusFilter(event.target.value || 'All');
+                  setPendingStatusesFilter(event.target.value || 'All');
                 }}
               >
                 <option value="All">All</option>
@@ -83,9 +85,9 @@ export default function InboxLayoutNew({
                 hint={null}
                 label="Filter by category"
                 name="category"
-                value={pendingCategoryFilter}
+                value={pendingCategoriesFilter}
                 onVaSelect={event => {
-                  setPendingCategoryFilter(event.target.value || 'All');
+                  setPendingCategoriesFilter(event.target.value || 'All');
                 }}
               >
                 <option value="All">All</option>
@@ -106,20 +108,20 @@ export default function InboxLayoutNew({
                 secondaryLabel="Clear all filters"
                 onPrimaryClick={() => {
                   setFilters(() => ({
-                    category: pendingCategoryFilter,
-                    status: pendingStatusFilter,
+                    categories: [pendingCategoriesFilter],
+                    statuses: [pendingStatusesFilter],
                     query: pendingQuery,
                   }));
                   focusElement('#search-description');
                 }}
                 onSecondaryClick={() => {
                   setFilters(() => ({
-                    status: 'All',
-                    category: 'All',
+                    statuses: ['All'],
+                    categories: ['All'],
                     query: '',
                   }));
-                  setPendingStatusFilter('All');
-                  setPendingCategoryFilter('All');
+                  setPendingStatusesFilter('All');
+                  setPendingCategoriesFilter('All');
                   setPendingQuery('');
                   focusElement('#search-description');
                 }}
@@ -145,7 +147,7 @@ export default function InboxLayoutNew({
             </VaSort>
           </div>
 
-          {inquiries.business?.length ? (
+          {inquiryTypes.includes('business') ? (
             <div className="tabs">
               <Tabs className="inbox-tab-container">
                 <TabList className="inbox-tab-list">
@@ -155,26 +157,26 @@ export default function InboxLayoutNew({
                 <TabPanel>
                   <InquiriesList
                     inquiries={filterAndSort({
-                      inquiriesArray: inquiries.business,
-                      filters,
+                      inquiriesArray: inquiries,
+                      filters: { ...filters, inquiryTypes: ['business'] },
                       sortOrder,
                     })}
                     tabName="Business"
-                    categoryFilter={filters.category}
-                    statusFilter={filters.status}
+                    categoryFilter={filters.categories[0]}
+                    statusFilter={filters.statuses[0]}
                     query={filters.query}
                   />
                 </TabPanel>
                 <TabPanel>
                   <InquiriesList
                     inquiries={filterAndSort({
-                      inquiriesArray: inquiries.personal,
-                      filters,
+                      inquiriesArray: inquiries,
+                      filters: { ...filters, inquiryTypes: ['personal'] },
                       sortOrder,
                     })}
                     tabName="Personal"
-                    categoryFilter={filters.category}
-                    statusFilter={filters.status}
+                    categoryFilter={filters.categories[0]}
+                    statusFilter={filters.statuses[0]}
                     query={filters.query}
                   />
                 </TabPanel>
@@ -183,12 +185,12 @@ export default function InboxLayoutNew({
           ) : (
             <InquiriesList
               inquiries={filterAndSort({
-                inquiriesArray: inquiries.personal,
-                filters,
+                inquiriesArray: inquiries,
+                filters: { ...filters, inquiryTypes: ['personal'] },
                 sortOrder,
               })}
-              categoryFilter={filters.category}
-              statusFilter={filters.status}
+              categoryFilter={filters.categories[0]}
+              statusFilter={filters.statuses[0]}
               query={filters.query}
             />
           )}
@@ -214,9 +216,7 @@ export default function InboxLayoutNew({
 
 InboxLayoutNew.propTypes = {
   categoryOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  inquiryTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   statusOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
-  inquiries: PropTypes.shape({
-    business: InquiriesList.propTypes.inquiries.isRequired,
-    personal: InquiriesList.propTypes.inquiries.isRequired,
-  }),
+  inquiries: InquiriesList.propTypes.inquiries,
 };

--- a/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
@@ -44,6 +44,12 @@ export default function InboxLayoutNew({
     query: '',
   });
 
+  const results = filterAndSort({
+    inquiriesArray: inquiries,
+    filters: { ...filters, inquiryTypes },
+    sortOrder,
+  });
+
   return (
     <div id="inbox">
       <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
@@ -130,12 +136,13 @@ export default function InboxLayoutNew({
               />
             </div>
           </div>
-          <div className="sort-container">
+          {!!results.length && (
             <VaSort
               width="xl"
               value={sortOrder}
               onVaSortSelect={e => {
                 setSortOrder(e.target.value);
+                focusElement('#search-description');
               }}
             >
               <option value={filterAndSort.sortOptions.lastUpdate.newest}>
@@ -145,7 +152,7 @@ export default function InboxLayoutNew({
                 Last Updated (oldest to newest)
               </option>
             </VaSort>
-          </div>
+          )}
 
           {inquiryTypes.includes('business') ? (
             <div className="tabs">

--- a/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
@@ -1,6 +1,7 @@
 import {
   VaButtonPair,
   VaSelect,
+  VaSort,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -32,7 +33,9 @@ export default function InboxLayoutNew({
   const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
   const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
   const [pendingQuery, setPendingQuery] = useState('');
-  const [sortOrder] = useState(filterAndSort.sortOptions.lastUpdate.newest);
+  const [sortOrder, setSortOrder] = useState(
+    filterAndSort.sortOptions.lastUpdate.newest,
+  );
   const [filters, setFilters] = useState({
     status: 'All',
     category: 'All',
@@ -125,6 +128,22 @@ export default function InboxLayoutNew({
               />
             </div>
           </div>
+          <div className="sort-container">
+            <VaSort
+              width="xl"
+              value={sortOrder}
+              onVaSortSelect={e => {
+                setSortOrder(e.target.value);
+              }}
+            >
+              <option value={filterAndSort.sortOptions.lastUpdate.newest}>
+                Last Updated (newest to oldest)
+              </option>
+              <option value={filterAndSort.sortOptions.lastUpdate.oldest}>
+                Last Updated (oldest to newest)
+              </option>
+            </VaSort>
+          </div>
 
           {inquiries.business?.length ? (
             <div className="tabs">
@@ -162,18 +181,16 @@ export default function InboxLayoutNew({
               </Tabs>
             </div>
           ) : (
-            <>
-              <InquiriesList
-                inquiries={filterAndSort({
-                  inquiriesArray: inquiries.personal,
-                  filters,
-                  sortOrder,
-                })}
-                categoryFilter={filters.category}
-                statusFilter={filters.status}
-                query={filters.query}
-              />
-            </>
+            <InquiriesList
+              inquiries={filterAndSort({
+                inquiriesArray: inquiries.personal,
+                filters,
+                sortOrder,
+              })}
+              categoryFilter={filters.category}
+              statusFilter={filters.status}
+              query={filters.query}
+            />
           )}
         </>
       ) : (

--- a/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
@@ -1,0 +1,201 @@
+import {
+  VaButtonPair,
+  VaSelect,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import React, { useState } from 'react';
+import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
+import PropTypes from 'prop-types';
+import InquiriesList from './InquiriesList';
+import { filterAndSort } from '../../utils/inbox';
+
+/**
+ * @typedef {import('./InquiryCard').Inquiry} Inquiry
+ */
+
+/**
+ * @typedef {Object} Props
+ * @property {string[]} categoryOptions
+ * @property {string[]} statusOptions
+ * @property {{ business: Inquiry[], personal: Inquiry[] }} inquiries
+ */
+
+/**
+ * @param {Props} props
+ */
+export default function InboxLayoutNew({
+  inquiries,
+  categoryOptions,
+  statusOptions,
+}) {
+  const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
+  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
+  const [pendingQuery, setPendingQuery] = useState('');
+  const [filters, setFilters] = useState({
+    status: 'All',
+    category: 'All',
+    query: '',
+  });
+
+  return (
+    <div id="inbox">
+      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
+        Your questions
+      </h2>
+      {inquiries.personal.length || inquiries.business.length ? (
+        <>
+          <div className="filter-container">
+            <div className="search-container">
+              <VaTextInput
+                value={pendingQuery}
+                label="Search"
+                inputMode="search"
+                onVaInput={e => {
+                  setPendingQuery(e.target.value || '');
+                }}
+              />
+            </div>
+            <div>
+              <VaSelect
+                hint={null}
+                label="Filter by status"
+                name="status"
+                value={pendingStatusFilter}
+                onVaSelect={event => {
+                  setPendingStatusFilter(event.target.value || 'All');
+                }}
+              >
+                <option value="All">All</option>
+                {statusOptions.map(status => (
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </VaSelect>
+            </div>
+            <div className="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--0">
+              <VaSelect
+                hint={null}
+                label="Filter by category"
+                name="category"
+                value={pendingCategoryFilter}
+                onVaSelect={event => {
+                  setPendingCategoryFilter(event.target.value || 'All');
+                }}
+              >
+                <option value="All">All</option>
+                {categoryOptions.map(category => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </VaSelect>
+            </div>
+
+            <div
+              // Keeps button pair aligned in parent correctly on mobile & desktop
+              className="vads-u-margin-bottom--neg0p5 medium-screen:vads-u-padding-right--0p5 vads-u-margin-x--neg0p5 medium-screen:vads-u-margin-x--0"
+            >
+              <VaButtonPair
+                primaryLabel="Apply filters"
+                secondaryLabel="Clear all filters"
+                onPrimaryClick={() => {
+                  setFilters(() => ({
+                    category: pendingCategoryFilter,
+                    status: pendingStatusFilter,
+                    query: pendingQuery,
+                  }));
+                  focusElement('#search-description');
+                }}
+                onSecondaryClick={() => {
+                  setFilters(() => ({
+                    status: 'All',
+                    category: 'All',
+                    query: '',
+                  }));
+                  setPendingStatusFilter('All');
+                  setPendingCategoryFilter('All');
+                  setPendingQuery('');
+                  focusElement('#search-description');
+                }}
+                leftButtonText="Apply"
+                rightButtonText="Clear"
+              />
+            </div>
+          </div>
+
+          {inquiries.business?.length ? (
+            <div className="tabs">
+              <Tabs className="inbox-tab-container">
+                <TabList className="inbox-tab-list">
+                  <Tab className="inbox-tab">Business</Tab>
+                  <Tab className="inbox-tab">Personal</Tab>
+                </TabList>
+                <TabPanel>
+                  <InquiriesList
+                    inquiries={filterAndSort({
+                      inquiriesArray: inquiries.business,
+                      filters,
+                    })}
+                    tabName="Business"
+                    categoryFilter={filters.category}
+                    statusFilter={filters.status}
+                    query={filters.query}
+                  />
+                </TabPanel>
+                <TabPanel>
+                  <InquiriesList
+                    inquiries={filterAndSort({
+                      inquiriesArray: inquiries.personal,
+                      filters,
+                    })}
+                    tabName="Personal"
+                    categoryFilter={filters.category}
+                    statusFilter={filters.status}
+                    query={filters.query}
+                  />
+                </TabPanel>
+              </Tabs>
+            </div>
+          ) : (
+            <>
+              <InquiriesList
+                inquiries={filterAndSort({
+                  inquiriesArray: inquiries.personal,
+                  filters,
+                })}
+                categoryFilter={filters.category}
+                statusFilter={filters.status}
+                query={filters.query}
+              />
+            </>
+          )}
+        </>
+      ) : (
+        <div className="vads-u-margin-bottom--5">
+          <va-alert
+            disable-analytics="false"
+            full-width="false"
+            status="info"
+            visible="true"
+            slim
+          >
+            <p className="vads-u-margin-y--0">
+              You haven’t submitted a question yet.
+            </p>
+          </va-alert>
+        </div>
+      )}
+    </div>
+  );
+}
+
+InboxLayoutNew.propTypes = {
+  categoryOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  statusOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  inquiries: PropTypes.shape({
+    business: InquiriesList.propTypes.inquiries.isRequired,
+    personal: InquiriesList.propTypes.inquiries.isRequired,
+  }),
+};

--- a/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
@@ -32,6 +32,7 @@ export default function InboxLayoutNew({
   const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
   const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
   const [pendingQuery, setPendingQuery] = useState('');
+  const [sortOrder] = useState(filterAndSort.sortOptions.lastUpdate.newest);
   const [filters, setFilters] = useState({
     status: 'All',
     category: 'All',
@@ -137,6 +138,7 @@ export default function InboxLayoutNew({
                     inquiries={filterAndSort({
                       inquiriesArray: inquiries.business,
                       filters,
+                      sortOrder,
                     })}
                     tabName="Business"
                     categoryFilter={filters.category}
@@ -149,6 +151,7 @@ export default function InboxLayoutNew({
                     inquiries={filterAndSort({
                       inquiriesArray: inquiries.personal,
                       filters,
+                      sortOrder,
                     })}
                     tabName="Personal"
                     categoryFilter={filters.category}
@@ -164,6 +167,7 @@ export default function InboxLayoutNew({
                 inquiries={filterAndSort({
                   inquiriesArray: inquiries.personal,
                   filters,
+                  sortOrder,
                 })}
                 categoryFilter={filters.category}
                 statusFilter={filters.status}

--- a/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
@@ -24,7 +24,7 @@ import { filterAndSort } from '../../utils/inbox';
 /**
  * @param {Props} props
  */
-export default function InboxLayout({
+export default function InboxLayoutOld({
   inquiries,
   categoryOptions,
   statusOptions,
@@ -191,7 +191,7 @@ export default function InboxLayout({
   );
 }
 
-InboxLayout.propTypes = {
+InboxLayoutOld.propTypes = {
   categoryOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
   statusOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
   inquiries: PropTypes.shape({

--- a/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
@@ -16,9 +16,10 @@ import { filterAndSort } from '../../utils/inbox';
 
 /**
  * @typedef {Object} Props
+ * @property {string[]} inquiryTypes
  * @property {string[]} categoryOptions
  * @property {string[]} statusOptions
- * @property {{ business: Inquiry[], personal: Inquiry[] }} inquiries
+ * @property {Inquiry[]} inquiries
  */
 
 /**
@@ -26,15 +27,16 @@ import { filterAndSort } from '../../utils/inbox';
  */
 export default function InboxLayoutOld({
   inquiries,
+  inquiryTypes,
   categoryOptions,
   statusOptions,
 }) {
-  const [pendingCategoryFilter, setPendingCategoryFilter] = useState('All');
-  const [pendingStatusFilter, setPendingStatusFilter] = useState('All');
+  const [pendingCategoriesFilter, setPendingCategoriesFilter] = useState('All');
+  const [pendingStatusesFilter, setPendingStatusesFilter] = useState('All');
   const [pendingQuery, setPendingQuery] = useState('');
   const [filters, setFilters] = useState({
-    status: 'All',
-    category: 'All',
+    statuses: ['All'],
+    categories: ['All'],
     query: '',
   });
 
@@ -43,7 +45,7 @@ export default function InboxLayoutOld({
       <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
         Your questions
       </h2>
-      {inquiries.personal.length || inquiries.business.length ? (
+      {inquiryTypes.length ? (
         <>
           <div className="filter-container">
             <div className="search-container">
@@ -61,9 +63,9 @@ export default function InboxLayoutOld({
                 hint={null}
                 label="Filter by status"
                 name="status"
-                value={pendingStatusFilter}
+                value={pendingStatusesFilter}
                 onVaSelect={event => {
-                  setPendingStatusFilter(event.target.value || 'All');
+                  setPendingStatusesFilter(event.target.value || 'All');
                 }}
               >
                 <option value="All">All</option>
@@ -79,9 +81,9 @@ export default function InboxLayoutOld({
                 hint={null}
                 label="Filter by category"
                 name="category"
-                value={pendingCategoryFilter}
+                value={pendingCategoriesFilter}
                 onVaSelect={event => {
-                  setPendingCategoryFilter(event.target.value || 'All');
+                  setPendingCategoriesFilter(event.target.value || 'All');
                 }}
               >
                 <option value="All">All</option>
@@ -102,20 +104,20 @@ export default function InboxLayoutOld({
                 secondaryLabel="Clear all filters"
                 onPrimaryClick={() => {
                   setFilters(() => ({
-                    category: pendingCategoryFilter,
-                    status: pendingStatusFilter,
+                    categories: [pendingCategoriesFilter],
+                    statuses: [pendingStatusesFilter],
                     query: pendingQuery,
                   }));
                   focusElement('#search-description');
                 }}
                 onSecondaryClick={() => {
                   setFilters(() => ({
-                    status: 'All',
-                    category: 'All',
+                    statuses: ['All'],
+                    categories: ['All'],
                     query: '',
                   }));
-                  setPendingStatusFilter('All');
-                  setPendingCategoryFilter('All');
+                  setPendingStatusesFilter('All');
+                  setPendingCategoriesFilter('All');
                   setPendingQuery('');
                   focusElement('#search-description');
                 }}
@@ -125,7 +127,7 @@ export default function InboxLayoutOld({
             </div>
           </div>
 
-          {inquiries.business?.length ? (
+          {inquiryTypes.includes('business') ? (
             <div className="tabs">
               <Tabs className="inbox-tab-container">
                 <TabList className="inbox-tab-list">
@@ -135,24 +137,24 @@ export default function InboxLayoutOld({
                 <TabPanel>
                   <InquiriesList
                     inquiries={filterAndSort({
-                      inquiriesArray: inquiries.business,
-                      filters,
+                      inquiriesArray: inquiries,
+                      filters: { ...filters, inquiryTypes: ['business'] },
                     })}
                     tabName="Business"
-                    categoryFilter={filters.category}
-                    statusFilter={filters.status}
+                    categoryFilter={filters.categories[0]}
+                    statusFilter={filters.statuses[0]}
                     query={filters.query}
                   />
                 </TabPanel>
                 <TabPanel>
                   <InquiriesList
                     inquiries={filterAndSort({
-                      inquiriesArray: inquiries.personal,
-                      filters,
+                      inquiriesArray: inquiries,
+                      filters: { ...filters, inquiryTypes: ['personal'] },
                     })}
                     tabName="Personal"
-                    categoryFilter={filters.category}
-                    statusFilter={filters.status}
+                    categoryFilter={filters.categories[0]}
+                    statusFilter={filters.statuses[0]}
                     query={filters.query}
                   />
                 </TabPanel>
@@ -161,11 +163,11 @@ export default function InboxLayoutOld({
           ) : (
             <InquiriesList
               inquiries={filterAndSort({
-                inquiriesArray: inquiries.personal,
-                filters,
+                inquiriesArray: inquiries,
+                filters: { ...filters, inquiryTypes: ['personal'] },
               })}
-              categoryFilter={filters.category}
-              statusFilter={filters.status}
+              categoryFilter={filters.categories[0]}
+              statusFilter={filters.statuses[0]}
               query={filters.query}
             />
           )}
@@ -191,9 +193,7 @@ export default function InboxLayoutOld({
 
 InboxLayoutOld.propTypes = {
   categoryOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  inquiryTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   statusOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
-  inquiries: PropTypes.shape({
-    business: InquiriesList.propTypes.inquiries.isRequired,
-    personal: InquiriesList.propTypes.inquiries.isRequired,
-  }),
+  inquiries: InquiriesList.propTypes.inquiries,
 };

--- a/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
@@ -159,17 +159,15 @@ export default function InboxLayoutOld({
               </Tabs>
             </div>
           ) : (
-            <>
-              <InquiriesList
-                inquiries={filterAndSort({
-                  inquiriesArray: inquiries.personal,
-                  filters,
-                })}
-                categoryFilter={filters.category}
-                statusFilter={filters.status}
-                query={filters.query}
-              />
-            </>
+            <InquiriesList
+              inquiries={filterAndSort({
+                inquiriesArray: inquiries.personal,
+                filters,
+              })}
+              categoryFilter={filters.category}
+              statusFilter={filters.status}
+              query={filters.query}
+            />
           )}
         </>
       ) : (

--- a/src/applications/ask-va/components/inbox/InquiriesList.jsx
+++ b/src/applications/ask-va/components/inbox/InquiriesList.jsx
@@ -12,10 +12,10 @@ import SearchDescription from './SearchDescription';
 
 /**
  * @typedef {Object} InquiriesListProps
- * @property {string} categoryFilter
  * @property {Inquiry[]} inquiries
- * @property {string} query
+ * @property {string} categoryFilter
  * @property {string} statusFilter
+ * @property {string} query
  * @property {string} [tabName]
  */
 
@@ -26,8 +26,8 @@ export default function InquiriesList({
   inquiries,
   categoryFilter,
   statusFilter,
-  tabName,
   query,
+  tabName,
 }) {
   const [currentPageNum, setCurrentPageNum] = useState(1);
   const itemsPerPage = 6;

--- a/src/applications/ask-va/components/inbox/InquiryCard.jsx
+++ b/src/applications/ask-va/components/inbox/InquiryCard.jsx
@@ -13,6 +13,7 @@ import { getConversationLink } from '../../utils/links';
  * @property {string} inquiryNumber
  * @property {string} categoryName
  * @property {string} submitterQuestion
+ * @property {string} levelOfAuthentication
  */
 
 export {};

--- a/src/applications/ask-va/containers/Inbox.jsx
+++ b/src/applications/ask-va/containers/Inbox.jsx
@@ -10,7 +10,8 @@ import { getAllInquiries } from '../utils/api';
 
 export default function Inbox() {
   const [hasError, setHasError] = useState(false);
-  const [inquiries, setInquiries] = useState({ business: [], personal: [] });
+  const [inquiries, setInquiries] = useState([]);
+  const [inquiryTypes, setInquiryTypes] = useState([]);
   const [categoryOptions, setCategoryOptions] = useState([]);
   const [statusOptions, setStatusOptions] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -18,13 +19,14 @@ export default function Inbox() {
   useEffect(() => {
     function saveInState(rawInquiries) {
       const {
-        business,
-        personal,
+        standardInquiries,
+        types,
         uniqueCategories,
         uniqueStatuses,
       } = standardizeInquiries(rawInquiries);
 
-      setInquiries({ business, personal });
+      setInquiries(standardInquiries);
+      setInquiryTypes(types);
       setCategoryOptions(uniqueCategories);
       setStatusOptions(uniqueStatuses);
       setIsLoading(false);
@@ -68,10 +70,14 @@ export default function Inbox() {
   return (
     <Toggler toggleName={Toggler.TOGGLE_NAMES.askVaEnhancedInbox}>
       <Toggler.Enabled>
-        <InboxLayoutNew {...{ inquiries, categoryOptions, statusOptions }} />
+        <InboxLayoutNew
+          {...{ inquiries, inquiryTypes, categoryOptions, statusOptions }}
+        />
       </Toggler.Enabled>
       <Toggler.Disabled>
-        <InboxLayoutOld {...{ inquiries, categoryOptions, statusOptions }} />
+        <InboxLayoutOld
+          {...{ inquiries, inquiryTypes, categoryOptions, statusOptions }}
+        />
       </Toggler.Disabled>
     </Toggler>
   );

--- a/src/applications/ask-va/containers/Inbox.jsx
+++ b/src/applications/ask-va/containers/Inbox.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { ServerErrorAlert } from '../config/helpers';
 import { mockTestingFlagForAPI } from '../constants';
 import { mockInquiries } from '../utils/mockData';
 import { standardizeInquiries } from '../utils/inbox';
-import InboxLayout from '../components/inbox/InboxLayout';
+import InboxLayoutOld from '../components/inbox/InboxLayoutOld';
+import InboxLayoutNew from '../components/inbox/InboxLayoutNew';
 import { getAllInquiries } from '../utils/api';
 
 export default function Inbox() {
@@ -62,5 +64,15 @@ export default function Inbox() {
     );
   }
 
-  return <InboxLayout {...{ inquiries, categoryOptions, statusOptions }} />;
+  // TODO feature toggle uses redux state - remember to remove from unit tests as well
+  return (
+    <Toggler toggleName={Toggler.TOGGLE_NAMES.askVaEnhancedInbox}>
+      <Toggler.Enabled>
+        <InboxLayoutNew {...{ inquiries, categoryOptions, statusOptions }} />
+      </Toggler.Enabled>
+      <Toggler.Disabled>
+        <InboxLayoutOld {...{ inquiries, categoryOptions, statusOptions }} />
+      </Toggler.Disabled>
+    </Toggler>
+  );
 }

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
@@ -204,6 +204,27 @@ describe('<InboxLayoutNew />', () => {
     expect(focusedElement).to.equal(searchDescription.parentElement);
   });
 
+  it('shifts focus to search description after selecting a sort order', () => {
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
+      />,
+    );
+    const sortSelect = view.container.querySelector('va-sort');
+
+    sortSelect.__events.vaSortSelect({
+      target: { value: filterAndSort.sortOptions.lastUpdate.oldest },
+    });
+
+    const focusedElement = view.container.ownerDocument.activeElement;
+    const searchDescription = view.getByText(/showing/i);
+
+    expect(focusedElement).to.equal(searchDescription.parentElement);
+  });
+
   it('searches results based on a query', () => {
     // Add an inquiry with a reference number guaranteed to be different
     const inquiriesCopy = [...personalInquiries];

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
@@ -10,15 +10,19 @@ import InboxLayoutNew from '~/applications/ask-va/components/inbox/InboxLayoutNe
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
 
 describe('<InboxLayoutNew />', () => {
-  const mockInquiries = standardizeInquiries(rawInquiries);
+  const mockData = standardizeInquiries(rawInquiries);
+  const personalInquiries = mockData.standardInquiries.filter(
+    inq => inq.levelOfAuthentication.toLowerCase() === 'personal',
+  );
   const selectedStatus = 'In progress';
 
   it('displays a message when there are no inquiries', () => {
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: [], business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={[]}
+        inquiries={[]}
       />,
     );
 
@@ -33,9 +37,10 @@ describe('<InboxLayoutNew />', () => {
   it('renders a list of inquiries', () => {
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -46,9 +51,10 @@ describe('<InboxLayoutNew />', () => {
   it('only renders filter options available in the list', () => {
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -60,19 +66,17 @@ describe('<InboxLayoutNew />', () => {
       .filter(option => option.parentElement.name === 'status')
       .map(option => option.textContent);
 
-    expect(visibleCategories).to.eql([
-      'All',
-      ...mockInquiries.uniqueCategories,
-    ]);
-    expect(visibleStatuses).to.eql(['All', ...mockInquiries.uniqueStatuses]);
+    expect(visibleCategories).to.eql(['All', ...mockData.uniqueCategories]);
+    expect(visibleStatuses).to.eql(['All', ...mockData.uniqueStatuses]);
   });
 
   it('applies and clears a filter', () => {
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -137,9 +141,10 @@ describe('<InboxLayoutNew />', () => {
 
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -176,9 +181,10 @@ describe('<InboxLayoutNew />', () => {
   it('shifts focus to search description after a button is clicked', () => {
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -200,7 +206,7 @@ describe('<InboxLayoutNew />', () => {
 
   it('searches results based on a query', () => {
     // Add an inquiry with a reference number guaranteed to be different
-    const inquiriesCopy = [...mockInquiries.personal];
+    const inquiriesCopy = [...personalInquiries];
     const newItem = {
       ...inquiriesCopy[inquiriesCopy.length - 1],
       inquiryNumber: 'A-3',
@@ -209,9 +215,10 @@ describe('<InboxLayoutNew />', () => {
 
     const view = render(
       <InboxLayoutNew
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: inquiriesCopy, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={inquiriesCopy}
       />,
     );
 
@@ -239,9 +246,10 @@ describe('<InboxLayoutNew />', () => {
     it('hides tabs when there are no business inquiries', () => {
       const view = render(
         <InboxLayoutNew
-          categoryOptions={mockInquiries.uniqueCategories}
-          statusOptions={mockInquiries.uniqueStatuses}
-          inquiries={{ personal: mockInquiries.personal, business: [] }}
+          categoryOptions={mockData.uniqueCategories}
+          statusOptions={mockData.uniqueStatuses}
+          inquiryTypes={['personal']}
+          inquiries={personalInquiries}
         />,
       );
 
@@ -251,9 +259,10 @@ describe('<InboxLayoutNew />', () => {
     it('shows tabs when there are business inquiries', () => {
       const view = render(
         <InboxLayoutNew
-          categoryOptions={mockInquiries.uniqueCategories}
-          statusOptions={mockInquiries.uniqueStatuses}
-          inquiries={mockInquiries}
+          categoryOptions={mockData.uniqueCategories}
+          statusOptions={mockData.uniqueStatuses}
+          inquiryTypes={mockData.types}
+          inquiries={mockData.standardInquiries}
         />,
       );
 
@@ -273,9 +282,10 @@ describe('<InboxLayoutNew />', () => {
     it('switches list content based on the selected tab', () => {
       const view = render(
         <InboxLayoutNew
-          categoryOptions={mockInquiries.uniqueCategories}
-          statusOptions={mockInquiries.uniqueStatuses}
-          inquiries={mockInquiries}
+          categoryOptions={mockData.uniqueCategories}
+          statusOptions={mockData.uniqueStatuses}
+          inquiryTypes={mockData.types}
+          inquiries={mockData.standardInquiries}
         />,
       );
 

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { standardizeInquiries } from '~/applications/ask-va/utils/inbox';
+import {
+  filterAndSort,
+  standardizeInquiries,
+} from '~/applications/ask-va/utils/inbox';
 import { expect } from 'chai';
 import InboxLayoutNew from '~/applications/ask-va/components/inbox/InboxLayoutNew';
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
@@ -117,6 +120,57 @@ describe('<InboxLayoutNew />', () => {
     expect(endTextContent)
       .to.eql(startTextContent)
       .but.not.eql(filteredTextContent);
+  });
+
+  it('updates sort order implicitly on selection', () => {
+    function getLastUpdatedDates(resultsArray) {
+      const q1 = 'Last updated: ';
+      const q2 = 'Reference number: ';
+      const firstResultText = resultsArray[0].textContent;
+      const lastResultText = resultsArray[resultsArray.length - 1].textContent;
+
+      // Get text between q1 and q2
+      const firstDate = firstResultText.split(q1)[1].split(q2)[0];
+      const lastDate = lastResultText.split(q1)[1].split(q2)[0];
+      return [firstDate, lastDate];
+    }
+
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    // Confirm newer values first
+    const sortSelect = view.container.querySelector('va-sort');
+    expect(sortSelect.getAttribute('value')).to.equal(
+      filterAndSort.sortOptions.lastUpdate.newest,
+    );
+
+    const initialResults = view.getAllByTestId('inquiry-card');
+    const [initialFirstDate, initialLastDate] = getLastUpdatedDates(
+      initialResults,
+    );
+    expect(new Date(initialFirstDate).getTime()).to.be.greaterThanOrEqual(
+      new Date(initialLastDate).getTime(),
+    );
+
+    // Change sort order
+    sortSelect.__events.vaSortSelect({
+      target: { value: filterAndSort.sortOptions.lastUpdate.oldest },
+    });
+
+    // Confirm older values first
+    expect(sortSelect.getAttribute('value')).to.equal(
+      filterAndSort.sortOptions.lastUpdate.oldest,
+    );
+    const finalResults = view.getAllByTestId('inquiry-card');
+    const [finalFirstDate, finalLastDate] = getLastUpdatedDates(finalResults);
+    expect(new Date(finalFirstDate).getTime()).to.be.lessThanOrEqual(
+      new Date(finalLastDate).getTime(),
+    );
   });
 
   it('shifts focus to search description after a button is clicked', () => {

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import { standardizeInquiries } from '~/applications/ask-va/utils/inbox';
+import { expect } from 'chai';
+import InboxLayoutNew from '~/applications/ask-va/components/inbox/InboxLayoutNew';
+import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
+
+describe('<InboxLayoutNew />', () => {
+  const mockInquiries = standardizeInquiries(rawInquiries);
+  const selectedStatus = 'In progress';
+
+  it('displays a message when there are no inquiries', () => {
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: [], business: [] }}
+      />,
+    );
+
+    const emptyInboxAlert = view.getByText(
+      'You haven’t submitted a question yet.',
+    );
+    const inquiryResult = view.queryByTestId('inquiry-card');
+    expect(emptyInboxAlert).to.exist;
+    expect(inquiryResult).to.not.exist;
+  });
+
+  it('renders a list of inquiries', () => {
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    const inquiryResults = view.getAllByTestId('inquiry-card');
+    expect(inquiryResults.length).to.be.greaterThanOrEqual(1);
+  });
+
+  it('only renders filter options available in the list', () => {
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    const allOptions = view.getAllByRole('option');
+    const visibleCategories = allOptions
+      .filter(option => option.parentElement.name === 'category')
+      .map(option => option.textContent);
+    const visibleStatuses = allOptions
+      .filter(option => option.parentElement.name === 'status')
+      .map(option => option.textContent);
+
+    expect(visibleCategories).to.eql([
+      'All',
+      ...mockInquiries.uniqueCategories,
+    ]);
+    expect(visibleStatuses).to.eql(['All', ...mockInquiries.uniqueStatuses]);
+  });
+
+  it('applies and clears a filter', () => {
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    // Confirm filter's starting value and list's variety
+    const statusSelect = view.container.querySelector(
+      'va-select[name="status"]',
+    );
+    expect(statusSelect.getAttribute('value')).to.equal('All');
+
+    const startingResults = view.getAllByTestId('inquiry-card');
+    expect(
+      startingResults.every(a =>
+        a.textContent.includes(`Status ${selectedStatus}`),
+      ),
+    ).to.be.false;
+
+    // Set status filter to "In progress" and apply filters
+    statusSelect.__events.vaSelect({
+      target: { value: selectedStatus },
+    });
+    expect(statusSelect.getAttribute('value')).to.equal(selectedStatus);
+
+    const buttonPair = view.container.querySelector('va-button-pair');
+    buttonPair.__events.primaryClick();
+
+    // Confirm only selected status is present
+    const filteredResults = view.getAllByTestId('inquiry-card');
+    expect(
+      filteredResults.every(a =>
+        a.textContent.includes(`Status ${selectedStatus}`),
+      ),
+    ).to.be.true;
+
+    // Reset filters & list, confirm it matches starting state
+    buttonPair.__events.secondaryClick();
+    const endingResults = view.getAllByTestId('inquiry-card');
+    const endTextContent = endingResults.map(end => end.textContent);
+    const startTextContent = startingResults.map(start => start.textContent);
+    const filteredTextContent = filteredResults.map(
+      filtered => filtered.textContent,
+    );
+
+    expect(statusSelect.getAttribute('value')).to.equal('All');
+
+    expect(endTextContent)
+      .to.eql(startTextContent)
+      .but.not.eql(filteredTextContent);
+  });
+
+  it('shifts focus to search description after a button is clicked', () => {
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: mockInquiries.personal, business: [] }}
+      />,
+    );
+
+    // Apply filters
+    const statusSelect = view.container.querySelector(
+      'va-select[name="status"]',
+    );
+    statusSelect.__events.vaSelect({
+      target: { value: selectedStatus },
+    });
+    const buttonPair = view.container.querySelector('va-button-pair');
+    buttonPair.__events.primaryClick();
+
+    const focusedElement = view.container.ownerDocument.activeElement;
+    const searchDescription = view.getByText(/showing/i);
+
+    expect(focusedElement).to.equal(searchDescription.parentElement);
+  });
+
+  it('searches results based on a query', () => {
+    // Add an inquiry with a reference number guaranteed to be different
+    const inquiriesCopy = [...mockInquiries.personal];
+    const newItem = {
+      ...inquiriesCopy[inquiriesCopy.length - 1],
+      inquiryNumber: 'A-3',
+    };
+    inquiriesCopy.push(newItem);
+
+    const view = render(
+      <InboxLayoutNew
+        categoryOptions={mockInquiries.uniqueCategories}
+        statusOptions={mockInquiries.uniqueStatuses}
+        inquiries={{ personal: inquiriesCopy, business: [] }}
+      />,
+    );
+
+    // Confirm starting state
+    const startingResults = view.getAllByTestId('inquiry-card');
+    expect(startingResults.length).to.equal(6);
+    expect(startingResults[0].textContent).to.include('Reference number: A-2');
+
+    const searchBox = view.container.querySelector('va-text-input');
+    expect(searchBox.value).to.equal('');
+
+    // Input a search query and apply
+    searchBox.__events.vaInput({ target: { value: 'A-3' } });
+    expect(searchBox.value).to.equal('A-3');
+    const buttonPair = view.container.querySelector('va-button-pair');
+    buttonPair.__events.primaryClick();
+
+    // Confirm the list is now just one desired result
+    const endingResults = view.getAllByTestId('inquiry-card');
+    expect(endingResults.length).to.equal(1);
+    expect(endingResults[0].textContent).to.include('Reference number: A-3');
+  });
+
+  describe('business and personal tabs', () => {
+    it('hides tabs when there are no business inquiries', () => {
+      const view = render(
+        <InboxLayoutNew
+          categoryOptions={mockInquiries.uniqueCategories}
+          statusOptions={mockInquiries.uniqueStatuses}
+          inquiries={{ personal: mockInquiries.personal, business: [] }}
+        />,
+      );
+
+      expect(view.queryByRole('tab')).to.not.exist;
+    });
+
+    it('shows tabs when there are business inquiries', () => {
+      const view = render(
+        <InboxLayoutNew
+          categoryOptions={mockInquiries.uniqueCategories}
+          statusOptions={mockInquiries.uniqueStatuses}
+          inquiries={mockInquiries}
+        />,
+      );
+
+      const tabButtons = view.getByRole('tablist');
+      const businessTab = view.getByRole('tab', {
+        name: /business/i,
+      });
+      const personalTab = view.getByRole('tab', {
+        name: /personal/i,
+      });
+
+      expect(tabButtons.childNodes.length).to.equal(2);
+      expect(businessTab).to.exist;
+      expect(personalTab).to.exist;
+    });
+
+    it('switches list content based on the selected tab', () => {
+      const view = render(
+        <InboxLayoutNew
+          categoryOptions={mockInquiries.uniqueCategories}
+          statusOptions={mockInquiries.uniqueStatuses}
+          inquiries={mockInquiries}
+        />,
+      );
+
+      // Confirm starting state
+      const businessTab = view.getByRole('tab', {
+        name: /business/i,
+      });
+      const personalTab = view.getByRole('tab', {
+        name: /personal/i,
+      });
+
+      const businessResults = view.getAllByTestId('inquiry-card');
+      expect(businessTab.getAttribute('aria-selected')).to.equal('true');
+      expect(personalTab.getAttribute('aria-selected')).to.equal('false');
+      expect(businessResults[0].textContent).to.include('Category: Education');
+
+      fireEvent.click(personalTab);
+
+      // Confirm content switched with tabs
+      const personalResults = view.getAllByTestId('inquiry-card');
+      expect(businessTab.getAttribute('aria-selected')).to.equal('false');
+      expect(personalTab.getAttribute('aria-selected')).to.equal('true');
+      expect(personalResults[0].textContent).to.not.include(
+        'Category: Education',
+      );
+    });
+  });
+});

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutOld.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutOld.unit.spec.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import InboxLayout from '~/applications/ask-va/components/inbox/InboxLayout';
+import InboxLayoutOld from '~/applications/ask-va/components/inbox/InboxLayoutOld';
 import { standardizeInquiries } from '~/applications/ask-va/utils/inbox';
 import { expect } from 'chai';
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
 
-describe('<InboxLayout />', () => {
+describe('<InboxLayoutOld />', () => {
   const mockInquiries = standardizeInquiries(rawInquiries);
   const selectedStatus = 'In progress';
 
   it('displays a message when there are no inquiries', () => {
     const view = render(
-      <InboxLayout
+      <InboxLayoutOld
         categoryOptions={mockInquiries.uniqueCategories}
         statusOptions={mockInquiries.uniqueStatuses}
         inquiries={{ personal: [], business: [] }}
@@ -28,7 +28,7 @@ describe('<InboxLayout />', () => {
 
   it('renders a list of inquiries', () => {
     const view = render(
-      <InboxLayout
+      <InboxLayoutOld
         categoryOptions={mockInquiries.uniqueCategories}
         statusOptions={mockInquiries.uniqueStatuses}
         inquiries={{ personal: mockInquiries.personal, business: [] }}
@@ -41,7 +41,7 @@ describe('<InboxLayout />', () => {
 
   it('only renders filter options available in the list', () => {
     const view = render(
-      <InboxLayout
+      <InboxLayoutOld
         categoryOptions={mockInquiries.uniqueCategories}
         statusOptions={mockInquiries.uniqueStatuses}
         inquiries={{ personal: mockInquiries.personal, business: [] }}
@@ -65,7 +65,7 @@ describe('<InboxLayout />', () => {
 
   it('applies and clears a filter', () => {
     const view = render(
-      <InboxLayout
+      <InboxLayoutOld
         categoryOptions={mockInquiries.uniqueCategories}
         statusOptions={mockInquiries.uniqueStatuses}
         inquiries={{ personal: mockInquiries.personal, business: [] }}
@@ -120,7 +120,7 @@ describe('<InboxLayout />', () => {
 
   it('shifts focus to search description after a button is clicked', () => {
     const view = render(
-      <InboxLayout
+      <InboxLayoutOld
         categoryOptions={mockInquiries.uniqueCategories}
         statusOptions={mockInquiries.uniqueStatuses}
         inquiries={{ personal: mockInquiries.personal, business: [] }}
@@ -153,7 +153,7 @@ describe('<InboxLayout />', () => {
     inquiriesCopy.push(newItem);
 
     const view = render(
-      <InboxLayout
+      <InboxLayoutOld
         categoryOptions={mockInquiries.uniqueCategories}
         statusOptions={mockInquiries.uniqueStatuses}
         inquiries={{ personal: inquiriesCopy, business: [] }}
@@ -183,7 +183,7 @@ describe('<InboxLayout />', () => {
   describe('business and personal tabs', () => {
     it('hides tabs when there are no business inquiries', () => {
       const view = render(
-        <InboxLayout
+        <InboxLayoutOld
           categoryOptions={mockInquiries.uniqueCategories}
           statusOptions={mockInquiries.uniqueStatuses}
           inquiries={{ personal: mockInquiries.personal, business: [] }}
@@ -195,7 +195,7 @@ describe('<InboxLayout />', () => {
 
     it('shows tabs when there are business inquiries', () => {
       const view = render(
-        <InboxLayout
+        <InboxLayoutOld
           categoryOptions={mockInquiries.uniqueCategories}
           statusOptions={mockInquiries.uniqueStatuses}
           inquiries={mockInquiries}
@@ -217,7 +217,7 @@ describe('<InboxLayout />', () => {
 
     it('switches list content based on the selected tab', () => {
       const view = render(
-        <InboxLayout
+        <InboxLayoutOld
           categoryOptions={mockInquiries.uniqueCategories}
           statusOptions={mockInquiries.uniqueStatuses}
           inquiries={mockInquiries}

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutOld.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutOld.unit.spec.jsx
@@ -6,15 +6,19 @@ import { expect } from 'chai';
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
 
 describe('<InboxLayoutOld />', () => {
-  const mockInquiries = standardizeInquiries(rawInquiries);
+  const mockData = standardizeInquiries(rawInquiries);
+  const personalInquiries = mockData.standardInquiries.filter(
+    inq => inq.levelOfAuthentication.toLowerCase() === 'personal',
+  );
   const selectedStatus = 'In progress';
 
   it('displays a message when there are no inquiries', () => {
     const view = render(
       <InboxLayoutOld
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: [], business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={[]}
+        inquiries={[]}
       />,
     );
 
@@ -29,9 +33,10 @@ describe('<InboxLayoutOld />', () => {
   it('renders a list of inquiries', () => {
     const view = render(
       <InboxLayoutOld
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -42,9 +47,10 @@ describe('<InboxLayoutOld />', () => {
   it('only renders filter options available in the list', () => {
     const view = render(
       <InboxLayoutOld
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -56,19 +62,17 @@ describe('<InboxLayoutOld />', () => {
       .filter(option => option.parentElement.name === 'status')
       .map(option => option.textContent);
 
-    expect(visibleCategories).to.eql([
-      'All',
-      ...mockInquiries.uniqueCategories,
-    ]);
-    expect(visibleStatuses).to.eql(['All', ...mockInquiries.uniqueStatuses]);
+    expect(visibleCategories).to.eql(['All', ...mockData.uniqueCategories]);
+    expect(visibleStatuses).to.eql(['All', ...mockData.uniqueStatuses]);
   });
 
   it('applies and clears a filter', () => {
     const view = render(
       <InboxLayoutOld
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -121,9 +125,10 @@ describe('<InboxLayoutOld />', () => {
   it('shifts focus to search description after a button is clicked', () => {
     const view = render(
       <InboxLayoutOld
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: mockInquiries.personal, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -145,7 +150,7 @@ describe('<InboxLayoutOld />', () => {
 
   it('searches results based on a query', () => {
     // Add an inquiry with a reference number guaranteed to be different
-    const inquiriesCopy = [...mockInquiries.personal];
+    const inquiriesCopy = [...personalInquiries];
     const newItem = {
       ...inquiriesCopy[inquiriesCopy.length - 1],
       inquiryNumber: 'A-3',
@@ -154,9 +159,10 @@ describe('<InboxLayoutOld />', () => {
 
     const view = render(
       <InboxLayoutOld
-        categoryOptions={mockInquiries.uniqueCategories}
-        statusOptions={mockInquiries.uniqueStatuses}
-        inquiries={{ personal: inquiriesCopy, business: [] }}
+        categoryOptions={mockData.uniqueCategories}
+        statusOptions={mockData.uniqueStatuses}
+        inquiryTypes={['personal']}
+        inquiries={inquiriesCopy}
       />,
     );
 
@@ -184,9 +190,10 @@ describe('<InboxLayoutOld />', () => {
     it('hides tabs when there are no business inquiries', () => {
       const view = render(
         <InboxLayoutOld
-          categoryOptions={mockInquiries.uniqueCategories}
-          statusOptions={mockInquiries.uniqueStatuses}
-          inquiries={{ personal: mockInquiries.personal, business: [] }}
+          categoryOptions={mockData.uniqueCategories}
+          statusOptions={mockData.uniqueStatuses}
+          inquiryTypes={['personal']}
+          inquiries={personalInquiries}
         />,
       );
 
@@ -196,9 +203,10 @@ describe('<InboxLayoutOld />', () => {
     it('shows tabs when there are business inquiries', () => {
       const view = render(
         <InboxLayoutOld
-          categoryOptions={mockInquiries.uniqueCategories}
-          statusOptions={mockInquiries.uniqueStatuses}
-          inquiries={mockInquiries}
+          categoryOptions={mockData.uniqueCategories}
+          statusOptions={mockData.uniqueStatuses}
+          inquiryTypes={mockData.types}
+          inquiries={mockData.standardInquiries}
         />,
       );
 
@@ -218,9 +226,10 @@ describe('<InboxLayoutOld />', () => {
     it('switches list content based on the selected tab', () => {
       const view = render(
         <InboxLayoutOld
-          categoryOptions={mockInquiries.uniqueCategories}
-          statusOptions={mockInquiries.uniqueStatuses}
-          inquiries={mockInquiries}
+          categoryOptions={mockData.uniqueCategories}
+          statusOptions={mockData.uniqueStatuses}
+          inquiryTypes={mockData.types}
+          inquiries={mockData.standardInquiries}
         />,
       );
 

--- a/src/applications/ask-va/tests/components/inbox/InquiriesList.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InquiriesList.unit.spec.jsx
@@ -6,14 +6,17 @@ import { standardizeInquiries } from '../../../utils/inbox';
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
 
 describe('InquiriesList', () => {
-  const mockInquiries = standardizeInquiries(rawInquiries);
+  const mockData = standardizeInquiries(rawInquiries);
+  const personalInquiries = mockData.standardInquiries.filter(
+    inq => inq.levelOfAuthentication.toLowerCase() === 'personal',
+  );
 
   it('only renders 6 items per page', () => {
     const view = render(
       <InquiriesList
         categoryFilter="All"
         statusFilter="All"
-        inquiries={mockInquiries.personal}
+        inquiries={personalInquiries}
       />,
     );
 
@@ -26,18 +29,18 @@ describe('InquiriesList', () => {
       <InquiriesList
         categoryFilter="All"
         statusFilter="All"
-        inquiries={mockInquiries.personal}
+        inquiries={personalInquiries}
       />,
     );
     const pageText = view.container.textContent;
 
-    expect(pageText).to.contain(mockInquiries.personal[0].inquiryNumber);
-    expect(pageText).to.contain(mockInquiries.personal[1].inquiryNumber);
-    expect(pageText).to.contain(mockInquiries.personal[2].inquiryNumber);
-    expect(pageText).to.contain(mockInquiries.personal[3].inquiryNumber);
-    expect(pageText).to.contain(mockInquiries.personal[4].inquiryNumber);
-    expect(pageText).to.contain(mockInquiries.personal[5].inquiryNumber);
-    expect(pageText).to.not.contain(mockInquiries.personal[6].inquiryNumber);
+    expect(pageText).to.contain(personalInquiries[0].inquiryNumber);
+    expect(pageText).to.contain(personalInquiries[1].inquiryNumber);
+    expect(pageText).to.contain(personalInquiries[2].inquiryNumber);
+    expect(pageText).to.contain(personalInquiries[3].inquiryNumber);
+    expect(pageText).to.contain(personalInquiries[4].inquiryNumber);
+    expect(pageText).to.contain(personalInquiries[5].inquiryNumber);
+    expect(pageText).to.not.contain(personalInquiries[6].inquiryNumber);
   });
 
   it('renders an alert if inquiries array is empty', () => {
@@ -60,13 +63,13 @@ describe('InquiriesList', () => {
       <InquiriesList
         categoryFilter="All"
         statusFilter="All"
-        inquiries={mockInquiries.personal}
+        inquiries={personalInquiries}
       />,
     );
 
     // Confirm starting state
-    const firstPageFirstNumber = mockInquiries.personal[0].inquiryNumber;
-    const secondPageFirstNumber = mockInquiries.personal[6].inquiryNumber;
+    const firstPageFirstNumber = personalInquiries[0].inquiryNumber;
+    const secondPageFirstNumber = personalInquiries[6].inquiryNumber;
     const pagination = view.container.querySelector('va-pagination');
 
     expect(view.getByText(firstPageFirstNumber)).to.exist;

--- a/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
@@ -6,11 +6,33 @@ import {
 } from 'platform/testing/unit/msw-adapter';
 import { server } from 'platform/testing/unit/mocha-setup';
 import React from 'react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
 
 import Inbox from '../../containers/Inbox';
 import { ENDPOINTS } from '../../utils/api';
 
 describe('<Inbox />', () => {
+  function setupStore(initialState) {
+    return configureStore({
+      reducer: state => state,
+      preloadedState: { ...initialState, askVA: {} },
+    });
+  }
+
+  // TODO remove once feature toggle is no longer needed
+  function renderWithStore(extraState = {}) {
+    const store = setupStore(extraState);
+    return {
+      store,
+      view: render(
+        <Provider store={store}>
+          <Inbox />
+        </Provider>,
+      ),
+    };
+  }
+
   beforeEach(() => {
     server.use(
       createGetHandler(ENDPOINTS.inquiries, () => {
@@ -38,7 +60,7 @@ describe('<Inbox />', () => {
   });
 
   it('renders InboxLayout when API succeeds', async () => {
-    const view = render(<Inbox />);
+    const { view } = renderWithStore();
 
     await waitFor(() => {
       // Check for heading and filters
@@ -53,7 +75,7 @@ describe('<Inbox />', () => {
   });
 
   it('shows a loading indicator before content', async () => {
-    const view = render(<Inbox />);
+    const { view } = renderWithStore();
 
     // Initially should show loading indicator
     const loadingIndicator = view.getByTestId('loading-indicator');
@@ -76,7 +98,7 @@ describe('<Inbox />', () => {
         return jsonResponse({}, { status: 500 });
       }),
     );
-    const view = render(<Inbox />);
+    const { view } = renderWithStore();
 
     await waitFor(() => {
       const errorAlert = view.container.querySelector('va-alert');

--- a/src/applications/ask-va/tests/e2e/fixtures/api_va_gov/feature-toggles.json
+++ b/src/applications/ask-va/tests/e2e/fixtures/api_va_gov/feature-toggles.json
@@ -1,63 +1,23 @@
 {
-    "data": {
-        "type": "feature_toggles",
-        "features": [
-            {
-                "name": "askVaAnnouncementBanner",
-                "value": false
-            },
-            {
-                "name": "ask_va_ask_va_announcement_banner",
-                "value": false
-            },
-            {
-                "name": "askVaCanaryRelease",
-                "value": true
-            },
-            {
-                "name": "ask_va_canary_release",
-                "value": true
-            },
-            {
-                "name": "askVaMockApiForTesting",
-                "value": false
-            },
-            {
-                "name": "ask_va_mock_api_for_testing",
-                "value": false
-            },
-            {
-                "name": "askVAFormFeature",
-                "value": false
-            },
-            {
-                "name": "ask_va_form_feature",
-                "value": false
-            },
-            {
-                "name": "askVADashboardFeature",
-                "value": false
-            },
-            {
-                "name": "ask_va_dashboard_feature",
-                "value": false
-            },
-            {
-                "name": "askVAIntroductionPageFeature",
-                "value": false
-            },
-            {
-                "name": "ask_va_introduction_page_feature",
-                "value": false
-            },
-            {
-                "name": "askVaAlertLinkToOldPortal",
-                "value": false
-            },
-            {
-                "name": "ask_va_alert_link_to_old_portal",
-                "value": false
-            }
-       ]
-    }
+  "data": {
+    "type": "feature_toggles",
+    "features": [
+      { "name": "ask_va_alert_link_to_old_portal", "value": false },
+      { "name": "askVaAlertLinkToOldPortal", "value": false },
+      { "name": "askVaAnnouncementBanner", "value": false },
+      { "name": "ask_va_ask_va_announcement_banner", "value": false },
+      { "name": "ask_va_canary_release", "value": true },
+      { "name": "askVaCanaryRelease", "value": true },
+      { "name": "ask_va_dashboard_feature", "value": false },
+      { "name": "askVADashboardFeature", "value": false },
+      { "name": "askVaEnhancedInbox", "value": false },
+      { "name": "ask_va_enhanced_inbox", "value": false },
+      { "name": "ask_va_form_feature", "value": false },
+      { "name": "askVAFormFeature", "value": false },
+      { "name": "ask_va_introduction_page_feature", "value": false },
+      { "name": "askVAIntroductionPageFeature", "value": false },
+      { "name": "ask_va_mock_api_for_testing", "value": false },
+      { "name": "askVaMockApiForTesting", "value": false }
+    ]
+  }
 }

--- a/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
@@ -22,9 +22,9 @@ describe('flattenInquiry', () => {
 describe('standardizeInquiries', () => {
   it('returns ONLY personal and business inquiries', () => {
     const output = standardizeInquiries(mockInquiries);
-    expect(output).to.have.property('inquiries');
+    expect(output).to.have.property('standardInquiries');
     expect(
-      output.inquiries?.every(inq =>
+      output.standardInquiries?.every(inq =>
         ['business', 'personal'].includes(
           inq.levelOfAuthentication.toLowerCase(),
         ),
@@ -34,14 +34,14 @@ describe('standardizeInquiries', () => {
 
   it('returns indicators of what inquiry types are present', () => {
     const output = standardizeInquiries(mockInquiries);
-    expect(output.inquiryTypes).to.include('personal');
-    expect(output.inquiryTypes).to.include('business');
+    expect(output.types).to.include('personal');
+    expect(output.types).to.include('business');
   });
 
   it('flattens inquiries as they are categorized', () => {
     const output = standardizeInquiries(mockInquiries);
-    expect(output.inquiries[0]).to.have.property('status');
-    expect(output.inquiries[0].status).to.equal('In progress');
+    expect(output.standardInquiries[0]).to.have.property('status');
+    expect(output.standardInquiries[0].status).to.equal('In progress');
   });
 
   it('returns only the categories present in the inquiries list', () => {
@@ -110,31 +110,45 @@ describe('filterAndSort', () => {
 
   it('returns all results if unfiltered', () => {
     const results = filterAndSort({ inquiriesArray: flatInquiries });
-    expect(results.length).to.equal(flatInquiries.length);
+    expect(results.length).to.equal(flatInquiries.length - 1);
   });
 
   it('filters by category', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      filters: { category: 'Veteran ID Card (VIC)' },
+      filters: { categories: ['Veteran ID Card (VIC)'] },
     });
-    expect(results.length).to.equal(3);
+    expect(results.length).to.equal(2);
   });
 
   it('filters by status', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      filters: { status: 'In progress' },
+      filters: { statuses: ['In progress'] },
     });
     expect(results.length).to.equal(6);
   });
 
-  it('filters by both category and status', () => {
+  it('filters by inquiry type', () => {
+    const personal = filterAndSort({
+      inquiriesArray: flatInquiries,
+      filters: { inquiryTypes: ['personal'] },
+    });
+    const business = filterAndSort({
+      inquiriesArray: flatInquiries,
+      filters: { inquiryTypes: ['business'] },
+    });
+    expect(personal.length).to.equal(7);
+    expect(business.length).to.equal(2);
+  });
+
+  it('filters by category, status, and type', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
       filters: {
-        category: 'Veteran ID Card (VIC)',
-        status: 'In progress',
+        categories: ['Veteran ID Card (VIC)'],
+        statuses: ['In progress'],
+        inquiryTypes: ['personal'],
       },
     });
     expect(results.length).to.equal(1);
@@ -142,7 +156,7 @@ describe('filterAndSort', () => {
 
   it('sorts by newest lastUpdate by default', () => {
     const firstDateBeforeSort = new Date(flatInquiries[0].lastUpdate);
-    expect(firstDateBeforeSort.getDate()).to.equal(12);
+    expect(firstDateBeforeSort.getDate()).to.equal(11);
 
     // Sorts by date
     const results = filterAndSort({ inquiriesArray: flatInquiries });
@@ -163,7 +177,7 @@ describe('filterAndSort', () => {
 
   it('sorts by oldest lastUpdate', () => {
     const firstDateBeforeSort = new Date(flatInquiries[0].lastUpdate);
-    expect(firstDateBeforeSort.getDate()).to.equal(12);
+    expect(firstDateBeforeSort.getDate()).to.equal(11);
 
     // Sorts by date
     const results = filterAndSort({
@@ -171,7 +185,7 @@ describe('filterAndSort', () => {
       sortOrder: filterAndSort.sortOptions.lastUpdate.oldest,
     });
     const firstDateAfterSort = new Date(results[0].lastUpdate);
-    expect(firstDateAfterSort.getDate()).to.equal(2);
+    expect(firstDateAfterSort.getDate()).to.equal(11);
 
     // Sorts by time (2 items updated on same day)
     const getIndex = (arr, id) => arr.findIndex(item => item.id === id);
@@ -199,11 +213,11 @@ describe('filterAndSort', () => {
   it('sorts by query: inquiry number', () => {
     const results = filterAndSort({
       inquiriesArray: flatInquiries,
-      filters: { query: '617' },
+      filters: { query: '852' },
     });
 
     expect(results.length).to.equal(1);
-    expect(results[0].id).to.equal('678b6a15-d1b0-ef11-b8e9-001dd830a0af');
+    expect(results[0].id).to.equal('3ac11cee-2ebe-ef11-b8e9-001dd809b958');
   });
 
   it('sorts by query: category name', () => {

--- a/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
@@ -22,21 +22,26 @@ describe('flattenInquiry', () => {
 describe('standardizeInquiries', () => {
   it('returns ONLY personal and business inquiries', () => {
     const output = standardizeInquiries(mockInquiries);
-    expect(output).to.have.property('personal');
-    expect(output).to.have.property('business');
-    expect(output).to.not.have.property('unauthenticated');
+    expect(output).to.have.property('inquiries');
+    expect(
+      output.inquiries?.every(inq =>
+        ['business', 'personal'].includes(
+          inq.levelOfAuthentication.toLowerCase(),
+        ),
+      ),
+    ).to.be.true;
   });
 
-  it('puts inquiries into the right buckets', () => {
+  it('returns indicators of what inquiry types are present', () => {
     const output = standardizeInquiries(mockInquiries);
-    expect(output.personal.length).to.equal(7);
-    expect(output.business.length).to.equal(2);
+    expect(output.inquiryTypes).to.include('personal');
+    expect(output.inquiryTypes).to.include('business');
   });
 
   it('flattens inquiries as they are categorized', () => {
     const output = standardizeInquiries(mockInquiries);
-    expect(output.personal[0]).to.have.property('status');
-    expect(output.personal[0].status).to.equal('In progress');
+    expect(output.inquiries[0]).to.have.property('status');
+    expect(output.inquiries[0].status).to.equal('In progress');
   });
 
   it('returns only the categories present in the inquiries list', () => {

--- a/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/utils/inbox.unit.spec.jsx
@@ -100,6 +100,8 @@ describe('paginateInquiries', () => {
 
 describe('filterAndSort', () => {
   const flatInquiries = mockInquiries.map(flattenInquiry);
+  const Dec18At420pmId = '1aed76e7-5bbd-ef11-b8e9-001dd830a0af';
+  const Dec18At530pmId = '46a76c10-5bbd-ef11-b8e9-001dd805523c';
 
   it('returns all results if unfiltered', () => {
     const results = filterAndSort({ inquiriesArray: flatInquiries });
@@ -133,7 +135,7 @@ describe('filterAndSort', () => {
     expect(results.length).to.equal(1);
   });
 
-  it('sorts by most recent lastUpdate', () => {
+  it('sorts by newest lastUpdate by default', () => {
     const firstDateBeforeSort = new Date(flatInquiries[0].lastUpdate);
     expect(firstDateBeforeSort.getDate()).to.equal(12);
 
@@ -145,23 +147,34 @@ describe('filterAndSort', () => {
     // Sorts by time (2 items updated on same day)
     const getIndex = (arr, id) => arr.findIndex(item => item.id === id);
 
-    const laterUpdateIndexBefore = getIndex(
-      flatInquiries,
-      '1aed76e7-5bbd-ef11-b8e9-001dd830a0af',
-    );
-    const earlierUpdateIndexBefore = getIndex(
-      flatInquiries,
-      '46a76c10-5bbd-ef11-b8e9-001dd805523c',
-    );
-    const laterUpdateIndexAfter = getIndex(
-      results,
-      '1aed76e7-5bbd-ef11-b8e9-001dd830a0af',
-    );
+    const laterUpdateIndexBefore = getIndex(flatInquiries, Dec18At420pmId);
+    const earlierUpdateIndexBefore = getIndex(flatInquiries, Dec18At530pmId);
+    const laterUpdateIndexAfter = getIndex(results, Dec18At420pmId);
+    const earlierUpdateIndexAfter = getIndex(results, Dec18At530pmId);
 
-    const earlierUpdateIndexAfter = getIndex(
-      results,
-      '46a76c10-5bbd-ef11-b8e9-001dd805523c',
-    );
+    expect(earlierUpdateIndexBefore < laterUpdateIndexBefore).to.be.true;
+    expect(laterUpdateIndexAfter < earlierUpdateIndexAfter).to.be.true;
+  });
+
+  it('sorts by oldest lastUpdate', () => {
+    const firstDateBeforeSort = new Date(flatInquiries[0].lastUpdate);
+    expect(firstDateBeforeSort.getDate()).to.equal(12);
+
+    // Sorts by date
+    const results = filterAndSort({
+      inquiriesArray: flatInquiries,
+      sortOrder: filterAndSort.sortOptions.lastUpdate.oldest,
+    });
+    const firstDateAfterSort = new Date(results[0].lastUpdate);
+    expect(firstDateAfterSort.getDate()).to.equal(2);
+
+    // Sorts by time (2 items updated on same day)
+    const getIndex = (arr, id) => arr.findIndex(item => item.id === id);
+
+    const laterUpdateIndexBefore = getIndex(flatInquiries, Dec18At420pmId);
+    const earlierUpdateIndexBefore = getIndex(flatInquiries, Dec18At530pmId);
+    const earlierUpdateIndexAfter = getIndex(results, Dec18At420pmId);
+    const laterUpdateIndexAfter = getIndex(results, Dec18At530pmId);
 
     expect(earlierUpdateIndexBefore < laterUpdateIndexBefore).to.be.true;
     expect(laterUpdateIndexAfter < earlierUpdateIndexAfter).to.be.true;

--- a/src/applications/ask-va/tests/utils/mock-inquiries.js
+++ b/src/applications/ask-va/tests/utils/mock-inquiries.js
@@ -12,7 +12,7 @@ export const mockInquiries = [
       hasBeenSplit: false,
       inquiryTopic: 'Audiology and hearing aids',
       levelOfAuthentication: 'Personal',
-      lastUpdate: '12/12/2024 12:00:00 AM',
+      lastUpdate: '12/11/2024 12:30:00 AM',
       queueId: 'f9d63862-d81f-ed11-b83c-001dd8069009',
       queueName: 'VHA Audiology',
       status: 'inprogress',

--- a/src/applications/ask-va/utils/inbox.js
+++ b/src/applications/ask-va/utils/inbox.js
@@ -24,8 +24,8 @@ export function flattenInquiry(rawInquiry) {
 /** Splits inquires into buckets by their Level of Authentication
  *  @param {Array} rawInquiries
  *  @returns {{
- *   inquiries: Inquiry[],
- *   inquiryTypes: ('business' | 'personal')[]
+ *   standardInquiries: Inquiry[],
+ *   types: ('business' | 'personal')[]
  *   uniqueCategories: string[]
  *   uniqueStatuses: string[]
  * }}
@@ -56,8 +56,8 @@ export function standardizeInquiries(rawInquiries) {
   );
   // Convert the Sets to arrays
   return {
-    ...output,
-    inquiryTypes: [...output.inquiryTypes],
+    standardInquiries: output.inquiries,
+    types: [...output.inquiryTypes],
     uniqueCategories: [...output.uniqueCategories],
     uniqueStatuses: [...output.uniqueStatuses],
   };
@@ -103,18 +103,26 @@ const sortOptions = {
  * **IMPORTANT:** be sure to use `filterAndSort.sortOptions` to set `sortOrder`
  * @param {object} _ destructured object
  * @param {Inquiry[]} _.inquiriesArray
- * @param {object} _.filters destructured object
- * @param {string} _.filters.category
- * @param {string} _.filters.status
- * @param {string} _.filters.query
- * @param {string} _.sortOrder use the `sortOptions` object to pick the right option
+ * @param {{
+ *   categories: string[]
+ *   statuses: string[]
+ *   inquiryTypes: ('business' | 'personal')[]
+ *   query: string
+ * }} _.filters destructured object
+ * @param {string} [_.sortOrder] use the `sortOptions` object to pick the right option
  * @returns {Inquiry[]}
  */
 export function filterAndSort({
   inquiriesArray,
-  filters: { category = 'All', status = 'All', query = '' } = {
-    category: 'All',
-    status: 'All',
+  filters: {
+    categories = ['All'],
+    statuses = ['All'],
+    inquiryTypes = ['business', 'personal'],
+    query = '',
+  } = {
+    categories: ['All'],
+    statuses: ['All'],
+    inquiryTypes: ['business', 'personal'],
     query: '',
   },
   sortOrder = sortOptions.lastUpdate.newest,
@@ -124,8 +132,9 @@ export function filterAndSort({
   const filteredAndSorted = inquiriesCopy
     .filter(inq => {
       return (
-        [inq.categoryName, 'All'].includes(category) &&
-        [inq.status, 'All'].includes(status)
+        (categories.includes('All') || categories.includes(inq.categoryName)) &&
+        (statuses.includes('All') || statuses.includes(inq.status)) &&
+        inquiryTypes.includes(inq.levelOfAuthentication.toLowerCase())
       );
     })
     .sort((a, b) => {

--- a/src/applications/ask-va/utils/inbox.js
+++ b/src/applications/ask-va/utils/inbox.js
@@ -24,20 +24,23 @@ export function flattenInquiry(rawInquiry) {
 /** Splits inquires into buckets by their Level of Authentication
  *  @param {Array} rawInquiries
  *  @returns {{
- *   business: Inquiry[],
- *   personal: Inquiry[],
+ *   inquiries: Inquiry[],
+ *   inquiryTypes: ('business' | 'personal')[]
  *   uniqueCategories: string[]
  *   uniqueStatuses: string[]
  * }}
  */
 export function standardizeInquiries(rawInquiries) {
-  const buckets = rawInquiries.reduce(
+  const output = rawInquiries.reduce(
     (accumulator, current) => {
       const loa = current.attributes.levelOfAuthentication.toLowerCase();
       const flattened = flattenInquiry(current);
 
-      // If business or personal, add to bucket
-      if (accumulator[loa]) accumulator[loa].push(flattened);
+      // If business or personal, add to output
+      if (['business', 'personal'].includes(loa)) {
+        accumulator.inquiries.push(flattened);
+        accumulator.inquiryTypes.add(loa);
+      }
 
       // Use Sets to track categories & statuses
       accumulator.uniqueCategories.add(flattened.categoryName);
@@ -45,17 +48,18 @@ export function standardizeInquiries(rawInquiries) {
       return accumulator;
     },
     {
-      business: [],
-      personal: [],
+      inquiries: [],
+      inquiryTypes: new Set(),
       uniqueCategories: new Set(),
       uniqueStatuses: new Set(),
     },
   );
   // Convert the Sets to arrays
   return {
-    ...buckets,
-    uniqueCategories: [...buckets.uniqueCategories],
-    uniqueStatuses: [...buckets.uniqueStatuses],
+    ...output,
+    inquiryTypes: [...output.inquiryTypes],
+    uniqueCategories: [...output.uniqueCategories],
+    uniqueStatuses: [...output.uniqueStatuses],
   };
 }
 

--- a/src/applications/ask-va/utils/inbox.js
+++ b/src/applications/ask-va/utils/inbox.js
@@ -1,5 +1,5 @@
 import Fuse from 'fuse.js';
-import { compareDesc } from 'date-fns';
+import { compareAsc, compareDesc } from 'date-fns';
 import { getVAStatusFromCRM } from '../config/helpers';
 
 /**
@@ -86,6 +86,26 @@ export function paginateInquiries(inquiries, itemsPerPage) {
     : [{ pageStart: 0, pageEnd: 0, items: [] }];
 }
 
+const sortOptions = {
+  lastUpdate: {
+    newest: 'lastUpdate.newest',
+    oldest: 'lastUpdate.oldest',
+  },
+};
+
+/**
+ * Set the list of inquiries to be displayed in the UI.
+ *
+ * **IMPORTANT:** be sure to use `filterAndSort.sortOptions` to set `sortOrder`
+ * @param {object} _ destructured object
+ * @param {Inquiry[]} _.inquiriesArray
+ * @param {object} _.filters destructured object
+ * @param {string} _.filters.category
+ * @param {string} _.filters.status
+ * @param {string} _.filters.query
+ * @param {string} _.sortOrder use the `sortOptions` object to pick the right option
+ * @returns {Inquiry[]}
+ */
 export function filterAndSort({
   inquiriesArray,
   filters: { category = 'All', status = 'All', query = '' } = {
@@ -93,6 +113,7 @@ export function filterAndSort({
     status: 'All',
     query: '',
   },
+  sortOrder = sortOptions.lastUpdate.newest,
 }) {
   // Since Array.sort() sorts it in place, create a shallow copy first
   const inquiriesCopy = [...inquiriesArray];
@@ -103,9 +124,18 @@ export function filterAndSort({
         [inq.status, 'All'].includes(status)
       );
     })
-    .sort((a, b) =>
-      compareDesc(new Date(a.lastUpdate), new Date(b.lastUpdate)),
-    );
+    .sort((a, b) => {
+      switch (sortOrder) {
+        case sortOptions.lastUpdate.newest:
+          return compareDesc(new Date(a.lastUpdate), new Date(b.lastUpdate));
+
+        case sortOptions.lastUpdate.oldest:
+          return compareAsc(new Date(a.lastUpdate), new Date(b.lastUpdate));
+
+        default:
+          return 0;
+      }
+    });
 
   const searchable = new Fuse(filteredAndSorted, {
     keys: ['inquiryNumber', 'submitterQuestion', 'categoryName'],
@@ -118,3 +148,5 @@ export function filterAndSort({
   // An empty query returns no results, so use the full list as a backup
   return query ? results : filteredAndSorted;
 }
+
+filterAndSort.sortOptions = sortOptions;

--- a/src/applications/ask-va/utils/inbox.js
+++ b/src/applications/ask-va/utils/inbox.js
@@ -51,7 +51,7 @@ export function standardizeInquiries(rawInquiries) {
       uniqueStatuses: new Set(),
     },
   );
-  // Convert the Set into an array
+  // Convert the Sets to arrays
   return {
     ...buckets,
     uniqueCategories: [...buckets.uniqueCategories],


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary


- Add gate for feature toggle, separate into `InboxLayoutOld` vs. `InboxLayoutNew`
- Add `sortOrder` to filter util & React state
- Add `<VaSort  />` to control `sortOrder`
- Refactor how the array of inquiries is set and passed around the app
  - Previously, this was strongly coupled to the separation of business and personal inquiries, but since the future UI doesn't separate them into tabs, this separation was getting in the way of conditionally rendering the `VaSort` because the code was filtering results down after the component was rendered. This refactor allowed us to filter items beforehand, so that we could use `results.length` to show or hide the sort dropdown.
- Ask VA owns this code.
- Flipper toggle will be used until new inbox passes Collaboration Cycle

## Related issue(s)

- Closes department-of-veterans-affairs/ask-va/issues/2162

## Testing done

- **Old behavior:** default to sorting by most recently updated
- **New behavior:** let user choose what to sort by (currently just `lastUpdated` newest or oldest)
- Sign in and use the "Sort by" dropdown to change the sort order of the inbox
- Extensive overhaul of tests to accommodate new shape of object returned from `standardizeInquiries` - needs to work with both old and new inbox layout
  - Utils and components have new unit tests, and some old tests were made stricter so future changes can't break things without us knowing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="377" height="246" alt="Screenshot 2026-03-09 at 10 34 29 AM" src="https://github.com/user-attachments/assets/682a7b72-39d0-4fac-8909-435608db953f" /> | <img width="379" height="354" alt="Screenshot 2026-03-09 at 10 33 18 AM" src="https://github.com/user-attachments/assets/cd73b6d9-ca55-4c6a-88fd-9b0889807397" /> |
| Desktop | <img width="682" height="292" alt="Screenshot 2026-03-09 at 10 34 53 AM" src="https://github.com/user-attachments/assets/12a57d49-fdb1-460d-b002-35c5871f5398" /> | <img width="665" height="358" alt="Screenshot 2026-03-09 at 10 35 51 AM" src="https://github.com/user-attachments/assets/eb4b79b6-6f3f-4bae-ba3b-3a8b92f6db3e" /> |

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user