### PR TITLE
add shipped alert to medication card for Medications Improvement

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -10,6 +10,7 @@ import {
   getPrescriptionDetailUrl,
   getRxStatus,
   rxSourceIsNonVA,
+  getTrackingUrl,
 } from '../../util/helpers';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 import {
@@ -27,6 +28,7 @@ import {
   DATETIME_FORMATS,
   RX_SOURCE,
   DISPENSE_STATUS,
+  dispStatusObj,
   dispStatusObjV2,
   medicationsUrls,
 } from '../../util/constants';
@@ -41,8 +43,8 @@ const MedicationsListCard = ({ rx }) => {
     selectMedicationsManagementImprovementsFlag,
   );
   const isFillInProgress =
-    rx.dispStatus === DISPENSE_STATUS.ACTIVE_REFILL_IN_PROCESS ||
-    rx.dispStatus === DISPENSE_STATUS.ACTIVE_SUBMITTED;
+    rx.dispStatus === dispStatusObj.refillinprocess ||
+    rx.dispStatus === dispStatusObj.submitted;
   const isInitialFill = isFillInProgress && !rx.sortedDispensedDate;
   const isOracleHealthCutoverEnabled = useSelector(
     selectMhvMedicationsOracleHealthCutoverFlag,
@@ -71,8 +73,18 @@ const MedicationsListCard = ({ rx }) => {
         rx?.refillStatus?.toLowerCase() === 'renew'
       : rx?.dispStatus === DISPENSE_STATUS.RENEW);
   const latestTrackingStatus = rx?.trackingList?.[0];
+  const isRecentlyShipped =
+    rx.dispStatus === dispStatusObj.shipped &&
+    rx.isTrackable &&
+    !!latestTrackingStatus?.completeDateTime;
+  const trackingUrl = getTrackingUrl(
+    latestTrackingStatus?.carrier,
+    latestTrackingStatus?.trackingNumber,
+  );
   const isNonVaPrescription = rxSourceIsNonVA(rx);
   const rxStatus = getRxStatus(rx);
+  const showSimplifiedCard =
+    isManagementImprovements && (isFillInProgress || isRecentlyShipped);
 
   const cardBodyContent = () => {
     if (pendingRenewal || pendingMed) {
@@ -121,8 +133,34 @@ const MedicationsListCard = ({ rx }) => {
               </p>
             </div>
           )}
+        {isManagementImprovements &&
+          isRecentlyShipped && (
+            <div
+              className="vads-u-display--flex vads-u-align-items--center vads-u-background-color--green-lightest vads-u-padding--1 vads-u-margin-top--1"
+              data-testid="shipped-alert"
+              role="status"
+            >
+              <va-icon icon="local_shipping" size={3} aria-hidden="true" />
+              <p className="vads-u-margin-y--0 vads-u-margin-left--1">
+                Refill has shipped.{' '}
+                {trackingUrl ? (
+                  <a
+                    href={trackingUrl}
+                    rel="noreferrer"
+                    data-testid="get-tracking-info-link"
+                  >
+                    Get tracking info
+                  </a>
+                ) : (
+                  <Link to={getPrescriptionDetailUrl(rx)}>
+                    Get tracking info
+                  </Link>
+                )}
+              </p>
+            </div>
+          )}
         {rx &&
-          (rx.isRefillable || (isManagementImprovements && isFillInProgress)) &&
+          (rx.isRefillable || showSimplifiedCard) &&
           rx.refillRemaining >= 0 && (
             <p
               className="vads-u-margin-bottom--0"
@@ -136,26 +174,27 @@ const MedicationsListCard = ({ rx }) => {
             </p>
           )}
         {rx && <LastFilledInfo {...rx} />}
-        {latestTrackingStatus && (
-          <p
-            className="vads-u-margin-top--1p5 vads-u-padding-bottom--1p5 vads-u-border-bottom--1px vads-u-border-color--gray"
-            data-testid="rx-card-details--shipped-on"
-            data-dd-privacy="mask"
-          >
-            <va-icon icon="local_shipping" size={3} aria-hidden="true" />
-            <span
-              className="vads-u-margin-left--2"
-              data-testid="shipping-date"
+        {latestTrackingStatus &&
+          !showSimplifiedCard && (
+            <p
+              className="vads-u-margin-top--1p5 vads-u-padding-bottom--1p5 vads-u-border-bottom--1px vads-u-border-color--gray"
+              data-testid="rx-card-details--shipped-on"
               data-dd-privacy="mask"
             >
-              Shipped on{' '}
-              {dateFormat(
-                latestTrackingStatus.completeDateTime,
-                DATETIME_FORMATS.longMonthDate,
-              )}
-            </span>
-          </p>
-        )}
+              <va-icon icon="local_shipping" size={3} aria-hidden="true" />
+              <span
+                className="vads-u-margin-left--2"
+                data-testid="shipping-date"
+                data-dd-privacy="mask"
+              >
+                Shipped on{' '}
+                {dateFormat(
+                  latestTrackingStatus.completeDateTime,
+                  DATETIME_FORMATS.longMonthDate,
+                )}
+              </span>
+            </p>
+          )}
         {!isManagementImprovements &&
           rxStatus !== 'Unknown' && (
             <p
@@ -175,7 +214,7 @@ const MedicationsListCard = ({ rx }) => {
             />
           )}
         {rx &&
-          !(isManagementImprovements && isFillInProgress) && (
+          !showSimplifiedCard && (
             <ExtraDetails
               {...rx}
               page={pageType.LIST}

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -74,7 +74,9 @@ const MedicationsListCard = ({ rx }) => {
       : rx?.dispStatus === DISPENSE_STATUS.RENEW);
   const latestTrackingStatus = rx?.trackingList?.[0];
   const isRecentlyShipped =
-    rx.dispStatus === dispStatusObj.shipped && rx.isTrackable;
+    rx.dispStatus === dispStatusObj.shipped &&
+    rx.isTrackable &&
+    Boolean(latestTrackingStatus);
   const trackingUrl = getTrackingUrl(
     latestTrackingStatus?.carrier,
     latestTrackingStatus?.trackingNumber,

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -74,9 +74,7 @@ const MedicationsListCard = ({ rx }) => {
       : rx?.dispStatus === DISPENSE_STATUS.RENEW);
   const latestTrackingStatus = rx?.trackingList?.[0];
   const isRecentlyShipped =
-    rx.dispStatus === dispStatusObj.shipped &&
-    rx.isTrackable &&
-    !!latestTrackingStatus?.completeDateTime;
+    rx.dispStatus === dispStatusObj.shipped && rx.isTrackable;
   const trackingUrl = getTrackingUrl(
     latestTrackingStatus?.carrier,
     latestTrackingStatus?.trackingNumber,

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -28,7 +28,6 @@ import {
   DATETIME_FORMATS,
   RX_SOURCE,
   DISPENSE_STATUS,
-  dispStatusObj,
   dispStatusObjV2,
   medicationsUrls,
 } from '../../util/constants';
@@ -43,8 +42,8 @@ const MedicationsListCard = ({ rx }) => {
     selectMedicationsManagementImprovementsFlag,
   );
   const isFillInProgress =
-    rx.dispStatus === dispStatusObj.refillinprocess ||
-    rx.dispStatus === dispStatusObj.submitted;
+    rx.dispStatus === DISPENSE_STATUS.ACTIVE_REFILL_IN_PROCESS ||
+    rx.dispStatus === DISPENSE_STATUS.ACTIVE_SUBMITTED;
   const isInitialFill = isFillInProgress && !rx.sortedDispensedDate;
   const isOracleHealthCutoverEnabled = useSelector(
     selectMhvMedicationsOracleHealthCutoverFlag,
@@ -74,7 +73,7 @@ const MedicationsListCard = ({ rx }) => {
       : rx?.dispStatus === DISPENSE_STATUS.RENEW);
   const latestTrackingStatus = rx?.trackingList?.[0];
   const isRecentlyShipped =
-    rx.dispStatus === dispStatusObj.shipped &&
+    rx.dispStatus === DISPENSE_STATUS.ACTIVE_SHIPPED &&
     rx.isTrackable &&
     Boolean(latestTrackingStatus);
   const trackingUrl = getTrackingUrl(

--- a/src/applications/mhv-medications/mocks/api/mhv-api/prescriptions/index.js
+++ b/src/applications/mhv-medications/mocks/api/mhv-api/prescriptions/index.js
@@ -16,6 +16,7 @@ const dispStatusObj = {
   INACTIVE: 'Inactive',
   INPROGRESS: 'In progress',
   STATUSNOTAVAILABLE: 'Status not available',
+  SHIPPED: 'Active: Shipped',
 };
 function mockPrescription(n = 0, attrs = {}, isV2 = false) {
   // Generate some refillable, some not

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
@@ -337,6 +337,143 @@ describe('Medication card component', () => {
       const { queryByTestId } = setup(rx, managementImprovementsState);
       expect(queryByTestId('fill-in-progress-alert')).to.be.null;
     });
+
+    it('shows shipped alert with external tracking link for known carrier', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: false,
+        isTrackable: true,
+        trackingList: [
+          {
+            completeDateTime: new Date().toISOString(),
+            carrier: 'USPS',
+            trackingNumber: '12345678901234',
+          },
+        ],
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByTestId('shipped-alert')).to.exist;
+      const link = getByText('Get tracking info');
+      expect(link).to.have.attribute(
+        'href',
+        `https://tools.usps.com/go/TrackConfirmAction_input?qtc_tLabels1=12345678901234`,
+      );
+    });
+
+    it('shows shipped alert with detail page link for unknown carrier', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: false,
+        isTrackable: true,
+        trackingList: [
+          {
+            completeDateTime: new Date().toISOString(),
+            carrier: 'OTHER',
+            trackingNumber: 'ABC123',
+          },
+        ],
+      };
+      const { getByTestId, getByText } = setup(rx, managementImprovementsState);
+      expect(getByTestId('shipped-alert')).to.exist;
+      const link = getByText('Get tracking info');
+      expect(link.getAttribute('href')).to.include(
+        `/prescription/${prescriptionsListItem.prescriptionId}`,
+      );
+    });
+
+    it('shows "Refills left" for recently shipped prescription', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: false,
+        isTrackable: true,
+        refillRemaining: 3,
+        trackingList: [
+          {
+            completeDateTime: new Date().toISOString(),
+            carrier: 'USPS',
+            trackingNumber: '12345678901234',
+          },
+        ],
+      };
+      const { getByTestId } = setup(rx, managementImprovementsState);
+      expect(getByTestId('rx-refill-remaining')).to.have.text(
+        'Refills left: 3',
+      );
+    });
+
+    it('hides old "Shipped on" block for recently shipped prescription', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: false,
+        isTrackable: true,
+        trackingList: [
+          {
+            completeDateTime: new Date().toISOString(),
+            carrier: 'USPS',
+            trackingNumber: '12345678901234',
+          },
+        ],
+      };
+      const { queryByTestId } = setup(rx, managementImprovementsState);
+      expect(queryByTestId('rx-card-details--shipped-on')).to.be.null;
+    });
+
+    it('hides ExtraDetails for recently shipped prescription', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: false,
+        isTrackable: true,
+        trackingList: [
+          {
+            completeDateTime: new Date().toISOString(),
+            carrier: 'USPS',
+            trackingNumber: '12345678901234',
+          },
+        ],
+      };
+      const { container } = setup(rx, managementImprovementsState);
+      expect(container.querySelector('.shipping-info')).to.be.null;
+    });
+
+    it('does not show shipped alert when isTrackable is false', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: true,
+        isTrackable: false,
+        trackingList: [
+          {
+            completeDateTime: new Date().toISOString(),
+            carrier: 'USPS',
+            trackingNumber: '12345678901234',
+          },
+        ],
+      };
+      const { queryByTestId } = setup(rx, managementImprovementsState);
+      expect(queryByTestId('shipped-alert')).to.be.null;
+    });
+
+    it('does not show shipped alert when tracking has no completeDateTime', () => {
+      const rx = {
+        ...prescriptionsListItem,
+        dispStatus: 'Active: Shipped',
+        isRefillable: true,
+        isTrackable: true,
+        trackingList: [
+          {
+            carrier: 'USPS',
+            trackingNumber: '12345678901234',
+          },
+        ],
+      };
+      const { queryByTestId } = setup(rx, managementImprovementsState);
+      expect(queryByTestId('shipped-alert')).to.be.null;
+    });
   });
 
   describe('when mhvMedicationsManagementImprovements flag is disabled', () => {

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListCard.unit.spec.jsx
@@ -457,23 +457,6 @@ describe('Medication card component', () => {
       const { queryByTestId } = setup(rx, managementImprovementsState);
       expect(queryByTestId('shipped-alert')).to.be.null;
     });
-
-    it('does not show shipped alert when tracking has no completeDateTime', () => {
-      const rx = {
-        ...prescriptionsListItem,
-        dispStatus: 'Active: Shipped',
-        isRefillable: true,
-        isTrackable: true,
-        trackingList: [
-          {
-            carrier: 'USPS',
-            trackingNumber: '12345678901234',
-          },
-        ],
-      };
-      const { queryByTestId } = setup(rx, managementImprovementsState);
-      expect(queryByTestId('shipped-alert')).to.be.null;
-    });
   });
 
   describe('when mhvMedicationsManagementImprovements flag is disabled', () => {

--- a/src/applications/mhv-medications/util/constants/status.js
+++ b/src/applications/mhv-medications/util/constants/status.js
@@ -12,6 +12,7 @@ export const dispStatusObj = {
   nonVA: ACTIVE_NON_VA,
   onHold: 'Active: On Hold',
   activeParked: 'Active: Parked',
+  shipped: 'Active: Shipped',
 };
 
 // New VA.gov statuses (OH)

--- a/src/applications/mhv-medications/util/constants/status.js
+++ b/src/applications/mhv-medications/util/constants/status.js
@@ -12,7 +12,6 @@ export const dispStatusObj = {
   nonVA: ACTIVE_NON_VA,
   onHold: 'Active: On Hold',
   activeParked: 'Active: Parked',
-  shipped: 'Active: Shipped',
 };
 
 // New VA.gov statuses (OH)
@@ -40,4 +39,5 @@ export const DISPENSE_STATUS = {
   ACTIVE: 'Active',
   ACTIVE_SUBMITTED: 'Active: Submitted',
   ACTIVE_REFILL_IN_PROCESS: 'Active: Refill in Process',
+  ACTIVE_SHIPPED: 'Active: Shipped',
 };

--- a/src/applications/mhv-medications/util/helpers/getTrackingInfo.js
+++ b/src/applications/mhv-medications/util/helpers/getTrackingInfo.js
@@ -2,7 +2,9 @@ import { trackingConfig } from '../constants';
 
 export const getTrackingUrl = (carrier, trackingNumber) => {
   const config = trackingConfig[carrier?.toLowerCase()];
-  return config && trackingNumber ? `${config.url}${trackingNumber}` : null;
+  return config && trackingNumber
+    ? `${config.url}${encodeURIComponent(trackingNumber)}`
+    : null;
 };
 
 export const getCarrierLabel = carrier => {

--- a/src/applications/mhv-medications/util/helpers/getTrackingInfo.js
+++ b/src/applications/mhv-medications/util/helpers/getTrackingInfo.js
@@ -1,0 +1,11 @@
+import { trackingConfig } from '../constants';
+
+export const getTrackingUrl = (carrier, trackingNumber) => {
+  const config = trackingConfig[carrier?.toLowerCase()];
+  return config && trackingNumber ? `${config.url}${trackingNumber}` : null;
+};
+
+export const getCarrierLabel = carrier => {
+  const config = trackingConfig[carrier?.toLowerCase()];
+  return config ? config.label : carrier;
+};

--- a/src/applications/mhv-medications/util/helpers/index.js
+++ b/src/applications/mhv-medications/util/helpers/index.js
@@ -23,6 +23,7 @@ export { getMostRecentRxRefill } from './getMostRecentRxRefill';
 export { getRefillHistory } from './getRefillHistory';
 export { getRxStatus } from './getRxStatus';
 export { getShowRefillHistory } from './getShowRefillHistory';
+export { getTrackingUrl, getCarrierLabel } from './getTrackingInfo';
 export { hasCmopNdcNumber } from './hasCmopNdcNumber';
 export { isArrayAndHasItems } from './isArrayAndHasItems';
 export { isOracleHealthPrescription } from './isOracleHealthPrescription';


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- When the mhvMedicationsManagementImprovements feature flag is enabled and a prescription has dispStatus: 'Active: Shipped' with trackable shipping data, a green "Refill has shipped" alert is now displayed on the medication card in the medications list (History page). This is Scenario 6 (S6) of the MMI card design updates.
- For known carriers (DHL, FedEx, UPS, USPS), the alert links directly to the carrier's tracking page. For unknown carriers, it links to the prescription detail page.
- The simplified card layout (introduced in S5 for refill-in-progress) is extended to shipped prescriptions: the legacy "Shipped on [date]" block and ExtraDetails panel are hidden, and "Refills left" is shown even when isRefillable is false.
- A showSimplifiedCard variable was extracted to consolidate the repeated compound condition used in three places.
- A new getTrackingInfo.js utilities for building carrier tracking URLs.
- shipped: 'Active: Shipped' in status constants.
- Feature is gated behind the mhvMedicationsManagementImprovements flipper. 


## Related issue(s)
department-of-veterans-affairs/va.gov-team#135867


## Testing done
- Old behavior: Medication cards with dispStatus: 'Active: Shipped' showed the legacy "Shipped on [date]" text, the full ExtraDetails panel, and no alert banner. No visual distinction was made for recently shipped prescriptions.
- New behavior (flag enabled): Cards with Active: Shipped status, isTrackable: true, and a completeDateTime in trackingList now display a green alert with a truck icon and "Refill has shipped. Get tracking info" link. The legacy shipped-on block and ExtraDetails are hidden. "Refills left" is shown.
- New behavior (flag disabled): No change from existing behavior. The shipped alert does not render, legacy layout remains intact.
- Steps to verify:
             - Enable the mhvMedicationsManagementImprovements feature flag
             - Navigate to the medications list page (/my-health/medications)
             - Find a prescription with dispStatus: 'Active: Shipped', isTrackable: true, and tracking data
             - Verify the green shipped alert renders with a tracking link
             - Verify known carriers (USPS, FedEx, UPS, DHL) link to the carrier's external tracking page
             - Verify unknown carriers link to the prescription detail page
             - Verify "Refills left: X" is shown
             - Verify the legacy "Shipped on [date]" block is hidden
              - Disable the flag and verify no shipped alert renders and the legacy layout is intact
              - Unit tests: 7 new tests added covering known carrier link, unknown carrier fallback link, refills left display, hidden legacy shipped-on block, hidden ExtraDetails, isTrackable: false guard. All 98 unit tests passing.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |  <img width="280" height="107" alt="Screenshot 2026-03-13 at 10 41 42 AM" src="https://github.com/user-attachments/assets/137a318e-8417-48af-9b83-d370d70803d1" /> |   <img width="326" height="117" alt="Screenshot 2026-03-13 at 10 28 35 AM" src="https://github.com/user-attachments/assets/854aaba3-e0a0-43e6-b5ec-ec359cbcdc5b" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
