### PR TITLE
10-7959f-2 | Remove app feature toggle

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/containers/App.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { shallowEqual, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import environment from 'platform/utilities/environment';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog';
 import { DowntimeNotification } from 'platform/monitoring/DowntimeNotification';
@@ -42,9 +42,8 @@ const BROWSER_MONITORING_PROPS = {
 };
 
 const App = ({ location, children }) => {
-  const isAppLoading = useSelector(
-    state => state.featureToggles?.loading || state.user?.profile?.loading,
-    shallowEqual,
+  const isAppLoading = useSelector(state =>
+    Boolean(state.featureToggles?.loading || state.user?.profile?.loading),
   );
 
   useBrowserMonitoring(BROWSER_MONITORING_PROPS);

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -9,8 +9,8 @@ import { useDefaultFormData } from '../hooks/useDefaultFormData';
 import formConfig from '../config/form';
 
 const App = ({ location, children }) => {
-  const isAppLoading = useSelector(
-    state => state.featureToggles?.loading || state.user?.profile?.loading,
+  const isAppLoading = useSelector(state =>
+    Boolean(state.featureToggles?.loading || state.user?.profile?.loading),
   );
 
   useDefaultFormData();

--- a/src/applications/ivc-champva/10-7959a/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/App.jsx
@@ -30,8 +30,8 @@ const BROWSER_MONITORING_PROPS = {
 };
 
 const App = ({ location, children }) => {
-  const isAppLoading = useSelector(
-    state => state.featureToggles?.loading || state.user?.profile?.loading,
+  const isAppLoading = useSelector(state =>
+    Boolean(state.featureToggles?.loading || state.user?.profile?.loading),
   );
 
   useDefaultFormData();

--- a/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { shallowEqual, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import environment from 'platform/utilities/environment';
-import { isProfileLoading } from 'platform/user/selectors';
 import { DowntimeNotification } from 'platform/monitoring/DowntimeNotification';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog';
@@ -29,11 +28,8 @@ const BROWSER_MONITORING_PROPS = {
 };
 
 const App = ({ location, children }) => {
-  const isAppLoading = useSelector(
-    state =>
-      state?.featureToggles?.loading === true ||
-      isProfileLoading(state) === true,
-    shallowEqual,
+  const isAppLoading = useSelector(state =>
+    Boolean(state.featureToggles?.loading || state.user?.profile?.loading),
   );
 
   useBrowserMonitoring(BROWSER_MONITORING_PROPS);

--- a/src/applications/ivc-champva/10-7959f-2/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/containers/App.jsx
@@ -1,35 +1,16 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { shallowEqual, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { DowntimeNotification } from 'platform/monitoring/DowntimeNotification';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
 const App = ({ location, children }) => {
-  const { isAppLoading, isAppEnabled } = useSelector(
-    state => ({
-      isAppLoading:
-        state?.featureToggles?.loading || state.user?.profile?.loading,
-      isAppEnabled: state.featureToggles?.form107959f2,
-    }),
-    shallowEqual,
+  const isAppLoading = useSelector(state =>
+    Boolean(state.featureToggles?.loading || state.user?.profile?.loading),
   );
 
-  const [routeChecked, setRouteChecked] = useState(false);
-
-  useLayoutEffect(
-    () => {
-      if (isAppLoading) return;
-      if (!isAppEnabled) {
-        window.location.replace('/health-care/foreign-medical-program');
-        return;
-      }
-      setRouteChecked(true);
-    },
-    [isAppLoading, isAppEnabled],
-  );
-
-  return isAppLoading || !routeChecked ? (
+  return isAppLoading ? (
     <va-loading-indicator
       message="Loading application..."
       class="vads-u-margin-y--4"

--- a/src/applications/ivc-champva/10-7959f-2/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/ivc-champva/10-7959f-2/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,9 +1,6 @@
 {
-    "data": {
-      "type": "feature_toggles",
-      "features": [
-        { "name": "loading", "value": false },
-        { "name": "form107959f2", "value": true }
-      ]
-    }
+  "data": {
+    "type": "feature_toggles",
+    "features": [{ "name": "loading", "value": false }]
   }
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR refactors the way application loading state is determined across several `ivc-champva` form applications. The main change is standardizing the logic for checking if the app is loading, making it more concise and consistent. Additionally, some unnecessary code and imports are removed, and feature toggle mocks are updated for tests.

**Standardization and simplification of loading state logic:**

* Replaced custom and sometimes duplicated logic for determining `isAppLoading` with a single, concise `useSelector` that checks if either `featureToggles.loading` or `user.profile.loading` is truthy, wrapped in `Boolean` for consistency. This affects `App.jsx` in `10-10d-extended`, `10-7959C`, `10-7959a`, `10-7959f-1`, and `10-7959f-2` applications. 

**Code cleanup and removal of unnecessary logic:**

* Removed unused imports such as `shallowEqual` and `isProfileLoading` from several `App.jsx` files, since the new selector logic no longer requires them.
* For the 10-7959f-2, remove additional state and effects (`routeChecked`, `isAppEnabled`, and a `useLayoutEffect` redirect) in favor of a simpler loading check, streamlining the component.

**Test fixture updates:**

* Updated the feature toggles mock in `10-7959f-2/tests/e2e/fixtures/mocks/feature-toggles.json` to remove the `form107959f2` toggle, reflecting the simplified logic.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#135969

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- 10-7959f-2 app is permanently enabled
- Loading logic is consistent across all IVC-CHAMPVA apps

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
