### PR TITLE
[ARC/135426] - reverting label being hidden on form upload

### DIFF
--- a/src/applications/representative-form-upload/containers/App.jsx
+++ b/src/applications/representative-form-upload/containers/App.jsx
@@ -48,7 +48,7 @@ const App = ({ children }) => {
         'va-text-input[name="root_veteranFullName_first"]',
         'va-text-input[name="root_claimantFullName_first"]',
       ],
-      '.usa-label{margin-top: 16px} #dateHint {display: none} .usa-form-group--month-select {width: 159px} .usa-accordion, .usa-accordion-bordered, .usa-accordion--bordered {margin: 24px 0 !important;} .usa-accordion__content.usa-prose {border:1px solid #f0f0f0;} .usa-hint {white-space: pre-line; margin-bottom: 16px} .input-wrap .usa-fieldset .usa-legend h3 {display:block}',
+      '.usa-label{margin-top: 16px} #dateHint {display: none} .usa-form-group--month-select {width: 159px} .usa-accordion, .usa-accordion-bordered, .usa-accordion--bordered {margin: 24px 0 !important;} .usa-accordion__content.usa-prose {border:1px solid #f0f0f0;} .usa-hint {white-space: pre-line; margin-bottom: 16px} .label-header {display:none} .label-header:has([for="fileInputField"]) {display:block}.input-wrap .usa-fieldset .usa-legend h3 {display:block}',
     );
   });
 

--- a/src/applications/representative-form-upload/containers/App.jsx
+++ b/src/applications/representative-form-upload/containers/App.jsx
@@ -48,7 +48,7 @@ const App = ({ children }) => {
         'va-text-input[name="root_veteranFullName_first"]',
         'va-text-input[name="root_claimantFullName_first"]',
       ],
-      '.usa-label{margin-top: 16px} #dateHint {display: none} .usa-form-group--month-select {width: 159px} .usa-accordion, .usa-accordion-bordered, .usa-accordion--bordered {margin: 24px 0 !important;} .usa-accordion__content.usa-prose {border:1px solid #f0f0f0;} .usa-hint {white-space: pre-line; margin-bottom: 16px} .label-header {display:none} .input-wrap .usa-fieldset .usa-legend h3 {display:block}',
+      '.usa-label{margin-top: 16px} #dateHint {display: none} .usa-form-group--month-select {width: 159px} .usa-accordion, .usa-accordion-bordered, .usa-accordion--bordered {margin: 24px 0 !important;} .usa-accordion__content.usa-prose {border:1px solid #f0f0f0;} .usa-hint {white-space: pre-line; margin-bottom: 16px} .input-wrap .usa-fieldset .usa-legend h3 {display:block}',
     );
   });
 


### PR DESCRIPTION
Showing "select a file to upload..", only hiding the duplicate "upload supporting docs.." see ticket:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/135426

working as intended on 526/686
<img width="840" height="757" alt="Screenshot 2026-03-09 at 12 13 54 PM" src="https://github.com/user-attachments/assets/8c5711a2-8c56-4433-a521-f02b9ddaf2e2" />
<img width="846" height="802" alt="Screenshot 2026-03-09 at 12 13 35 PM" src="https://github.com/user-attachments/assets/7cee8b8f-a545-499d-8fce-004d177e8738" />

