### PR TITLE
FDF: changes to support new confirmation text

### DIFF
--- a/src/applications/dependents/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/dependents/686c-674/containers/ConfirmationPage.jsx
@@ -55,7 +55,7 @@ export default function ConfirmationPage() {
           </p>
         </div>
         <div className="vads-u-margin-bottom--3">
-          <div className="dd-privacy-hidden">
+          <div>
             <strong>Date submitted</strong>
           </div>
           <p
@@ -95,24 +95,26 @@ export default function ConfirmationPage() {
         <Toggler.Enabled>
           {submissionId ? (
             <section>
-              <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2 save-a-copy">
+              <h2 className="vads-u-margin-top--3 vads-u-margin-bottom--2 save-a-copy">
                 Save a copy of your form
               </h2>
               <span>
                 You can open, download, or print a copy of your submitted form
                 now.
               </span>
-              <div className="vads-u-margin-top--1p5">
-                <va-link
-                  external
-                  text="Download or print the information you submitted"
-                  class="form-renderer"
-                  href={
-                    submissionId ? `/my-va/submissions/${submissionId}` : ''
-                  }
-                />
+              <div className="vads-u-margin-top--2">
+                <strong>
+                  <va-link
+                    external
+                    text="Download or print the information you submitted"
+                    class="form-renderer"
+                    href={
+                      submissionId ? `/my-va/submissions/${submissionId}` : ''
+                    }
+                  />
+                </strong>
               </div>
-              <div className="vads-u-margin-top--1p5">
+              <div className="vads-u-margin-top--2 vads-u-margin-bottom--3">
                 <strong>Note:</strong> You won't be able to access a copy of the
                 information you submitted once you leave this page.
               </div>

--- a/src/applications/dependents/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/dependents/686c-674/containers/ConfirmationPage.jsx
@@ -38,25 +38,37 @@ export default function ConfirmationPage() {
 
   const submissionBox = () => {
     return (
-      <va-summary-box class="vads-u-margin-top--4">
-        <h3 slot="headline">Your submission information</h3>
-        <p>
+      <div className="vads-u-margin-top--4">
+        <h2 slot="headline" className="save-a-copy">
+          Your submission information
+        </h2>
+        <div>
           <strong>Your name</strong>
-        </p>
-        <p className="dd-privacy-hidden" data-dd-action-name="Veteran's name">
-          {veteranFirstName} {veteranLastName}
-        </p>
-        <p>
-          <strong>Date submitted</strong>
-        </p>
-        <p data-testid="dateSubmitted">{dateSubmitted}</p>
+          <p
+            className="dd-privacy-hidden vads-u-margin-top--0"
+            data-dd-action-name="Veteran's name"
+          >
+            {veteranFirstName} {veteranLastName}
+          </p>
+        </div>
+        <div>
+          <div className="dd-privacy-hidden">
+            <strong>Date submitted</strong>
+          </div>
+          <p
+            data-testid="dateSubmitted"
+            className="dd-privacy-hidden vads-u-margin-top--0"
+          >
+            {dateSubmitted}
+          </p>
+        </div>
         <va-button
           text="Print this page for your records"
           onClick={() => {
             window.print();
           }}
         />
-      </va-summary-box>
+      </div>
     );
   };
 
@@ -80,7 +92,7 @@ export default function ConfirmationPage() {
         <Toggler.Enabled>
           {submissionId ? (
             <section>
-              <h2 className="vads-u-margin-top--3 vads-u-margin-bottom--2">
+              <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2 save-a-copy">
                 Save a copy of your form
               </h2>
               <span>
@@ -96,6 +108,10 @@ export default function ConfirmationPage() {
                     submissionId ? `/my-va/submissions/${submissionId}` : ''
                   }
                 />
+              </div>
+              <div className="vads-u-margin-top--1p5">
+                <strong>Note:</strong> You won't be able to access a copy of the
+                information you submitted once you leave this page.
               </div>
             </section>
           ) : (

--- a/src/applications/dependents/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/dependents/686c-674/containers/ConfirmationPage.jsx
@@ -38,11 +38,14 @@ export default function ConfirmationPage() {
 
   const submissionBox = () => {
     return (
-      <div className="vads-u-margin-top--4">
-        <h2 slot="headline" className="save-a-copy">
+      <div>
+        <h2
+          slot="headline"
+          className="save-a-copy vads-u-margin-top--3 vads-u-margin-bottom--3"
+        >
           Your submission information
         </h2>
-        <div>
+        <div className="vads-u-margin-bottom--3">
           <strong>Your name</strong>
           <p
             className="dd-privacy-hidden vads-u-margin-top--0"
@@ -51,7 +54,7 @@ export default function ConfirmationPage() {
             {veteranFirstName} {veteranLastName}
           </p>
         </div>
-        <div>
+        <div className="vads-u-margin-bottom--3">
           <div className="dd-privacy-hidden">
             <strong>Date submitted</strong>
           </div>

--- a/src/applications/dependents/686c-674/sass/new-686.scss
+++ b/src/applications/dependents/686c-674/sass/new-686.scss
@@ -23,3 +23,9 @@ margin-left: 0 !important;
 .progress-box .va-growable button {
   margin-right: 0.5em !important;
 }
+
+.save-a-copy {
+  color: rgba(50, 58, 69, 1);
+  line-height: 39px;
+  letter-spacing: 0%;
+}

--- a/src/applications/dependents/686c-674/tests/containers/confirmationPage.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/containers/confirmationPage.unit.spec.jsx
@@ -54,7 +54,7 @@ describe('Dependents Form (686c-674) confirmation page', () => {
       </Provider>,
     );
 
-    expect($$('h2', container).length).to.eql(6);
+    expect($$('h2', container).length).to.eql(7);
     expect($$('va-link', container).length).to.eql(4);
     expect($$('va-alert[status="success', container).length).to.equal(1);
     expect($('va-button', container).getAttribute('text')).to.eq(


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- Implementing design updates to the 686c confirmation page. This PR implements the changes for BOTH tickets.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
The FDF section is hidden behind the dependents_enable_form_viewer_mfe flipper. 
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#120894
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/120894)
[department-of-veterans-affairs/va.gov-team#133019
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/133019)

## Testing done

- _Describe what the old behavior was prior to the change_
- Making slight design adjustments to the confirmation page.
- Removing the blue box around the submission information section in order to follow [this pattern](https://design.va.gov/patterns/help-users-to/keep-a-record-of-submitted-information)
- Adding a new information blurb for the FDF link
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Normal section
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="414" height="784" alt="Screenshot 2026-03-12 at 3 21 03 PM" src="https://github.com/user-attachments/assets/b29bd91d-84ad-4c62-91f9-9a701c05beef" />  |  <img width="350" height="756" alt="Screenshot 2026-03-12 at 4 53 42 PM" src="https://github.com/user-attachments/assets/f5c354e7-79e9-46fb-b4af-6a71ccd315b3" /> |
| Desktop | <img width="956" height="865" alt="Screenshot 2026-03-12 at 3 20 02 PM" src="https://github.com/user-attachments/assets/b7633dfd-08f7-44a2-a5ee-f1c63d7324df" />  | <img width="935" height="866" alt="Screenshot 2026-03-12 at 4 52 04 PM" src="https://github.com/user-attachments/assets/721a1217-b0b1-4bb1-a6f8-449c10bd8b11" />  |

FDF Section

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="370" height="790" alt="Screenshot 2026-03-12 at 3 29 15 PM" src="https://github.com/user-attachments/assets/3456b00b-6ac1-46e8-bb69-715b37164a3d" />   | <img width="383" height="587" alt="Screenshot 2026-03-12 at 3 09 16 PM" src="https://github.com/user-attachments/assets/c4729821-a8ce-4948-8a2b-bdb8e7c0e447" />      |
| Desktop | <img width="938" height="765" alt="Screenshot 2026-03-12 at 3 28 55 PM" src="https://github.com/user-attachments/assets/c8986f13-16de-4aab-8a0a-6d0dd3e91113" />  | <img width="780" height="717" alt="Screenshot 2026-03-12 at 3 08 04 PM" src="https://github.com/user-attachments/assets/3ee6f01b-7e4b-42a5-92ba-2f383eb1e2c8" />      |

## What areas of the site does it impact?
The 686c confirmation page 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
