### PR TITLE
Search result url styling updates

### DIFF
--- a/src/applications/search/components/Result.jsx
+++ b/src/applications/search/components/Result.jsx
@@ -134,6 +134,11 @@ const Result = ({
             })}
           />
         </h4>
+        {!searchResultsUiUpdateEnabled && (
+          <p className="result-url vads-u-font-size--base vads-u-color--green">
+            {replaceWithStagingDomain(result.url)}
+          </p>
+        )}
         <p
           className="result-desc"
           /* eslint-disable react/no-danger */
@@ -147,15 +152,11 @@ const Result = ({
           }}
           /* eslint-enable react/no-danger */
         />
-        <p
-          className={`result-url vads-u-font-size--base ${
-            searchResultsUiUpdateEnabled
-              ? 'vads-u-color--gray'
-              : 'vads-u-color--green'
-          }`}
-        >
-          {replaceWithStagingDomain(result.url)}
-        </p>
+        {searchResultsUiUpdateEnabled && (
+          <p className="result-url vads-u-font-size--base vads-u-color--gray">
+            {replaceWithStagingDomain(result.url)}
+          </p>
+        )}
       </li>
     );
   }

--- a/src/applications/search/components/Result.jsx
+++ b/src/applications/search/components/Result.jsx
@@ -147,7 +147,13 @@ const Result = ({
           }}
           /* eslint-enable react/no-danger */
         />
-        <p className="result-url vads-u-color--gray vads-u-font-size--base">
+        <p
+          className={`result-url vads-u-font-size--base ${
+            searchResultsUiUpdateEnabled
+              ? 'vads-u-color--gray'
+              : 'vads-u-color--green'
+          }`}
+        >
           {replaceWithStagingDomain(result.url)}
         </p>
       </li>

--- a/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
+++ b/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
@@ -1,4 +1,5 @@
 import stub from '../../constants/stub.json';
+import stubNoBestBets from '../../constants/stub-no-best-bets.json';
 import stubPage2 from '../../constants/stub-page-2.json';
 import stubNewTerm from '../../constants/stub-new-term.json';
 import zeroResultsStub from '../../constants/stubZeroResults.json';
@@ -81,7 +82,7 @@ describe('Global search', () => {
 
   it('successfully searches and renders results when searching on the results page', () => {
     cy.intercept('GET', '/v0/search?query=*', {
-      body: stub,
+      body: stubNoBestBets,
       statusCode: 200,
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


## Summary

- Set result-url styling when feature flag is/isn't enabled. 

Not enabled:
<img width="575" height="436" alt="image" src="https://github.com/user-attachments/assets/f5ff058f-c935-46d0-a8a6-3265ac5d9959" />

Enabled:
<img width="581" height="517" alt="image" src="https://github.com/user-attachments/assets/584e48d8-5050-445f-bc36-d3294ebb047d" />


## Related issue(s)
- https://github.com/department-of-veterans-affairs/unified-search/issues/144