### PR TITLE
686c | Update Add Child Birthplace Postal Code Validation

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/placeOfBirth.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/placeOfBirth.js
@@ -8,6 +8,22 @@ import {
   asciiValidation,
 } from '../../helpers';
 
+export const validateBirthPostalCode = (
+  errors,
+  postalCode,
+  formData,
+  _schema,
+  _errorMessages,
+  currentIndex,
+) => {
+  const isOutsideUsa =
+    formData?.childrenToAdd?.[currentIndex]?.birthLocation?.outsideUsa ||
+    formData?.birthLocation?.outsideUsa;
+  if (!isOutsideUsa && postalCode && !/^\d{5}$/.test(postalCode)) {
+    errors.addError('Enter a valid 5-digit postal code');
+  }
+};
+
 export const placeOfBirth = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
@@ -77,8 +93,8 @@ export const placeOfBirth = {
           'ui:webComponentField': VaTextInputField,
           'ui:errorMessages': {
             required: 'Enter a postal code',
-            pattern: 'Enter a valid 5-digit postal code',
           },
+          'ui:validations': [validateBirthPostalCode],
           'ui:required': (formData, index) =>
             !(
               formData?.childrenToAdd?.[index]?.birthLocation?.outsideUsa ||

--- a/src/applications/dependents/686c-674/config/helpers.js
+++ b/src/applications/dependents/686c-674/config/helpers.js
@@ -207,7 +207,6 @@ export const customLocationSchemaStatePostal = {
         },
         postalCode: {
           type: 'string',
-          pattern: '^\\d{5}$',
         },
       },
     },

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/placeOfBirth.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/placeOfBirth.unit.spec.jsx
@@ -2,12 +2,14 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
 import React from 'react';
+import sinon from 'sinon';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import {
   DefinitionTester,
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../../../config/form';
+import { validateBirthPostalCode } from '../../../../config/chapters/report-add-child/placeOfBirth';
 
 const defaultStore = createCommonStore();
 
@@ -39,5 +41,85 @@ describe('686 add child place of birth', () => {
 
     const formDOM = getFormDOM(form);
     expect(formDOM.querySelectorAll('va-select').length).to.eq(1);
+  });
+});
+
+describe('validateBirthPostalCode', () => {
+  let errors;
+
+  beforeEach(() => {
+    errors = { addError: sinon.spy() };
+  });
+
+  it('does nothing when postalCode is undefined', () => {
+    validateBirthPostalCode(errors, undefined, {}, null, null, 0);
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('does nothing when postalCode is an empty string', () => {
+    validateBirthPostalCode(errors, '', {}, null, null, 0);
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('does nothing for a valid 5-digit US postal code', () => {
+    validateBirthPostalCode(errors, '12345', {}, null, null, 0);
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('adds an error for a non-5-digit postal code when inside the US', () => {
+    const fd = { childrenToAdd: [{ birthLocation: { outsideUsa: false } }] };
+    validateBirthPostalCode(errors, '1234', fd, null, null, 0);
+    expect(errors.addError.calledOnce).to.be.true;
+    expect(errors.addError.firstCall.args[0]).to.equal(
+      'Enter a valid 5-digit postal code',
+    );
+  });
+
+  it('adds an error for a 6-digit postal code when inside the US', () => {
+    const fd = { childrenToAdd: [{ birthLocation: { outsideUsa: false } }] };
+    validateBirthPostalCode(errors, '123456', fd, null, null, 0);
+    expect(errors.addError.calledOnce).to.be.true;
+  });
+
+  it('adds an error for a non-numeric postal code when inside the US', () => {
+    const fd = { childrenToAdd: [{ birthLocation: { outsideUsa: false } }] };
+    validateBirthPostalCode(errors, 'ABCDE', fd, null, null, 0);
+    expect(errors.addError.calledOnce).to.be.true;
+  });
+
+  it('does nothing for an invalid postal code when outsideUsa is true via childrenToAdd', () => {
+    const fd = { childrenToAdd: [{ birthLocation: { outsideUsa: true } }] };
+    validateBirthPostalCode(errors, 'ABCDE12345', fd, null, null, 0);
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('uses the correct array index when multiple children exist', () => {
+    const fd = {
+      childrenToAdd: [
+        { birthLocation: { outsideUsa: false } },
+        { birthLocation: { outsideUsa: true } },
+      ],
+    };
+    const errorsInside = { addError: sinon.spy() };
+    const errorsOutside = { addError: sinon.spy() };
+
+    // index 0 is inside USA — should error
+    validateBirthPostalCode(errorsInside, 'ABCDE', fd, null, null, 0);
+    expect(errorsInside.addError.calledOnce).to.be.true;
+
+    // index 1 is outside USA — should not error
+    validateBirthPostalCode(errorsOutside, 'ABCDE', fd, null, null, 1);
+    expect(errorsOutside.addError.called).to.be.false;
+  });
+
+  it('does nothing for an invalid postal code when outsideUsa is true via formData.birthLocation', () => {
+    const fd = { birthLocation: { outsideUsa: true } };
+    validateBirthPostalCode(errors, 'ABCDE12345', fd, null, null, 0);
+    expect(errors.addError.called).to.be.false;
+  });
+
+  it('adds an error when formData has no outsideUsa flag', () => {
+    validateBirthPostalCode(errors, '1234', {}, null, null, 0);
+    expect(errors.addError.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION
## Summary

- Adds proper postal code validation depending on if "Outside US" is selected for the dependent's place of birth.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/135076

## Testing done

- Manual verification of postal code updates in add and edit mode
- Unit tests added

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
