### PR TITLE
update meds card for initial fill in progress (Scenario 5)

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -40,9 +40,10 @@ const MedicationsListCard = ({ rx }) => {
   const isManagementImprovements = useSelector(
     selectMedicationsManagementImprovementsFlag,
   );
-  const isRefillInProgress =
+  const isFillInProgress =
     rx.dispStatus === DISPENSE_STATUS.ACTIVE_REFILL_IN_PROCESS ||
     rx.dispStatus === DISPENSE_STATUS.ACTIVE_SUBMITTED;
+  const isInitialFill = isFillInProgress && !rx.sortedDispensedDate;
   const isOracleHealthCutoverEnabled = useSelector(
     selectMhvMedicationsOracleHealthCutoverFlag,
   );
@@ -105,15 +106,15 @@ const MedicationsListCard = ({ rx }) => {
     return (
       <>
         {isManagementImprovements &&
-          isRefillInProgress && (
+          isFillInProgress && (
             <div
               className="vads-u-display--flex vads-u-align-items--center vads-u-background-color--green-lightest vads-u-padding--1 vads-u-margin-top--1"
-              data-testid="refill-in-progress-alert"
+              data-testid="fill-in-progress-alert"
               role="status"
             >
               <va-icon icon="schedule" size={3} aria-hidden="true" />
               <p className="vads-u-margin-y--0 vads-u-margin-left--1">
-                Refill in progress.{' '}
+                {isInitialFill ? 'Fill' : 'Refill'} in progress.{' '}
                 <Link to={medicationsUrls.MEDICATIONS_IN_PROGRESS}>
                   Go to in-progress medications
                 </Link>
@@ -121,8 +122,7 @@ const MedicationsListCard = ({ rx }) => {
             </div>
           )}
         {rx &&
-          (rx.isRefillable ||
-            (isManagementImprovements && isRefillInProgress)) &&
+          (rx.isRefillable || (isManagementImprovements && isFillInProgress)) &&
           rx.refillRemaining >= 0 && (
             <p
               className="vads-u-margin-bottom--0"
@@ -175,7 +175,7 @@ const MedicationsListCard = ({ rx }) => {
             />
           )}
         {rx &&
-          !(isManagementImprovements && isRefillInProgress) && (
+          !(isManagementImprovements && isFillInProgress) && (
             <ExtraDetails
               {...rx}
               page={pageType.LIST}

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
@@ -194,7 +194,7 @@ describe('Medication card component', () => {
         isRefillable: false,
       };
       const { getByTestId, getByText } = setup(rx, managementImprovementsState);
-      expect(getByTestId('refill-in-progress-alert')).to.exist;
+      expect(getByTestId('fill-in-progress-alert')).to.exist;
       const link = getByText('Go to in-progress medications');
       expect(link).to.have.attribute(
         'href',
@@ -209,7 +209,7 @@ describe('Medication card component', () => {
         isRefillable: false,
       };
       const { getByTestId, getByText } = setup(rx, managementImprovementsState);
-      expect(getByTestId('refill-in-progress-alert')).to.exist;
+      expect(getByTestId('fill-in-progress-alert')).to.exist;
       const link = getByText('Go to in-progress medications');
       expect(link).to.have.attribute(
         'href',
@@ -230,6 +230,94 @@ describe('Medication card component', () => {
       );
     });
 
+    it('shows "Fill in progress" text for initial fill with "Active: Refill in Process"', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Refill in Process',
+        isRefillable: false,
+        sortedDispensedDate: null,
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByTestId('fill-in-progress-alert')).to.exist;
+      expect(getByText(/Fill in progress\./)).to.exist;
+      const link = getByText('Go to in-progress medications');
+      expect(link).to.have.attribute(
+        'href',
+        medicationsUrls.MEDICATIONS_IN_PROGRESS,
+      );
+    });
+
+    it('shows "Fill in progress" text for initial fill with "Active: Submitted"', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Submitted',
+        isRefillable: false,
+        sortedDispensedDate: null,
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByTestId('fill-in-progress-alert')).to.exist;
+      expect(getByText(/Fill in progress\./)).to.exist;
+      const link = getByText('Go to in-progress medications');
+      expect(link).to.have.attribute(
+        'href',
+        medicationsUrls.MEDICATIONS_IN_PROGRESS,
+      );
+    });
+
+    it('shows "Not filled yet" for initial fill in progress', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Refill in Process',
+        isRefillable: false,
+        sortedDispensedDate: null,
+        refillRemaining: 3,
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByText(/Fill in progress\./)).to.exist;
+      expect(getByTestId('active-not-filled-rx')).to.have.text(
+        'Not filled yet',
+      );
+    });
+
+    it('shows "Refills left" for initial fill in progress', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Submitted',
+        isRefillable: false,
+        sortedDispensedDate: null,
+        refillRemaining: 3,
+      };
+      const { getByTestId } = setup(rx, managementImprovementsState);
+      expect(getByTestId('rx-refill-remaining')).to.have.text(
+        'Refills left: 3',
+      );
+    });
+
+    it('shows "Refill in progress" (not "Fill") when previously dispensed', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Refill in Process',
+        isRefillable: false,
+        sortedDispensedDate: '2026-01-05T05:00:00.000Z',
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByTestId('fill-in-progress-alert')).to.exist;
+      expect(getByText(/Refill in progress\./)).to.exist;
+    });
+
+    it('shows "Last filled on" date for refill in progress', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Refill in Process',
+        isRefillable: false,
+        sortedDispensedDate: '2026-01-05T05:00:00.000Z',
+        refillRemaining: 3,
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByText(/Refill in progress\./)).to.exist;
+      expect(getByTestId('rx-last-filled-date')).to.exist;
+    });
+
     it('hides ExtraDetails for refill-in-progress prescriptions', () => {
       const rx = {
         ...prescriptionsListItem,
@@ -240,19 +328,19 @@ describe('Medication card component', () => {
       expect(container.querySelector('.shipping-info')).to.be.null;
     });
 
-    it('does not show refill-in-progress alert for Active status', () => {
+    it('does not show fill-in-progress alert for Active status', () => {
       const rx = {
         ...prescriptionsListItem,
         isRefillable: true,
         dispStatus: 'Active',
       };
       const { queryByTestId } = setup(rx, managementImprovementsState);
-      expect(queryByTestId('refill-in-progress-alert')).to.be.null;
+      expect(queryByTestId('fill-in-progress-alert')).to.be.null;
     });
   });
 
   describe('when mhvMedicationsManagementImprovements flag is disabled', () => {
-    it('does not show refill-in-progress alert and shows original layout', () => {
+    it('does not show fill-in-progress alert and shows original layout', () => {
       const rx = {
         ...prescriptionsListItem,
         dispStatus: 'Active: Refill in Process',
@@ -260,7 +348,7 @@ describe('Medication card component', () => {
         prescriptionNumber: '12345',
       };
       const { queryByTestId, getByTestId } = setup(rx);
-      expect(queryByTestId('refill-in-progress-alert')).to.be.null;
+      expect(queryByTestId('fill-in-progress-alert')).to.be.null;
       expect(getByTestId('rx-number')).to.exist;
       expect(getByTestId('rxStatus')).to.exist;
     });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Implements Scenario 5 — "A new prescription with the initial fill in progress" for the MHV Medications List Card component.
When a prescription has dispStatus of Active: Refill in Process or Active: Submitted and has no sortedDispensedDate, the card now displays "Fill in progress." instead of "Refill in progress."
- The existing isRefillInProgress variable was renamed to isFillInProgress to reflect that it covers both initial fills and refills. A new isInitialFill derived boolean drives the conditional text.
- The data-testid was updated from refill-in-progress-alert to fill-in-progress-alert to reflect the broader scope.
- Gated behind the existing mhvMedicationsManagementImprovements feature flag.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#135866

## Testing done
- Old behavior: All prescriptions with Active: Refill in Process or Active: Submitted status showed "Refill in progress." regardless of whether they had ever been dispensed.
- New behavior: Prescriptions that have never been dispensed sortedDispensedDate now show "Fill in progress." instead of "Refill in progress." Previously dispensed prescriptions continue to show "Refill in progress."
- Steps to verify:
             - Enable the mhv_medications_management_improvements feature flag in local mock toggles
             - Set a mock prescription's dispStatus to "Active: Refill in Process" (or "Active: Submitted"), isRefillable to false, and sortedDispensedDate to nil
             - Navigate to the Medications History page (/my-health/medications)
             - Confirm the card shows: green background alert with clock icon, "Fill in progress." text with "Go to in-progress medications" link, "Refills left: N", and last filled date
             - Confirm ExtraDetails (expected fill date, pharmacy phone) is not rendered
             - Confirm the "Go to in-progress medications" link navigates to /my-health/medications/in-progress
             - Confirm the same behavior applies for dispStatus: "Active: Submitted".
             - Disable the feature flag and confirm the card renders with the original layout (status label, prescription number, ExtraDetails all visible)
- 7 unit tests added under describe('when mhvMedicationsManagementImprovements flag is enabled' in MedicationsListCard.unit.spec.jsx

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop  |  <img width="285" height="151" alt="Screenshot 2026-03-11 at 11 54 50 AM" src="https://github.com/user-attachments/assets/4808c987-13b6-422e-afff-bc37b20c6d52" />  |    <img width="317" height="109" alt="Screenshot 2026-03-11 at 11 55 50 AM" src="https://github.com/user-attachments/assets/77355543-56b1-4c44-93ce-e001e54b521f" />   |
| Desktop |   <img width="359" height="154" alt="Screenshot 2026-03-11 at 11 46 06 AM" src="https://github.com/user-attachments/assets/20d7cd68-6768-4fd5-aba8-6abbe67af4c5" />  |   <img width="329" height="109" alt="Screenshot 2026-03-11 at 11 39 53 AM" src="https://github.com/user-attachments/assets/0d206d2a-1d83-4f4c-9958-c4fac4022995" /> |

## What areas of the site does it impact?
- MHV Medications History page (/my-health/medications) only. Changes are scoped to the MedicationsListCard component and only activate behind the mhv_medications_management_improvements feature flag.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
