### PR TITLE
[135446] Add error context to PDF font download failures

### DIFF
--- a/src/platform/pdf/registerFonts.js
+++ b/src/platform/pdf/registerFonts.js
@@ -35,12 +35,13 @@ const downloadAndRegisterFont = async (doc, font) => {
     fs.writeFileSync(knownFonts[font], encodedFont);
     doc.registerFont(font, knownFonts[font]);
   } catch (error) {
-    throw new Error(
+    const wrappedError = new Error(
       `Failed to download or register font ${font} from ${url}: ${
         error.message
       }`,
-      { cause: error },
     );
+    wrappedError.cause = error;
+    throw wrappedError;
   }
 };
 

--- a/src/platform/pdf/registerFonts.js
+++ b/src/platform/pdf/registerFonts.js
@@ -36,7 +36,10 @@ const downloadAndRegisterFont = async (doc, font) => {
     doc.registerFont(font, knownFonts[font]);
   } catch (error) {
     throw new Error(
-      `Failed to fetch font ${font} from ${url}: ${error.message}`,
+      `Failed to download or register font ${font} from ${url}: ${
+        error.message
+      }`,
+      { cause: error },
     );
   }
 };

--- a/src/platform/pdf/registerFonts.js
+++ b/src/platform/pdf/registerFonts.js
@@ -27,12 +27,18 @@ const downloadAndRegisterFont = async (doc, font) => {
   const bucket = environment.isLocalhost()
     ? ''
     : BUCKETS[environment.BUILDTYPE];
-  const request = await fetch(`${bucket}/generated/${knownFonts[font]}`);
-  const binaryFont = await request.arrayBuffer();
-  const encodedFont = Buffer.from(binaryFont).toString('base64');
-  fs.writeFileSync(knownFonts[font], encodedFont);
-
-  doc.registerFont(font, knownFonts[font]);
+  const url = `${bucket}/generated/${knownFonts[font]}`;
+  try {
+    const request = await fetch(url);
+    const binaryFont = await request.arrayBuffer();
+    const encodedFont = Buffer.from(binaryFont).toString('base64');
+    fs.writeFileSync(knownFonts[font], encodedFont);
+    doc.registerFont(font, knownFonts[font]);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch font ${font} from ${url}: ${error.message}`,
+    );
+  }
 };
 
 export const registerFonts = async function(doc, fonts) {

--- a/src/platform/pdf/test/registerFonts.unit.spec.jsx
+++ b/src/platform/pdf/test/registerFonts.unit.spec.jsx
@@ -40,21 +40,26 @@ describe('registerFonts', () => {
 
   describe('downloadAndRegisterFont error context', () => {
     it('includes font name and URL when fetch rejects', async () => {
-      fetchStub.rejects(new Error('Failed to fetch'));
+      const originalError = new Error('Failed to fetch');
+      fetchStub.rejects(originalError);
 
       try {
         await registerFonts(doc, ['Bitter-Bold']);
         expect.fail('should have thrown');
       } catch (error) {
-        expect(error.message).to.include('Failed to fetch font Bitter-Bold');
+        expect(error.message).to.include(
+          'Failed to download or register font Bitter-Bold',
+        );
         expect(error.message).to.include('/generated/bitter-bold.ttf');
         expect(error.message).to.include('Failed to fetch');
+        expect(error.cause).to.equal(originalError);
       }
     });
 
     it('includes font name and URL when arrayBuffer fails', async () => {
+      const originalError = new Error('body stream error');
       fetchStub.resolves({
-        arrayBuffer: sinon.stub().rejects(new Error('body stream error')),
+        arrayBuffer: sinon.stub().rejects(originalError),
       });
 
       try {
@@ -62,12 +67,13 @@ describe('registerFonts', () => {
         expect.fail('should have thrown');
       } catch (error) {
         expect(error.message).to.include(
-          'Failed to fetch font SourceSansPro-Regular',
+          'Failed to download or register font SourceSansPro-Regular',
         );
         expect(error.message).to.include(
           '/generated/sourcesanspro-regular-webfont.ttf',
         );
         expect(error.message).to.include('body stream error');
+        expect(error.cause).to.equal(originalError);
       }
     });
 

--- a/src/platform/pdf/test/registerFonts.unit.spec.jsx
+++ b/src/platform/pdf/test/registerFonts.unit.spec.jsx
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'fs';
+import { registerFonts, knownFonts } from '../registerFonts';
+
+describe('registerFonts', () => {
+  let doc;
+  let fetchStub;
+  let existsSyncStub;
+  let writeFileSyncStub;
+
+  beforeEach(() => {
+    doc = { registerFont: sinon.stub() };
+    fetchStub = sinon.stub(global, 'fetch');
+    existsSyncStub = sinon.stub(fs, 'existsSync').throws(new Error('ENOENT'));
+    writeFileSyncStub = sinon.stub(fs, 'writeFileSync');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    existsSyncStub.restore();
+    writeFileSyncStub.restore();
+  });
+
+  describe('knownFonts', () => {
+    it('contains expected font entries', () => {
+      expect(knownFonts).to.have.property('Bitter-Bold');
+      expect(knownFonts).to.have.property('SourceSansPro-Regular');
+      expect(knownFonts).to.have.property('RobotoMono-Regular');
+    });
+  });
+
+  describe('registerFonts', () => {
+    it('skips unknown fonts', async () => {
+      await registerFonts(doc, ['NonExistentFont']);
+      expect(doc.registerFont.called).to.be.false;
+      expect(fetchStub.called).to.be.false;
+    });
+  });
+
+  describe('downloadAndRegisterFont error context', () => {
+    it('includes font name and URL when fetch rejects', async () => {
+      fetchStub.rejects(new Error('Failed to fetch'));
+
+      try {
+        await registerFonts(doc, ['Bitter-Bold']);
+        expect.fail('should have thrown');
+      } catch (error) {
+        expect(error.message).to.include('Failed to fetch font Bitter-Bold');
+        expect(error.message).to.include('/generated/bitter-bold.ttf');
+        expect(error.message).to.include('Failed to fetch');
+      }
+    });
+
+    it('includes font name and URL when arrayBuffer fails', async () => {
+      fetchStub.resolves({
+        arrayBuffer: sinon.stub().rejects(new Error('body stream error')),
+      });
+
+      try {
+        await registerFonts(doc, ['SourceSansPro-Regular']);
+        expect.fail('should have thrown');
+      } catch (error) {
+        expect(error.message).to.include(
+          'Failed to fetch font SourceSansPro-Regular',
+        );
+        expect(error.message).to.include(
+          '/generated/sourcesanspro-regular-webfont.ttf',
+        );
+        expect(error.message).to.include('body stream error');
+      }
+    });
+
+    it('downloads and registers font on success', async () => {
+      const fakeBuffer = new ArrayBuffer(8);
+      fetchStub.resolves({
+        arrayBuffer: sinon.stub().resolves(fakeBuffer),
+      });
+
+      await registerFonts(doc, ['Bitter-Bold']);
+      expect(doc.registerFont.calledOnce).to.be.true;
+      expect(doc.registerFont.firstCall.args[0]).to.equal('Bitter-Bold');
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Improves error observability in the PDF generation pipeline by wrapping [downloadAndRegisterFont](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in a try/catch that includes the font name and URL in the error message. This change helps diagnose "Failed to fetch" errors reported in Datadog RUM during PDF/image download operations.

**Before:** Errors bubble up as generic [TypeError: Failed to fetch](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with no indication of which font or URL failed.

**After:** Errors now include actionable context, e.g.:
[Failed to fetch font Bitter-Bold from https://.../generated/bitter-bold.ttf: Failed to fetch](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Changes**
- registerFonts.js - Wrap downloadAndRegisterFont in try/catch with descriptive error including font name and URL
- src/platform/pdf/test/registerFonts.unit.spec.js - New test spec covering error context for fetch rejection, arrayBuffer failure, and successful download path

**Context**
This addresses observability gaps surfaced while investigating Tier 3 support tickets like the one below, where Veterans report images/documents failing to download in MHV. The generic "Failed to fetch" errors in Datadog RUM made it difficult to pinpoint the root cause. With this change, future occurrences will include the specific font and URL that failed, enabling faster triage.

**Related Tier 3 ticket context:**
Veteran reports images won't download or open in MHV. When downloading, the images buffer then stop but are never downloaded.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#135446

## Testing done

- Unit tests passing
- No downstream code changes required - downloadAndRegisterFontis only called internally within registerFonts.js, and the only external consumer (utils.js) imports registerFonts without catching or inspecting errors

## Screenshots

No UI change.

## What areas of the site does it impact?

Pdf issues are logged in Datadog with error context

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
