### PR TITLE
update med card for S2 — no refill in progress for MMI designs

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -20,6 +20,7 @@ import {
   selectMhvMedicationsOracleHealthCutoverFlag,
   selectCernerPilotFlag,
   selectV2StatusMappingFlag,
+  selectMedicationsManagementImprovementsFlag,
 } from '../../util/selectors';
 import { selectOracleHealthMigrations } from '../../selectors/selectUser';
 import {
@@ -35,6 +36,9 @@ const MedicationsListCard = ({ rx }) => {
   const useV2StatusMapping = isCernerPilot && isV2StatusMapping;
   const isPendingDispense =
     rx.prescriptionSource === RX_SOURCE.PENDING_DISPENSE;
+  const isManagementImprovements = useSelector(
+    selectMedicationsManagementImprovementsFlag,
+  );
   const isOracleHealthCutoverEnabled = useSelector(
     selectMhvMedicationsOracleHealthCutoverFlag,
   );
@@ -100,11 +104,14 @@ const MedicationsListCard = ({ rx }) => {
           rx.isRefillable &&
           rx.refillRemaining >= 0 && (
             <p
+              className="vads-u-margin-bottom--0"
               data-testid="rx-refill-remaining"
               data-dd-privacy="mask"
               id={`refill-remaining-${rx.prescriptionId}`}
             >
-              Refills remaining: {rx.refillRemaining}
+              {isManagementImprovements
+                ? `Refills left: ${rx.refillRemaining}`
+                : `Refills remaining: ${rx.refillRemaining}`}
             </p>
           )}
         {rx && <LastFilledInfo {...rx} />}
@@ -128,16 +135,17 @@ const MedicationsListCard = ({ rx }) => {
             </span>
           </p>
         )}
-        {rxStatus !== 'Unknown' && (
-          <p
-            id={`status-${rx.prescriptionId}`}
-            className="vads-u-margin-top--1p5 vads-u-font-weight--bold"
-            data-testid="rxStatus"
-            data-dd-privacy="mask"
-          >
-            {rxStatus}
-          </p>
-        )}
+        {!isManagementImprovements &&
+          rxStatus !== 'Unknown' && (
+            <p
+              id={`status-${rx.prescriptionId}`}
+              className="vads-u-margin-top--1p5 vads-u-font-weight--bold"
+              data-testid="rxStatus"
+              data-dd-privacy="mask"
+            >
+              {rxStatus}
+            </p>
+          )}
         {isRefillBlocked &&
           rx.isRefillable && (
             <OracleHealthInCardAlert
@@ -178,7 +186,8 @@ const MedicationsListCard = ({ rx }) => {
             {rx?.prescriptionName || rx?.orderableItem}
           </span>
         </Link>
-        {!pendingMed &&
+        {!isManagementImprovements &&
+          !pendingMed &&
           !pendingRenewal &&
           rxStatus !== 'Unknown' &&
           !isNonVaPrescription && (

--- a/src/applications/mhv-medications/components/shared/LastFilledInfo.jsx
+++ b/src/applications/mhv-medications/components/shared/LastFilledInfo.jsx
@@ -15,7 +15,11 @@ const LastFilledInfo = rx => {
   return (
     <>
       {nonVA && (
-        <p data-testid="rx-last-filled-info" data-dd-privacy="mask">
+        <p
+          className="vads-u-margin-top--0"
+          data-testid="rx-last-filled-info"
+          data-dd-privacy="mask"
+        >
           {dateFormat(
             orderedDate,
             DATETIME_FORMATS.longMonthDate,
@@ -25,7 +29,11 @@ const LastFilledInfo = rx => {
         </p>
       )}
       {showLastFilledDate && (
-        <p data-testid="rx-last-filled-date" data-dd-privacy="mask">
+        <p
+          className="vads-u-margin-top--0"
+          data-testid="rx-last-filled-date"
+          data-dd-privacy="mask"
+        >
           {dateFormat(
             sortedDispensedDate,
             DATETIME_FORMATS.longMonthDate,
@@ -37,7 +45,11 @@ const LastFilledInfo = rx => {
       {!nonVA &&
         !showLastFilledDate &&
         !isCernerPilot && (
-          <p data-testid="active-not-filled-rx" data-dd-privacy="mask">
+          <p
+            className="vads-u-margin-top--0"
+            data-testid="active-not-filled-rx"
+            data-dd-privacy="mask"
+          >
             Not filled yet
           </p>
         )}

--- a/src/applications/mhv-medications/components/shared/RefillButton.jsx
+++ b/src/applications/mhv-medications/components/shared/RefillButton.jsx
@@ -4,9 +4,11 @@ import { differenceInDays, parseISO } from 'date-fns';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { pharmacyPhoneNumber } from '@department-of-veterans-affairs/mhv/exports';
 import { datadogRum } from '@datadog/browser-rum';
+import { useSelector } from 'react-redux';
 import { useRefillPrescriptionMutation } from '../../api/prescriptionsApi';
 import CallPharmacyPhone from './CallPharmacyPhone';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
+import { selectMedicationsManagementImprovementsFlag } from '../../util/selectors';
 
 const REFILL_SUPPRESSION_DAYS = 15;
 
@@ -32,6 +34,9 @@ const RefillButton = rx => {
     refillPrescription,
     { isLoading, isSuccess, isError },
   ] = useRefillPrescriptionMutation();
+  const isManagementImprovements = useSelector(
+    selectMedicationsManagementImprovementsFlag,
+  );
 
   const { prescriptionId, isRefillable, refillSubmitDate, stationNumber } = rx;
 
@@ -97,7 +102,7 @@ const RefillButton = rx => {
         data-testid="refill-request-button"
         hidden={isSuccess || isLoading}
         onClick={onRequestRefill}
-        text="Request a refill"
+        text={isManagementImprovements ? 'Request refill' : 'Request a refill'}
       />
     </div>
   );

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
@@ -56,7 +56,7 @@ describe('Medication card component', () => {
 
   const setup = (rx = prescriptionsListItem, initialState = {}) => {
     return renderWithStoreAndRouterV6(<MedicationsListCard rx={rx} />, {
-      state: initialState,
+      initialState,
       reducers,
     });
   };

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
@@ -145,6 +145,48 @@ describe('Medication card component', () => {
     );
   });
 
+  describe('when mhvMedicationsManagementImprovements flag is enabled', () => {
+    const managementImprovementsState = {
+      featureToggles: {
+        [FEATURE_FLAG_NAMES.mhvMedicationsManagementImprovements]: true,
+      },
+    };
+
+    it('shows "Refills left" instead of "Refills remaining"', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        isRefillable: true,
+        dispStatus: 'Active',
+        refillRemaining: 3,
+      };
+      const { getByTestId } = setup(rx, managementImprovementsState);
+      expect(getByTestId('rx-refill-remaining')).to.have.text(
+        'Refills left: 3',
+      );
+    });
+
+    it('hides prescription number', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        isRefillable: true,
+        dispStatus: 'Active',
+        prescriptionNumber: '12345',
+      };
+      const { queryByTestId } = setup(rx, managementImprovementsState);
+      expect(queryByTestId('rx-number')).to.be.null;
+    });
+
+    it('hides status label', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        isRefillable: true,
+        dispStatus: 'Active',
+      };
+      const { queryByTestId } = setup(rx, managementImprovementsState);
+      expect(queryByTestId('rxStatus')).to.be.null;
+    });
+  });
+
   it('Does not show number of refills when it is not refillable', () => {
     const rx = {
       ...prescriptionsListItem,

--- a/src/applications/mhv-medications/tests/components/shared/RefillButton.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/RefillButton.unit.spec.jsx
@@ -8,6 +8,7 @@ import {
   resetFetch,
 } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { datadogRum } from '@datadog/browser-rum';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { prescriptionsApi } from '../../../api/prescriptionsApi';
 import reducer from '../../../reducers';
 import RefillButton from '../../../components/shared/RefillButton';
@@ -153,6 +154,23 @@ describe('Refill Button component', () => {
       const screen = setup({ refillSubmitDate: 'invalid-date' });
       const button = screen.getByTestId('refill-request-button');
       expect(button).to.exist;
+    });
+  });
+
+  describe('when mhvMedicationsManagementImprovements flag is enabled', () => {
+    it('renders "Request refill"', () => {
+      const screen = renderWithStoreAndRouterV6(<RefillButton {...rx} />, {
+        initialState: {
+          featureToggles: {
+            [FEATURE_FLAG_NAMES.mhvMedicationsManagementImprovements]: true,
+          },
+        },
+        reducers: reducer,
+        initialEntries: ['/1234567890'],
+        additionalMiddlewares: [prescriptionsApi.middleware],
+      });
+      const button = screen.getByTestId('refill-request-button');
+      expect(button).to.have.property('text', 'Request refill');
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Updates the medication list card MedicationsListCard and RefillButton on the Medications History page to match Figma specs for Scenario 2 (prescription that does not have another refill in progress).
- All changes are gated behind the mhv_medications_management_improvements feature flag. When the flag is off, existing behavior is fully preserved.
- Changes when the flag is enabled:
               - "Refills remaining: X" → "Refills left: X"
               - Prescription number is hidden from the card
               - Status label is hidden from the card
               - "Request a refill" button text → "Request refill"
- This is a purely frontend change. Gap check confirmed all required source fields (disp_status, is_refillable, refill_remaining, refill_submit_date, sortedDispensedDate) are already available — no vets-api changes needed.
- The mhv_medications_management_improvements flipper will remain required until MMI rollout is complete and validated in production.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#135862

## Testing done
- Old behavior (flag off): Med card displays "Refills remaining: X", prescription number, status label, and "Request a refill" button.
- New behavior (flag on): Med card displays "Refills left: X", hides prescription number, hides status label, and shows "Request refill" button. Medication name link, "Last filled on" date, and refill button functionality are unchanged.
- Steps to verify:
            - Run the app locally with mhv_medications_management_improvements flag disabled — confirm the Meds History page cards render with existing text/layout (no regressions).
            - Enable the flag in local feature toggles mock — confirm cards now show "Refills left: X", no prescription number, no status label, and "Request refill" on the button.
            - Verify pending med/renewal cards are unaffected by the flag.
- Unit tests added (4 new tests)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |   <img width="284" height="131" alt="Screenshot 2026-03-11 at 11 02 21 AM" src="https://github.com/user-attachments/assets/ce35d259-58a4-46d2-b4aa-95b732be86ac" />  |  <img width="314" height="111" alt="Screenshot 2026-03-11 at 11 01 22 AM" src="https://github.com/user-attachments/assets/951efa0d-a3fe-4afe-b263-ed716bcb9eec" />  |

## What areas of the site does it impact?
MHV Medications — Medications History page (/my-health/medications/history). Only the MedicationsListCard and RefillButton components are modified. No other pages or applications are affected.

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
