### PR TITLE
Add OtherWaysToSendYourDocuments component to evidence request pages when canUploadFile is true

### DIFF
--- a/src/applications/claims-status/components/claim-document-request-pages/FirstPartyRequestPage.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/FirstPartyRequestPage.jsx
@@ -5,6 +5,7 @@ import { VaLink } from '@department-of-veterans-affairs/component-library/dist/r
 import { buildDateFormatter } from '../../utils/helpers';
 import * as TrackedItem from '../../utils/trackedItemContent';
 import AddFilesForm from '../claim-files-tab/AddFilesForm';
+import OtherWaysToSendYourDocuments from '../claim-files-tab-v2/OtherWaysToSendYourDocuments';
 import { resolveSharedContent } from './shared/descriptionContent';
 import RequestNotifications from './shared/RequestNotifications';
 
@@ -208,12 +209,18 @@ export default function FirstPartyRequestPage({
       )}
 
       {item.canUploadFile && (
-        <AddFilesForm
-          progress={progress}
-          uploading={uploading}
-          onCancel={onCancel}
-          onSubmit={files => onSubmit(files)}
-        />
+        <>
+          <AddFilesForm
+            hideOtherWaysLink
+            progress={progress}
+            uploading={uploading}
+            onCancel={onCancel}
+            onSubmit={files => onSubmit(files)}
+          />
+          <div className="vads-u-margin-top--4">
+            <OtherWaysToSendYourDocuments />
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/applications/claims-status/components/claim-document-request-pages/ThirdPartyRequestPage.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/ThirdPartyRequestPage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { buildDateFormatter } from '../../utils/helpers';
 import * as TrackedItem from '../../utils/trackedItemContent';
 import AddFilesForm from '../claim-files-tab/AddFilesForm';
+import OtherWaysToSendYourDocuments from '../claim-files-tab-v2/OtherWaysToSendYourDocuments';
 import { resolveSharedContent } from './shared/descriptionContent';
 import RequestNotifications from './shared/RequestNotifications';
 
@@ -105,12 +106,18 @@ export default function ThirdPartyRequestPage({
       )}
 
       {item.canUploadFile && (
-        <AddFilesForm
-          progress={progress}
-          uploading={uploading}
-          onCancel={onCancel}
-          onSubmit={files => onSubmit(files)}
-        />
+        <>
+          <AddFilesForm
+            hideOtherWaysLink
+            progress={progress}
+            uploading={uploading}
+            onCancel={onCancel}
+            onSubmit={files => onSubmit(files)}
+          />
+          <div className="vads-u-margin-top--4">
+            <OtherWaysToSendYourDocuments />
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -228,7 +228,14 @@ const createSubmissionPayload = (files, docTypes, encrypted) => {
   }));
 };
 
-const AddFilesForm = ({ fileTab, onSubmit, uploading, progress, onCancel }) => {
+const AddFilesForm = ({
+  fileTab,
+  hideOtherWaysLink,
+  onSubmit,
+  uploading,
+  progress,
+  onCancel,
+}) => {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const toggleValue = useToggleValue(TOGGLE_NAMES.cstShowDocumentUploadStatus);
   const { id: claimId } = useParams();
@@ -397,24 +404,25 @@ const AddFilesForm = ({ fileTab, onSubmit, uploading, progress, onCancel }) => {
             {mailMessage}
           </va-additional-info>
         )}
-        {toggleValue && (
-          <>
-            <div className="vads-u-margin-top--3 vads-u-margin-bottom--5">
-              <va-link
-                href={otherWaysToSendHref}
-                text={SEND_YOUR_DOCUMENTS_TEXT}
-                onClick={e => {
-                  // Only prevent default and scroll if we're on the files tab
-                  // Otherwise, let the link navigate to the files page
-                  if (fileTab) {
-                    e.preventDefault();
-                    setPageFocus(`#${ANCHOR_LINKS.otherWaysToSendDocuments}`);
-                  }
-                }}
-              />
-            </div>
-          </>
-        )}
+        {toggleValue &&
+          !hideOtherWaysLink && (
+            <>
+              <div className="vads-u-margin-top--3 vads-u-margin-bottom--5">
+                <va-link
+                  href={otherWaysToSendHref}
+                  text={SEND_YOUR_DOCUMENTS_TEXT}
+                  onClick={e => {
+                    // Only prevent default and scroll if we're on the files tab
+                    // Otherwise, let the link navigate to the files page
+                    if (fileTab) {
+                      e.preventDefault();
+                      setPageFocus(`#${ANCHOR_LINKS.otherWaysToSendDocuments}`);
+                    }
+                  }}
+                />
+              </div>
+            </>
+          )}
         <VaModal
           id="upload-status"
           onCloseEvent={() => setCanShowUploadModal(false)}
@@ -443,6 +451,7 @@ AddFilesForm.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   fileTab: PropTypes.bool,
+  hideOtherWaysLink: PropTypes.bool,
 };
 
 export default AddFilesForm;

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/FirstPartyRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/FirstPartyRequestPage.unit.spec.jsx
@@ -600,7 +600,36 @@ describe('<FirstPartyRequestPage>', () => {
         } else {
           expect(addFilesForm).to.not.exist;
         }
+
+        // Verify OtherWaysToSendYourDocuments
+        const otherWays = queryByTestId('other-ways-to-send-documents');
+        if (testCase.showsAddFilesForm) {
+          expect(otherWays).to.exist;
+        } else {
+          expect(otherWays).to.not.exist;
+        }
       });
+    });
+  });
+
+  describe('OtherWaysToSendYourDocuments', () => {
+    it('should render when canUploadFile is true', () => {
+      const item = createTrackedItem({ canUploadFile: true });
+      const { getByTestId, getByText } = renderWithReduxAndRouter(
+        <FirstPartyRequestPage {...defaultProps} item={item} />,
+        { initialState },
+      );
+      expect(getByTestId('other-ways-to-send-documents')).to.exist;
+      getByText('Other ways to send your documents');
+    });
+
+    it('should not render when canUploadFile is false', () => {
+      const item = createTrackedItem({ canUploadFile: false });
+      const { queryByTestId } = renderWithReduxAndRouter(
+        <FirstPartyRequestPage {...defaultProps} item={item} />,
+        { initialState },
+      );
+      expect(queryByTestId('other-ways-to-send-documents')).to.not.exist;
     });
   });
 

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/ThirdPartyRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/ThirdPartyRequestPage.unit.spec.jsx
@@ -462,7 +462,36 @@ describe('<ThirdPartyRequestPage>', () => {
         } else {
           expect(addFilesForm).to.not.exist;
         }
+
+        // Verify OtherWaysToSendYourDocuments
+        const otherWays = queryByTestId('other-ways-to-send-documents');
+        if (testCase.showsAddFilesForm) {
+          expect(otherWays).to.exist;
+        } else {
+          expect(otherWays).to.not.exist;
+        }
       });
+    });
+  });
+
+  describe('OtherWaysToSendYourDocuments', () => {
+    it('should render when canUploadFile is true', () => {
+      const item = createTrackedItem({ canUploadFile: true });
+      const { getByTestId, getByText } = renderWithReduxAndRouter(
+        <ThirdPartyRequestPage {...defaultProps} item={item} />,
+        { initialState },
+      );
+      expect(getByTestId('other-ways-to-send-documents')).to.exist;
+      getByText('Other ways to send your documents');
+    });
+
+    it('should not render when canUploadFile is false', () => {
+      const item = createTrackedItem({ canUploadFile: false });
+      const { queryByTestId } = renderWithReduxAndRouter(
+        <ThirdPartyRequestPage {...defaultProps} item={item} />,
+        { initialState },
+      );
+      expect(queryByTestId('other-ways-to-send-documents')).to.not.exist;
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds the existing `OtherWaysToSendYourDocuments` component to the `FirstPartyRequestPage` and `ThirdPartyRequestPage` evidence request pages when the tracked item's `canUploadFile` property is `true`. This gives Veterans alternative methods (mail and in-person) to submit their documents directly on the evidence request pages, instead of only linking to the files tab.

### Changes
- **FirstPartyRequestPage:** Added `OtherWaysToSendYourDocuments` component below `AddFilesForm`, conditionally rendered when `canUploadFile` is `true`
- **ThirdPartyRequestPage:** Same as above
- **AddFilesForm:** Added `hideOtherWaysLink` prop to suppress the redundant "Send your documents another way" link when the full component is rendered inline on evidence request pages. The link remains on the files tab where it scrolls to the component further down the page.
- **Unit tests:** Added tests for both pages covering `canUploadFile: true` (component renders) and `canUploadFile: false` (component does not render) scenarios. Updated path coverage test assertions accordingly.

## Related Issue(s)
- **Ticket:** department-of-veterans-affairs/va.gov-team#135661

## How to Test Locally

1. **Start the mock API server:**
   `yarn mock-api --responses src/applications/claims-status/tests/local-dev-mock-api/common.js`

2. **Start the development server:**
   `yarn watch --env entry=claims-status`

3. **Test First Party Evidence Request Page (canUploadFile: true):**
   - Navigate to: `http://localhost:3001/track-claims/your-claims/3/needed-from-you/1`
   - Verify `OtherWaysToSendYourDocuments` component renders below the upload form
   - Verify "Send your documents another way" link is **not** present

4. **Test First Party Evidence Request Page (canUploadFile: false):**
   - Navigate to: `http://localhost:3001/track-claims/your-claims/3/needed-from-you/8`
   - Verify `OtherWaysToSendYourDocuments` component does **not** render
   - Verify upload form does **not** render

5. **Test Third Party Evidence Request Page (canUploadFile: true):**
   - Navigate to: `http://localhost:3001/track-claims/your-claims/3/needed-from-others/9`
   - Verify `OtherWaysToSendYourDocuments` component renders below the upload form
   - Verify "Send your documents another way" link is **not** present

6. **Test Files Tab (link still present):**
   - Navigate to: `http://localhost:3001/track-claims/your-claims/3/files`
   - Verify "Send your documents another way" link is still present in the upload form
   - Verify the link scrolls to the `OtherWaysToSendYourDocuments` section at the bottom

## Testing Done
- [x] Unit tests pass for `FirstPartyRequestPage` (34 passing)
- [x] Unit tests pass for `ThirdPartyRequestPage` (25 passing)
- [x] Unit tests pass for `AddFilesForm` (8 passing)
- [x] Manual verification in local environment

## Screenshots

|                                                  | Before | After |
| ------------------------------------------------ | ------ | ----- |
| First Party Request Page (`canUploadFile: true`)  |  <img width="575" height="961" alt="Screenshot 2026-03-11 at 7 23 15 PM" src="https://github.com/user-attachments/assets/c802d40e-20b2-4234-a789-88dc2c80cf18" />  |   <img width="502" height="1144" alt="Screenshot 2026-03-11 at 7 20 56 PM" src="https://github.com/user-attachments/assets/e8e198f5-18d7-401f-a0ce-b1c74370e98b" /> |
| Third Party Request Page (`canUploadFile: true`)  |  <img width="640" height="791" alt="Screenshot 2026-03-11 at 7 23 45 PM" src="https://github.com/user-attachments/assets/8e4a577d-4fe9-481b-9f7f-cd67d92ae6f2" />  |  <img width="527" height="1074" alt="Screenshot 2026-03-11 at 7 21 36 PM" src="https://github.com/user-attachments/assets/ad5d6dff-6827-4783-ae6b-8886314656e4" />     |
| Files Tab (link still present)                    |   <img width="613" height="536" alt="Screenshot 2026-03-11 at 7 22 28 PM" src="https://github.com/user-attachments/assets/6ed24bf8-0f4f-467e-8997-dc506ba65f9f" />  |  <img width="620" height="544" alt="Screenshot 2026-03-11 at 7 22 19 PM" src="https://github.com/user-attachments/assets/38e5d324-505a-4999-91e4-828529072442" /> |

## What areas of the site does it impact?

This change impacts the **Claim Status Tool (CST)** evidence request pages — specifically the `FirstPartyRequestPage` and `ThirdPartyRequestPage` components. A minor prop addition was made to the shared `AddFilesForm` component, but it has no effect on existing behavior in other locations (files tab) where it is used.

## Acceptance criteria

- [x] `OtherWaysToSendYourDocuments` component renders on `FirstPartyRequestPage` and `ThirdPartyRequestPage` when the tracked item has `canUploadFile: true`
- [x] Component does not render when `canUploadFile` is `false` or not present
- [x] Unit tests cover both `canUploadFile: true` and `canUploadFile: false` scenarios

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
