### PR TITLE
[133911] Replace native buttons with va-button components in DownloadFileType

### DIFF
--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -97,9 +97,17 @@ const DownloadFileType = props => {
 
   const progressBarRef = useRef(null);
   const noRecordsFoundRef = useRef(null);
+  const isMounted = useRef(true);
 
   useFocusOutline(progressBarRef);
   useFocusOutline(noRecordsFoundRef);
+
+  // Cleanup: track mounted state to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   useEffect(
     () => {
@@ -395,7 +403,10 @@ const DownloadFileType = props => {
         sendDatadogError(error, 'Blue Button report - download_report_pdf');
         dispatch(addAlert(ALERT_TYPE_BB_ERROR, error));
       } finally {
-        setIsGenerating(false);
+        // Only update state if component is still mounted
+        if (isMounted.current) {
+          setIsGenerating(false);
+        }
       }
     },
     [
@@ -451,7 +462,10 @@ const DownloadFileType = props => {
         sendDatadogError(error, 'Blue Button report - download_report_txt');
         dispatch(addAlert(ALERT_TYPE_BB_ERROR, error));
       } finally {
-        setIsGenerating(false);
+        // Only update state if component is still mounted
+        if (isMounted.current) {
+          setIsGenerating(false);
+        }
       }
     },
     [
@@ -548,7 +562,7 @@ const DownloadFileType = props => {
         )}
       {isDataFetched &&
         recordCount > 0 && (
-          <form onSubmit={e => handleSubmit(e)}>
+          <form onSubmit={handleSubmit}>
             <fieldset>
               <legend
                 className="vads-u-display--block vads-u-width--full vads-u-font-size--source-sans-normalized vads-u-font-weight--normal vads-u-padding-y--2 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light"
@@ -586,29 +600,20 @@ const DownloadFileType = props => {
                 <DownloadingRecordsInfo description="Blue Button Report" />
               </div>
             </fieldset>
-
-            <div className="medium-screen:vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-align-items--center">
-              <button
-                type="button"
-                className="usa-button-secondary vads-u-margin-y--0p5"
-                onClick={handleBack}
-              >
-                <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-align-items--center vads-u-justify-content--center">
-                  <va-icon icon="navigate_far_before" size={2} />
-                  <span className="vads-u-margin-left--0p5">Back</span>
-                </div>
-              </button>
-              <button
-                type="submit"
-                className="vads-u-margin-y--0p5 vads-u-width--auto"
-                data-testid="download-report-button"
-                disabled={isGenerating}
-                aria-disabled={isGenerating || undefined}
-                aria-busy={isGenerating || undefined}
-              >
-                Download report
-              </button>
-            </div>
+            <ul className="mr-button-group">
+              <li className="mr-button-group__item">
+                <va-button back text="Back" secondary onClick={handleBack} />
+              </li>
+              <li className="mr-button-group__item">
+                <va-button
+                  text="Download report"
+                  submit="prevent"
+                  onClick={handleSubmit}
+                  loading={isGenerating}
+                  data-testid="download-report-button"
+                />
+              </li>
+            </ul>
           </form>
         )}
       <NeedHelpSection />

--- a/src/applications/mhv-medical-records/sass/medical-records.scss
+++ b/src/applications/mhv-medical-records/sass/medical-records.scss
@@ -153,3 +153,45 @@ va-loading-indicator {
 .initial-fhir-load {
   width: 300px;
 }
+
+// Copy of usa-button-group
+.mr-button-group {
+  margin-bottom: 0;
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  list-style-type: none;
+  padding-left: 0;
+
+  .mr-button-group__item {
+    margin: 0.25rem !important;
+
+    va-button {
+      height: 100%;
+      margin-left: 0;
+      margin-right: 0;
+      width: 100%;
+
+      &::part(button) {
+        width: 100%;
+      }
+    }
+
+    @media all and (min-width: 30em) {
+      margin-top: 0;
+      margin-bottom: 0;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  @media all and (min-width: 30em) {
+    flex-wrap: nowrap;
+    align-items: stretch;
+    flex-direction: row;
+    margin: 0 -0.25rem;
+  }
+}

--- a/src/applications/mhv-medical-records/sass/medical-records.scss
+++ b/src/applications/mhv-medical-records/sass/medical-records.scss
@@ -165,7 +165,7 @@ va-loading-indicator {
   padding-left: 0;
 
   .mr-button-group__item {
-    margin: 0.25rem !important;
+    margin: 0.25rem;
 
     va-button {
       height: 100%;

--- a/src/applications/mhv-medical-records/tests/components/DownloadFileType.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/DownloadFileType.unit.spec.jsx
@@ -282,13 +282,11 @@ describe('DownloadFileType — AAL logging', () => {
     expect(postCreateAALStub.calledWithMatch({ status: 0 })).to.be.true;
   });
 
-  // This test verifies the double-click prevention mechanism by checking that:
-  // 1. The button gets disabled immediately after clicking
-  // 2. The aria-busy attribute is set for screen readers
+  // This test verifies the double-click prevention mechanism.
   // Note: Testing that makePdf is only called once is flaky due to module caching
   // issues with stubbing (same issue affects the AAL logging tests above).
   // The early return guard `if (isGenerating) return;` in generatePdf and generateTxt
-  // provides the actual double-click prevention, and the disabled button state
+  // provides the actual double-click prevention, and the loading va-button attribute
   // tested here ensures the UI properly indicates this to users.
   it('disables download button during PDF generation to prevent double-clicks (PDF)', async () => {
     // Make makePdf return a promise that doesn't resolve immediately
@@ -296,22 +294,30 @@ describe('DownloadFileType — AAL logging', () => {
     makePdfStub.returns(new Promise(() => {})); // Never resolves
 
     const screen = renderWithFormat('pdf');
+
+    // Wait for the component to be fully ready with fileType set from Redux
+    // The useEffect should have synced fileTypeFilter to local fileType state
+    // Check that the PDF radio option is checked (indicates fileType is set)
+    await waitFor(() => {
+      const pdfOption = screen.container.querySelector(
+        'va-radio-option[value="pdf"]',
+      );
+      expect(pdfOption).to.exist;
+      expect(pdfOption.getAttribute('checked')).to.equal('true');
+    });
+
     const btn = await screen.findByTestId('download-report-button');
 
-    // Button should be enabled initially
-    expect(btn.textContent).to.contain('Download report');
-    expect(btn).to.not.have.attr('disabled');
-    expect(btn).to.not.have.attr('aria-disabled');
-    expect(btn).to.not.have.attr('aria-busy');
+    // va-button should not be loading initially
+    expect(btn).to.have.attr('text', 'Download report');
+    expect(btn).to.have.attr('loading', 'false');
 
     // Click the button
     await userEvent.click(btn);
 
-    // Button should now be disabled with aria attributes
+    // va-button should now have loading attribute set to true, which disables it and shows the loading state
     await waitFor(() => {
-      expect(btn).to.have.attr('disabled');
-      expect(btn).to.have.attr('aria-disabled', 'true');
-      expect(btn).to.have.attr('aria-busy', 'true');
+      expect(btn).to.have.attr('loading', 'true');
     });
   });
 
@@ -336,6 +342,17 @@ describe('DownloadFileType — AAL logging', () => {
     makePdfStub.returns(new Promise(() => {})); // Never resolves
 
     const screen = renderWithFormat('pdf');
+
+    // Wait for the component to be fully ready with fileType set from Redux
+    // Check that the PDF radio option is checked (indicates fileType is set)
+    await waitFor(() => {
+      const pdfOption = screen.container.querySelector(
+        'va-radio-option[value="pdf"]',
+      );
+      expect(pdfOption).to.exist;
+      expect(pdfOption.getAttribute('checked')).to.equal('true');
+    });
+
     const btn = await screen.findByTestId('download-report-button');
 
     // Loading indicator should not exist initially

--- a/src/applications/mhv-medical-records/tests/components/DownloadFileType.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/DownloadFileType.unit.spec.jsx
@@ -310,7 +310,7 @@ describe('DownloadFileType — AAL logging', () => {
 
     // va-button should not be loading initially
     expect(btn).to.have.attr('text', 'Download report');
-    expect(btn).to.have.attr('loading', 'false');
+    expect(btn).to.not.have.attr('loading', 'true');
 
     // Click the button
     await userEvent.click(btn);

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-network-error-labs-and-tests.cypress.spec.js
@@ -11,10 +11,16 @@ describe('Medical Records View Labs and Tests', () => {
     cy.intercept('GET', '/my_health/v1/medical_records/labs_and_tests*', {
       statusCode: 404,
     });
+    cy.intercept('GET', '/my_health/v2/medical_records/labs_and_tests*', {
+      statusCode: 404,
+    });
     cy.intercept('GET', '/my_health/v1/medical_records/radiology*', {
       statusCode: 404,
     });
     cy.intercept('GET', '/my_health/v1/medical_records/imaging*', {
+      statusCode: 404,
+    });
+    cy.intercept('GET', '/my_health/v2/medical_records/imaging*', {
       statusCode: 404,
     });
     cy.visit('my-health/medical-records');
@@ -22,9 +28,7 @@ describe('Medical Records View Labs and Tests', () => {
     cy.wait('@session');
 
     cy.visit('my-health/medical-records/labs-and-tests');
-    cy.get('[data-testid="expired-alert-message"]', {
-      includeShadowDom: true,
-    }).should('be.visible');
+    cy.get('[data-testid="expired-alert-message"]').should('be.visible');
 
     // Axe check
     cy.injectAxe();

--- a/src/applications/mhv-medical-records/tests/e2e/pages/BaseDetailsPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/BaseDetailsPage.js
@@ -4,13 +4,11 @@ class BaseDetailsPage {
   };
 
   clickPrintOrDownload = () => {
-    // Wait for menu button to be visible and enabled, then click
     cy.get('[data-testid="print-download-menu"]')
       .should('be.visible')
       .and('not.be.disabled')
       .click();
-    // Wait for the menu to open before proceeding
-    cy.get('[data-testid="print-download-menu"]').should(
+    cy.get('[data-testid="print-download-menu"]', { timeout: 10000 }).should(
       'have.attr',
       'aria-expanded',
       'true',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Replace the `Back` and `Download report` buttons on the Blue Button file type selection page (Step 3 of 3) from native HTML `<button>` elements to `<va-button>` web components, aligning with the VA Design System. Also fixes a memory leak warning introduced by the change.

**Changes**
- DownloadFileType.jsx
  - Replace native `<button type="button">` (Back) and `<button type="submit">` (Download report) with `<va-button>` web components
  - Use `<ul class="mr-button-group">` layout for button pair
  - Use va-button `loading` prop instead of native `disabled`/`aria-disabled`/`aria-busy` for download state indication
  - Add `submit="prevent"` to prevent unvalidated form submission; `onClick` handles submission with validation
  - Simplify form `onSubmit` from `onSubmit={e => handleSubmit(e)}` to `onSubmit={handleSubmit}]`
  - Add `isMounted` ref pattern to prevent setState on unmounted component, fixing "Can't perform a React state update on an unmounted component" warning that appeared after the update

- medical-records.scss
  - Add `.mr-button-group` CSS for responsive button layout (stacked on mobile, side-by-side on desktop)

- DownloadFileType.unit.spec.jsx
  - Update assertions from native button properties (textContent, disabled, aria-disabled, aria-busy) to va-button attributes (text, loading)
  - Add explicit wait for radio option `checked="true"`state before clicking, fixing a race condition where `useEffect` hadn't synced Redux `fileTypeFilter` to local fileType]` state in full test suite runs

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#133911


## Testing done

- Updated unit tests to verify the new `va-button` loading behavior, ensuring that the download button is properly disabled and shows a loading state during report generation, and confirming the UI prevents double-clicks. 
- Manually verified UX: button displays, loading state works, validation prevents submission without file type selection, back navigation works

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img width="456" height="733" alt="Screenshot 2026-03-13 at 7 16 05 AM" src="https://github.com/user-attachments/assets/7edd227e-f146-4371-af59-50d4391d2757" />    |    <img width="456" height="733" alt="Screenshot 2026-03-13 at 7 16 12 AM" src="https://github.com/user-attachments/assets/c0497e04-218d-488b-b624-2dd106d761d1" />   |
| Desktop |   <img width="895" height="681" alt="Screenshot 2026-03-13 at 7 14 55 AM" src="https://github.com/user-attachments/assets/2e27323a-38fe-4a79-a82d-fb42297e5ae9" />     |   <img width="895" height="681" alt="Screenshot 2026-03-13 at 7 15 04 AM" src="https://github.com/user-attachments/assets/8b853a0b-9679-42f5-81b9-fbb12dffb227" />    |

## What areas of the site does it impact?

MHV Medical Records - BB Download

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
