### PR TITLE
Pension - Update under 65 conditional pages

### DIFF
--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/additionalEvidence.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/additionalEvidence.js
@@ -8,7 +8,8 @@ export default {
   title: 'Medical records needed',
   path: 'medical/evidence',
   initialData: {},
-  depends: formData => requiresAdditionalEvidence(formData),
+  depends: formData =>
+    !formData.isOver65 && requiresAdditionalEvidence(formData),
   uiSchema: {
     ...titleUI('Medical records needed', MedicalEvidenceNotice),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/medicalConditions.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/medicalConditions.js
@@ -13,7 +13,7 @@ const { medicalCondition } = fullSchemaPensions.properties;
 export default {
   title: 'Medical condition',
   path: 'medical/history/condition',
-  depends: form => hasNoSocialSecurityDisability(form),
+  depends: form => !form.isOver65 && hasNoSocialSecurityDisability(form),
   uiSchema: {
     ...titleUI(
       'Tell us if you have a medical condition that prevents you from working',

--- a/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/additionalEvidence.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/additionalEvidence.unit.spec.jsx
@@ -34,4 +34,35 @@ describe('pension medical evidence', () => {
       .true;
     expect(requiresAdditionalEvidence({ medicalCondition: true })).to.be.true;
   });
+
+  describe('depends logic', () => {
+    it('shows page when applicant is under 65 and has Social Security disability', () => {
+      const formData = {
+        isOver65: false,
+        socialSecurityDisability: true,
+        medicalCondition: false,
+      };
+      expect(additionalEvidence.depends(formData)).to.be.true;
+    });
+
+    it('shows page when applicant is under 65 and has medical condition', () => {
+      const formData = {
+        isOver65: false,
+        socialSecurityDisability: false,
+        medicalCondition: true,
+      };
+
+      expect(additionalEvidence.depends(formData)).to.be.true;
+    });
+
+    it('does not show page when applicant is 65 or older', () => {
+      const formData = {
+        isOver65: true,
+        socialSecurityDisability: true,
+        medicalCondition: true,
+      };
+
+      expect(additionalEvidence.depends(formData)).to.be.false;
+    });
+  });
 });

--- a/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/medicalCondition.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/medicalCondition.unit.spec.jsx
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import {
   testComponentFieldsMarkedAsRequired,
   testNumberOfWebComponentFields,
@@ -41,4 +42,30 @@ describe('pension medical condition page', () => {
     },
     pageTitle,
   );
+
+  describe('depends logic', () => {
+    it('shows page when applicant is under 65 and has no Social Security disability', () => {
+      const formData = {
+        isOver65: false,
+        socialSecurityDisability: false,
+      };
+      expect(medicalConditions.depends(formData)).to.be.true;
+    });
+
+    it('does not show page when applicant is 65 or older and has no Social Security disability', () => {
+      const formData = {
+        isOver65: true,
+        socialSecurityDisability: false,
+      };
+      expect(medicalConditions.depends(formData)).to.be.false;
+    });
+
+    it('does not show page when applicant is 65 or older', () => {
+      const formData = {
+        isOver65: true,
+      };
+
+      expect(medicalConditions.depends(formData)).to.be.false;
+    });
+  });
 });

--- a/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/socialSecurityDisability.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/socialSecurityDisability.unit.spec.jsx
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import {
   testComponentFieldsMarkedAsRequired,
   testNumberOfWebComponentFields,
@@ -41,4 +42,21 @@ describe('pension social security disability page', () => {
     },
     pageTitle,
   );
+
+  describe('depends logic', () => {
+    it('shows page when applicant is under 65', () => {
+      const formData = {
+        isOver65: false,
+      };
+      expect(socialSecurityDisability.depends(formData)).to.be.true;
+    });
+
+    it('does not show page when applicant is 65 or older', () => {
+      const formData = {
+        isOver65: true,
+      };
+
+      expect(socialSecurityDisability.depends(formData)).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
### Summary of Changes
This PR fixes conditional page display logic in the **Pension Benefits form (VA Form 21P-527EZ)** for applicants **under 65**. Some pages were incorrectly displaying for applicants who are **65 or older**. This update corrects the age-based conditions so only applicants who meet the intended under-65 criteria see those pages.

### Issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/135595

### How to Set Up in Local Environment
1. Run the local environment
2. Navigate to the Pension Benefits form:  
   http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/medical/history/age

### How to Test
1. Start a new Pension Benefits application with an applicant age **under 65**.
2. Verify the conditional pages intended for under-65 applicants display as expected.
3. Change the applicant age **65 or older**.
4. Verify the same conditional pages are **skipped** and do not display.
5. Confirm navigation, validation, and Review & Submit behave correctly for both age scenarios.
6. Verify there are no console errors or accessibility regressions.

### Feature Flag Note
- No new feature flags introduced.

### Acceptance Criteria
- [x] Conditional pages intended for applicants under 65 display only when the applicant is under 65.
- [x] Applicants 65 or older no longer see incorrectly displayed under-65 pages.
- [x] No regressions in navigation, validation, or accessibility.
- [x] No console errors.

### Definition of Done
- [ ] Code reviewed and approved.
- [ ] Verified locally with applicant ages under 65 and 65 or older.
- [ ] No console errors or accessibility issues.
- [ ] Tests updated or verified passing.