### PR TITLE
feat(travel-pay): Use 'travel reimbursement claims' in content

### DIFF
--- a/src/applications/travel-pay/components/TravelPayStatusContent.jsx
+++ b/src/applications/travel-pay/components/TravelPayStatusContent.jsx
@@ -15,8 +15,8 @@ function ComplexClaimsEntryContent() {
   return (
     <>
       <p className="vads-u-font-family--serif vads-u-font-size--lg">
-        File new claims for travel reimbursement and review the status of all
-        your travel claims.
+        File new claims for travel pay and review the status of all your travel
+        reimbursement claims.
       </p>
       <h2 className="vads-u-margin-top--2">
         File a new claim for travel pay online
@@ -60,8 +60,8 @@ function SmocEntryContent() {
   return (
     <>
       <p className="vads-u-font-family--serif vads-u-font-size--lg">
-        File new claims for travel reimbursement and review the status of all
-        your travel claims.
+        File new claims for travel pay and review the status of all your travel
+        reimbursement claims.
       </p>
       <h2 className="vads-u-margin-top--2">
         File a new claim for travel reimbursement online
@@ -180,7 +180,9 @@ export default function TravelPayStatusContent() {
         )}
 
       <div className="btsss-claims-sort-and-filter-container">
-        <h2 className="vads-u-margin-top--2">Your travel claims</h2>
+        <h2 className="vads-u-margin-top--2">
+          Your travel reimbursement claims
+        </h2>
         <p>
           {complexClaimsEnabled
             ? "This list shows all the travel reimbursement claims you've started or filed."


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates the H2 on the travel claims list page from 'Your travel claims' to 'Your travel reimbursement claims'
- Updates the intro paragraph in both SmocEntryContent and ComplexClaimsEntryContent to say 'File new claims for travel pay and review the status of all your travel reimbursement claims.'

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#134508

## Testing done

No test files changed.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |    <img width="574" height="230" alt="Screenshot 2026-03-12 at 12 31 18" src="https://github.com/user-attachments/assets/2ac43ba3-0a13-4e14-8075-aae8df55904b" /> <img width="579" height="283" alt="Screenshot 2026-03-12 at 12 31 25" src="https://github.com/user-attachments/assets/26a09fe0-1a01-43c5-849b-5b707dadbc3c" />    |    <img width="551" height="234" alt="Screenshot 2026-03-12 at 12 32 32" src="https://github.com/user-attachments/assets/ece27ced-f8f3-4b2e-bd4d-5201c83b8b1f" /> <img width="566" height="290" alt="Screenshot 2026-03-12 at 12 33 04" src="https://github.com/user-attachments/assets/6579d2f7-ca6d-480e-ada6-52dc70b81d6a" />   |

## What areas of the site does it impact?

Travel Pay claims list

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

I saw in Figma changes to MyHealtheVet, but this is part of mhv-landing-page, and it doesn't look like we are responsible for that?