### PR TITLE
Fix validate dom nesting warning

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/ItemList.jsx
+++ b/src/applications/mhv-medical-records/components/shared/ItemList.jsx
@@ -44,7 +44,7 @@ const ItemList = props => {
       </span>
     );
   }
-  return <p className="vads-u-margin-top--0">None recorded</p>;
+  return <span className="vads-u-margin-top--0">None recorded</span>;
 };
 
 export default ItemList;

--- a/src/applications/mhv-medical-records/tests/components/ItemList.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/ItemList.unit.spec.jsx
@@ -24,7 +24,7 @@ describe('Record list item component', () => {
 
     const emptyMessageElement = screen.getByText('None recorded', {
       exact: true,
-      selector: 'p',
+      selector: 'span',
     });
     expect(emptyMessageElement).to.exist;
   });

--- a/src/applications/mhv-medical-records/tests/e2e/pages/BaseDetailsPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/BaseDetailsPage.js
@@ -8,6 +8,13 @@ class BaseDetailsPage {
       .should('be.visible')
       .and('not.be.disabled')
       .click();
+    cy.get('[data-testid="print-download-menu"]', { timeout: 10000 })
+      .should('have.attr', 'aria-expanded')
+      .then(expanded => {
+        if (expanded !== 'true') {
+          cy.get('[data-testid="print-download-menu"]').click();
+        }
+      });
     cy.get('[data-testid="print-download-menu"]', { timeout: 10000 }).should(
       'have.attr',
       'aria-expanded',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fixes a validateDOMNesting React warning: <p> cannot appear as a descendant of <p>.

**Changes**
- ItemList.jsx: Changed the empty-state fallback from `<p>` to `<span>`, consistent with the `<span>` used for the string and single-item cases in the same component
- ItemList.unit.spec.jsx: Updated the test selector from 'p' to 'span' to match

Affected areas
The fix resolves the warning for all three `LabelValue` + `ItemList` usages:
- Allergy details (reaction field)
- Condition details (comments field)
- Chem/Hem lab details (comments field)

## Related issue(s)

N/A

## Testing done

- Unit tests updated and passing.
- No visual or functional change - `<span>` with the same class renders identically.

## Screenshots

N/A

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
