### PR TITLE
#135806: Add Contextual Logging for Appointment Creation

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -135,6 +135,7 @@ describe('VAOS vaccine flow: ReviewPage', () => {
       slot: {
         id: store.getState().covid19Vaccine.newBooking.availableSlots[0].id,
       },
+      systemType: 'vista',
     });
   });
 

--- a/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.js
@@ -4,11 +4,17 @@ import {
   selectCovid19VaccineFormData,
 } from '../selectors';
 import { getClinicId } from '../../../services/healthcare-service';
+import { isCernerLocation } from '../../../services/location';
+import { selectRegisteredCernerFacilityIds } from '../../../redux/selectors';
+import { APPOINTMENT_SYSTEM } from '../../../utils/constants';
 
 export function transformFormToVAOSAppointment(state) {
   const data = selectCovid19VaccineFormData(state);
   const clinic = getChosenClinicInfo(state);
   const slot = getChosenSlot(state);
+  const cernerSiteIds = selectRegisteredCernerFacilityIds(state);
+  const isCerner = isCernerLocation(data.vaFacility, cernerSiteIds);
+  const ehr = isCerner ? APPOINTMENT_SYSTEM.cerner : APPOINTMENT_SYSTEM.vista;
 
   return {
     kind: 'clinic',
@@ -19,5 +25,6 @@ export function transformFormToVAOSAppointment(state) {
       desiredDate: slot.start,
     },
     locationId: data.vaFacility,
+    systemType: ehr,
   };
 }

--- a/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.unit.spec.jsx
+++ b/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.unit.spec.jsx
@@ -1,0 +1,125 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as locationModule from '../../../services/location';
+import * as selectors from '../../../redux/selectors';
+import { transformFormToVAOSAppointment } from './formSubmitTransformers';
+
+describe('COVID-19 Vaccine data transformation', () => {
+  let isCernerLocationStub;
+  let selectRegisteredCernerFacilityIdsStub;
+
+  beforeEach(() => {
+    isCernerLocationStub = sinon.stub(locationModule, 'isCernerLocation');
+    selectRegisteredCernerFacilityIdsStub = sinon.stub(
+      selectors,
+      'selectRegisteredCernerFacilityIds',
+    );
+  });
+
+  afterEach(() => {
+    isCernerLocationStub.restore();
+    selectRegisteredCernerFacilityIdsStub.restore();
+  });
+
+  const baseState = {
+    covid19Vaccine: {
+      newBooking: {
+        data: {
+          vaFacility: '983',
+          clinicId: '983_308',
+          date1: ['2024-01-15T09:30:00Z'],
+        },
+        clinics: {
+          '983': [
+            {
+              id: '983_308',
+              serviceName: 'Green Team Clinic1',
+              stationId: '983',
+            },
+          ],
+        },
+        availableSlots: [
+          {
+            id: 'slot-1',
+            start: '2024-01-15T09:30:00Z',
+            end: '2024-01-15T10:00:00Z',
+          },
+        ],
+      },
+    },
+  };
+
+  describe('transformFormToVAOSAppointment', () => {
+    it('should include systemType as vista for VistA facility', () => {
+      selectRegisteredCernerFacilityIdsStub.returns([]);
+      isCernerLocationStub.returns(false);
+
+      const result = transformFormToVAOSAppointment(baseState);
+
+      expect(result.systemType).to.equal('vista');
+      expect(result).to.deep.include({
+        kind: 'clinic',
+        status: 'booked',
+        locationId: '983',
+      });
+    });
+
+    it('should include systemType as cerner for Cerner facility', () => {
+      selectRegisteredCernerFacilityIdsStub.returns(['757']);
+      isCernerLocationStub.returns(true);
+
+      const state = {
+        covid19Vaccine: {
+          newBooking: {
+            data: {
+              vaFacility: '757',
+              clinicId: '757_100',
+              date1: ['2024-01-15T09:30:00Z'],
+            },
+            clinics: {
+              '757': [
+                {
+                  id: '757_100',
+                  serviceName: 'Cerner Clinic',
+                  stationId: '757',
+                },
+              ],
+            },
+            availableSlots: [
+              {
+                id: 'slot-1',
+                start: '2024-01-15T09:30:00Z',
+                end: '2024-01-15T10:00:00Z',
+              },
+            ],
+          },
+        },
+      };
+
+      const result = transformFormToVAOSAppointment(state);
+
+      expect(result.systemType).to.equal('cerner');
+      expect(result).to.deep.include({
+        kind: 'clinic',
+        status: 'booked',
+        locationId: '757',
+      });
+    });
+
+    it('should return correct appointment structure with slot info', () => {
+      selectRegisteredCernerFacilityIdsStub.returns([]);
+      isCernerLocationStub.returns(false);
+
+      const result = transformFormToVAOSAppointment(baseState);
+
+      expect(result).to.have.property('kind', 'clinic');
+      expect(result).to.have.property('status', 'booked');
+      expect(result).to.have.property('systemType', 'vista');
+      expect(result).to.have.property('locationId', '983');
+      expect(result.slot).to.deep.equal({ id: 'slot-1' });
+      expect(result.extension).to.deep.equal({
+        desiredDate: '2024-01-15T09:30:00Z',
+      });
+    });
+  });
+});

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -187,6 +187,7 @@ describe('VAOS Page: ReviewPage CC request with VAOS service', () => {
           },
         },
       ],
+      systemType: 'hsrm',
     });
   });
 

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -280,6 +280,7 @@ describe('VAOS Page: ReviewPage direct scheduling', () => {
         desiredDate: '2021-05-06T00:00:00+00:00',
       },
       slot: store.getState().newAppointment.availableSlots[0],
+      systemType: 'vista',
     });
   });
 

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -106,6 +106,7 @@ describe('VAOS Page: ReviewPage VA request with VAOS service', () => {
         },
       ],
       preferredTimesForPhoneCall: ['Morning', 'Afternoon', 'Evening'],
+      systemType: 'vista',
     });
   });
 
@@ -155,6 +156,7 @@ describe('VAOS Page: ReviewPage VA request with VAOS service', () => {
         },
       ],
       preferredTimesForPhoneCall: ['Morning', 'Afternoon', 'Evening'],
+      systemType: 'vista',
     });
   });
 

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -14,6 +14,7 @@ import { getReasonCode } from './getReasonCode';
 
 export function transformFormToVAOSCCRequest(state) {
   const data = getFormData(state);
+  const { ehr } = state.newAppointment;
   const provider = data.communityCareProvider;
   const residentialAddress = selectVAPResidentialAddress(state);
   const parentFacility = getChosenCCSystemById(state);
@@ -97,11 +98,13 @@ export function transformFormToVAOSCCRequest(state) {
     )?.value,
     preferredLocation,
     practitioners,
+    systemType: ehr,
   };
 }
 
 export function transformFormToVAOSVARequest(state, updateLimits = false) {
   const data = getFormData(state);
+  const { ehr } = state.newAppointment;
   const typeOfCare = getTypeOfCare(data);
 
   return {
@@ -133,6 +136,7 @@ export function transformFormToVAOSVARequest(state, updateLimits = false) {
     preferredTimesForPhoneCall: Object.entries(data.bestTimeToCall || {})
       .filter(item => item[1])
       .map(item => titleCase(item[0])),
+    systemType: ehr,
   };
 }
 
@@ -168,5 +172,6 @@ export function transformFormToVAOSAppointment(state, updateLimits = false) {
       isDS: true,
       updateLimits,
     }),
+    systemType: ehr,
   };
 }

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.jsx
@@ -130,6 +130,7 @@ describe('VAOS V2 data transformation', () => {
         extension: { desiredDate: '2019-12-02T00:00:00+00:00' },
         locationId: '983',
         reasonCode: reasonTextTransformed,
+        systemType: 'vista',
       });
     });
 
@@ -168,6 +169,7 @@ describe('VAOS V2 data transformation', () => {
         extension: { desiredDate: '2019-12-02T00:00:00+00:00' },
         locationId: '983',
         reasonCode: reasonTextTransformed,
+        systemType: 'cerner',
       });
     });
 
@@ -206,6 +208,7 @@ describe('VAOS V2 data transformation', () => {
         extension: { desiredDate: '2019-12-02T00:00:00+00:00' },
         locationId: '983',
         reasonCode: reasonTextTransformed,
+        systemType: 'vista',
       });
     });
   });
@@ -217,6 +220,7 @@ describe('VAOS V2 data transformation', () => {
       // Given the VA request is submitted
       const state = {
         newAppointment: {
+          ehr: 'vista',
           data: {
             phoneNumber: '5035551234',
             bestTimeToCall: {
@@ -287,6 +291,7 @@ describe('VAOS V2 data transformation', () => {
           { start: '2019-11-20T12:00:00Z', end: '2019-11-20T23:59:00Z' },
         ],
         preferredTimesForPhoneCall: ['Morning'],
+        systemType: 'vista',
       });
     });
   });
@@ -298,6 +303,7 @@ describe('VAOS V2 data transformation', () => {
       // Given the VA request is submitted
       const state = {
         newAppointment: {
+          ehr: 'hsrm',
           data: {
             phoneNumber: '5035551234',
             bestTimeToCall: {
@@ -385,6 +391,7 @@ describe('VAOS V2 data transformation', () => {
           { start: '2019-11-20T12:00:00Z', end: '2019-11-20T23:59:00Z' },
         ],
         preferredTimesForPhoneCall: ['Morning'],
+        systemType: 'hsrm',
       });
     });
   });


### PR DESCRIPTION
Add `system_type` parameter and contextual DataDog logging for appointment creation.

We need to differentiate appointment creation metrics in DataDog by scheduling type (direct schedule vs request) and EHR system. Currently, `post_appointment` API calls log success/failure but lack contextual data to filter by these dimensions.

vets-website: Pass a new `system_type` field in the appointment creation request body with values: vista, cerner, or hsrm.

## Summary

- Pass system_type (vista | cerner | hsrm) in appointment creation requests

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/135806


## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
