### PR TITLE
Blue Sky: Add navigation links

### DIFF
--- a/src/applications/mhv-medications/containers/MedicationHistory.jsx
+++ b/src/applications/mhv-medications/containers/MedicationHistory.jsx
@@ -10,7 +10,7 @@ import ApiErrorNotification from '../components/shared/ApiErrorNotification';
 import MedicationsList from '../components/MedicationsList/MedicationsList';
 import MedicationsListSort from '../components/MedicationsList/MedicationsListSort';
 import { useFetchMedicationHistory } from '../hooks/MedicationHistory/useFetchMedicationHistory';
-import { pageType } from '../util/dataDogConstants';
+import { pageType, dataDogActionNames } from '../util/dataDogConstants';
 import {
   rxListSortingOptions,
   rxListSortingOptionsV2,
@@ -278,9 +278,26 @@ const MedicationHistory = () => {
   return (
     <div>
       <h1 data-testid="medication-history-heading">Medication history</h1>
-      <Link to="/in-progress">Go to your in-progress medications</Link>
+      <Link
+        data-testid="in-progress-link"
+        to="/in-progress"
+        data-dd-action-name={
+          dataDogActionNames.medicationsHistoryPage
+            .GO_TO_YOUR_IN_PROGRESS_MEDICATIONS_LINK
+        }
+      >
+        Go to your in-progress medications
+      </Link>
       <span className="vads-u-margin-x--1">|</span>
-      <Link to="/refill">Refill medications</Link>
+      <Link
+        data-testid="refill-link"
+        to="/"
+        data-dd-action-name={
+          dataDogActionNames.medicationsHistoryPage.REFILL_MEDICATIONS_LINK
+        }
+      >
+        Refill medications
+      </Link>
       {renderContent()}
       <NeedHelp page={pageType.HISTORY} headingLevel={2} />
     </div>

--- a/src/applications/mhv-medications/containers/PrescriptionsInProgress.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionsInProgress.jsx
@@ -5,7 +5,7 @@ import InProgressMedicationsProcessList from '../components/PrescriptionsInProgr
 import NeedHelp from '../components/shared/NeedHelp';
 import ApiErrorNotification from '../components/shared/ApiErrorNotification';
 import useFetchPrescriptionsInProgress from '../hooks/PrescriptionsInProgress/useFetchPrescriptionsInProgress';
-import { pageType } from '../util/dataDogConstants';
+import { pageType, dataDogActionNames } from '../util/dataDogConstants';
 
 const PrescriptionsInProgress = () => {
   const {
@@ -59,9 +59,26 @@ const PrescriptionsInProgress = () => {
         the date of shipping. To review all your medications, go to your
         medication history.
       </p>
-      <Link to="/history">Go to your medication history</Link>
+      <Link
+        data-testid="history-link"
+        to="/history"
+        data-dd-action-name={
+          dataDogActionNames.inProgressPage
+            .GO_TO_REVIEW_AND_PRINT_MEDICATION_HISTORY_LINK
+        }
+      >
+        Review and print list of medications
+      </Link>
       <span className="vads-u-margin-x--1">|</span>
-      <Link to="/refill">Refill medications</Link>
+      <Link
+        data-testid="refill-link"
+        to="/"
+        data-dd-action-name={
+          dataDogActionNames.inProgressPage.REFILL_MEDICATIONS_LINK
+        }
+      >
+        Refill medications
+      </Link>
       {renderContent()}
       <NeedHelp page={pageType.IN_PROGRESS} headingLevel={2} />
     </div>

--- a/src/applications/mhv-medications/containers/RefillPrescriptionsV2.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptionsV2.jsx
@@ -351,6 +351,27 @@ const RefillPrescriptionsV2 = () => {
         >
           Medications
         </h1>
+        <Link
+          data-testid="in-progress-link"
+          to="/in-progress"
+          data-dd-action-name={
+            dataDogActionNames.refillPage
+              .GO_TO_YOUR_IN_PROGRESS_MEDICATIONS_LINK
+          }
+        >
+          Go to your in-progress medications
+        </Link>
+        <span className="vads-u-margin-x--1">|</span>
+        <Link
+          data-testid="history-link"
+          to="/history"
+          data-dd-action-name={
+            dataDogActionNames.refillPage
+              .GO_TO_REVIEW_AND_PRINT_MEDICATION_HISTORY_LINK
+          }
+        >
+          Review and print list of medications
+        </Link>
         {refillAlertList.length > 0 && (
           <DelayedRefillAlert
             dataDogActionName={dataDogActionNames.refillPage.REFILL_ALERT_LINK}
@@ -389,7 +410,6 @@ const RefillPrescriptionsV2 = () => {
                   <strong>Note:</strong> Note: If you can’t find the medication
                   you’re looking for, you may need to renew it before you can
                   refill it.
-                  {/* TODO: This link needs to be updated to the Medications List page filtered for renewable meds */}
                   <Link
                     data-testid="medications-page-link"
                     className="vads-u-margin-top--2 vads-u-display--block"

--- a/src/applications/mhv-medications/tests/containers/MedicationHistory.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/MedicationHistory.unit.spec.jsx
@@ -204,7 +204,7 @@ describe('MedicationHistory container', () => {
         name: /Refill medications/i,
       });
       expect(link).to.exist;
-      expect(link.getAttribute('href')).to.equal('/refill');
+      expect(link.getAttribute('href')).to.equal('/');
     });
   });
 

--- a/src/applications/mhv-medications/tests/containers/PrescriptionsInProgress.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/PrescriptionsInProgress.unit.spec.jsx
@@ -123,7 +123,7 @@ describe('PrescriptionsInProgress container', () => {
     stubFetchHook(mockCategorizedPrescriptions);
     const screen = setup();
     const link = screen.getByRole('link', {
-      name: /Go to your medication history/i,
+      name: /Review and print list of medications/i,
     });
     expect(link).to.exist;
     expect(link.getAttribute('href')).to.equal('/history');
@@ -136,7 +136,7 @@ describe('PrescriptionsInProgress container', () => {
       name: /Refill medications/i,
     });
     expect(link).to.exist;
-    expect(link.getAttribute('href')).to.equal('/refill');
+    expect(link.getAttribute('href')).to.equal('/');
   });
 
   it('renders NeedHelp component', () => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsHistoryPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsHistoryPage.js
@@ -71,7 +71,7 @@ class MedicationsHistoryPage {
   };
 
   verifyRefillLink = () => {
-    cy.get('a[href$="/refill"]').should('contain', 'Refill medications');
+    cy.findByTestId('refill-link').should('contain', 'Refill medications');
   };
 
   verifyLoadingIndicator = () => {

--- a/src/applications/mhv-medications/util/dataDogConstants.js
+++ b/src/applications/mhv-medications/util/dataDogConstants.js
@@ -97,6 +97,26 @@ export const dataDogActionNames = {
     GO_TO_UPDATE_NOTIFICATION_SETTINGS_LINK: `Go to update notification settings link - ${
       pageType.REFILL
     }`,
+    GO_TO_YOUR_IN_PROGRESS_MEDICATIONS_LINK: `Go To Your In-Progress Medications Link - ${
+      pageType.REFILL
+    }`,
+    GO_TO_REVIEW_AND_PRINT_MEDICATION_HISTORY_LINK: `Go To Review And Print Medication History Link - ${
+      pageType.REFILL
+    }`,
+  },
+  inProgressPage: {
+    GO_TO_REVIEW_AND_PRINT_MEDICATION_HISTORY_LINK: `Go To Review And Print Medication History Link - ${
+      pageType.IN_PROGRESS
+    }`,
+    REFILL_MEDICATIONS_LINK: `Refill Medications Link - ${
+      pageType.IN_PROGRESS
+    }`,
+  },
+  medicationsHistoryPage: {
+    GO_TO_YOUR_IN_PROGRESS_MEDICATIONS_LINK: `Go To Your In-Progress Medications Link - ${
+      pageType.HISTORY
+    }`,
+    REFILL_MEDICATIONS_LINK: `Refill Medications Link - ${pageType.HISTORY}`,
   },
   renewalModal: {
     MODAL_OPEN: 'Rx Renewal Modal Open',


### PR DESCRIPTION
# [MHV Medications] - Add navigation links with Datadog tracking across medication pages

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added `data-testid` and `data-dd-action-name` attributes to navigation links across three medication pages for Datadog RUM analytics and test targeting
- **Refill page** (`RefillPrescriptionsV2.jsx`): Added new "Go to your in-progress medications" and "Review and print list of medications" links below the h1 heading with Datadog tracking via `refillPage.GO_TO_YOUR_IN_PROGRESS_MEDICATIONS_LINK` and `refillPage.GO_TO_REVIEW_AND_PRINT_MEDICATION_HISTORY_LINK`
- **In-progress page** (`PrescriptionsInProgress.jsx`): Updated existing links with `data-testid` and Datadog action names. Changed history link text from "Go to your medication history" to "Review and print list of medications". Updated refill link route from `/refill` to `/`
- **Medication history page** (`MedicationHistory.jsx`): Updated existing links with `data-testid` and Datadog action names. Updated refill link route from `/refill` to `/`
- Added Datadog RUM action name constants scoped per page: `refillPage`, `inProgressPage`, and `medicationsHistoryPage`
- Removed a stale TODO comment from the renewable meds link section in `RefillPrescriptionsV2.jsx`
- **Team**: MHV Medications team owns these pages and will maintain these changes
- **Feature flag**: `mhvMedicationsManagementImprovements` — controls the V2 refill page experience

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#0000

## Testing done

**Old behavior**:
- The Refill Prescriptions V2 page had no cross-navigation links
- Existing navigation links on the History and In-progress pages lacked `data-testid` and Datadog tracking attributes
- The History and In-progress pages linked to `/refill` instead of `/` for the refill link

**Steps to verify**:
1. Start dev server: `yarn watch --env entry=mhv-medications`
2. **Refill page** (`/my-health/medications/refill`):
   - Verify "Go to your in-progress medications" and "Review and print list of medications" links appear below the "Medications" heading with a pipe `|` separator
   - Click each link and verify navigation to `/in-progress` and `/history` respectively
   - Verify links are hidden during loading state
3. **In-progress page** (`/my-health/medications/in-progress`):
   - Verify "Review and print list of medications" link navigates to `/history`
   - Verify "Refill medications" link navigates to `/` (root/refill page)
4. **Medication history page** (`/my-health/medications/history`):
   - Verify "Go to your in-progress medications" link navigates to `/in-progress`
   - Verify "Refill medications" link navigates to `/` (root/refill page)
5. Inspect each link in browser DevTools and confirm `data-testid` and `data-dd-action-name` attributes are present

**Tests completed**:
- Manual testing: Verified all navigation links render correctly and navigate to expected routes on all three pages

## Screenshots
Root/Refill Page
<img width="1016" height="553" alt="Screenshot 2026-03-10 at 2 45 43 PM" src="https://github.com/user-attachments/assets/6ed6b5b3-4371-4564-aa90-6be87ee1e901" />

In-Progress Page
<img width="1010" height="523" alt="Screenshot 2026-03-10 at 2 45 57 PM" src="https://github.com/user-attachments/assets/d8749650-32e9-4bb4-9f40-d61c80e6473a" />

History Page
<img width="1020" height="446" alt="Screenshot 2026-03-10 at 2 46 27 PM" src="https://github.com/user-attachments/assets/c58ca62d-30cb-4f0c-8e00-4dd288500047" />

## What areas of the site does it impact?

Changes affect three MHV Medications pages:
- Refill Prescriptions V2 (`/my-health/medications/refill`)
- In-progress Medications (`/my-health/medications/in-progress`)
- Medication History (`/my-health/medications/history`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). — Unit tests need to be added/updated for MedicationHistory, PrescriptionsInProgress, and RefillPrescriptionsV2
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated — N/A, no external documentation changes needed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution — Datadog RUM action names added for navigation links on all three pages
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — N/A, uses existing Datadog RUM tracking

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

- Please verify the Datadog action name constants (`refillPage`, `inProgressPage`, `medicationsHistoryPage`) follow the team's naming conventions
- Confirm the refill link route change from `/refill` to `/` is intentional on the History and In-progress pages
