### PR TITLE
SSN validation to prevent duplication on 601 and 0537

### DIFF
--- a/src/applications/simple-forms/21P-601/pages/claimantSSN.js
+++ b/src/applications/simple-forms/21P-601/pages/claimantSSN.js
@@ -3,12 +3,23 @@ import {
   ssnUI,
   ssnSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { validateClaimantSsnNotMatchVeteranSsn } from '../utils/validations';
+
+const claimantSsnUI = ssnUI();
+claimantSsnUI['ui:validations'] = [
+  ...(claimantSsnUI['ui:validations'] || []),
+  validateClaimantSsnNotMatchVeteranSsn,
+];
+claimantSsnUI['ui:options'] = {
+  ...(claimantSsnUI['ui:options'] || {}),
+  useAllFormData: true,
+};
 
 export default {
   uiSchema: {
     ...titleUI('Your identification information'),
     claimantIdentification: {
-      ssn: ssnUI(),
+      ssn: claimantSsnUI,
     },
   },
   schema: {

--- a/src/applications/simple-forms/21P-601/tests/unit/validations.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-601/tests/unit/validations.unit.spec.jsx
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { validateClaimantSsnNotMatchVeteranSsn } from '../../utils/validations';
+
+describe('21P-601 validations', () => {
+  describe('validateClaimantSsnNotMatchVeteranSsn', () => {
+    const buildErrors = () => {
+      const messages = [];
+      return {
+        errors: { addError: message => messages.push(message) },
+        messages,
+      };
+    };
+
+    it('adds an error when claimant and veteran SSN match', () => {
+      const { errors, messages } = buildErrors();
+
+      validateClaimantSsnNotMatchVeteranSsn(errors, '123-45-6789', {
+        veteranIdentification: { ssn: '123456789' },
+      });
+
+      expect(messages).to.have.lengthOf(1);
+    });
+
+    it('adds an error when both SSNs match with dashes', () => {
+      const { errors, messages } = buildErrors();
+
+      validateClaimantSsnNotMatchVeteranSsn(errors, '123-45-6789', {
+        veteranIdentification: { ssn: '123-45-6789' },
+      });
+
+      expect(messages).to.have.lengthOf(1);
+    });
+
+    it('does not add an error when claimant and veteran SSN are different', () => {
+      const { errors, messages } = buildErrors();
+
+      validateClaimantSsnNotMatchVeteranSsn(errors, '123-45-6789', {
+        veteranIdentification: { ssn: '987-65-4321' },
+      });
+
+      expect(messages).to.be.empty;
+    });
+
+    it('does not add an error when claimant SSN is missing', () => {
+      const { errors, messages } = buildErrors();
+
+      validateClaimantSsnNotMatchVeteranSsn(errors, '', {
+        veteranIdentification: { ssn: '123456789' },
+      });
+
+      expect(messages).to.be.empty;
+    });
+
+    it('does not add an error when veteran SSN is missing', () => {
+      const { errors, messages } = buildErrors();
+
+      validateClaimantSsnNotMatchVeteranSsn(errors, '123456789', {});
+
+      expect(messages).to.be.empty;
+    });
+
+    it('does not add an error when veteranIdentification is undefined', () => {
+      const { errors, messages } = buildErrors();
+
+      validateClaimantSsnNotMatchVeteranSsn(errors, '123456789', {
+        veteranIdentification: undefined,
+      });
+
+      expect(messages).to.be.empty;
+    });
+  });
+});

--- a/src/applications/simple-forms/21P-601/utils/validations.js
+++ b/src/applications/simple-forms/21P-601/utils/validations.js
@@ -1,0 +1,19 @@
+export const validateClaimantSsnNotMatchVeteranSsn = (
+  errors,
+  claimantSsn,
+  formData,
+) => {
+  const veteranSsn = formData?.veteranIdentification?.ssn;
+  if (!claimantSsn || !veteranSsn) {
+    return;
+  }
+
+  const normalizedClaimantSsn = claimantSsn.replace(/\D/g, '');
+  const normalizedVeteranSsn = veteranSsn.replace(/\D/g, '');
+
+  if (normalizedClaimantSsn === normalizedVeteranSsn) {
+    errors.addError(
+      "Your Social Security number must be different from the Veteran's Social Security number.",
+    );
+  }
+};

--- a/src/applications/simple-forms/21p-0537/pages/spouseVeteranId.js
+++ b/src/applications/simple-forms/21p-0537/pages/spouseVeteranId.js
@@ -3,9 +3,18 @@ import {
   ssnOrVaFileNumberSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { validateSpouseSsnNotMatchVeteranSsn } from '../utils/validations';
 
 const spouseVeteranIdUI = ssnOrVaFileNumberUI();
 spouseVeteranIdUI.ssn['ui:title'] = "Spouse's Social Security number";
+spouseVeteranIdUI.ssn['ui:validations'] = [
+  ...(spouseVeteranIdUI.ssn['ui:validations'] || []),
+  validateSpouseSsnNotMatchVeteranSsn,
+];
+spouseVeteranIdUI.ssn['ui:options'] = {
+  ...(spouseVeteranIdUI.ssn['ui:options'] || {}),
+  useAllFormData: true,
+};
 spouseVeteranIdUI.vaFileNumber['ui:title'] = "Spouse's VA file number";
 
 export default {

--- a/src/applications/simple-forms/21p-0537/tests/unit/pages.unit.spec.jsx
+++ b/src/applications/simple-forms/21p-0537/tests/unit/pages.unit.spec.jsx
@@ -7,6 +7,7 @@ import spouseVeteranId from '../../pages/spouseVeteranId';
 import spouseVeteranStatus from '../../pages/spouseVeteranStatus';
 import terminationDetails from '../../pages/terminationDetails';
 import terminationStatus from '../../pages/terminationStatus';
+import { validateSpouseSsnNotMatchVeteranSsn } from '../../utils/validations';
 
 describe('21P-0537 page configurations', () => {
   describe('marriageInfo', () => {
@@ -109,6 +110,14 @@ describe('21P-0537 page configurations', () => {
         'spouseVeteranId',
       );
     });
+
+    it('includes spouse SSN cross-field validation', () => {
+      const validations =
+        spouseVeteranId.uiSchema.remarriage.spouseVeteranId.ssn[
+          'ui:validations'
+        ];
+      expect(validations).to.include(validateSpouseSsnNotMatchVeteranSsn);
+    });
   });
 
   describe('spouseVeteranStatus', () => {
@@ -167,6 +176,53 @@ describe('21P-0537 page configurations', () => {
       expect(
         terminationStatus.schema.properties.remarriage.required,
       ).to.include('hasTerminated');
+    });
+  });
+
+  describe('validateSpouseSsnNotMatchVeteranSsn', () => {
+    const buildErrors = () => {
+      const messages = [];
+      return {
+        errors: { addError: message => messages.push(message) },
+        messages,
+      };
+    };
+
+    it('adds an error when spouse and veteran SSN match', () => {
+      const { errors, messages } = buildErrors();
+
+      validateSpouseSsnNotMatchVeteranSsn(errors, '123-45-6789', {
+        veteranIdentification: { ssn: '123456789' },
+      });
+
+      expect(messages).to.have.lengthOf(1);
+    });
+
+    it('does not add an error when spouse and veteran SSN are different', () => {
+      const { errors, messages } = buildErrors();
+
+      validateSpouseSsnNotMatchVeteranSsn(errors, '123-45-6789', {
+        veteranIdentification: { ssn: '987-65-4321' },
+      });
+
+      expect(messages).to.be.empty;
+    });
+
+    it('does not add an error when either SSN is missing', () => {
+      const missingSpouse = buildErrors();
+      validateSpouseSsnNotMatchVeteranSsn(missingSpouse.errors, '', {
+        veteranIdentification: { ssn: '123456789' },
+      });
+
+      const missingVeteran = buildErrors();
+      validateSpouseSsnNotMatchVeteranSsn(
+        missingVeteran.errors,
+        '123456789',
+        {},
+      );
+
+      expect(missingSpouse.messages).to.be.empty;
+      expect(missingVeteran.messages).to.be.empty;
     });
   });
 });

--- a/src/applications/simple-forms/21p-0537/utils/validations.js
+++ b/src/applications/simple-forms/21p-0537/utils/validations.js
@@ -1,0 +1,19 @@
+export const validateSpouseSsnNotMatchVeteranSsn = (
+  errors,
+  spouseSsn,
+  formData,
+) => {
+  const veteranSsn = formData?.veteranIdentification?.ssn;
+  if (!spouseSsn || !veteranSsn) {
+    return;
+  }
+
+  const normalizedSpouseSsn = spouseSsn.replace(/\D/g, '');
+  const normalizedVeteranSsn = veteranSsn.replace(/\D/g, '');
+
+  if (normalizedSpouseSsn === normalizedVeteranSsn) {
+    errors.addError(
+      "Spouse's Social Security number must be different from the deceased Veteran's Social Security number.",
+    );
+  }
+};


### PR DESCRIPTION
## Summary

When the spouse's SSN is entered, validate that it doesn't match the deceased veteran's SSN previously entered.


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#135659


## Testing done

- Prior to the change a user was able to use the same SSN for themselves and another person
- On staging, navigate to 537 or 601. Enter a social security number for the user and the same social security for the spouse, and you will not see an error. If you run this branch, it will trigger an error
- all unit test are passing


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |   
<img width="728" height="620" alt="Screenshot 2026-03-11 at 4 11 28 PM" src="https://github.com/user-attachments/assets/1a8e5a1a-c916-4b34-b556-4a9ad99025a4" />|     <img width="949" height="836" alt="Screenshot 2026-03-11 at 4 11 46 PM" src="https://github.com/user-attachments/assets/4690a9ea-278d-462d-b71a-b00a73cd3e3f" />|

## What areas of the site does it impact?

21p-601 and 21p-0537

## Acceptance criteria
Users should see a validation error if they entered two social security numbers that match. 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

