### PR TITLE
bug #5783 - alert is not announced to screen readers

### DIFF
--- a/src/applications/mock-sip-form/tests/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/mock-sip-form/tests/fixtures/mocks/local-mock-responses.js
@@ -1,0 +1,40 @@
+const commonResponses = require('../../../../../platform/testing/local-dev-mock-api/common');
+
+module.exports = {
+  ...commonResponses,
+
+  'GET /v0/in_progress_forms/XX-123': {
+    formData: { email: 'test@test.com' },
+    metadata: {
+      version: 0,
+      returnUrl: '/first-page',
+      savedAt: Date.now(),
+      expiresAt: Date.now() + 86400000,
+      lastUpdated: Date.now(),
+    },
+  },
+
+  // normal autosave success:
+  'PUT /v0/in_progress_forms/XX-123': {
+    data: {
+      attributes: {
+        metadata: {
+          version: 0,
+          returnUrl: '/first-page',
+          savedAt: Date.now(),
+          expiresAt: Date.now() + 86400000,
+          lastUpdated: Date.now(),
+          inProgressFormId: 12345,
+        },
+      },
+    },
+  },
+
+  // error autosave:
+  // 'PUT /v0/in_progress_forms/XX-123': (req, res) => res.status(500).json({}),
+
+  'POST /v0/mock_sip_form': {
+    formSubmissionId: '123fake-submission-id-567',
+    timestamp: '2016-05-16',
+  },
+};

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -8,6 +8,22 @@ import {
   APP_TYPE_DEFAULT,
 } from '../../forms-system/src/js/constants';
 
+function getSaveErrorAnnouncement(autoSavedStatus, appType, isLoggedIn) {
+  if (autoSavedStatus === SAVE_STATUSES.clientFailure) {
+    return `We’re sorry. We’re unable to connect to VA.gov. Please check that you’re connected to the Internet, so we can save your ${appType} in progress.`;
+  }
+
+  if (autoSavedStatus === SAVE_STATUSES.failure) {
+    return `We’re sorry, but we’re having some issues and are working to fix them. You can continue filling out the ${appType}, but it will not be automatically saved as you fill it out.`;
+  }
+
+  if (!isLoggedIn && autoSavedStatus === SAVE_STATUSES.noAuth) {
+    return `Sorry, you’re no longer signed in. Sign in to save your ${appType} in progress.`;
+  }
+
+  return '';
+}
+
 function SaveStatus({
   form: {
     lastSavedDate,
@@ -56,9 +72,20 @@ function SaveStatus({
   const appSavedSuccessfullyMessage =
     formConfig?.customText?.appSavedSuccessfullyMessage ||
     APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE;
+  const errorAnnouncement = hasError
+    ? getSaveErrorAnnouncement(autoSavedStatus, appType, isLoggedIn)
+    : '';
 
   return (
     <div>
+      <div
+        role="alert"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="save-status-error-announcement"
+      >
+        {errorAnnouncement}
+      </div>
       {autoSavedStatus === SAVE_STATUSES.success && (
         <div className="panel saved-success-container vads-u-display--flex vads-u-padding--1 vads-u-margin-bottom--1p5 vads-u-display--block">
           <va-alert status="success" slim uswds>
@@ -74,18 +101,12 @@ function SaveStatus({
         <p className="saved-form-autosaving">Saving...</p>
       )}
       {hasError && (
-        <va-alert
-          status="error"
-          role="alert"
-          class="schemaform-save-error"
-          slim
-          uswds
-        >
+        <va-alert status="error" class="schemaform-save-error" slim uswds>
           <p className="vads-u-margin--0">
             {autoSavedStatus === SAVE_STATUSES.clientFailure &&
-              `We’re sorry. We’re unable to connect to VA.gov. Please check that you’re connected to the Internet, so we can save your ${appType} in progress.`}
+              getSaveErrorAnnouncement(autoSavedStatus, appType, isLoggedIn)}
             {autoSavedStatus === SAVE_STATUSES.failure &&
-              `We’re sorry, but we’re having some issues and are working to fix them. You can continue filling out the ${appType}, but it will not be automatically saved as you fill it out.`}
+              getSaveErrorAnnouncement(autoSavedStatus, appType, isLoggedIn)}
             {!isLoggedIn &&
               autoSavedStatus === SAVE_STATUSES.noAuth && (
                 <span>

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -23,6 +23,11 @@ describe('<SaveStatus>', () => {
     const { container } = render(<SaveStatus {...props} />);
     expect(container).to.not.be.undefined;
   });
+  it('should keep live region empty before save error', () => {
+    const { getByTestId } = render(<SaveStatus {...props} />);
+    const liveRegion = getByTestId('save-status-error-announcement');
+    expect(liveRegion.textContent).to.equal('');
+  });
   it('should show last saved date', () => {
     const testProps = {
       ...props,
@@ -73,8 +78,10 @@ describe('<SaveStatus>', () => {
       ...props,
       form: { ...props.form, autoSavedStatus: SAVE_STATUSES.failure },
     };
-    const { container } = render(<SaveStatus {...testProps} />);
+    const { container, getByTestId } = render(<SaveStatus {...testProps} />);
     expect(container.textContent).to.have.string('having some issues');
+    const liveRegion = getByTestId('save-status-error-announcement');
+    expect(liveRegion.textContent).to.have.string('having some issues');
   });
   it('should display the appSavedSuccessfullyMessage & SiP ID', () => {
     const appSavedSuccessfullyMessageProps = {


### PR DESCRIPTION

Alert was in fact announced to screen readers regardless of this change, just slowly. But this should solve that at least.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated src/platform/forms/save-in-progress/SaveStatus.jsx:
  - Added a persistent, screen-reader-only live region:
    - role="alert"
    - aria-atomic="true"
    - starts empty on initial render
    - gets populated only when save status is an error
  - Added getSaveErrorAnnouncement(...) helper so the alert text is centralized and reused.
  - Kept the visible va-alert error UI intact, but removed role="alert" from that visible component so announcement behavior comes from the dedicated live region.
- Updated tests in src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx:
  - Verifies live region is empty before error.
  - Verifies live region contains the failure copy when regular save error occurs.

## Related issue(s)
CLOSES https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5783


## Testing done

- Updated tests in src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx:
  - Verifies live region is empty before error.
  - Verifies live region contains the failure copy when regular save error occurs.

- Ran:
  - yarn test:unit src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
  - Result: 11 passing

## Screenshots

https://github.com/user-attachments/assets/b44709e5-b1d2-493b-b4ec-c2e07132029d


## What areas of the site does it impact?

Save Status error field

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

You have to use a screen reader to test this.
