### PR TITLE
feat(mhv-landing-page): add AAL feature toggle and selector

### DIFF
--- a/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
@@ -2,6 +2,7 @@ const { snakeCase } = require('lodash');
 
 // Please, keep these feature toggle settings up-to-date with production's feature toggles settings.
 const APPLICATION_FEATURE_TOGGLES = Object.freeze({
+  mhvAccountActivityLogEnabled: true,
   mhvVaHealthChatEnabled: true,
   mhvLandingPagePersonalization: true,
   mhvMilestone2ChangesEnabled: true,

--- a/src/applications/mhv-landing-page/selectors/featureToggles.js
+++ b/src/applications/mhv-landing-page/selectors/featureToggles.js
@@ -9,3 +9,12 @@ import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlag
 export const personalizationEnabled = state => {
   return toggleValues(state)[FEATURE_FLAG_NAMES.mhvLandingPagePersonalization];
 };
+
+/**
+ * Determines if the Account Activity Log page is enabled.
+ * @param {Object} state Current redux state.
+ * @returns {Boolean} true if the account activity log is enabled
+ */
+export const accountActivityEnabled = state => {
+  return toggleValues(state)[FEATURE_FLAG_NAMES.mhvAccountActivityLogEnabled];
+};

--- a/src/applications/mhv-landing-page/selectors/index.js
+++ b/src/applications/mhv-landing-page/selectors/index.js
@@ -9,7 +9,10 @@ import {
   isVAPatient,
 } from '~/platform/user/selectors';
 
-import { personalizationEnabled } from './featureToggles';
+import {
+  accountActivityEnabled,
+  personalizationEnabled,
+} from './featureToggles';
 import { hasEdipi } from './hasEdipi';
 import { hasMhvAccount } from './hasMhvAccount';
 import { selectGreetingName } from './personalInformation';
@@ -40,6 +43,7 @@ import {
 } from './accountInformation';
 
 export {
+  accountActivityEnabled,
   hasEdipi,
   hasMhvAccount,
   hasMessagingAccess,

--- a/src/applications/mhv-landing-page/tests/selectors/accountActivityEnabled.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/selectors/accountActivityEnabled.unit.spec.jsx
@@ -1,0 +1,24 @@
+/* eslint-disable camelcase */
+import { expect } from 'chai';
+import { accountActivityEnabled } from '../../selectors';
+
+describe('My HealtheVet on VA.gov -- accountActivityEnabled selector', () => {
+  it('returns true when the feature toggle is enabled', () => {
+    const state = {
+      featureToggles: { mhv_account_activity_log_enabled: true },
+    };
+    expect(accountActivityEnabled(state)).to.be.true;
+  });
+
+  it('returns false when the feature toggle is disabled', () => {
+    const state = {
+      featureToggles: { mhv_account_activity_log_enabled: false },
+    };
+    expect(accountActivityEnabled(state)).to.be.false;
+  });
+
+  it('returns undefined when the toggle is not present', () => {
+    const state = { featureToggles: {} };
+    expect(accountActivityEnabled(state)).to.be.undefined;
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -188,6 +188,7 @@
   "mhvAcceleratedDeliveryLabsAndTestsEnabled": "mhv_accelerated_delivery_labs_and_tests_enabled",
   "mhvBypassDowntimeNotification": "mhv_bypass_downtime_notification",
   "mhvEmailConfirmation": "mhv_email_confirmation",
+  "mhvAccountActivityLogEnabled": "mhv_account_activity_log_enabled",
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",
   "mhvMedicalRecordsCcdExtendedFileTypes": "mhv_medical_records_ccd_extended_file_types",
   "mhvMedicalRecordsCcdOH": "mhv_medical_records_ccd_oh",


### PR DESCRIPTION
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

- [x] No

## Summary

- Adds the `mhvAccountActivityLogEnabled` feature toggle and `accountActivityEnabled` selector for the upcoming Account Activity Log (AAL) page in the MHV Landing Page application.
- This is PR 1 of 4 in a series building the AAL feature. This PR is independently mergeable and introduces no user-facing changes — it only adds toggle infrastructure that will be consumed by later PRs.
- Team: MHV on VA.gov — Horizon
- The feature toggle `mhv_account_activity_log_enabled` will gate the AAL page. No end date set yet; success criteria is full AAL page launch behind the toggle.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#133775

## Testing done

- Verified the `accountActivityEnabled` selector returns `true` when the toggle is enabled, `false` when disabled, and `undefined` when absent.
- 3 new unit tests added and passing:
  ```
  My HealtheVet on VA.gov -- accountActivityEnabled selector
    ✓ returns true when the feature toggle is enabled
    ✓ returns false when the feature toggle is disabled
    ✓ returns undefined when the toggle is not present
  ```
- All 195 existing + new mhv-landing-page unit tests passing.
- No UI changes to test — this PR only adds a selector and toggle definition.

## Screenshots

N/A — no UI changes in this PR.

## What areas of the site does it impact?

No user-facing impact. Only adds a feature toggle definition (`featureFlagNames.json`) and a selector in `mhv-landing-page`. The toggle is enabled in mock API feature toggles for local development.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This is the first of 4 PRs for the Account Activity Log feature:
1. **This PR** — Feature toggle + selector (independent, mergeable now)
2. **PR2a** — Leaf components: ActivityCard, ActivityFilters, mock data, SCSS (independent, mergeable now)
3. **PR2b** — AccountActivityPage component (depends on PR2a)
4. **PR3** — Container + route wiring (depends on PR1 + PR2a + PR2b)