### PR TITLE
133580 fix flaky unit test

### DIFF
--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -403,6 +403,7 @@ describe('Medications Prescriptions container', () => {
           'api-status': 'successful',
         });
       });
+
       // Check that datadogRum.addAction was called
       await waitFor(() => {
         expect(addActionSpy.called).to.be.true;

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -388,7 +388,7 @@ describe('Medications Prescriptions container', () => {
       global.window.dataLayer = [];
     });
 
-    it.skip('should call recordEvent when rxRenewalMessageSuccess query param is present', async () => {
+    it('should call recordEvent when rxRenewalMessageSuccess query param is present', async () => {
       const addActionSpy = sinon.spy(datadogRum, 'addAction');
       setup(initialState, '/?rxRenewalMessageSuccess=true');
 

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -403,7 +403,6 @@ describe('Medications Prescriptions container', () => {
           'api-status': 'successful',
         });
       });
-
       // Check that datadogRum.addAction was called
       await waitFor(() => {
         expect(addActionSpy.called).to.be.true;

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -389,7 +389,7 @@ describe('Medications Prescriptions container', () => {
     });
 
     it('should call recordEvent when rxRenewalMessageSuccess query param is present', async () => {
-      const addActionSpy = sinon.spy(datadogRum, 'addAction');
+      const addActionSpy = sandbox.spy(datadogRum, 'addAction');
       setup(initialState, '/?rxRenewalMessageSuccess=true');
 
       await waitFor(() => {
@@ -409,8 +409,6 @@ describe('Medications Prescriptions container', () => {
         expect(addActionSpy.called).to.be.true;
       });
       expect(addActionSpy.calledWith('Rx Renewal Success')).to.be.true;
-
-      addActionSpy.restore();
     });
 
     it('should not call recordEvent when rxRenewalMessageSuccess query param is not present', async () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request updates the unit test for the Medications Prescriptions container by re-enabling a previously skipped test and making a minor adjustment to how spies are created and cleaned up.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133580

## Testing done

* Re-enabled the test for calling `recordEvent` when the `rxRenewalMessageSuccess` query parameter is present, ensuring this important user interaction is tested.
* Updated the test to use `sandbox.spy` instead of `sinon.spy` for spying on `datadogRum.addAction`, and removed the unnecessary manual restore, relying on the sandbox for cleanup.

## What areas of the site does it impact?

* Medications unit tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
