### PR TITLE
Fix 25 CodeQL alerts for missing workflow permissions

### DIFF
--- a/.github/workflows/check-feature-toggles.yml
+++ b/.github/workflows/check-feature-toggles.yml
@@ -7,6 +7,8 @@ jobs:
   search:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Check out vets-website
       - name: Check out vets-website

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -161,6 +161,8 @@ jobs:
   determine-cd-eligibility:
     name: Determine CD Eligibility
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build]
     outputs:
       deploy_to_prod: ${{ steps.deploy-to-prod.outputs.can_deploy }}
@@ -464,6 +466,8 @@ jobs:
   unit-tests-stress-test:
     name: Unit Test Stability Review
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     timeout-minutes: 30
     needs: [tests-prep]
     if: ${{ always() && !cancelled() && needs.tests-prep.outputs.unit-tests-to-stress-test == 'true' && github.ref != 'refs/heads/main' && needs.tests-prep.result == 'success' }}
@@ -585,6 +589,8 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -616,6 +622,8 @@ jobs:
     name: Linting (All)
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/revert/yeoman-update' }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -1889,6 +1897,8 @@ jobs:
     needs: [determine-cd-eligibility, archive, build]
     if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     outputs:
       environments: ${{ steps.set-environments.outputs.environments }}
     env:

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   holiday-checker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is_holiday: ${{ steps.holiday-check.outputs.is_holiday }}
     steps:
@@ -35,6 +37,8 @@ jobs:
 
   cancel-run-if-holiday:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: holiday-checker
     if: ${{ github.event.inputs.bypass_freeze != 'true' && needs.holiday-checker.outputs.is_holiday == 'true' }}
     steps:
@@ -253,6 +257,8 @@ jobs:
   holiday-decision-gate:
     name: Holiday Decision Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [holiday-checker, main-deployment]
     steps:
       - name: Check if deployment should proceed
@@ -265,6 +271,8 @@ jobs:
 
   get-workflow-environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: holiday-decision-gate
     outputs:
       environment_name: ${{ steps.check-environment.outputs.env_name }}
@@ -280,6 +288,8 @@ jobs:
   set-env:
     name: Set Env Variables
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: holiday-decision-gate
     outputs:
       LATEST_TAG_VERSION: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   get-registries:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       registries: ${{ steps.set-matrix.outputs.registries }}
     steps:

--- a/.github/workflows/e2e-stress-test.yml
+++ b/.github/workflows/e2e-stress-test.yml
@@ -191,6 +191,8 @@ jobs:
   cypress-tests-prep:
     name: Prep for Cypress Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [fetch-e2e-allow-list]
     outputs:
       cypress-tests-to-stress-test: ${{ steps.cypress-tests-to-stress-test.outputs.tests }}

--- a/.github/workflows/freeze-enforcer.yml
+++ b/.github/workflows/freeze-enforcer.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   holiday-checker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is_holiday: ${{ steps.holiday-check.outputs.is_holiday }}
     steps:

--- a/.github/workflows/full-suite-tests.yml
+++ b/.github/workflows/full-suite-tests.yml
@@ -32,6 +32,8 @@ jobs:
   validate-inputs:
     name: Validate Inputs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check that at least one test suite is selected
         run: |
@@ -191,6 +193,8 @@ jobs:
     name: Tests Prep
     needs: [fetch-allow-lists]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     outputs:
       disallowed-tests: ${{ steps.disallowed-tests.outputs.tests }}
       cypress-tests: ${{ steps.cypress-tests.outputs.selected }}

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -65,6 +65,8 @@ jobs:
   set-environment:
     name: Set environment to deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       environment: ${{ steps.set-output.outputs.environment }}
     needs: permissions-check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,6 +54,9 @@ jobs:
     name: Check Cross App Imports
     needs: [fetch-unit-tests-allow-list]
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -117,6 +120,9 @@ jobs:
   annotate-files:
     name: Platform-elected file notations
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
@@ -381,6 +387,8 @@ jobs:
   linting:
     name: Linting (Files Changed)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017

--- a/.github/workflows/shai-hulud-2-check.yml
+++ b/.github/workflows/shai-hulud-2-check.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   security-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: gensecaihq/Shai-Hulud-2.0-Detector@v1

--- a/.github/workflows/unit-test-coverage-report.yml
+++ b/.github/workflows/unit-test-coverage-report.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   list-apps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
         apps: ${{ steps.get-apps.outputs.apps }}
     steps:

--- a/.github/workflows/unit-test-stress-test.yml
+++ b/.github/workflows/unit-test-stress-test.yml
@@ -100,6 +100,8 @@ jobs:
     name: Tests Prep
     needs: [fetch-unit-tests-allow-list]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       app_folders: ${{ steps.get-changed-apps.outputs.folders }}
       apps-to-stress-test: ${{ steps.apps-to-stress-test.outputs.apps_to_test }}
@@ -166,6 +168,8 @@ jobs:
   unit-tests-stress-test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [fetch-unit-tests-allow-list, tests-prep]
 
     env:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Adds explicit least-privilege `permissions` blocks to 25 GitHub Actions jobs across 13 workflow files to resolve medium-severity CodeQL alerts for the `actions/missing-workflow-permissions` rule.
- When a job does not declare explicit permissions, the `GITHUB_TOKEN` receives the repository's default permissions, which are broader than necessary. This change enforces the principle of least privilege by granting each job only the specific permissions it requires.
- Most jobs only need `contents: read`. Jobs that create check annotations (`check-cross-app-imports`, `annotate-files`) also receive `checks: write`. The `close-stale-pull-requests` job receives `contents: write`, `issues: write`, and `pull-requests: write` as it needs to label and close stale PRs.
- Platform SRE team owns this change.

### Files changed (13 workflows, 25 jobs)

| File | Jobs Fixed |
|------|-----------|
| `continuous-integration.yml` | `determine-cd-eligibility`, `unit-tests-stress-test`, `security-audit`, `linting`, `set-deploy-environments` |
| `daily-deploy-production.yml` | `holiday-checker`, `cancel-run-if-holiday`, `holiday-decision-gate`, `get-workflow-environment`, `set-env` |
| `pull-request.yml` | `check-cross-app-imports`, `annotate-files`, `linting` |
| `full-suite-tests.yml` | `validate-inputs`, `tests-prep` |
| `unit-test-stress-test.yml` | `tests-prep`, `unit-tests-stress-test` |
| `check-feature-toggles.yml` | `search` |
| `close-stale-pull-requests.yml` | `stale` |
| `daily-lighthouse-scan.yml` | `get-registries` |
| `e2e-stress-test.yml` | `cypress-tests-prep` |
| `freeze-enforcer.yml` | `holiday-checker` |
| `manual-deploy-dev-staging.yml` | `set-environment` |
| `shai-hulud-2-check.yml` | `security-check` |
| `unit-test-coverage-report.yml` | `list-apps` |

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-sensitive#5394

## Testing done

- These changes are additive-only — each edit adds a `permissions` block to a job that previously had none. No existing permissions are modified or removed.
- Verified that the permissions assigned to each job match what the job's steps actually require (e.g., jobs using `actions/checkout` need `contents: read`, jobs using the `annotations` composite action need `checks: write`).
- CI on this PR exercises several of the modified workflows (`continuous-integration.yml`, `pull-request.yml`) and will confirm they still function correctly with the restricted permissions.
- Full validation: after merge, CodeQL re-scan should show 0 open alerts for the `actions/missing-workflow-permissions` rule.

## Screenshots

Not applicable — no UI changes. This is a CI/CD workflow configuration change.

## What areas of the site does it impact?

No site functionality is impacted. This change only affects GitHub Actions workflow permissions declarations.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). — Not applicable; workflow YAML changes have no unit tests. Validation is via CI pass and CodeQL re-scan.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) — Not applicable; no documentation changes needed.
- [ ] Screenshot of the developed feature is added — Not applicable; no visual feature.
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed — Not applicable; no user-facing changes.

### Error Handling

- [ ] Browser console contains no warnings or errors. — Not applicable; no browser changes.
- [ ] Events are being sent to the appropriate logging solution — Not applicable.
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) — Not applicable.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user — Not applicable; no application code changes.

## Requested Feedback

This PR resolves all 25 open CodeQL alerts for the `actions/missing-workflow-permissions` rule. For the `check-cross-app-imports` and `annotate-files` jobs in `pull-request.yml`, `checks: write` was added in addition to `contents: read` because they use the `annotations` composite action (which wraps `yuzutech/annotations-action` to create check runs). Reviewers should verify this is sufficient — if those jobs also interact with the GitHub API in other ways, additional permissions may be needed.