### PR TITLE
[DBC] remove obsolete SHA submit transform

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -28,7 +28,6 @@ import {
   addForm0781,
   addForm0781V2,
   addForm8940,
-  setSeparationHealthAssessmentAttachmentId,
   addFileAttachments,
   normalizeIncreases,
   sanitizeNewDisabilities,
@@ -363,7 +362,6 @@ export function transform(formConfig, form) {
     addForm0781,
     addForm0781V2,
     addForm8940,
-    setSeparationHealthAssessmentAttachmentId, // TODO: Remove this when handled downstream.
     addFileAttachments,
     transformCountryCodeToName,
     fullyDevelopedClaim,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
@@ -105,7 +105,8 @@
     "separationHealthAssessmentUploads": [
       {
         "name": "sha-maximal.pdf",
-        "confirmationCode": "sha-maximal-code"
+        "confirmationCode": "sha-maximal-code",
+        "attachmentId": "L702"
       }
     ],
     "view:unemployable": false,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-bdd-test.json
@@ -47,7 +47,8 @@
       "separationHealthAssessmentUploads": [
         {
           "name": "sha-minimal.pdf",
-          "confirmationCode": "sha-minimal-code"
+          "confirmationCode": "sha-minimal-code",
+          "attachmentId": "L702"
         }
       ],
       "view:powStatus": false,

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -57,7 +57,7 @@ describe('Summary of Evidence', () => {
   ];
 
   const separationHealthAssessmentUploads = [
-    { name: 'sha-a.pdf', confirmationCode: 'abc123' },
+    { name: 'sha-a.pdf', confirmationCode: 'abc123', attachmentId: 'L702' },
   ];
 
   const bddServiceInformation = {

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.jsx
@@ -388,6 +388,7 @@ describe('SHA upload attachment transformation', () => {
           {
             name: 'sha-part-a.pdf',
             confirmationCode: 'sha-code-123',
+            attachmentId: 'L702',
             size: 1024,
             type: 'application/pdf',
           },
@@ -401,7 +402,8 @@ describe('SHA upload attachment transformation', () => {
     const hasShaAttachment = result.form526.attachments.some(
       attachment =>
         attachment.name === 'sha-part-a.pdf' &&
-        attachment.confirmationCode === 'sha-code-123',
+        attachment.confirmationCode === 'sha-code-123' &&
+        attachment.attachmentId === 'L702',
     );
     expect(hasShaAttachment).to.be.true;
     expect(result.form526).to.not.have.property(

--- a/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.jsx
@@ -2135,6 +2135,7 @@ describe('addFileAttachments', () => {
         {
           name: 'sha-part-a.pdf',
           confirmationCode: 'sha-code-123',
+          attachmentId: 'L702',
           size: 1024,
           type: 'application/pdf',
         },
@@ -2147,6 +2148,7 @@ describe('addFileAttachments', () => {
     expect(result.attachments).to.have.lengthOf(1);
     expect(result.attachments[0].name).to.equal('sha-part-a.pdf');
     expect(result.attachments[0].confirmationCode).to.equal('sha-code-123');
+    expect(result.attachments[0].attachmentId).to.equal('L702');
     expect(result).to.not.have.property('separationHealthAssessmentUploads');
     expect(result.veteranFullName).to.deep.equal({
       first: 'Sam',
@@ -2160,6 +2162,7 @@ describe('addFileAttachments', () => {
         {
           name: 'sha-part-a.pdf',
           confirmationCode: 'sha-code-123',
+          attachmentId: 'L702',
           size: 1024,
           type: 'application/pdf',
         },
@@ -2178,8 +2181,12 @@ describe('addFileAttachments', () => {
 
     expect(result.attachments).to.have.lengthOf(2);
     const names = result.attachments.map(attachment => attachment.name);
+    const shaAttachment = result.attachments.find(
+      attachment => attachment.name === 'sha-part-a.pdf',
+    );
     expect(names).to.include('sha-part-a.pdf');
     expect(names).to.include('buddy-statement.pdf');
+    expect(shaAttachment.attachmentId).to.equal('L702');
     expect(result).to.not.have.property('separationHealthAssessmentUploads');
     expect(result).to.not.have.property('additionalDocuments');
   });

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -938,20 +938,6 @@ export const flattenAttachments = formData => {
   return clonedData;
 };
 
-// TODO: Remove this when handled downstream.
-export const setSeparationHealthAssessmentAttachmentId = formData => {
-  const uploads = formData.separationHealthAssessmentUploads;
-  if (!uploads) return formData;
-
-  const clonedData = _.cloneDeep(formData);
-  clonedData.separationHealthAssessmentUploads = uploads.map(upload => ({
-    ...upload,
-    attachmentId: 'L702',
-  }));
-
-  return clonedData;
-};
-
 // Flatten all attachment pages into attachments ARRAY
 export const addFileAttachments = formData => {
   const clonedData = flattenAttachments(formData);


### PR DESCRIPTION
<img width="577" height="229" alt="Screenshot 2026-03-11 at 1 21 49 PM" src="https://github.com/user-attachments/assets/1d105ec9-0ed3-4ebe-bdc0-54636d1e2805" />

_Redux state diff_


Removes now-extraneous SHA submit transform. Update tests to reflect that changing the file input updates form data w/ `attachmentId` directly now.