### PR TITLE
[Ask VA] Make inbox single-column

### DIFF
--- a/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutNew.jsx
@@ -52,7 +52,7 @@ export default function InboxLayoutNew({
 
   return (
     <div id="inbox">
-      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
+      <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--0">
         Your questions
       </h2>
       {inquiryTypes.length ? (
@@ -136,23 +136,29 @@ export default function InboxLayoutNew({
               />
             </div>
           </div>
-          {!!results.length && (
-            <VaSort
-              width="xl"
-              value={sortOrder}
-              onVaSortSelect={e => {
-                setSortOrder(e.target.value);
-                focusElement('#search-description');
-              }}
-            >
-              <option value={filterAndSort.sortOptions.lastUpdate.newest}>
-                Last Updated (newest to oldest)
-              </option>
-              <option value={filterAndSort.sortOptions.lastUpdate.oldest}>
-                Last Updated (oldest to newest)
-              </option>
-            </VaSort>
-          )}
+          <div
+            className={`sort-container ${
+              results.length ? 'vads-u-padding-top--2' : ''
+            }`}
+          >
+            {!!results.length && (
+              <VaSort
+                width="xl"
+                value={sortOrder}
+                onVaSortSelect={e => {
+                  setSortOrder(e.target.value);
+                  focusElement('#search-description');
+                }}
+              >
+                <option value={filterAndSort.sortOptions.lastUpdate.newest}>
+                  Last Updated (newest to oldest)
+                </option>
+                <option value={filterAndSort.sortOptions.lastUpdate.oldest}>
+                  Last Updated (oldest to newest)
+                </option>
+              </VaSort>
+            )}
+          </div>
 
           {inquiryTypes.includes('business') ? (
             <div className="tabs">

--- a/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
+++ b/src/applications/ask-va/components/inbox/InboxLayoutOld.jsx
@@ -41,7 +41,7 @@ export default function InboxLayoutOld({
   });
 
   return (
-    <div id="inbox">
+    <div id="inbox-old">
       <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--0">
         Your questions
       </h2>

--- a/src/applications/ask-va/components/inbox/InquiriesList.jsx
+++ b/src/applications/ask-va/components/inbox/InquiriesList.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import InquiryCard from './InquiryCard';
 import { paginateInquiries } from '../../utils/inbox';
 import SearchDescription from './SearchDescription';
@@ -29,6 +30,10 @@ export default function InquiriesList({
   query,
   tabName,
 }) {
+  // TODO delete after new inbox goes live
+  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
+  const isNewInbox = useToggleValue(TOGGLE_NAMES.askVaEnhancedInbox);
+
   const [currentPageNum, setCurrentPageNum] = useState(1);
   const itemsPerPage = 6;
 
@@ -38,7 +43,7 @@ export default function InquiriesList({
   const totalPages = pages.length;
 
   return (
-    <div>
+    <>
       <SearchDescription
         total={inquiries.length}
         pageEnd={currentPageContents.pageEnd}
@@ -51,7 +56,7 @@ export default function InquiriesList({
         }}
       />
       {inquiries.length ? (
-        <div className="inquiries-list">
+        <div className={isNewInbox ? 'inquiries-list' : 'inquiries-list-old'}>
           {currentPageContents.items.map(inquiry => (
             <InquiryCard key={inquiry.id} {...{ inquiry }} />
           ))}
@@ -84,7 +89,7 @@ export default function InquiriesList({
           className="vads-u-border-top--0 vads-u-padding-top--0 vads-u-padding-bottom--0"
         />
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/applications/ask-va/sass/ask-va.scss
+++ b/src/applications/ask-va/sass/ask-va.scss
@@ -356,6 +356,14 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 // ---- Inbox ----- //
 
 #inbox {
+  margin: 40px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+// TODO delete after new inbox goes live
+#inbox-old {
   margin-bottom: 40px;
 }
 
@@ -364,7 +372,6 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
   flex-direction: row;
   gap: 0.5rem;
   align-items: flex-end;
-  margin-bottom: 1rem;
 
   > div {
     flex: 1;
@@ -374,6 +381,10 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     flex-direction: column;
     align-items: stretch;
   }
+}
+
+.sort-container {
+  border-top: solid 1px var(--vads-color-base-light);
 }
 
 .inbox-tab-container {
@@ -437,6 +448,14 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 }
 
 .inquiries-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 0 0;
+}
+
+// TODO delete after new inbox goes live
+.inquiries-list-old {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 20px;

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutNew.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
 import {
   filterAndSort,
   standardizeInquiries,
@@ -16,8 +17,24 @@ describe('<InboxLayoutNew />', () => {
   );
   const selectedStatus = 'In progress';
 
+  function setupStore(initialState) {
+    return configureStore({
+      reducer: state => state,
+      preloadedState: { ...initialState, askVA: {} },
+    });
+  }
+
+  // TODO delete after new inbox goes live
+  function renderWithStore(children) {
+    const store = setupStore({});
+    return {
+      store,
+      view: render(<Provider store={store}>{children}</Provider>),
+    };
+  }
+
   it('displays a message when there are no inquiries', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -35,7 +52,7 @@ describe('<InboxLayoutNew />', () => {
   });
 
   it('renders a list of inquiries', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -49,7 +66,7 @@ describe('<InboxLayoutNew />', () => {
   });
 
   it('only renders filter options available in the list', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -71,7 +88,7 @@ describe('<InboxLayoutNew />', () => {
   });
 
   it('applies and clears a filter', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -139,7 +156,7 @@ describe('<InboxLayoutNew />', () => {
       return [firstDate, lastDate];
     }
 
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -179,7 +196,7 @@ describe('<InboxLayoutNew />', () => {
   });
 
   it('shifts focus to search description after a button is clicked', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -205,7 +222,7 @@ describe('<InboxLayoutNew />', () => {
   });
 
   it('shifts focus to search description after selecting a sort order', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -234,7 +251,7 @@ describe('<InboxLayoutNew />', () => {
     };
     inquiriesCopy.push(newItem);
 
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutNew
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -265,7 +282,7 @@ describe('<InboxLayoutNew />', () => {
 
   describe('business and personal tabs', () => {
     it('hides tabs when there are no business inquiries', () => {
-      const view = render(
+      const { view } = renderWithStore(
         <InboxLayoutNew
           categoryOptions={mockData.uniqueCategories}
           statusOptions={mockData.uniqueStatuses}
@@ -278,7 +295,7 @@ describe('<InboxLayoutNew />', () => {
     });
 
     it('shows tabs when there are business inquiries', () => {
-      const view = render(
+      const { view } = renderWithStore(
         <InboxLayoutNew
           categoryOptions={mockData.uniqueCategories}
           statusOptions={mockData.uniqueStatuses}
@@ -301,7 +318,7 @@ describe('<InboxLayoutNew />', () => {
     });
 
     it('switches list content based on the selected tab', () => {
-      const view = render(
+      const { view } = renderWithStore(
         <InboxLayoutNew
           categoryOptions={mockData.uniqueCategories}
           statusOptions={mockData.uniqueStatuses}

--- a/src/applications/ask-va/tests/components/inbox/InboxLayoutOld.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InboxLayoutOld.unit.spec.jsx
@@ -3,6 +3,8 @@ import { fireEvent, render } from '@testing-library/react';
 import InboxLayoutOld from '~/applications/ask-va/components/inbox/InboxLayoutOld';
 import { standardizeInquiries } from '~/applications/ask-va/utils/inbox';
 import { expect } from 'chai';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
 
 describe('<InboxLayoutOld />', () => {
@@ -12,8 +14,24 @@ describe('<InboxLayoutOld />', () => {
   );
   const selectedStatus = 'In progress';
 
+  function setupStore(initialState) {
+    return configureStore({
+      reducer: state => state,
+      preloadedState: { ...initialState, askVA: {} },
+    });
+  }
+
+  // TODO delete after new inbox goes live
+  function renderWithStore(children) {
+    const store = setupStore({});
+    return {
+      store,
+      view: render(<Provider store={store}>{children}</Provider>),
+    };
+  }
+
   it('displays a message when there are no inquiries', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutOld
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -31,7 +49,7 @@ describe('<InboxLayoutOld />', () => {
   });
 
   it('renders a list of inquiries', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutOld
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -45,7 +63,7 @@ describe('<InboxLayoutOld />', () => {
   });
 
   it('only renders filter options available in the list', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutOld
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -67,7 +85,7 @@ describe('<InboxLayoutOld />', () => {
   });
 
   it('applies and clears a filter', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutOld
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -123,7 +141,7 @@ describe('<InboxLayoutOld />', () => {
   });
 
   it('shifts focus to search description after a button is clicked', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutOld
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -157,7 +175,7 @@ describe('<InboxLayoutOld />', () => {
     };
     inquiriesCopy.push(newItem);
 
-    const view = render(
+    const { view } = renderWithStore(
       <InboxLayoutOld
         categoryOptions={mockData.uniqueCategories}
         statusOptions={mockData.uniqueStatuses}
@@ -188,7 +206,7 @@ describe('<InboxLayoutOld />', () => {
 
   describe('business and personal tabs', () => {
     it('hides tabs when there are no business inquiries', () => {
-      const view = render(
+      const { view } = renderWithStore(
         <InboxLayoutOld
           categoryOptions={mockData.uniqueCategories}
           statusOptions={mockData.uniqueStatuses}
@@ -201,7 +219,7 @@ describe('<InboxLayoutOld />', () => {
     });
 
     it('shows tabs when there are business inquiries', () => {
-      const view = render(
+      const { view } = renderWithStore(
         <InboxLayoutOld
           categoryOptions={mockData.uniqueCategories}
           statusOptions={mockData.uniqueStatuses}
@@ -224,7 +242,7 @@ describe('<InboxLayoutOld />', () => {
     });
 
     it('switches list content based on the selected tab', () => {
-      const view = render(
+      const { view } = renderWithStore(
         <InboxLayoutOld
           categoryOptions={mockData.uniqueCategories}
           statusOptions={mockData.uniqueStatuses}

--- a/src/applications/ask-va/tests/components/inbox/InquiriesList.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/inbox/InquiriesList.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
 import InquiriesList from '../../../components/inbox/InquiriesList';
 import { standardizeInquiries } from '../../../utils/inbox';
 import { mockInquiries as rawInquiries } from '../../utils/mock-inquiries';
@@ -11,8 +13,24 @@ describe('InquiriesList', () => {
     inq => inq.levelOfAuthentication.toLowerCase() === 'personal',
   );
 
+  function setupStore(initialState) {
+    return configureStore({
+      reducer: state => state,
+      preloadedState: { ...initialState, askVA: {} },
+    });
+  }
+
+  // TODO delete after new inbox goes live
+  function renderWithStore(children) {
+    const store = setupStore({});
+    return {
+      store,
+      view: render(<Provider store={store}>{children}</Provider>),
+    };
+  }
+
   it('only renders 6 items per page', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InquiriesList
         categoryFilter="All"
         statusFilter="All"
@@ -25,7 +43,7 @@ describe('InquiriesList', () => {
   });
 
   it('renders first 6 inquiries on first page', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InquiriesList
         categoryFilter="All"
         statusFilter="All"
@@ -44,7 +62,7 @@ describe('InquiriesList', () => {
   });
 
   it('renders an alert if inquiries array is empty', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InquiriesList
         inquiries={[]}
         categoryFilter="All"
@@ -59,7 +77,7 @@ describe('InquiriesList', () => {
   });
 
   it('updates results based on pagination', () => {
-    const view = render(
+    const { view } = renderWithStore(
       <InquiriesList
         categoryFilter="All"
         statusFilter="All"

--- a/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
+++ b/src/applications/ask-va/tests/containers/Inbox.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('<Inbox />', () => {
     });
   }
 
-  // TODO remove once feature toggle is no longer needed
+  // TODO delete after new inbox goes live
   function renderWithStore(extraState = {}) {
     const store = setupStore(extraState);
     return {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders 

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added conditional logic to apply new or old CSS based on feature toggle state
- Added new CSS rules to replace grid with vertical column, adjust spacing
- Added Redux state to unit tests so the flipper code would work
- Ask VA owns this code
- Flipper toggle in use until new inbox passes Collaboration Cycle

## Related issue(s)

- Closes department-of-veterans-affairs/ask-va/issues/2189

## Testing done

- The only user facing changes were styling tweaks
- The conditional logic added to apply different CSS classes at certain points (a boolean, returned from a hook, is plugged into a ternary operator) meant that we needed Redux state for the tests of `<InquiriesList />` and its parents, `<InboxLayoutOld />` and `<InboxLayoutNew />`
- Sign in, set the ask_va_enhanced_inbox flipper to "Fully enabled", and see that the inbox is now a single column

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="373" height="708" alt="Screenshot 2026-03-12 at 11 56 50 AM" src="https://github.com/user-attachments/assets/2def634b-fa07-42e8-9bc1-e4d89d47b63b" /> | <img width="374" height="694" alt="Screenshot 2026-03-12 at 11 56 06 AM" src="https://github.com/user-attachments/assets/8158576b-3c1d-4e12-9445-5a9066776b80" /> |
| Desktop | <img width="687" height="733" alt="Screenshot 2026-03-12 at 11 57 18 AM" src="https://github.com/user-attachments/assets/4ddcf0b5-5f72-4408-baf6-406730dbd83f" /> | <img width="719" height="763" alt="Screenshot 2026-03-12 at 11 55 38 AM" src="https://github.com/user-attachments/assets/eb7ce923-970c-448a-8112-6f2da8136169" /> |

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user