### PR TITLE
#133514: Add empty view for in-progress page (with missing link/descriptive text

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionsInProgress/InProgressMedicationsEmptyView.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionsInProgress/InProgressMedicationsEmptyView.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ProcessList from '../shared/ProcessList';
+import { refillProcessStepGuideV2 } from '../../util/processListData';
+
+const InProgressMedicationsEmptyView = () => (
+  <>
+    <div className="vads-u-padding-y--3 vads-u-border-bottom--1px vads-u-border-color--gray-light">
+      <va-card background data-testid="in-progress-empty-view-card">
+        <div>
+          <h2 className="vads-u-margin--0 vads-u-font-size--h3">
+            You don’t have any in-progress medications right now
+          </h2>
+          <p className="vads-u-margin-top--1 vads-u-margin-bottom--0">
+            If you have questions about a prescription, contact your care team.
+          </p>
+        </div>
+      </va-card>
+    </div>
+    <ProcessList stepGuideProps={refillProcessStepGuideV2} />
+  </>
+);
+
+export default InProgressMedicationsEmptyView;

--- a/src/applications/mhv-medications/containers/PrescriptionsInProgress.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionsInProgress.jsx
@@ -6,6 +6,7 @@ import NeedHelp from '../components/shared/NeedHelp';
 import ApiErrorNotification from '../components/shared/ApiErrorNotification';
 import useFetchPrescriptionsInProgress from '../hooks/PrescriptionsInProgress/useFetchPrescriptionsInProgress';
 import { pageType, dataDogActionNames } from '../util/dataDogConstants';
+import InProgressMedicationsEmptyView from '../components/PrescriptionsInProgress/InProgressMedicationsEmptyView';
 
 const PrescriptionsInProgress = () => {
   const {
@@ -34,7 +35,15 @@ const PrescriptionsInProgress = () => {
       return <ApiErrorNotification errorType="access" content="medications" />;
     }
 
-    // TODO: Implement empty state design for when there are no in-progress medications
+    if (
+      inProgress.length === 0 &&
+      shipped.length === 0 &&
+      submitted.length === 0 &&
+      tooEarly.length === 0
+    ) {
+      return <InProgressMedicationsEmptyView />;
+    }
+
     return (
       <InProgressMedicationsProcessList
         inProgress={inProgress}

--- a/src/applications/mhv-medications/tests/components/PrescriptionsInProgress/InProgressMedicationsEmptyView.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionsInProgress/InProgressMedicationsEmptyView.unit.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, within } from '@testing-library/react';
+import { expect } from 'chai';
+import InProgressMedicationsEmptyView from '../../../components/PrescriptionsInProgress/InProgressMedicationsEmptyView';
+
+describe('InProgressMedicationsEmptyView Component', () => {
+  const setup = () => render(<InProgressMedicationsEmptyView />);
+
+  it('renders without errors', () => {
+    const screen = setup();
+    expect(screen).to.exist;
+    expect(screen.getByTestId('in-progress-empty-view-card')).to.exist;
+  });
+
+  it('renders the correct content', () => {
+    const screen = setup();
+    const { container } = screen;
+
+    // "You don't have any..." card
+    const card = within(screen.getByTestId('in-progress-empty-view-card'));
+    expect(
+      card.getByRole('heading', {
+        level: 2,
+        name: 'You don’t have any in-progress medications right now',
+      }),
+    ).to.exist;
+    expect(
+      card.getByText(
+        'If you have questions about a prescription, contact your care team.',
+      ),
+    ).to.exist;
+
+    // Process list content
+    expect(screen.getByText('How the refill process works on VA.gov')).to.exist;
+    const processListItems = container.querySelectorAll('va-process-list-item');
+    expect(processListItems.length).to.equal(3);
+    expect(processListItems[0]).to.have.attribute(
+      'header',
+      'You request a refill',
+    );
+    expect(processListItems[1]).to.have.attribute(
+      'header',
+      'We process your refill request',
+    );
+    expect(processListItems[2]).to.have.attribute(
+      'header',
+      'We ship your refill to you',
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/containers/PrescriptionsInProgress.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/PrescriptionsInProgress.unit.spec.jsx
@@ -205,6 +205,7 @@ describe('PrescriptionsInProgress container', () => {
     it('displays the process list when prescriptions are loaded', () => {
       stubFetchHook(mockCategorizedPrescriptions);
       const screen = setup();
+      expect(screen.queryByTestId('in-progress-empty-view-card')).to.not.exist;
       const processListItems = screen.container.querySelectorAll(
         'va-process-list-item',
       );
@@ -235,18 +236,22 @@ describe('PrescriptionsInProgress container', () => {
     it('renders process list with empty prescriptions array', () => {
       stubFetchHook(emptyPrescriptions);
       const screen = setup();
+      expect(screen.getByTestId('in-progress-empty-view-card')).to.exist;
+      expect(screen.queryByTestId('in-progress-medications-process-list')).to
+        .not.exist;
+
       const processListItems = screen.container.querySelectorAll(
         'va-process-list-item',
       );
       expect(processListItems.length).to.equal(3);
       expect(processListItems[0].getAttribute('header')).to.equal(
-        'Request submitted',
+        'You request a refill',
       );
       expect(processListItems[1].getAttribute('header')).to.equal(
-        'Fill in progress',
+        'We process your refill request',
       );
       expect(processListItems[2].getAttribute('header')).to.equal(
-        'Medication shipped',
+        'We ship your refill to you',
       );
     });
 

--- a/src/applications/mhv-medications/tests/e2e/medications-in-progress-page-success-empty.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-in-progress-page-success-empty.cypress.spec.js
@@ -1,0 +1,31 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsInProgressPage from './pages/MedicationsInProgressPage';
+import inProgressPrescriptions from './fixtures/in-progress-prescriptions.json';
+
+describe('In-progress medications page - successful data load (empty view)', () => {
+  it('displays the empty view when there are no in-progress medications', () => {
+    const site = new MedicationsSite();
+    site.loginWithManagementImprovements();
+
+    const emptyData = JSON.parse(JSON.stringify(inProgressPrescriptions));
+
+    emptyData.data = [];
+    emptyData.meta = {
+      totalPages: 0,
+      totalEntries: 0,
+      ...emptyData.meta,
+    };
+
+    const inProgressPage = new MedicationsInProgressPage();
+    inProgressPage.visitPage(emptyData);
+    cy.wait('@prescriptions');
+
+    inProgressPage.verifyHeading();
+    inProgressPage.verifyEmptyViewCard();
+    inProgressPage.verifyEmptyViewProcessListSteps();
+    inProgressPage.verifyNeedHelpSection();
+
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsInProgressPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsInProgressPage.js
@@ -22,6 +22,16 @@ class MedicationsInProgressPage {
     );
   };
 
+  verifyEmptyViewCard = () => {
+    cy.findByTestId('in-progress-empty-view-card').should('exist');
+  };
+
+  verifyEmptyViewProcessListSteps = () => {
+    cy.findByText('You request a refill').should('exist');
+    cy.findByText('We process your refill request').should('exist');
+    cy.findByText('We ship your refill to you').should('exist');
+  };
+
   verifyProcessListSteps = () => {
     cy.findByText('Request submitted').should('exist');
     cy.findByText('Fill in progress').should('exist');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This adds a new view to the medications in-progress page when there are no meds to populate it.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133514

## Testing done

- Verify new view renders as expected when no medications match any of the in-progress page sections.
- Verify new view does NOT render when at least one medication appears in any of the four sections (submitted, too early, in-progress, and shipped)

Note: The `"Go to your in-progress medications page..."` text and the accompanying link were intentionally left out of this change, see [this thread](https://dsva.slack.com/archives/C04PRFEJQTY/p1773417781278179).

### Setup instructions

By default the mock data returns a few meds in the `in-progress` section, so this new view won't show.

Updating the `useFetchPrescriptionsInProgress` to override `data` to `[]` is an easy way to mock this (see videos below).

## Screenshots

https://github.com/user-attachments/assets/6867cecc-db69-49a1-9903-8c2a94fad7b6

https://github.com/user-attachments/assets/3883de0c-3976-413e-9338-974005ddf24f

## What areas of the site does it impact?

This only impacts the new /medications/in-progress page.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
