### PR TITLE
[CVE No ticket] add redux devtools action as a reference to mock form…

### DIFF
--- a/src/applications/lgy/coe/form/tests/fixtures/mocks/coe-redux-action.js
+++ b/src/applications/lgy/coe/form/tests/fixtures/mocks/coe-redux-action.js
@@ -1,0 +1,115 @@
+/*
+ * Saving this action from a discussion on the Confirmation page PR.
+ * You can paste this into Redux DevTools and then dispatch it to fill
+ * out the form and see how the Confirmation page is meant to look
+ * when you don't have a true response coming through.
+ */
+
+export default {
+  type: 'SET_DATA',
+  data: {
+    files2: [
+      {
+        name: 'test-file.png',
+        size: 6892,
+        confirmationCode: '5',
+        isEncrypted: false,
+        type: 'image/png',
+        additionalData: {
+          attachmentType: 'Discharge papers (DD214)',
+        },
+      },
+    ],
+    loanHistory: {
+      hadPriorLoans: false,
+      certificateUse: 'ENTITLEMENT_INQUIRY_ONLY',
+    },
+    'view:optionsAccordion': {},
+    'view:periodsOfServiceMissingInformation': {},
+    'view:hasServicePeriods': false,
+    militaryHistory: {
+      separatedDueToDisability: true,
+    },
+    identity: 'VETERAN',
+    veteran: {
+      mailingAddress: {
+        addressLine1: '1200 Park Ave',
+        addressLine2: 'c/o Pixar',
+        addressLine3: '',
+        addressPou: 'CORRESPONDENCE',
+        addressType: 'DOMESTIC',
+        city: 'Emeryville',
+        countryName: 'United States',
+        countryCodeIso2: 'US',
+        countryCodeIso3: 'USA',
+        countryCodeFips: '',
+        countyCode: '',
+        countyName: '',
+        createdAt: '2020-05-30T03:57:20.000+00:00',
+        effectiveEndDate: '',
+        effectiveStartDate: '2020-07-10T20:10:45.000+00:00',
+        id: 173917,
+        internationalPostalCode: '',
+        province: '',
+        sourceDate: '2020-07-10T20:10:45.000+00:00',
+        sourceSystemUser: '',
+        stateCode: 'CA',
+        transactionId: '7139aa82-fd06-45ea-a217-9654869924bd',
+        updatedAt: '2020-07-10T20:10:46.000+00:00',
+        validationKey: '',
+        vet360Id: '1273780',
+        zipCode: '94608',
+        zipCodeSuffix: '',
+      },
+      homePhone: {
+        areaCode: '503',
+        countryCode: '1',
+        phoneNumber: '2222222',
+      },
+      email: {
+        emailAddress: 'test@user.com',
+      },
+      undefined: {
+        areaCode: '510',
+        countryCode: '1',
+        createdAt: '2020-06-12T16:56:37.000+00:00',
+        extension: '17477',
+        effectiveEndDate: '',
+        effectiveStartDate: '2020-07-14T19:07:45.000+00:00',
+        id: 146766,
+        isInternational: false,
+        isTextable: '',
+        isTextPermitted: '',
+        isTty: '',
+        isVoicemailable: '',
+        phoneNumber: '9223000',
+        phoneType: 'HOME',
+        sourceDate: '2020-07-14T19:07:45.000+00:00',
+        sourceSystemUser: '',
+        transactionId: '92c49d39-22b2-4bd6-92b4-0b7e7c63c6a9',
+        updatedAt: '2020-07-14T19:07:46.000+00:00',
+        vet360Id: '1273780',
+      },
+    },
+    fullName: {},
+    applicantAddress: {
+      country: 'USA',
+      'view:militaryBaseDescription': {},
+    },
+    'view:preDischargeClaimAdditionalInfo': {},
+    'view:preDischargeClaimWhyAccordion': {},
+    'view:purpleHeartWhyAccordion': {},
+    periodsOfService: [
+      {
+        serviceBranch: 'AF',
+        dateRange: {
+          from: '2000-01-01',
+          to: '2001-01-01',
+        },
+      },
+    ],
+    'view:documentRequirements': {},
+    'view:documentUploadDescription': {},
+    'view:coeFormRebuildCveteam': true,
+  },
+};


### PR DESCRIPTION
… submission locally

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This are changes to the COE form, which our team, CVE, owns.
- Simply changes to our mocks to document an action.

## Related issue(s)

- N/A

## What areas of the site does it impact?

No others.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
