### PR TITLE
[Disability Benefits] Enhance BDD flow validations and UI messages

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -738,7 +738,8 @@ const formConfig = {
           title:
             'Supporting documents and additional forms for your disability claim',
           depends: formData =>
-            formData.disability526SupportingEvidenceEnhancement,
+            formData.disability526SupportingEvidenceEnhancement &&
+            !isBDD(formData),
           // TODO: update this path to `'supporting-evidence/additional-evidence', once we can get rid of `additionalDocuments` page
           path: 'supporting-evidence/additional-evidence-intro',
           CustomPage: AdditionalEvidenceIntroPage,

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'platform/utilities/data';
 import { DATA_PATHS } from '../constants';
-import { getBddShaUploads, isUploadingBddSha } from '../utils';
+import { getBddShaUploads, isUploadingBddSha, isBDD } from '../utils';
 
 const SECTION_CONFIGURATIONS = {
   'bdd-sha-uploads': {
@@ -15,6 +15,14 @@ const SECTION_CONFIGURATIONS = {
         : 'We’ll submit the Separation Health Assessment Part A document that you uploaded',
   },
 };
+
+const NO_EVIDENCE_MESSAGE = (
+  <p>
+    You haven’t uploaded any evidence. This may delay us processing your claim.
+    In addition, we may also schedule a claim exam for you to help us decide
+    your claim.
+  </p>
+);
 
 const SECTION_ORDERS = {
   UNENHANCED: [
@@ -110,21 +118,39 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
     formData,
     false,
   );
+  const hasSeparationHealthAssessment = _.get(
+    'view:hasSeparationHealthAssessment',
+    formData,
+    false,
+  );
+  // Legacy/non-enhanced flow: show NO_EVIDENCE_MESSAGE when either
+  // - there's truly no evidence, or
+  // - the user explicitly chose "no" for evidence and STR, even if stale uploads remain
+  const legacyNoEvidence =
+    !formData.disability526SupportingEvidenceEnhancement &&
+    !sectionsList.length &&
+    (!evidenceLength ||
+      (!selectedEvidence && !serviceTreatmentRecordsSelected));
+
+  // Enhanced, non-BDD flow: show NO_EVIDENCE_MESSAGE only when there is truly no evidence
+  const enhancedNoEvidenceNonBdd =
+    formData.disability526SupportingEvidenceEnhancement &&
+    !isBDD(formData) &&
+    !evidenceLength &&
+    !selectedEvidence &&
+    !serviceTreatmentRecordsSelected &&
+    !sectionsList.length;
+
+  const bddBothSubmitLater =
+    isBDD(formData) &&
+    selectedEvidence === false &&
+    serviceTreatmentRecordsSelected === false &&
+    !hasSeparationHealthAssessment;
   // Evidence isn't always properly cleared out from form data if removed so
   // need to also check that 'no evidence' was explicitly selected
   // TODO: refactor logic for this content when removing current flow
-  if (
-    !formData.disability526SupportingEvidenceEnhancement &&
-    !sectionsList.length &&
-    (!evidenceLength || (!selectedEvidence && !serviceTreatmentRecordsSelected))
-  ) {
-    return (
-      <p>
-        You haven’t uploaded any evidence. This may delay us processing your
-        claim. In addition, we may also schedule a claim exam for you to help us
-        decide your claim.
-      </p>
-    );
+  if (legacyNoEvidence) {
+    return NO_EVIDENCE_MESSAGE;
   }
 
   let vaContent = null;
@@ -264,7 +290,10 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
 
   return (
     <div className="vads-u-margin-top--3">
-      {(evidenceLength || selectedEvidence || sectionsList.length) &&
+      {(bddBothSubmitLater || enhancedNoEvidenceNonBdd) && NO_EVIDENCE_MESSAGE}
+      {!bddBothSubmitLater &&
+        !enhancedNoEvidenceNonBdd &&
+        (evidenceLength || selectedEvidence || sectionsList.length > 0) &&
         formData.disability526SupportingEvidenceEnhancement && (
           <p>You provided documents to support your claim.</p>
         )}

--- a/src/applications/disability-benefits/all-claims/tests/config/supportingEvidencePages.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/config/supportingEvidencePages.unit.spec.jsx
@@ -35,6 +35,8 @@ describe('Supporting Evidence Pages - Conditional Rendering', () => {
     evidenceTypes,
     evidenceRequest,
     medicalRecords,
+    evidenceTypesBDD,
+    evidenceChoiceIntro,
   } = formConfig.chapters.supportingEvidence.pages;
 
   describe('evidenceTypes depends', () => {
@@ -98,6 +100,35 @@ describe('Supporting Evidence Pages - Conditional Rendering', () => {
         'view:hasEvidence': true,
       });
       expect(medicalRecords.depends(formData)).to.be.false;
+    });
+  });
+
+  describe('evidenceTypesBDD depends', () => {
+    it('should return true for BDD users', () => {
+      const formData = createBDDFormData();
+      expect(evidenceTypesBDD.depends(formData)).to.be.true;
+    });
+
+    it('should return false for non-BDD users', () => {
+      const formData = createLegacyFlowFormData();
+      expect(evidenceTypesBDD.depends(formData)).to.be.false;
+    });
+  });
+
+  describe('evidenceChoiceIntro depends', () => {
+    it('should return true for non-BDD enhancement flow users', () => {
+      const formData = createEnhancementFlowFormData();
+      expect(evidenceChoiceIntro.depends(formData)).to.be.true;
+    });
+
+    it('should return false for BDD enhancement flow users', () => {
+      const formData = createBDDFormData(createEnhancementFlowFormData());
+      expect(evidenceChoiceIntro.depends(formData)).to.be.false;
+    });
+
+    it('should return false for legacy flow users', () => {
+      const formData = createLegacyFlowFormData();
+      expect(evidenceChoiceIntro.depends(formData)).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -128,6 +128,82 @@ describe('Summary of Evidence', () => {
     form.unmount();
   });
 
+  it("should render 'no evidence' warning in legacy flow when both evidence and STR toggles are false and no evidence", () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          disability526SupportingEvidenceEnhancement: false,
+          'view:hasEvidence': false,
+          'view:uploadServiceTreatmentRecordsQualifier': {
+            'view:hasServiceTreatmentRecordsToUpload': false,
+          },
+        }}
+      />,
+    );
+
+    expect(form.render().text()).to.contain(
+      'You haven’t uploaded any evidence.',
+    );
+    expect(form.find('li').length).to.equal(0);
+    form.unmount();
+  });
+
+  it("should render 'no evidence' warning in enhanced non-BDD flow when there is truly no evidence", () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          disability526SupportingEvidenceEnhancement: true,
+          'view:hasEvidence': false,
+          'view:uploadServiceTreatmentRecordsQualifier': {
+            'view:hasServiceTreatmentRecordsToUpload': false,
+          },
+        }}
+      />,
+    );
+
+    const text = form.render().text();
+    expect(text).to.contain(
+      'Summary of supporting evidence for your disability claim',
+    );
+    expect(text).to.contain('You haven’t uploaded any evidence.');
+    expect(text).to.not.contain(
+      'You provided documents to support your claim.',
+    );
+    form.unmount();
+  });
+
+  it("should render 'no evidence' warning in BDD enhanced flow when both evidence and STR toggles are false", () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:isBddData': true,
+          disability526SupportingEvidenceEnhancement: true,
+          'view:hasEvidence': false,
+          'view:uploadServiceTreatmentRecordsQualifier': {
+            'view:hasServiceTreatmentRecordsToUpload': false,
+          },
+          serviceInformation: bddServiceInformation,
+        }}
+      />,
+    );
+
+    const text = form.render().text();
+    expect(text).to.contain('You haven’t uploaded any evidence.');
+    expect(text).to.not.contain(
+      'You provided documents to support your claim.',
+    );
+    form.unmount();
+  });
+
   it('should not render any evidence whose evidence type was not selected', () => {
     const form = mount(
       <DefinitionTester
@@ -357,6 +433,7 @@ describe('Summary of Evidence', () => {
           'view:isBddData': true,
           serviceInformation: bddServiceInformation,
           'view:hasSeparationHealthAssessment': true,
+          'view:hasEvidence': true,
           separationHealthAssessmentUploads,
         }}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.jsx
@@ -907,6 +907,50 @@ describe('526 All Claims validations', () => {
 
       expect(fixtures.wrappedValidator.calledOnce).to.be.true;
     });
+
+    it('should not call wrappedValidator in BDD enhancement flow when view:hasEvidence is false', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        'view:isBddData': true,
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasEvidence': false,
+        serviceInformation: {
+          servicePeriods: [
+            {
+              dateRange: {
+                to: daysFromToday(120),
+              },
+            },
+          ],
+        },
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.called).to.be.false;
+    });
+
+    it('should call wrappedValidator in BDD enhancement flow when view:hasEvidence is true', () => {
+      const fixtures = createTestFixtures();
+      const formData = {
+        'view:isBddData': true,
+        disability526SupportingEvidenceEnhancement: true,
+        'view:hasEvidence': true,
+        serviceInformation: {
+          servicePeriods: [
+            {
+              dateRange: {
+                to: daysFromToday(120),
+              },
+            },
+          ],
+        },
+      };
+
+      callValidateIfHasEvidence(formData, fixtures);
+
+      expect(fixtures.wrappedValidator.calledOnce).to.be.true;
+    });
   });
 
   describe('validateMedicalRecordsAtLeastOne', () => {

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -20,6 +20,7 @@ import {
   claimingRated,
   showSeparationLocation,
   sippableId,
+  isBDD,
   isEvidenceEnhancement,
 } from './utils';
 
@@ -216,13 +217,14 @@ export function validateMilitaryTreatmentState(
 
 /**
  * Whether the user has indicated they have evidence (gate for evidence-type validations).
- * In enhancement flow uses view:hasMedicalRecords; in legacy flow uses view:hasEvidence.
+ * In enhancement flow uses view:hasMedicalRecords (non-BDD) or view:hasEvidence (BDD);
+ * in legacy flow uses view:hasEvidence.
  *
  * @param {Object} formData - Full formData
  * @returns {boolean}
  */
 const getHasEvidence = formData =>
-  isEvidenceEnhancement(formData)
+  isEvidenceEnhancement(formData) && !isBDD(formData)
     ? _.get('view:hasMedicalRecords', formData, true)
     : _.get('view:hasEvidence', formData, true);
 
@@ -689,7 +691,7 @@ export const validateSeparationDate = (
   currentIndex,
   appStateData,
 ) => {
-  const { isBDD, servicePeriods = [] } = appStateData;
+  const { isBDD: isBDDClaim, servicePeriods = [] } = appStateData;
   const branch = servicePeriods[currentIndex]?.serviceBranch || '';
 
   // Parse the date first to validate it
@@ -713,7 +715,7 @@ export const validateSeparationDate = (
 
   // Check if date is more than 180 days in the future (applies to both BDD and non-BDD)
   if (isAfter(separationDate, add(today, { days: 180 }))) {
-    if (isBDD) {
+    if (isBDDClaim) {
       errors.addError(
         'Your separation date must be before 180 days from today',
       );
@@ -723,7 +725,7 @@ export const validateSeparationDate = (
       );
     }
   } else if (
-    !isBDD &&
+    !isBDDClaim &&
     !isReserves &&
     isAfter(separationDate, add(today, { days: 90 }))
   ) {


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Updated validation logic to differentiate between BDD and non-BDD enhancement flows
  - Modified the `getHasEvidence` function to ensure correct evidence checks based on BDD status
  - Improved conditional rendering of evidence messages in the summary component
  - Added unit tests to cover new BDD-specific scenarios and ensure proper validation behavior
  - Refactored related components to maintain clarity and functionality across different claim types
- _(If bug, how to reproduce)_
  - With the [disability_526_supporting_evidence_enhancement](https://staging-api.va.gov/flipper/features/disability_526_supporting_evidence_enhancement) feature toggled on
  - Begin a BDD claim
  - Fill out the form up until `/supporting-evidence/evidence-types-bdd`
  - Click "Continue"
- _(What is the solution, why is this the solution)_
  - Split validation and routing based on BDD + enhancement flags so BDD “submit later” flows navigate correctly and the summary shows either “no evidence” or “you provided documents” in the right cases
  - Matches real user paths (BDD vs. non-BDD, submit now vs. later), avoids stale data showing as real evidence, and is guarded by new unit tests to prevent regressions
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - 🌊 Disability Benefits Pathways team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - [disability_526_supporting_evidence_enhancement](https://staging-api.va.gov/flipper/features/disability_526_supporting_evidence_enhancement) 

## Related issue(s)

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/135353

## Testing done

- _Describe what the old behavior was prior to the change_
  - With the [disability_526_supporting_evidence_enhancement](https://staging-api.va.gov/flipper/features/disability_526_supporting_evidence_enhancement) feature toggled on
  - When filling out a BDD claim
  - If no evidence is provided
  - Clicking "Continue" has no effect, and in particular, does not continue to the "Summary of evidence" page
- _Describe the steps required to verify your changes are working as expected_
  - **DD, enhancement ON, submit later flow**
    - Enable [disability_526_supporting_evidence_enhancement](https://staging-api.va.gov/flipper/features/disability_526_supporting_evidence_enhancement) 
    - Start a BDD claim, proceed to `/supporting-evidence/evidence-types-bdd`
    - Select “No, I will submit more information later” and Continue
    - Verify you land on `/supporting-evidence/summary` and see the “no evidence” message (not “You provided documents…”).
  - **BDD, enhancement ON, evidence provided**
    - In the same flow, select “Yes” and upload at least one evidence type (or SHA A / STR where appropriate)
    - Continue to the summary page
    - Verify you do not see the “no evidence” message and do see “You provided documents to support your claim.”
  - **Non-BDD, enhancement OFF, no evidence**
    - With enhancement off, start a non-BDD claim
    - Answer “No” for both evidence and STR, without uploading anything
    - Verify the summary page shows the “no evidence” message and no evidence list items
- _Describe the tests completed and the results_
  - **Unit tests:** Ran `validations.unit.spec.jsx`, `supportingEvidencePages.unit.spec.jsx`, and `summaryOfEvidence.unit.spec.jsx`
    - **Result:** All updated and existing tests pass, including new BDD/enhancement and no‑evidence scenarios
  - **Behavioral coverage:** Tests now cover:
    - BDD vs. non‑BDD validation for `view:hasEvidence`
    - Supporting evidence page gating for enhancement vs. legacy flows
    - Summary page messaging for “no evidence” vs. “you provided documents” across legacy, enhanced, and SHA A cases

## Screenshots

|         | Before (unresponsive on continue) | After (routes to evidence summary) |
| ------- | ------ | ----- |
| BDD + enhancement ON without evidence | <img width="349" height="647" alt="Screenshot 2026-03-12 at 4 53 24 PM" src="https://github.com/user-attachments/assets/52d322e1-5420-4462-bbef-07472868acc2" /> | <img width="307" height="508" alt="Screenshot 2026-03-12 at 4 48 35 PM" src="https://github.com/user-attachments/assets/ee44cb87-5e6c-4697-9094-0834c33dcc4f" /> |

## What areas of the site does it impact?

Supporting evidence section of Form 526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user