### PR TITLE
CST 134900 Add alert improvement feature flags

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -59,6 +59,7 @@
   "confirmContactEmailInterstitialEnabled": "confirm_contact_email_interstitial_enabled",
   "cstClaimPhases": "cst_claim_phases",
   "cstClaimsListFilter": "cst_claims_list_filter",
+  "cstEvidenceRequestsStackedAlerts": "cst_evidence_requests_stacked_alerts",
   "cstMultiClaimProvider": "cst_multi_claim_provider",
   "cstIncludeDdl5103Letters": "cst_include_ddl_5103_letters",
   "cstIncludeDdlBoaLetters": "cst_include_ddl_boa_letters",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders

### :warning: TeamSites :warning:
- [x] No

## Summary

- This work is behind a feature toggle (flipper): YES — this PR adds the toggles
- Adds `cstAlertImprovementsEvidenceRequests` and `cstAlertImprovementsBoardAppeals` to `featureFlagNames.json`
- When enabled, aligns claim status tool alerts with VADS best practices
- Separate flags support independent rollout timelines
- Team: Benefits Management Tools 1
- **Merge the backend PR first**

## Related issue(s)

- Evidence Requests: department-of-veterans-affairs/va.gov-team#134900
- Evidence Requests Epic: department-of-veterans-affairs/va.gov-team#119389
- Board Appeals: department-of-veterans-affairs/va.gov-team#135074
- Board Appeals Epic: department-of-veterans-affairs/va.gov-team#129597
- Backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/27052

## Testing done

- Feature flag name addition only — no logic changes
- Flag names appear in `featureFlagNames.json` with correct camelCase keys and snake_case values
- No linting errors

## Screenshots

N/A — no UI changes

## What areas of the site does it impact?

Claims Status Tool (CST) — no impact until flag is enabled

## Acceptance criteria

### Quality Assurance & Testing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling
- [x] Browser console contains no warnings or errors

### Authentication
- N/A — no route changes