### PR TITLE
[CVE 2483] fix mismatch for feature toggle in App.jsx

### DIFF
--- a/src/applications/lgy/coe/form/containers/App.jsx
+++ b/src/applications/lgy/coe/form/containers/App.jsx
@@ -41,7 +41,7 @@ function App({
     () => {
       if (
         !isLoadingFeatureFlags &&
-        formData[TOGGLE_KEY] !== coeRebuildEnabled
+        formData[`view:${TOGGLE_KEY}`] !== coeRebuildEnabled
       ) {
         setFormData({
           ...formData,

--- a/src/applications/lgy/coe/form/containers/App.jsx
+++ b/src/applications/lgy/coe/form/containers/App.jsx
@@ -36,21 +36,26 @@ function App({
   } = useFeatureToggle();
   const coeRebuildEnabled = useToggleValue(TOGGLE_NAMES[TOGGLE_KEY]);
   const isLoadingFeatureFlags = useToggleLoadingValue();
+  const viewToggleKey = `view:${TOGGLE_KEY}`;
+  const currentToggleValue = formData[viewToggleKey];
 
   useEffect(
     () => {
-      if (
-        !isLoadingFeatureFlags &&
-        formData[`view:${TOGGLE_KEY}`] !== coeRebuildEnabled
-      ) {
+      if (!isLoadingFeatureFlags && currentToggleValue !== coeRebuildEnabled) {
         setFormData({
           ...formData,
-          [`view:${TOGGLE_KEY}`]: coeRebuildEnabled,
+          [viewToggleKey]: coeRebuildEnabled,
         });
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isLoadingFeatureFlags, coeRebuildEnabled, formData[TOGGLE_KEY]],
+    [
+      isLoadingFeatureFlags,
+      coeRebuildEnabled,
+      currentToggleValue,
+      setFormData,
+      formData,
+      viewToggleKey,
+    ],
   );
 
   useEffect(

--- a/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
@@ -9,6 +9,7 @@ import thunk from 'redux-thunk';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import App from '../../containers/App';
+import { TOGGLE_KEY } from '../../constants';
 
 const getData = ({
   loggedIn = true,
@@ -128,5 +129,67 @@ describe('App', () => {
     expect(getCoeMock.called).to.be.true;
     // we are skippingt generateCoe action
     expect(getCoeMock.args[0][0]).to.be.true;
+  });
+});
+
+describe('feature toggle useEffect logic', () => {
+  const viewToggleKey = `view:${TOGGLE_KEY}`;
+
+  it('should set the toggle value on formData using the view: prefix key', () => {
+    const formData = {};
+    const coeRebuildEnabled = true;
+    const isLoadingFeatureFlags = false;
+    const setFormData = sinon.spy();
+
+    if (
+      !isLoadingFeatureFlags &&
+      formData[viewToggleKey] !== coeRebuildEnabled
+    ) {
+      setFormData({
+        ...formData,
+        [viewToggleKey]: coeRebuildEnabled,
+      });
+    }
+
+    expect(setFormData.calledOnce).to.be.true;
+    expect(setFormData.firstCall.args[0][viewToggleKey]).to.equal(true);
+  });
+
+  it('should not call setFormData when toggle is already set correctly', () => {
+    const formData = { [viewToggleKey]: true };
+    const coeRebuildEnabled = true;
+    const isLoadingFeatureFlags = false;
+    const setFormData = sinon.spy();
+
+    if (
+      !isLoadingFeatureFlags &&
+      formData[viewToggleKey] !== coeRebuildEnabled
+    ) {
+      setFormData({
+        ...formData,
+        [viewToggleKey]: coeRebuildEnabled,
+      });
+    }
+
+    expect(setFormData.called).to.be.false;
+  });
+
+  it('should not call setFormData while feature flags are loading', () => {
+    const formData = {};
+    const coeRebuildEnabled = true;
+    const isLoadingFeatureFlags = true;
+    const setFormData = sinon.spy();
+
+    if (
+      !isLoadingFeatureFlags &&
+      formData[viewToggleKey] !== coeRebuildEnabled
+    ) {
+      setFormData({
+        ...formData,
+        [viewToggleKey]: coeRebuildEnabled,
+      });
+    }
+
+    expect(setFormData.called).to.be.false;
   });
 });

--- a/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
@@ -7,15 +7,21 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { TOGGLE_NAMES } from 'platform/utilities/feature-toggles/useFeatureToggle';
 
 import App from '../../containers/App';
 import { TOGGLE_KEY } from '../../constants';
+
+const toggleSnakeKey = TOGGLE_NAMES[TOGGLE_KEY]; // 'coe_form_rebuild_cveteam'
+const viewToggleKey = `view:${TOGGLE_KEY}`;
 
 const getData = ({
   loggedIn = true,
   getCoeMock = () => {},
   showCOE = true,
   loading = false,
+  toggleEnabled = false,
+  formData = {},
 } = {}) => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
@@ -23,7 +29,6 @@ const getData = ({
   return {
     props: {
       children: <div>children</div>,
-      formData: {},
       getCoe: () => {},
       getCoeMock,
       loggedIn,
@@ -34,7 +39,7 @@ const getData = ({
         login: {
           currentlyLoggedIn: loggedIn,
         },
-        profile: {},
+        profile: loggedIn ? { claims: { coe: true } } : {},
       },
       form: {
         loadedStatus: 'success',
@@ -42,12 +47,13 @@ const getData = ({
         loadedData: {
           metadata: {},
         },
-        data: {},
+        data: formData,
       },
       featureToggles: {
         loading,
         // eslint-disable-next-line camelcase
         coe_access: showCOE,
+        [toggleSnakeKey]: toggleEnabled,
       },
       scheduledDowntime: {
         globalDowntime: null,
@@ -132,64 +138,58 @@ describe('App', () => {
   });
 });
 
-describe('feature toggle useEffect logic', () => {
-  const viewToggleKey = `view:${TOGGLE_KEY}`;
+describe('feature toggle sync to formData', () => {
+  it('dispatches SET_DATA with the view:-prefixed key when toggle is enabled', () => {
+    const { props, mockStore } = getData({
+      toggleEnabled: true,
+      formData: {}, // no view:coeFormRebuildCveteam yet
+    });
 
-  it('should set the toggle value on formData using the view: prefix key', () => {
-    const formData = {};
-    const coeRebuildEnabled = true;
-    const isLoadingFeatureFlags = false;
-    const setFormData = sinon.spy();
+    render(
+      <Provider store={mockStore}>
+        <App {...props} />
+      </Provider>,
+    );
 
-    if (
-      !isLoadingFeatureFlags &&
-      formData[viewToggleKey] !== coeRebuildEnabled
-    ) {
-      setFormData({
-        ...formData,
-        [viewToggleKey]: coeRebuildEnabled,
-      });
-    }
-
-    expect(setFormData.calledOnce).to.be.true;
-    expect(setFormData.firstCall.args[0][viewToggleKey]).to.equal(true);
+    const actions = mockStore.getActions();
+    const setDataAction = actions.find(a => a.type === 'SET_DATA');
+    expect(setDataAction).to.exist;
+    expect(setDataAction.data[viewToggleKey]).to.be.true;
   });
 
-  it('should not call setFormData when toggle is already set correctly', () => {
-    const formData = { [viewToggleKey]: true };
-    const coeRebuildEnabled = true;
-    const isLoadingFeatureFlags = false;
-    const setFormData = sinon.spy();
+  it('dispatches SET_DATA with false when toggle is disabled', () => {
+    const { props, mockStore } = getData({
+      toggleEnabled: false,
+      formData: { [viewToggleKey]: true }, // was true, now toggle says false
+    });
 
-    if (
-      !isLoadingFeatureFlags &&
-      formData[viewToggleKey] !== coeRebuildEnabled
-    ) {
-      setFormData({
-        ...formData,
-        [viewToggleKey]: coeRebuildEnabled,
-      });
-    }
+    render(
+      <Provider store={mockStore}>
+        <App {...props} />
+      </Provider>,
+    );
 
-    expect(setFormData.called).to.be.false;
+    const actions = mockStore.getActions();
+    const setDataAction = actions.find(a => a.type === 'SET_DATA');
+    expect(setDataAction).to.exist;
+    expect(setDataAction.data[viewToggleKey]).to.be.false;
   });
 
-  it('should not call setFormData while feature flags are loading', () => {
-    const formData = {};
-    const coeRebuildEnabled = true;
-    const isLoadingFeatureFlags = true;
-    const setFormData = sinon.spy();
+  it('does not dispatch SET_DATA while feature flags are still loading', () => {
+    const { props, mockStore } = getData({
+      loading: true,
+      toggleEnabled: true,
+      formData: {}, // mismatched, but loading — should not sync
+    });
 
-    if (
-      !isLoadingFeatureFlags &&
-      formData[viewToggleKey] !== coeRebuildEnabled
-    ) {
-      setFormData({
-        ...formData,
-        [viewToggleKey]: coeRebuildEnabled,
-      });
-    }
+    render(
+      <Provider store={mockStore}>
+        <App {...props} />
+      </Provider>,
+    );
 
-    expect(setFormData.called).to.be.false;
+    const actions = mockStore.getActions();
+    const setDataAction = actions.find(a => a.type === 'SET_DATA');
+    expect(setDataAction).to.not.exist;
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This is work for the CVE team, which owns this form app.
- It fixes a bug where the view with the feature toggle name is inconsistently added to the formData, presumably because there's a mismatch in the conditional and the set.

## Related issue(s)

- CVE ticket [# 2483](https://va.ghe.com/software/va-cve/issues/2483)

## QA

- You can check the state for the intro page with and without this change to see that with it the view is set but without it is not.
- Without the change in this PR you can check the state of the intro page against one of the new pages, like applicant-information, which will have the view set while it still does not with the intro page, demonstrating the inconsistency. This does not happen with the change.

## What areas of the site does it impact?

No other areas.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
