### PR TITLE
133725 - Removing Conditional Meds By Mail text

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListHeader.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListHeader.jsx
@@ -12,13 +12,8 @@ const MedicationsListHeader = ({
   showRxRenewalMessageSuccessAlert,
 }) => {
   const hasMedsByMailFacility = useSelector(selectHasMedsByMailFacility);
-  let titleNotesMessage =
+  const titleNotesMessage =
     'Bring your medications list to each appointment. And tell your provider about any new allergies or reactions.';
-
-  if (!hasMedsByMailFacility) {
-    titleNotesMessage +=
-      ' If you use Meds by Mail, you can also call your servicing center and ask them to update your records.';
-  }
 
   const titleNotesBottomMarginUnit = hasMedsByMailFacility ? 3 : 2;
 

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListHeader.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListHeader.unit.spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import MedicationsListHeader from '../../../components/MedicationsList/MedicationsListHeader';
 import reducers from '../../../reducers';
-import { MEDS_BY_MAIL_FACILITY_ID } from '../../../util/constants';
 
 describe('MedicationsListHeader component', () => {
   const defaultProps = {
@@ -84,36 +83,5 @@ describe('MedicationsListHeader component', () => {
     });
     const alert = screen.queryByTestId('rx-renewal-message-success-alert');
     expect(alert).to.not.exist;
-  });
-
-  it('displays MedsByMailContent when user has meds by mail facility', () => {
-    const initialState = {
-      user: {
-        profile: {
-          facilities: [
-            {
-              facilityId: MEDS_BY_MAIL_FACILITY_ID,
-              isCerner: false,
-            },
-          ],
-        },
-      },
-    };
-    const screen = setup({}, initialState);
-    // Actually verify MedsByMailContent is rendered
-    expect(screen.getByTestId('meds-by-mail-header')).to.exist;
-
-    // And verify the extra "Meds by Mail" text is NOT in the title notes
-    const titleNotes = screen.getByTestId('Title-Notes');
-    expect(titleNotes.textContent).to.not.include('Meds by Mail');
-  });
-
-  it('does not display MedsByMailContent when user does not have meds by mail facility', () => {
-    const screen = setup();
-    const medsByMailHeader = screen.queryByTestId('meds-by-mail-header');
-    expect(medsByMailHeader).to.not.exist;
-
-    const titleNotes = screen.getByTestId('Title-Notes');
-    expect(titleNotes.textContent).to.include('Meds by Mail');
   });
 });

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -12,7 +12,6 @@ import * as prescriptionsApiModule from '../../api/prescriptionsApi';
 import { stubAllergiesApi, stubPrescriptionsListApi } from '../testing-utils';
 import Prescriptions from '../../containers/Prescriptions';
 import emptyPrescriptionsList from '../e2e/fixtures/empty-prescriptions-list.json';
-import { MEDS_BY_MAIL_FACILITY_ID } from '../../util/constants';
 
 let sandbox;
 
@@ -273,49 +272,6 @@ describe('Medications Prescriptions container', () => {
   it('displays filter accordion', async () => {
     const screen = setup();
     expect(await screen.getByTestId('filter-accordion')).to.exist;
-  });
-
-  it('displays Meds by Mail content for Meds by Mail users', async () => {
-    const screen = setup({
-      ...initialState,
-      user: {
-        profile: {
-          userFullName: { first: 'test', last: 'last', suffix: 'jr' },
-          dob: '2000-01-01',
-          facilities: [{ facilityId: MEDS_BY_MAIL_FACILITY_ID }],
-        },
-      },
-    });
-
-    expect(
-      screen.queryByText(
-        /If you use Meds by Mail, you can also call your servicing center and ask them to update your records\./,
-        {
-          selector: 'p',
-        },
-      ),
-    ).not.to.exist;
-
-    expect(screen.getByTestId('meds-by-mail-header')).to.exist;
-    expect(screen.getByTestId('meds-by-mail-top-level-text')).to.exist;
-    expect(screen.getByTestId('meds-by-mail-additional-info')).to.exist;
-  });
-
-  it('does not display Meds by Mail content for non-Meds by Mail users', async () => {
-    const screen = setup();
-
-    expect(
-      screen.getByText(
-        /If you use Meds by Mail, you can also call your servicing center and ask them to update your records\./,
-        {
-          selector: 'p',
-        },
-      ),
-    ).to.exist;
-
-    expect(screen.queryByTestId('meds-by-mail-header')).not.to.exist;
-    expect(screen.queryByTestId('meds-by-mail-top-level-text')).not.to.exist;
-    expect(screen.queryByTestId('meds-by-mail-additional-info')).not.to.exist;
   });
 
   describe('renderRxRenewalMessageSuccess', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed the sentence "If you use Meds by Mail, you can also call your servicing center and ask them to update your records." from the medications list page (`/my-health/medications`).
- This sentence was appended to the title notes for users who did **not** have a Meds by Mail facility in their profile. The original ticket intended for this text to be fully removed, but it was only conditionally hidden when the `MedsByMailContent` component was introduced.
- The `MedsByMailContent` component (shown to users who **do** have a Meds by Mail facility) is unchanged.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#133725

## Testing done

- **Old behavior**: Users without the Meds by Mail facility ID in their profile saw the sentence "If you use Meds by Mail, you can also call your servicing center and ask them to update your records." appended to the title notes paragraph on the medications list page.
- **New behavior**: All users see the same title notes: "Bring your medications list to each appointment. And tell your provider about any new allergies or reactions." — the Meds by Mail sentence no longer appears for any user.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img width="581" height="218" alt="image" src="https://github.com/user-attachments/assets/3bea3738-dbc4-4a29-acd0-194cefccbc56" />|<img width="696" height="186" alt="Screenshot 2026-03-09 at 14 44 56" src="https://github.com/user-attachments/assets/be4e3037-9d04-4e80-9c98-4f4b717e9519" />|

## What areas of the site does it impact?

Medications list page (`/my-health/medications`) only. The title notes paragraph text is the only change — no other pages or components are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
