### PR TITLE
Adds more choices for type of care

### DIFF
--- a/src/applications/survivors-benefits/config/chapters/06-financial-information/careFacilityExpenses/careExpensesPages.js
+++ b/src/applications/survivors-benefits/config/chapters/06-financial-information/careFacilityExpenses/careExpensesPages.js
@@ -20,7 +20,8 @@ import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array
 import { customTextSchema } from '../../../definitions';
 import {
   careRecipientLabels,
-  careTypeLabels,
+  allCareTypeLabels,
+  getCareTypeLabels,
   careFrequencyLabels,
 } from '../../../../utils/labels';
 import { transformDate } from '../../05-claim-information/helpers';
@@ -196,13 +197,16 @@ const typeOfCarePage = {
     ...arrayBuilderItemSubsequentPageTitleUI('Type of care'),
     careType: radioUI({
       title: 'Select the type of care.',
-      labels: careTypeLabels,
+      labels: allCareTypeLabels,
+      updateSchema: (formData, schema, uiSchema, index, path, fullData) => ({
+        enum: Object.keys(getCareTypeLabels(fullData)),
+      }),
     }),
   },
   schema: {
     type: 'object',
     properties: {
-      careType: radioSchema(Object.keys(careTypeLabels)),
+      careType: radioSchema(Object.keys(allCareTypeLabels)),
     },
     required: ['careType'],
   },

--- a/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/careExpensesPages.unit.spec.jsx
+++ b/src/applications/survivors-benefits/tests/unit/pages/06-financial-information/careExpensesPages.unit.spec.jsx
@@ -18,6 +18,62 @@ import {
 const arrayPath = 'careExpenses';
 
 describe('Care Expenses Pages', () => {
+  describe('typeOfCarePage with feature toggle', () => {
+    it('renders default care type options when toggle is disabled', () => {
+      const { careTypePage } = careExpensesPages;
+      const formData = {};
+      const form = render(
+        <DefinitionTester
+          arrayPath={arrayPath}
+          schema={careTypePage.schema}
+          uiSchema={careTypePage.uiSchema}
+          pagePerItemIndex={0}
+          data={{
+            survivorsBenefitsForm2025VersionEnabled: false,
+            [arrayPath]: [formData],
+          }}
+        />,
+      );
+      const formDOM = getFormDOM(form);
+      const vaRadioOptions = $$('va-radio-option', formDOM);
+      expect(vaRadioOptions.length).to.equal(2);
+      expect(vaRadioOptions[0].getAttribute('label')).to.equal(
+        'Residential care facility',
+      );
+      expect(vaRadioOptions[1].getAttribute('label')).to.equal(
+        'In-home care attendant',
+      );
+    });
+
+    it('renders 2025 care type options when toggle is enabled', () => {
+      const { careTypePage } = careExpensesPages;
+      const formData = {};
+      const form = render(
+        <DefinitionTester
+          arrayPath={arrayPath}
+          schema={careTypePage.schema}
+          uiSchema={careTypePage.uiSchema}
+          pagePerItemIndex={0}
+          data={{
+            survivorsBenefitsForm2025VersionEnabled: true,
+            [arrayPath]: [formData],
+          }}
+        />,
+      );
+      const formDOM = getFormDOM(form);
+      const vaRadioOptions = $$('va-radio-option', formDOM);
+      expect(vaRadioOptions.length).to.equal(4);
+      expect(vaRadioOptions[0].getAttribute('label')).to.equal('Nursing home');
+      expect(vaRadioOptions[1].getAttribute('label')).to.equal(
+        'Residential care facility',
+      );
+      expect(vaRadioOptions[2].getAttribute('label')).to.equal('Adult daycare');
+      expect(vaRadioOptions[3].getAttribute('label')).to.equal(
+        'In-home care attendant',
+      );
+    });
+  });
+
   it('renders the care expenses page intro', async () => {
     const { careExpensesIntro } = careExpensesPages;
 

--- a/src/applications/survivors-benefits/utils/labels.jsx
+++ b/src/applications/survivors-benefits/utils/labels.jsx
@@ -90,6 +90,18 @@ export const careTypeLabels = {
   IN_HOME_CARE_ATTENDANT: 'In-home care attendant',
 };
 
+export const allCareTypeLabels = {
+  NURSING_HOME: 'Nursing home',
+  CARE_FACILITY: 'Residential care facility',
+  ADULT_DAYCARE: 'Adult daycare',
+  IN_HOME_CARE_ATTENDANT: 'In-home care attendant',
+};
+
+export const getCareTypeLabels = formData =>
+  formData?.survivorsBenefitsForm2025VersionEnabled
+    ? allCareTypeLabels
+    : careTypeLabels;
+
 export const frequencyLabels = {
   MONTHLY: 'Once a month',
   ANNUALLY: 'Once a year',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- UI changes for chapter 6 expenses
- Changes checkbox options
- Behind feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/135109

## Testing done

- Toggle the 2025 feature on and off locally
- you should see the checkboxes change from two to four
- They should be the correct checkboxes in both cases

## Screenshots

Feature toggle off:

<img width="3238" height="4368" alt="image" src="https://github.com/user-attachments/assets/e7079e49-43c2-4019-af51-6905b3b383d7" />

Feature toggle on:

<img width="3238" height="4554" alt="image" src="https://github.com/user-attachments/assets/a5a60948-9b8f-4434-a527-5bade3765529" />


## What areas of the site does it impact?

Survivors-benefits - Chapter 6 - Care expenses

## Acceptance criteria

- [ ] Toggle works
- [ ] expense types are correct

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
