### PR TITLE
fix: add missing OIDC permissions to build job in manual deploy workflow

### DIFF
--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -97,6 +97,9 @@ jobs:
     name: Build
     runs-on: ubuntu-16-cores-latest
     needs: set-environment
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix: ${{ fromJson(needs.set-environment.outputs.environment) }}
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- The `build` job in the manual dev/staging deploy workflow (`manual-deploy-dev-staging.yml`) is missing the `permissions` block needed for OIDC authentication with AWS.
- Other jobs in this workflow (`permissions-check`, `deploy`, `notify-failure`) all declare `id-token: write` and `contents: read` explicitly. When any job in a workflow declares explicit permissions, jobs without a `permissions` block receive the most restrictive defaults — which excludes `id-token: write`.
- This causes the `Configure AWS credentials` step in the `build` job to fail with: `Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers`.
- The fix adds the same `permissions` block used by the other jobs in this workflow.
- Platform SRE team owns this workflow.

## Related issue(s)

- No associated issue — this is an urgent fix for a broken workflow on main.

## Testing done

- Verified that `permissions-check`, `deploy`, and `notify-failure` all declare `id-token: write` + `contents: read` and authenticate successfully.
- The `build` job is the only job missing this declaration.
- After merging, the manual deploy workflow should be re-run to confirm the build job authenticates successfully.

## Screenshots

Not applicable — no UI changes. This is a workflow permissions configuration fix.

## What areas of the site does it impact?

No areas of the site are impacted. This fixes the manual dev/staging deploy workflow which is used by the FE COP team for ad-hoc deployments.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). — Not applicable; no testable code changed.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#)) — Not applicable.
- [ ] Screenshot of the developed feature is added — Not applicable; no visual feature.
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed — Not applicable; no UI changes.

### Error Handling

- [ ] Browser console contains no warnings or errors. — Not applicable; no browser-facing changes.
- [ ] Events are being sent to the appropriate logging solution — Not applicable.
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — Not applicable.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user — Not applicable; no application code changes.

## Requested Feedback

None — straightforward permissions fix. The build job was the only job in this workflow missing the OIDC permissions declaration.