### PR TITLE
10-7959a | Add Duty-to-Assist GA Event

### DIFF
--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -105,11 +105,13 @@ export default function transformForSubmit(
       return '10-7959a_resubmission_pdi_number';
     };
 
-    recordEvent({ event: getEventName() });
+    const recordDtaEvent =
+      form.data['view:champvaEnableClaimResubmitQuestion'] &&
+      form.data.claimStatus === 'resubmission' &&
+      form.data['view:hasClaimDocs'] === false;
 
-    if (form.data['view:hasClaimDocs'] === false) {
-      recordEvent({ event: '10-7959a_duty_to_assist' });
-    }
+    if (recordDtaEvent) recordEvent({ event: '10-7959a_duty_to_assist' });
+    recordEvent({ event: getEventName() });
   }
 
   return JSON.stringify({

--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -106,6 +106,10 @@ export default function transformForSubmit(
     };
 
     recordEvent({ event: getEventName() });
+
+    if (form.data['view:hasClaimDocs'] === false) {
+      recordEvent({ event: '10-7959a_duty_to_assist' });
+    }
   }
 
   return JSON.stringify({

--- a/src/applications/ivc-champva/10-7959a/tests/unit/config/transformers.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959a/tests/unit/config/transformers.unit.spec.jsx
@@ -93,6 +93,20 @@ describe('Submit transformer', () => {
       });
     });
 
+    it('should fire duty to assist event when claim is resubmission and no claim docs are available', () => {
+      submitForm({
+        overrides: {
+          claimStatus: 'resubmission',
+          pdiOrClaimNumber: ID_NUMBER_OPTIONS[0],
+          'view:champvaEnableClaimResubmitQuestion': true,
+          'view:hasClaimDocs': false,
+        },
+      });
+      sinon.assert.calledWithExactly(recordEventStub.firstCall, {
+        event: '10-7959a_duty_to_assist',
+      });
+    });
+
     it('should not fire recordEvent when disableAnalytics is true', () => {
       submitForm({ overrides: { claimStatus: 'new' }, disableAnalytics: true });
       sinon.assert.notCalled(recordEventStub);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR introduces an additional event tracking step to the form submission process. Now, when the user indicates they do not have claim documents, a specific analytics event is recorded for improved tracking.

Analytics enhancement:

* Added logic to record the `'10-7959a_duty_to_assist'` event when the user selects they do not have claim documents on the form.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#135931

## Testing done

- N/A

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Acceptance criteria

- Event tracks when feature is enabled

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
