### PR TITLE
fix(travel-pay): Keep amount as X.XX when editing expense

### DIFF
--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -75,6 +75,17 @@ export const toBase64 = file =>
     reader.onerror = reject;
   });
 
+const formatCostRequestedForInput = amount => {
+  if (amount === null || amount === undefined || amount === '') {
+    return '';
+  }
+
+  const strAmount = amount.toString().trim();
+  const parsedAmount = Number(strAmount);
+
+  return Number.isNaN(parsedAmount) ? strAmount : parsedAmount.toFixed(2);
+};
+
 const ExpensePage = () => {
   // Router hooks
   const navigate = useNavigate();
@@ -181,6 +192,9 @@ const ExpensePage = () => {
           let initialState = {
             ...fetchedExpense,
             purchaseDate: normalizeDate(fetchedExpense.dateIncurred) || '',
+            costRequested: formatCostRequestedForInput(
+              fetchedExpense.costRequested,
+            ),
           };
 
           // Normalize date fields for expense types that use them

--- a/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
+++ b/src/applications/travel-pay/components/complex-claims/pages/ExpensePage.jsx
@@ -62,6 +62,7 @@ import ExpenseAirTravelFields from './ExpenseAirTravelFields';
 import ExpenseLodgingFields from './ExpenseLodgingFields';
 import ExpenseCommonCarrierFields from './ExpenseCommonCarrierFields';
 import CancelExpenseModal from './CancelExpenseModal';
+import { formatAmount } from '../../../util/complex-claims-helper';
 
 export const toBase64 = file =>
   new Promise((resolve, reject) => {
@@ -74,17 +75,6 @@ export const toBase64 = file =>
     };
     reader.onerror = reject;
   });
-
-const formatCostRequestedForInput = amount => {
-  if (amount === null || amount === undefined || amount === '') {
-    return '';
-  }
-
-  const strAmount = amount.toString().trim();
-  const parsedAmount = Number(strAmount);
-
-  return Number.isNaN(parsedAmount) ? strAmount : parsedAmount.toFixed(2);
-};
 
 const ExpensePage = () => {
   // Router hooks
@@ -192,9 +182,10 @@ const ExpensePage = () => {
           let initialState = {
             ...fetchedExpense,
             purchaseDate: normalizeDate(fetchedExpense.dateIncurred) || '',
-            costRequested: formatCostRequestedForInput(
-              fetchedExpense.costRequested,
-            ),
+            costRequested:
+              fetchedExpense.costRequested != null
+                ? formatAmount(fetchedExpense.costRequested)
+                : '',
           };
 
           // Normalize date fields for expense types that use them

--- a/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/complex-claims/pages/ExpensePage.unit.spec.jsx
@@ -1422,6 +1422,40 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
     expect(costField.getAttribute('value')).to.equal('10.50');
   });
 
+  it('formats integer costRequested as x.00 in edit mode', async () => {
+    apiStub.restore();
+    apiStub = sinon.stub(api, 'apiRequest').callsFake(url => {
+      if (url.includes('/claims/43555/expenses/meal/')) {
+        return Promise.resolve({
+          id: TEST_EXPENSE_ID,
+          expenseType: 'Meal',
+          vendorName: 'Saved Vendor',
+          dateIncurred: '2025-11-17',
+          costRequested: 10,
+          description: 'Test expense description',
+        });
+      }
+      if (url.includes('/documents/')) {
+        return Promise.resolve({
+          headers: {
+            get: key => (key === 'Content-Type' ? 'application/pdf' : '1024'),
+          },
+          arrayBuffer: async () => new TextEncoder().encode('dummy').buffer,
+        });
+      }
+      return Promise.reject(new Error('Unmocked API call'));
+    });
+
+    const { container } = renderEditPage();
+
+    await waitFor(() => {
+      const costField = container.querySelector(
+        'va-text-input[name="costRequested"]',
+      );
+      expect(costField?.getAttribute('value')).to.equal('10.00');
+    });
+  });
+
   it('uses "Save and continue" text for continue button', async () => {
     const { container } = renderEditPage();
 
@@ -1757,7 +1791,7 @@ describe('Travel Pay – ExpensePage (Editing existing expense)', () => {
       const inputText = container.querySelector(
         'va-text-input[name="costRequested"]',
       );
-      expect(inputText?.getAttribute('value')).to.equal('0');
+      expect(inputText?.getAttribute('value')).to.equal('0.00');
     });
 
     const inputText = container.querySelector(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The upstream API's JSON serializer omits trailing zeroes on whole-dollar amounts.
- Normalize these to X.XX so users editing an expense aren't required to re-enter ".00".

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132033
- https://github.com/department-of-veterans-affairs/vets-website/pull/42663
- https://github.com/department-of-veterans-affairs/vets-website/pull/43019

## Testing done

- Tests created and also manually tested.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |    <img width="401" height="123" alt="Screenshot 2026-03-11 at 12 32 19" src="https://github.com/user-attachments/assets/abc73b2f-817d-499c-9438-d200bd174b33" />    |    <img width="451" height="168" alt="Screenshot 2026-03-11 at 12 32 49" src="https://github.com/user-attachments/assets/9618d0f0-721b-44d1-afc3-439f0b9ddd60" />   |

## What areas of the site does it impact?

Travel pay editing expense receipts

## Acceptance criteria

- [ ] Editing an expense always shows 5.50 or 10.00, not 5.5 or 10

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

