### PR TITLE
[VAMCS-23371] Fix Mapbox tokens missing in production, staging, and dev builds

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -39,6 +39,53 @@ jobs:
             .cache/yarn
             node_modules
 
+      - name: Configure AWS credentials
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_region: us-gov-west-1
+          role: ${{ vars.AWS_ASSUME_ROLE }}
+
+      # This fallback token is not a real token, this portion of a token prevents Mapbox from crashing
+      # when app specific tokens are unavailable for any reason, instead it will provide errors.
+      - name: Set Mapbox Token fallback
+        run: echo "MAPBOX_TOKEN=pk.eyJ1IjoicGxhY2Vob2xkZXIifQ==" >> "$GITHUB_ENV"
+
+      - name: Get Mapbox Token (Facility Locator)
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_facility_locator
+          env_variable_name: MAPBOX_TOKEN_FACILITY_LOCATOR
+
+      - name: Get Mapbox Token (Static Pages)
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_static_pages
+          env_variable_name: MAPBOX_TOKEN_STATIC_PAGES
+
+      - name: Get Mapbox Token (GI)
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_gi
+          env_variable_name: MAPBOX_TOKEN_GI
+
+      - name: Get Mapbox Token (Ask VA)
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_ask_va
+          env_variable_name: MAPBOX_TOKEN_ASK_VA
+
+      - name: Get Mapbox Token (Caregivers)
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_caregivers
+          env_variable_name: MAPBOX_TOKEN_CAREGIVERS
+
+      - name: Get Mapbox Token (Representative Search)
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_representative_search
+          env_variable_name: MAPBOX_TOKEN_REPRESENTATIVE_SEARCH
+
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILD_ENV }}
         timeout-minutes: 30
@@ -58,12 +105,6 @@ jobs:
 
       - name: Compress and archive build
         run: tar -C build/${{ env.BUILD_ENV }} -cjf ${{ env.BUILD_ENV }}.tar.bz2 .
-
-      - name: Configure AWS credentials
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_region: us-gov-west-1
-          role: ${{ vars.AWS_ASSUME_ROLE }}
 
       - name: Upload build
         run: aws s3 cp ${{ env.BUILD_ENV }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${{ env.COMMIT_SHA }}/${{ env.BUILD_ENV }}.tar.bz2 --acl public-read --region us-gov-west-1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,6 @@ jobs:
           filter: blob:none
 
       - name: Configure AWS credentials
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/configure-aws-credentials
         with:
           aws_region: us-gov-west-1
@@ -72,42 +71,36 @@ jobs:
         run: echo "MAPBOX_TOKEN=pk.eyJ1IjoicGxhY2Vob2xkZXIifQ==" >> "$GITHUB_ENV"
 
       - name: Get Mapbox Token (Facility Locator)
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets
         with:
           ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_facility_locator
           env_variable_name: MAPBOX_TOKEN_FACILITY_LOCATOR
 
       - name: Get Mapbox Token (Static Pages)
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets
         with:
           ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_static_pages
           env_variable_name: MAPBOX_TOKEN_STATIC_PAGES
 
       - name: Get Mapbox Token (GI)
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets
         with:
           ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_gi
           env_variable_name: MAPBOX_TOKEN_GI
 
       - name: Get Mapbox Token (Ask VA)
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets
         with:
           ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_ask_va
           env_variable_name: MAPBOX_TOKEN_ASK_VA
 
       - name: Get Mapbox Token (Caregivers)
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets
         with:
           ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_caregivers
           env_variable_name: MAPBOX_TOKEN_CAREGIVERS
 
       - name: Get Mapbox Token (Representative Search)
-        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: ./.github/workflows/inject-secrets
         with:
           ssm_parameter: /dsva-vagov/vets-website/prod/mapbox_token_representative_search


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

**Production outage fix** — Mapbox maps on https://www.va.gov/find-locations (and all other Mapbox-consuming apps) are broken because the production JS bundle contains only the placeholder Mapbox token (`pk.eyJ1IjoicGxhY2Vob2xkZXIifQ==`) instead of the real app-specific tokens from AWS SSM.

### Root cause

After #42868 migrated Mapbox tokens from hardcoded values to AWS SSM Parameter Store, there were **two gaps** in the CI/CD pipeline:

1. **`build-and-tag.yml` (production — the primary issue):** This workflow runs a fresh full `yarn build` after CI completes and uploads the archive to S3, **overwriting** the CI archive. The daily production deploy (`daily-deploy-production.yml`) downloads this archive to deploy. However, `build-and-tag.yml` had **no Mapbox token injection at all** — no AWS credential configuration before the build step, no SSM secret fetching. So every production build since the migration was compiled with `process.env.MAPBOX_TOKEN_FACILITY_LOCATOR = undefined`, falling through to the invalid placeholder.

2. **`continuous-integration.yml` (staging/dev):** The token injection steps were gated behind `if: ${{ matrix.buildtype == 'vagovprod' }}`, so only the prod matrix leg got real tokens. Staging and dev builds fell back to the placeholder.

### Fixes (2 commits)

1. **`continuous-integration.yml`**: Remove the 7 `if: matrix.buildtype == 'vagovprod'` conditions so all buildtypes (vagovdev, vagovstaging, vagovprod) get real tokens from SSM.

2. **`build-and-tag.yml`**: Move AWS credential configuration before the build step and add the Mapbox token fallback + all 6 app-specific SSM token injection steps (matching what `continuous-integration.yml` already does). This ensures the production archive that the daily deploy picks up contains real tokens.

- **Team**: Sitewide Facilities (Agile Six)
- **No flipper required**

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#131972
- department-of-veterans-affairs/vets-website#42868 — Original PR that introduced the per-app token migration

## Testing done

- Verified production bundle on S3 currently contains only the placeholder token:
  ```
  curl -s --compressed 'https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/facilities.entry.js' \
    | grep -oE 'pk\.[A-Za-z0-9_=+/.-]{20,}'
  # Output: pk.eyJ1IjoicGxhY2Vob2xkZXIifQ==
  ```
- Confirmed SSM parameters exist and contain valid tokens (verified via AWS Console)
- Confirmed CI logs for the migration commit show tokens were correctly injected (masked `***`) in the CI build — proving SSM injection works
- Traced the deploy pipeline to confirm `build-and-tag.yml` overwrites the CI archive and is what production actually deploys
- Validated YAML syntax after edits

## Screenshots

N/A — CI workflow change, no UI modifications.

## What areas of the site does it impact?

All Mapbox-consuming applications across **all environments** (production, staging, dev):
- facility-locator
- static-pages (facility detail maps)
- GI Bill comparison tool
- Ask VA
- caregivers
- representative-search

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - N/A — CI workflow-only change, no application code modified
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated — N/A
- [x] Screenshot of the developed feature is added — N/A, no UI change
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed — N/A, no UI change

### Error Handling

- [x] Browser console contains no warnings or errors. — N/A, CI-only change
- [x] Events are being sent to the appropriate logging solution — N/A
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user — N/A, CI-only change

## Requested Feedback

This is an urgent fix for a production outage caused by #42868. The `build-and-tag.yml` workflow was not updated to inject Mapbox SSM tokens, so every production build since the migration has been compiled without real tokens. Please prioritize review.