### PR TITLE
10-10d | Update applicant address validation

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/utils/validations.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/utils/validations.unit.spec.jsx
@@ -970,6 +970,7 @@ describe('1010d `validateApplicant` form validation', () => {
     applicantGender: { gender: 'M' },
     applicantPhone: '555-123-4567',
     applicantAddress: {
+      country: 'USA',
       street: '123 Main St',
       city: 'Anytown',
       state: 'NY',
@@ -998,6 +999,32 @@ describe('1010d `validateApplicant` form validation', () => {
       expect(validateApplicant(applicant)).to.be.false;
     });
 
+    it('should return "false" when state is omitted for non-required country', () => {
+      const applicant = makeApplicant({
+        applicantAddress: {
+          street: '123 Main St',
+          city: 'Paris',
+          country: 'FRA',
+        },
+        applicantRelationshipToSponsor: { relationshipToVeteran: 'other' },
+      });
+      expect(validateApplicant(applicant)).to.be.false;
+    });
+
+    it('should return "true" when state is omitted for required country', () => {
+      const applicant = makeApplicant({
+        applicantAddress: {
+          country: 'CAN',
+          street: '123 Main St',
+          city: 'Toronto',
+          postalCode: 'A1A A1A',
+        },
+        applicantRelationshipToSponsor: { relationshipToVeteran: 'other' },
+      });
+
+      expect(validateApplicant(applicant)).to.be.true;
+    });
+
     [
       ['first name is omitted', { applicantName: { last: 'Doe' } }],
       ['last name is omitted', { applicantName: { first: 'John' } }],
@@ -1011,11 +1038,15 @@ describe('1010d `validateApplicant` form validation', () => {
       ],
       [
         'city is omitted',
-        { applicantAddress: { street: '123 Main St', state: 'NY' } },
+        {
+          applicantAddress: { street: '123 Main St', state: 'NY' },
+        },
       ],
       [
         'state is omitted',
-        { applicantAddress: { street: '123 Main St', city: 'Anytown' } },
+        {
+          applicantAddress: { street: '123 Main St', city: 'Anytown' },
+        },
       ],
       [
         'relationship to sponsor is omitted',

--- a/src/applications/ivc-champva/10-10d-extended/utils/validations.js
+++ b/src/applications/ivc-champva/10-10d-extended/utils/validations.js
@@ -12,6 +12,8 @@ const ERR_FUTURE_DATE = content['validation--date-range--future'];
 const ERR_SSN_UNIQUE = content['validation--ssn-unique'];
 const ERR_SSN_INVALID = content['validation--ssn-invalid'];
 
+const STATE_REQUIRED_COUNTRIES = new Set(['USA', 'CAN', 'MEX']);
+
 const normalizeSSN = val => String(val ?? '').replace(/\D/g, '');
 
 const getCurrentItemIndex = () => {
@@ -396,16 +398,20 @@ const validateApplicantBasicFields = item => {
     applicantSsn,
     applicantGender: { gender } = {},
     applicantPhone,
-    applicantAddress: { street, city, state } = {},
+    applicantAddress: { country, street, city, state } = {},
     applicantRelationshipToSponsor,
   } = item ?? {};
+
+  const normalizedCountry = String(country ?? '').toUpperCase();
+  const isStateRequired =
+    !normalizedCountry || STATE_REQUIRED_COUNTRIES.has(normalizedCountry);
 
   if (!applicantName?.first || !applicantName?.last) return true;
   if (!applicantDob) return true;
   if (!applicantSsn) return true;
   if (!gender) return true;
   if (!applicantPhone) return true;
-  if (!street || !city || !state) return true;
+  if (!street || !city || (isStateRequired && !state)) return true;
   return !applicantRelationshipToSponsor?.relationshipToVeteran;
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the applicant address validation logic in the 10-10d CHAMPVA application to handle country-specific requirements for the `state` field. Specifically, it introduces a distinction between countries where a state is required (USA, CAN, MEX) and others where it is not, and updates both the validation logic and the associated unit tests accordingly.

**Validation logic improvements:**

* Updated `validateApplicantBasicFields` in to require the `state` field only for addresses in USA, CAN, or MEX, using a new `STATE_REQUIRED_COUNTRIES` set. For other countries, `state` is not required.

**Unit test enhancements:**

* Added and updated test cases to verify that omitting `state` for non-required countries (e.g., FRA) causes validation to pass, while omitting it for required countries like CAN fails validation.
* Modified existing test data to include `country` in the applicant address and clarified test cases for omitting `city` and `state`.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#135933

## Testing done

- Prior to the edits, if a country outside of the USA, CAN and MEX is selected and no state was filled in, the validation would trigger to force users to input a state value
- After the edits, if if a country outside of the USA, CAN and MEX is selected and no state was filled in, the validation leaves it alone, as it should

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Array item validation matches the correct field validation pattern

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
