### PR TITLE
VEBT-4902: 22-0839 - Implement updated revised instuctions for YRP

### DIFF
--- a/src/applications/edu-benefits/0839/components/YellowRibbonInstructionsPage.jsx
+++ b/src/applications/edu-benefits/0839/components/YellowRibbonInstructionsPage.jsx
@@ -10,11 +10,9 @@ const YellowRibbonInstructionsPage = () => {
   }, []);
 
   return (
-    <div className="form-22-0839-container row">
-      <div className="vads-u-padding-x--1">
-        <Breadcrumbs />
-      </div>
-      <div className="usa-width-two-thirds vads-u-margin-bottom--4">
+    <div className="form-22-0839-container row vads-u-padding-x--2 desktop:vads-u-padding-x--0">
+      <Breadcrumbs />
+      <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
         <h1>Instructions for completing the Yellow Ribbon Program agreement</h1>
 
         <p className="vads-u-margin-top--2">

--- a/src/applications/edu-benefits/0839/components/YellowRibbonInstructionsPage.jsx
+++ b/src/applications/edu-benefits/0839/components/YellowRibbonInstructionsPage.jsx
@@ -23,6 +23,23 @@ const YellowRibbonInstructionsPage = () => {
           any inquiries.
         </p>
 
+        <p>
+          In support of VA’s modernization and paperless initiatives, the Yellow
+          Ribbon Agreement (VA Form 22-0839) is now fully digital. VA no longer
+          accepts email submissions to the Yellow Ribbon Mailbox; instead,
+          institutions must submit agreements through the official online tool.
+          Historically, School Certifying Officials completed the form, obtained
+          an authorized electronic or wet signature, and submitted it to the
+          Yellow Ribbon mailbox. The digital form no longer allows for joint
+          processing by both the SCO and an authorizing official. Consequently,
+          schools must establish internal concurrence procedures if a SCO acts
+          as the Authorizing Official. Please note that the person completing
+          this form will now sign and submit it digitally as the Authorizing
+          Official. This agreement must be signed by an official with the legal
+          authority to bind the institution to the VA. Authenticating with ID.me
+          or LOGIN.GOV serves as your official electronic signature.
+        </p>
+
         <h2 className="vads-u-margin-top--3">General eligibility</h2>
         <p>
           The institution must be an Institution of Higher Learning (IHL) that
@@ -31,33 +48,41 @@ const YellowRibbonInstructionsPage = () => {
           campus of such institution located outside of the United States.
           Foreign schools are eligible to participate as of August 1, 2021.
         </p>
+        <p className="vads-u-color--secondary-dark">
+          <strong>Note:</strong> Foreign schools may apply for or modify VA
+          Yellow Ribbon Program agreements annually from June 1st to July 31st.
+          VA will provide official guidance and application instructions on June
+          1st. Please check our announcement page for updates.
+        </p>
 
         <h2 className="vads-u-margin-top--3">Name, title, and facility code</h2>
         <p>
           Enter your first and last name, official title at your institution,
           and your school’s facility code. You can also select any branch
-          campuses or extension schools you want to include in this Yellow
-          Ribbon Program agreement.
+          campuses you want to include in this Yellow Ribbon Program agreement.
         </p>
         <p>
-          <strong>Note:</strong> Any location with an "X" as the third character
-          in its facility code will not be included in this agreement.
+          <strong>Note:</strong> Locations with an ‘X’ as the third character of
+          their facility code are excluded from this agreement, as extension
+          campuses mirror the main institution’s contributions.
         </p>
 
         <h2 className="vads-u-margin-top--3">Select your agreement type</h2>
         <p className="vads-u-margin-bottom--0">
           Choose one of the following options:
         </p>
-        <ul className="vads-u-margin-y--1">
-          <li>Start a new open-ended agreement</li>
-          <li>Modify an existing agreement</li>
-        </ul>
+        <p className="vads-u-margin-y--1">
+          • Start a new open-ended agreement
+          <br />• Modify an existing agreement
+          <br />
+          <strong>Note:</strong> Both require completion of the entire form.
+        </p>
         <p className="vads-u-margin-top--0">
-          Both of these options will require you to complete the entire form.
-          <br /> If you are withdrawing from the Yellow Ribbon Program
-          agreement, you will only need to provide your first and last name,
-          official title, your school’s facility code, and any additional
-          locations you want to withdraw.
+          • Withdraw from Yellow Ribbon agreement
+          <br />
+          <strong>Note:</strong> Requires your first and last name, official
+          title, facility code and any additional locations you want to
+          withdraw.
         </p>
 
         <h2 className="vads-u-margin-top--3">
@@ -81,7 +106,7 @@ const YellowRibbonInstructionsPage = () => {
         </p>
         <p className="vads-u-margin-top--0">
           Enter the academic year for which this agreement applies (e.g.,
-          2020-2021).
+          2020–2021).
           <br />
           <strong>Note:</strong> For VA purposes, an academic year runs from
           August 1 to July 31.
@@ -99,77 +124,73 @@ const YellowRibbonInstructionsPage = () => {
           For each specific Yellow Ribbon Program contribution, provide the
           following details:
         </p>
-        <div className="vads-u-border--1 vads-u-border-color--primary ">
-          <ul>
-            <li>
-              Maximum number of students: Enter the maximum number or unlimited
-              number of students your school will support.
-            </li>
-            <li>
-              Degree level: Indicate the applicable degree level (undergraduate,
-              graduate, doctoral, or all) for the specific contribution.
-            </li>
-            <li>
-              College or professional school: You may leave this blank, or
-              specify the sub-element of your institution (such as a college or
-              professional school) in which students must be enrolled to receive
-              the contribution.
-              <br />
-              Note: Do not list specific degree programs (e.g., Master of
-              Business Administration, Juris Doctorate, Bachelor of Science in
-              Nursing).
-            </li>
-            <li>
-              Maximum contribution amount: Enter the maximum annual contribution
-              amount per student, or the amount to pay toward remaining tuition
-              that the Post-9/11 GI Bill doesn’t cover (unlimited). Enter the
-              total amount your school plans to contribute each year, not by
-              term or credit hour. If the amount entered is over $99,999, the
-              system will treat it as an unlimited contribution.
-            </li>
-          </ul>
-        </div>
+        <ul>
+          <li>
+            Maximum number of students: Enter the maximum number or unlimited
+            number of students your school will support.
+          </li>
+          <li>
+            Degree level: Indicate the applicable degree level (undergraduate,
+            graduate, doctoral, or all) for the specific contribution.
+          </li>
+          <li>
+            College or professional school: You may leave this blank, or specify
+            the sub-element of your institution (such as a college or
+            professional school) in which students must be enrolled to receive
+            the contribution.
+            <br />
+            <strong>Note:</strong> Do not list specific degree programs (e.g.,
+            Master of Business Administration, Juris Doctorate, Bachelor of
+            Science in Nursing).
+          </li>
+          <li>
+            Maximum contribution amount: Enter the maximum annual contribution
+            amount per student, or the amount to pay toward remaining tuition
+            that the Post-9/11 GI Bill doesn’t cover (unlimited). Enter the
+            total amount your school plans to contribute each year, not by term
+            or credit hour. If the amount entered is over $99,999, the system
+            will treat it as an unlimited contribution.
+          </li>
+        </ul>
 
         <h2 className="vads-u-margin-top--3">
-          Foreign schools only - Provide contribution details
+          Foreign schools only – Provide contribution details
         </h2>
         <p>
           For each Yellow Ribbon Program contribution, provide the following
           information:
         </p>
-        <div className="vads-u-border--1 vads-u-border-color--primary">
-          <ul>
-            <li>
-              Maximum number of students: Enter the maximum number of eligible
-              students. If your institution will offer contributions to an
-              unlimited number of qualifying students, enter "unlimited."
-            </li>
-            <li>
-              Degree level: Indicate the applicable degree level (undergraduate,
-              graduate, doctoral, or all).
-              <br />
-              Note: You may not list specific degree programs (e.g., Master of
-              Business Administration, Juris Doctorate, Bachelor of Science in
-              Nursing).
-            </li>
-            <li>
-              Currency used by school’s billing system: Specify the currency
-              used for student billing. You may use the currency’s official name
-              or its ISO 4217 code.
-              <br />
-              Example: European Euro or EUR
-            </li>
-            <li>
-              Maximum contribution amount: Enter the maximum annual contribution
-              amount per student, or the amount to pay toward remaining tuition
-              that the Post-9/11 GI Bill doesn’t cover (unlimited). Enter the
-              total amount your school plans to contribute each year in your
-              institution’s official billing currency, not by term or credit
-              hour. If the amount entered is over $99,999 USD, the system will
-              treat it as an unlimited contribution.
-            </li>
-          </ul>
-        </div>
+        <ul>
+          <li>
+            Maximum number of students: Enter the maximum number of eligible
+            students. If your institution will offer contributions to an
+            unlimited number of qualifying students, enter "unlimited."
+          </li>
+          <li>
+            Degree level: Indicate the applicable degree level (undergraduate,
+            graduate, doctoral, or all).
+            <br />
+            <strong>Note:</strong> You may not list specific degree programs
+            (e.g., Master of Business Administration, Juris Doctorate, Bachelor
+            of Science in Nursing).
+          </li>
+          <li>
+            Currency used by school’s billing system: Specify the currency used
+            for student billing. You may use the currency’s official name or its
+            ISO 4217 code.
+            <br />
+            Example: European Euro or EUR
+          </li>
+          <li>
+            Maximum contribution amount: Enter the maximum annual contribution
+            amount per student, or the amount to pay toward remaining tuition
+            that the Post-9/11 GI Bill doesn’t cover (unlimited). Enter the
+            total amount your school plans to contribute each year in your
+            institution’s official billing currency, not by term or credit hour.
+            If the amount entered is over $99,999 USD, the system will treat it
+            as an unlimited contribution.
+          </li>
+        </ul>
         <p className="vads-u-margin-top--2">
           You must report your contributions in the official currency of record
           for your institution—not in U.S. dollars. The VA will convert this
@@ -185,13 +206,13 @@ const YellowRibbonInstructionsPage = () => {
           Include contact information for the following individuals at your
           institution (first name, last name, phone number, and email address):
         </p>
-        <div className="vads-u-border--1 vads-u-border-color--primary">
-          <ul>
-            <li>Yellow Ribbon Program Point of Contact</li>
-            <li>School’s financial representative</li>
-            <li>School Certifying Official (SCO)</li>
-          </ul>
-        </div>
+        <ul>
+          <li>
+            Yellow Ribbon Program Point of Contact/School’s Financial
+            Representative
+          </li>
+          <li>School Certifying Official (SCO)</li>
+        </ul>
         <p>
           This information ensures VA can reach the appropriate contacts
           regarding your institution’s Yellow Ribbon Program participation.
@@ -201,17 +222,11 @@ const YellowRibbonInstructionsPage = () => {
           Signature of authorizing official
         </h2>
         <p>
-          The individual signing this agreement must be legally authorized to
-          bind your institution to the terms of this agreement with the VA. You
-          must also provide their title, phone number, and the date of
-          signature. Agreements will not be processed without a valid
-          authorizing signature.
-        </p>
-        <p>
-          By signing this agreement, your institution certifies that, as of the
-          date signed, at least one VA-approved program at your institution
-          charges tuition and/or fees that exceed the maximum amounts payable in
-          your state or territory under the Post-9/11 GI Bill.
+          This form must be completed by an official who is legally authorized
+          to bind the institution to this agreement with VA. The authentication
+          of the submitter is documented through ID.me or LOGIN.GOV Schools must
+          establish their own internal processes for concurrence if a School
+          Certifying Official (SCO) is submitting as the Authorizing Official.
         </p>
 
         <h2 className="vads-u-margin-top--3">Submitting your completed form</h2>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- In edu form 22-0839 update markup on instructions page to match latest designs
- Add responsive margin for mobile

## Related issue(s)
https://jira.devops.va.gov/browse/VEBT-4902

## Testing done
<img width="1437" height="489" alt="Screenshot 2026-03-12 at 12 47 24 PM" src="https://github.com/user-attachments/assets/cf6c0cec-c335-443b-8ee3-b126ad8ebefa" />


## Screenshots

### Before
<img width="681" height="299" alt="Screenshot 2026-03-12 at 12 48 24 PM" src="https://github.com/user-attachments/assets/f597895d-3eda-4a64-bb45-19f36b6642a6" />
|
<img width="709" height="692" alt="Screenshot 2026-03-12 at 12 50 27 PM" src="https://github.com/user-attachments/assets/1647f0d4-b760-4559-bbe1-958cbcc97cc9" />
|
<img width="675" height="576" alt="Screenshot 2026-03-12 at 12 54 05 PM" src="https://github.com/user-attachments/assets/0cae757c-5e86-4a81-9629-b57dff312e68" />
|
<img width="679" height="525" alt="Screenshot 2026-03-12 at 1 26 00 PM" src="https://github.com/user-attachments/assets/2e66e011-a638-4848-aa21-db2a3c624dc0" />
|
<img width="759" height="698" alt="Screenshot 2026-03-12 at 1 26 19 PM" src="https://github.com/user-attachments/assets/feb74ff0-87f4-4e78-883c-17bd687c9ca0" />

### After
<img width="683" height="620" alt="Screenshot 2026-03-12 at 12 48 46 PM" src="https://github.com/user-attachments/assets/f17ec4c9-0126-4783-877a-0b9c0514f590" />
|
<img width="639" height="850" alt="Screenshot 2026-03-12 at 12 50 51 PM" src="https://github.com/user-attachments/assets/c36a8805-0161-47b2-aaf1-de9895c7df48" />
|
<img width="616" height="535" alt="Screenshot 2026-03-12 at 12 53 49 PM" src="https://github.com/user-attachments/assets/55021e1e-3dc0-4b4b-b8a1-7964a14525fc" />
|
<img width="672" height="538" alt="Screenshot 2026-03-12 at 1 24 42 PM" src="https://github.com/user-attachments/assets/3eb7ea85-754e-4698-b6a7-4111a34782fd" />
|
<img width="666" height="585" alt="Screenshot 2026-03-12 at 1 25 05 PM" src="https://github.com/user-attachments/assets/16ca5cec-2a8c-4115-9a10-9c7f365772e8" />

## What areas of the site does it impact?
edu-benefits/0839

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA