### PR TITLE
Update dependent education expenses descriptions for clarity

### DIFF
--- a/src/applications/ezr/components/FormDescriptions/DependentExpensesDescription.jsx
+++ b/src/applications/ezr/components/FormDescriptions/DependentExpensesDescription.jsx
@@ -4,7 +4,7 @@ import { LAST_YEAR } from '../../utils/constants';
 const DependentExpensesDescription = (
   <span className="vads-u-display--block vads-u-color--gray-medium">
     If your dependent didn’t report any gross income on their {LAST_YEAR} taxes,
-    enter $0-even if they paid for education or training expenses.
+    enter $0&mdash;even if they paid for education or training expenses.
   </span>
 );
 

--- a/src/applications/ezr/components/FormDescriptions/DependentExpensesDescription.jsx
+++ b/src/applications/ezr/components/FormDescriptions/DependentExpensesDescription.jsx
@@ -3,9 +3,8 @@ import { LAST_YEAR } from '../../utils/constants';
 
 const DependentExpensesDescription = (
   <span className="vads-u-display--block vads-u-color--gray-medium">
-    Only enter an amount if they had gross income to report to the IRS in{' '}
-    {LAST_YEAR}. This income is the minimum amount of gross income the IRS
-    requires to file a federal income tax return.
+    If your dependent didn’t report any gross income on their {LAST_YEAR} taxes,
+    enter $0-even if they paid for education or training expenses.
   </span>
 );
 

--- a/src/applications/ezr/config/chapters/householdInformation/dependentEducationExpenses.js
+++ b/src/applications/ezr/config/chapters/householdInformation/dependentEducationExpenses.js
@@ -23,7 +23,10 @@ export default {
       ),
     ),
     dependentEducationExpenses: currencyUI({
-      title: content['household-dependent-education-expenses-label'],
+      title: replaceStrValues(
+        content['household-dependent-education-expenses-label'],
+        LAST_YEAR,
+      ),
       description: DependentExpensesDescription,
     }),
   },

--- a/src/applications/ezr/locales/en/content.json
+++ b/src/applications/ezr/locales/en/content.json
@@ -159,7 +159,7 @@
   "household-dependent-dob-label": "Dependent’s date of birth",
   "household-dependent-earned-income-label": "Did your dependent earn income in %s?",
   "household-dependent-edit-button-aria-label": "Edit your dependents",
-  "household-dependent-education-expenses-label": "Enter the total amount of money your dependent paid for college, vocational rehabilitation, or training (like tuition, books, or supplies)",
+  "household-dependent-education-expenses-label": "If your dependent reported any gross income on their %s taxes, enter the amount of money they paid for college, vocational rehabilitation, or training. Include the total of payments for expenses like tuition, books, and supplies.",
   "household-dependent-generic-label": "Dependent",
   "household-dependent-generic-label-plural": "Dependents",
   "household-dependent-income-gross-label": "Enter your dependent’s gross annual income from %s",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Implemented the 10-10EZR copy update for the Dependent education expenses page context to match the Figma direction

Changes made:

Updated the required field prompt text in src/applications/ezr/locales/en/content.json:162

Old: “Enter the total amount of money your dependent paid…”

New: “If your dependent reported any gross income on their %s taxes, enter the amount… Include… tuition, books, and supplies.”

Updated the helper/description text in 

src/applications/ezr/components/FormDescriptions/DependentExpensesDescription.jsx:6
Old IRS threshold explanation replaced with:
“If your dependent didn’t report any gross income on their {LAST_YEAR} taxes, enter $0-even if they paid for education or training expenses.”

Updated page config to inject the year into the new %s label in src/applications/ezr/config/chapters/householdInformation/dependentEducationExpenses.js:26

Wrapped the label with [replaceStrValues(..., LAST_YEAR)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/orgs/department-of-veterans-affairs/projects/1917/views/2?pane=issue&itemId=161785557&issue=department-of-veterans-affairs%7Cva.gov-team%7C134864

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
