### PR TITLE
Fixed Login Container Google Analytics Bug

### DIFF
--- a/src/platform/user/authentication/components/LoginContainer.jsx
+++ b/src/platform/user/authentication/components/LoginContainer.jsx
@@ -18,7 +18,12 @@ export default function LoginContainer({
   const isOccMobile = [EXTERNAL_APPS.VA_OCC_MOBILE]?.includes(
     externalApplication,
   );
-  const { href, onClick } = useInternalTestingAuth();
+
+  const isUnifiedOccMobile = isUnifiedSignIn && isOccMobile;
+
+  const { href, onClick } = useInternalTestingAuth({
+    generateHref: isUnifiedOccMobile,
+  });
 
   return (
     <>
@@ -46,14 +51,13 @@ export default function LoginContainer({
           />
           <LoginInfo />
         </div>
-        {isUnifiedSignIn &&
-          isOccMobile && (
-            <div className="row">
-              <div className="columns">
-                <va-link href={href} text="VA staff" onClick={onClick} />
-              </div>
+        {isUnifiedOccMobile && (
+          <div className="row">
+            <div className="columns">
+              <va-link href={href} text="VA staff" onClick={onClick} />
             </div>
-          )}
+          </div>
+        )}
       </section>
     </>
   );

--- a/src/platform/user/authentication/hooks/index.js
+++ b/src/platform/user/authentication/hooks/index.js
@@ -45,14 +45,18 @@ export function useIdentityVerificationURL({ policy, useOAuth }) {
 /**
  *
  * @param {Object} queryParams - Used for unit testing ONLY
+ * @param {Boolean} generateHref - Determines if href should be generated
  * @returns {String} URL for VA OCC Mobile test accounts
  */
 export function useInternalTestingAuth({
   queryParams = { operation: 'myhealthevet_test_account' },
+  generateHref = true,
 } = {}) {
   const [href, setHref] = useState('');
 
   useEffect(() => {
+    if (!generateHref) return;
+
     async function generateURL() {
       const url = await sessionTypeUrl({
         type: 'mhv',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed a bug in `LoginContainer.jsx` that was causing Google Analytics to be called every time the component was run.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1169)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running:
  - `yarn test:unit src/platform/user/tests/authentication/authentication-hooks.unit.spec.jsx`
  - `yarn test:unit src/platform/user/tests/authentication/components/LoginContainer.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `LoginContainer.jsx` and the related tests.

## Acceptance criteria
- [x] Fix Login Container so that GA is only called when appropriate.