### PR TITLE
Move axe checks to better cover ui state

### DIFF
--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -52,7 +52,6 @@ describe('VASS Error Paths', () => {
 
         it('should display an error when identity verification fails for the first time', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.enterLastName('WrongName');
           VerifyPageObject.enterDateOfBirth('1990-01-01');
@@ -61,12 +60,12 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:request-otp');
 
           VerifyPageObject.assertInvalidCredentialsErrorAlert();
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_invalidCredentials');
         });
 
         it('should display a verification error alert after 3 failed attempts', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.fillAndSubmitForm();
 
@@ -81,6 +80,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertInvalidVerificationErrorAlert({
             exist: true,
           });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_3FailedAttempts');
         });
       });
@@ -98,7 +98,6 @@ describe('VASS Error Paths', () => {
 
         it('should display a verification error alert', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.fillAndSubmitForm();
 
@@ -107,6 +106,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertInvalidVerificationErrorAlert({
             exist: true,
           });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_rateLimited');
         });
       });
@@ -124,13 +124,13 @@ describe('VASS Error Paths', () => {
 
         it('should display a wrapper error alert', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.fillAndSubmitForm();
 
           cy.wait('@vass:post:request-otp');
 
           VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_serverError500');
         });
       });
@@ -148,13 +148,13 @@ describe('VASS Error Paths', () => {
 
         it('should display a wrapper error alert', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.fillAndSubmitForm();
 
           cy.wait('@vass:post:request-otp');
 
           VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_serviceUnavailable503');
         });
       });
@@ -167,13 +167,13 @@ describe('VASS Error Paths', () => {
       describe('when the user leaves the last name input empty', () => {
         it('should not submit the form and display an error when the user submits the form', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.enterLastName('');
           VerifyPageObject.enterDateOfBirth('1990-01-01');
           VerifyPageObject.clickSubmit();
 
           VerifyPageObject.assertLastNameError('Please enter your last name');
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_emptyLastName');
         });
       });
@@ -181,7 +181,6 @@ describe('VASS Error Paths', () => {
       describe('when the user leaves the date of birth input empty', () => {
         it('should not submit the form and display an error when the user submits the form', () => {
           VerifyPageObject.assertVerifyPage();
-          cy.injectAxeThenAxeCheck();
 
           VerifyPageObject.enterLastName('Smith');
           VerifyPageObject.clickSubmit();
@@ -189,6 +188,7 @@ describe('VASS Error Paths', () => {
           VerifyPageObject.assertDateOfBirthError(
             'Please enter your date of birth',
           );
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_verify_emptyDateOfBirth');
         });
       });
@@ -214,7 +214,6 @@ describe('VASS Error Paths', () => {
 
         it('should display an invalid OTP error', () => {
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.enterOTP('123456');
           EnterOTPPageObject.clickContinue();
@@ -226,6 +225,7 @@ describe('VASS Error Paths', () => {
             containsText:
               'The one-time verification code you entered doesn’t match the one we sent you. Check your email and try again.',
           });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_invalidCode');
         });
 
@@ -236,7 +236,6 @@ describe('VASS Error Paths', () => {
           });
 
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.enterOTP('123456');
           EnterOTPPageObject.clickContinue();
@@ -248,6 +247,7 @@ describe('VASS Error Paths', () => {
             containsText:
               'The one-time verification code you entered doesn’t match the one we sent you. You have 1 try left. Then you’ll need to wait 15 minutes before trying again.',
           });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_lastAttempt');
         });
       });
@@ -262,7 +262,6 @@ describe('VASS Error Paths', () => {
 
         it('should display a verification error alert', () => {
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.enterOTP('123456');
           EnterOTPPageObject.clickContinue();
@@ -270,6 +269,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertVerificationErrorPage();
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_accountLocked');
         });
       });
@@ -284,7 +284,6 @@ describe('VASS Error Paths', () => {
 
         it('should display an OTP error alert', () => {
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.enterOTP('123456');
           EnterOTPPageObject.clickContinue();
@@ -296,6 +295,7 @@ describe('VASS Error Paths', () => {
             containsText:
               'The one-time verification code you entered has expired. Select the link in your email to get a new code and schedule a call.',
           });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_expired');
         });
       });
@@ -310,7 +310,6 @@ describe('VASS Error Paths', () => {
 
         it('should display a wrapper error alert', () => {
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.enterOTP('123456');
           EnterOTPPageObject.clickContinue();
@@ -318,6 +317,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_serverError500');
         });
       });
@@ -332,7 +332,6 @@ describe('VASS Error Paths', () => {
 
         it('should display a wrapper error alert', () => {
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.enterOTP('123456');
           EnterOTPPageObject.clickContinue();
@@ -340,6 +339,7 @@ describe('VASS Error Paths', () => {
           cy.wait('@vass:post:authenticate-otp');
 
           EnterOTPPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_serviceUnavailable503');
         });
       });
@@ -349,13 +349,13 @@ describe('VASS Error Paths', () => {
       describe('when the user leaves the OTP input empty', () => {
         it('should not submit the form and display an error when the user submits the form', () => {
           EnterOTPPageObject.assertEnterOTPPage();
-          cy.injectAxeThenAxeCheck();
 
           EnterOTPPageObject.submitEmptyForm();
 
           EnterOTPPageObject.assertOTPError(
             'Please enter your one-time verification code',
           );
+          cy.injectAxeThenAxeCheck();
           saveScreenshot('vass_error_otp_emptyInput');
         });
       });
@@ -364,7 +364,6 @@ describe('VASS Error Paths', () => {
         describe('when the user enters a non-numeric OTP', () => {
           it('should not submit the form and display an error when the user submits the form', () => {
             EnterOTPPageObject.assertEnterOTPPage();
-            cy.injectAxeThenAxeCheck();
 
             EnterOTPPageObject.enterOTP('aaaaaa');
             EnterOTPPageObject.clickContinue();
@@ -372,6 +371,7 @@ describe('VASS Error Paths', () => {
             EnterOTPPageObject.assertOTPError(
               'Your verification code should only contain numbers',
             );
+            cy.injectAxeThenAxeCheck();
             saveScreenshot('vass_error_otp_nonNumericInput');
           });
         });
@@ -379,7 +379,6 @@ describe('VASS Error Paths', () => {
         describe('when the user enters a less than 6 digits OTP', () => {
           it('should not submit the form and display an error when the user submits the form', () => {
             EnterOTPPageObject.assertEnterOTPPage();
-            cy.injectAxeThenAxeCheck();
 
             EnterOTPPageObject.enterOTP('12345');
             EnterOTPPageObject.clickContinue();
@@ -387,6 +386,7 @@ describe('VASS Error Paths', () => {
             EnterOTPPageObject.assertOTPError(
               'Your verification code should be 6 digits',
             );
+            cy.injectAxeThenAxeCheck();
             saveScreenshot('vass_error_otp_tooShort');
           });
         });
@@ -421,9 +421,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
-        cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_availability_notWithinCohort');
       });
     });
@@ -449,9 +449,9 @@ describe('VASS Error Paths', () => {
         EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
         cy.wait('@vass:get:appointment-details');
-        cy.injectAxeThenAxeCheck();
 
         AlreadyScheduledPageObject.assertAlreadyScheduledPage();
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_availability_alreadyBooked');
       });
     });
@@ -467,9 +467,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
-        cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_availability_noSlots');
       });
     });
@@ -485,9 +485,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
-        cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_availability_serverError500');
       });
     });
@@ -503,9 +503,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:get:appointment-availability');
-        cy.injectAxeThenAxeCheck();
 
         DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_availability_serviceUnavailable503');
       });
     });
@@ -543,9 +543,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
         cy.wait('@vass:get:topics');
-        cy.injectAxeThenAxeCheck();
 
         TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_topics_serverError500');
       });
     });
@@ -561,9 +561,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
         cy.wait('@vass:get:topics');
-        cy.injectAxeThenAxeCheck();
 
         TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_topics_serviceUnavailable503');
       });
     });
@@ -604,9 +604,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         ReviewPageObject.clickConfirmAppointment();
         cy.wait('@vass:post:appointment');
-        cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_create_saveFailed');
       });
     });
@@ -622,9 +622,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         ReviewPageObject.clickConfirmAppointment();
         cy.wait('@vass:post:appointment');
-        cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_create_serverError500');
       });
     });
@@ -640,9 +640,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         ReviewPageObject.clickConfirmAppointment();
         cy.wait('@vass:post:appointment');
-        cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_create_serviceUnavailable503');
       });
     });
@@ -684,9 +684,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         ReviewPageObject.clickConfirmAppointment();
         cy.wait('@vass:post:appointment');
-        cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_details_notFound');
       });
     });
@@ -702,9 +702,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         ReviewPageObject.clickConfirmAppointment();
         cy.wait('@vass:post:appointment');
-        cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_details_serverError500');
       });
     });
@@ -720,9 +720,9 @@ describe('VASS Error Paths', () => {
       it('should display a wrapper error alert', () => {
         ReviewPageObject.clickConfirmAppointment();
         cy.wait('@vass:post:appointment');
-        cy.injectAxeThenAxeCheck();
 
         ReviewPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_details_serviceUnavailable503');
       });
     });
@@ -778,12 +778,12 @@ describe('VASS Error Paths', () => {
         cy.wait('@vass:post:authenticate-otp');
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');
-        cy.injectAxeThenAxeCheck();
 
         CancelAppointmentPageObject.assertWrapperErrorAlert({
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_cancel_failed');
       });
     });
@@ -800,12 +800,12 @@ describe('VASS Error Paths', () => {
         EnterOTPPageObject.fillAndSubmitOTP();
         cy.wait('@vass:post:authenticate-otp');
         cy.wait('@vass:get:appointment-details');
-        cy.injectAxeThenAxeCheck();
 
         CancelAppointmentPageObject.assertWrapperErrorAlert({
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_cancel_appointmentNotFound');
       });
     });
@@ -823,12 +823,12 @@ describe('VASS Error Paths', () => {
         cy.wait('@vass:post:authenticate-otp');
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');
-        cy.injectAxeThenAxeCheck();
 
         CancelAppointmentPageObject.assertWrapperErrorAlert({
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_cancel_cancellationNotFound');
       });
     });
@@ -846,12 +846,12 @@ describe('VASS Error Paths', () => {
         cy.wait('@vass:post:authenticate-otp');
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');
-        cy.injectAxeThenAxeCheck();
 
         CancelAppointmentPageObject.assertWrapperErrorAlert({
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_cancel_serverError500');
       });
     });
@@ -869,12 +869,12 @@ describe('VASS Error Paths', () => {
         cy.wait('@vass:post:authenticate-otp');
         CancelAppointmentPageObject.clickYesCancelAppointment();
         cy.wait('@vass:post:cancel-appointment');
-        cy.injectAxeThenAxeCheck();
 
         CancelAppointmentPageObject.assertWrapperErrorAlert({
           exist: true,
           flowType: FLOW_TYPES.CANCEL,
         });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_cancel_serviceUnavailable503');
       });
     });
@@ -904,13 +904,13 @@ describe('VASS Error Paths', () => {
         cy.wait('@vass:post:authenticate-otp');
         cy.wait('@vass:get:appointment-availability');
         DateTimeSelectionPageObject.assertDateTimeSelectionPage();
-        cy.injectAxeThenAxeCheck();
         cy.on('window:confirm', text => {
           expect(text).to.contains(
             'This page is asking you to confirm that you want to leave — information you’ve entered may not be saved',
           );
           return true; // accept
         });
+        cy.injectAxeThenAxeCheck();
         cy.go('back');
       });
     });
@@ -921,9 +921,8 @@ describe('VASS Error Paths', () => {
       });
 
       it('should show the wrapper error alert', () => {
-        cy.injectAxeThenAxeCheck();
-
         VerifyPageObject.assertWrapperErrorAlert({ exist: true });
+        cy.injectAxeThenAxeCheck();
         saveScreenshot('vass_error_navigation_noUuid');
       });
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Move Axe checks to better check the corresponding pages for errors.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#42846


## Testing done

- Only axe check changes - A full e2e test re-run will be sufficient

## Screenshots

N/A - No UI changes

## What areas of the site does it impact?

- VASS

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
