### PR TITLE
Add UI validation in e2e tests for Topics and DateTime

### DIFF
--- a/src/applications/vass/tests/e2e/error-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/error-path.cypress.spec.js
@@ -410,103 +410,182 @@ describe('VASS Error Paths', () => {
       VerifyPageObject.fillAndSubmitForm();
       cy.wait('@vass:post:request-otp');
     });
-    describe('when the user is not within the cohort window', () => {
-      beforeEach(() => {
-        mockAppointmentAvailabilityApi({
-          response: MockAppointmentAvailabilityResponse.createNotWithinCohortError(),
-          responseCode: 403,
+
+    describe('API Errors', () => {
+      describe('when the user is not within the cohort window', () => {
+        beforeEach(() => {
+          mockAppointmentAvailabilityApi({
+            response: MockAppointmentAvailabilityResponse.createNotWithinCohortError(),
+            responseCode: 403,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:get:appointment-availability');
+
+          DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_availability_notWithinCohort');
         });
       });
 
-      it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitOTP();
-        cy.wait('@vass:get:appointment-availability');
+      describe('when the user already has an appointment booked', () => {
+        beforeEach(() => {
+          const appointmentId = 'e61e1a40-1e63-f011-bec2-001dd80351ea';
+          mockAppointmentAvailabilityApi({
+            response: MockAppointmentAvailabilityResponse.createAppointmentAlreadyBookedError(
+              { appointmentId },
+            ),
+            responseCode: 409,
+          });
+          mockAppointmentDetailsApi({
+            response: new MockAppointmentDetailsResponse({
+              appointmentId,
+            }).toJSON(),
+            responseCode: 200,
+          });
+        });
 
-        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_availability_notWithinCohort');
+        it('should redirect to the already scheduled page', () => {
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:get:appointment-availability');
+          cy.wait('@vass:get:appointment-details');
+
+          AlreadyScheduledPageObject.assertAlreadyScheduledPage();
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_availability_alreadyBooked');
+        });
+      });
+
+      describe('when no slots are available', () => {
+        beforeEach(() => {
+          mockAppointmentAvailabilityApi({
+            response: MockAppointmentAvailabilityResponse.createNoSlotsAvailableError(),
+            responseCode: 404,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:get:appointment-availability');
+
+          DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_availability_noSlots');
+        });
+      });
+
+      describe('when the API returns a server error', () => {
+        beforeEach(() => {
+          mockAppointmentAvailabilityApi({
+            response: MockAppointmentAvailabilityResponse.createVassApiError(),
+            responseCode: 500,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:get:appointment-availability');
+
+          DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_availability_serverError500');
+        });
+      });
+
+      describe('when the service is unavailable', () => {
+        beforeEach(() => {
+          mockAppointmentAvailabilityApi({
+            response: MockAppointmentAvailabilityResponse.createServiceError(),
+            responseCode: 503,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:get:appointment-availability');
+
+          DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_availability_serviceUnavailable503');
+        });
       });
     });
 
-    describe('when the user already has an appointment booked', () => {
+    describe('UI Errors', () => {
+      const appointmentId = 'appointment-id';
       beforeEach(() => {
-        const appointmentId = 'e61e1a40-1e63-f011-bec2-001dd80351ea';
         mockAppointmentAvailabilityApi({
-          response: MockAppointmentAvailabilityResponse.createAppointmentAlreadyBookedError(
-            { appointmentId },
-          ),
-          responseCode: 409,
-        });
-        mockAppointmentDetailsApi({
-          response: new MockAppointmentDetailsResponse({
+          response: new MockAppointmentAvailabilityResponse({
             appointmentId,
+            availableSlots: MockAppointmentAvailabilityResponse.createSlots(),
           }).toJSON(),
           responseCode: 200,
         });
       });
+      describe('when does not select a date and time slot', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
 
-      it('should redirect to the already scheduled page', () => {
-        EnterOTPPageObject.fillAndSubmitOTP();
-        cy.wait('@vass:get:appointment-availability');
-        cy.wait('@vass:get:appointment-details');
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:post:authenticate-otp');
+          cy.wait('@vass:get:appointment-availability');
 
-        AlreadyScheduledPageObject.assertAlreadyScheduledPage();
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_availability_alreadyBooked');
-      });
-    });
+          DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+          DateTimeSelectionPageObject.submitWithoutSelection();
 
-    describe('when no slots are available', () => {
-      beforeEach(() => {
-        mockAppointmentAvailabilityApi({
-          response: MockAppointmentAvailabilityResponse.createNoSlotsAvailableError(),
-          responseCode: 404,
+          DateTimeSelectionPageObject.assertValidationError(
+            'Please select a preferred date and time for your appointment.',
+          );
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_dateTime_emptyInput');
         });
       });
 
-      it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitOTP();
-        cy.wait('@vass:get:appointment-availability');
+      describe('when the user submits the form without selecting a time slot after selecting a date', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          EnterOTPPageObject.assertEnterOTPPage();
 
-        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_availability_noSlots');
-      });
-    });
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:post:authenticate-otp');
+          cy.wait('@vass:get:appointment-availability');
 
-    describe('when the API returns a server error', () => {
-      beforeEach(() => {
-        mockAppointmentAvailabilityApi({
-          response: MockAppointmentAvailabilityResponse.createVassApiError(),
-          responseCode: 500,
+          DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+          DateTimeSelectionPageObject.selectFirstAvailableDate();
+          DateTimeSelectionPageObject.clickContinue();
+
+          DateTimeSelectionPageObject.assertValidationError(
+            'Please select a preferred date and time for your appointment.',
+          );
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_dateTime_missingTimeSelection');
         });
       });
 
-      it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitOTP();
-        cy.wait('@vass:get:appointment-availability');
+      describe('when the user selects a valid date and time after triggering a validation error', () => {
+        it('should clear the validation error and proceed to topic selection', () => {
+          mockTopicsApi();
 
-        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_availability_serverError500');
-      });
-    });
+          EnterOTPPageObject.assertEnterOTPPage();
 
-    describe('when the service is unavailable', () => {
-      beforeEach(() => {
-        mockAppointmentAvailabilityApi({
-          response: MockAppointmentAvailabilityResponse.createServiceError(),
-          responseCode: 503,
+          EnterOTPPageObject.fillAndSubmitOTP();
+          cy.wait('@vass:post:authenticate-otp');
+          cy.wait('@vass:get:appointment-availability');
+
+          DateTimeSelectionPageObject.assertDateTimeSelectionPage();
+          DateTimeSelectionPageObject.submitWithoutSelection();
+          DateTimeSelectionPageObject.assertValidationError(
+            'Please select a preferred date and time for your appointment.',
+          );
+
+          DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+          cy.wait('@vass:get:topics');
+
+          TopicSelectionPageObject.assertTopicSelectionPage();
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_dateTime_validationClearsAfterSelection');
         });
-      });
-
-      it('should display a wrapper error alert', () => {
-        EnterOTPPageObject.fillAndSubmitOTP();
-        cy.wait('@vass:get:appointment-availability');
-
-        DateTimeSelectionPageObject.assertWrapperErrorAlert({ exist: true });
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_availability_serviceUnavailable503');
       });
     });
   });
@@ -532,39 +611,106 @@ describe('VASS Error Paths', () => {
       EnterOTPPageObject.fillAndSubmitOTP();
     });
 
-    describe('when the API returns a server error', () => {
-      beforeEach(() => {
-        mockTopicsApi({
-          response: MockTopicsResponse.createVassApiError(),
-          responseCode: 500,
+    describe('API Errors', () => {
+      describe('when the API returns a server error', () => {
+        beforeEach(() => {
+          mockTopicsApi({
+            response: MockTopicsResponse.createVassApiError(),
+            responseCode: 500,
+          });
+        });
+
+        it('should display a wrapper error alert', () => {
+          DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+          cy.wait('@vass:get:topics');
+
+          TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_topics_serverError500');
         });
       });
 
-      it('should display a wrapper error alert', () => {
-        DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
-        cy.wait('@vass:get:topics');
+      describe('when the service is unavailable', () => {
+        beforeEach(() => {
+          mockTopicsApi({
+            response: MockTopicsResponse.createServiceError(),
+            responseCode: 503,
+          });
+        });
 
-        TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_topics_serverError500');
+        it('should display a wrapper error alert', () => {
+          DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+          cy.wait('@vass:get:topics');
+
+          TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_topics_serviceUnavailable503');
+        });
       });
     });
 
-    describe('when the service is unavailable', () => {
-      beforeEach(() => {
-        mockTopicsApi({
-          response: MockTopicsResponse.createServiceError(),
-          responseCode: 503,
+    describe('UI Errors', () => {
+      describe('when the user leaves all topic selections empty', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          mockTopicsApi();
+
+          DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+          cy.wait('@vass:get:topics');
+
+          TopicSelectionPageObject.assertTopicSelectionPage();
+          TopicSelectionPageObject.submitWithoutSelection();
+
+          TopicSelectionPageObject.assertValidationError(
+            'Please choose a topic for your appointment.',
+          );
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_topics_emptySelection');
         });
       });
 
-      it('should display a wrapper error alert', () => {
-        DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
-        cy.wait('@vass:get:topics');
+      describe('when the user unselects all topics after making a selection', () => {
+        it('should not submit the form and display an error when the user submits the form', () => {
+          mockTopicsApi();
 
-        TopicSelectionPageObject.assertWrapperErrorAlert({ exist: true });
-        cy.injectAxeThenAxeCheck();
-        saveScreenshot('vass_error_topics_serviceUnavailable503');
+          DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+          cy.wait('@vass:get:topics');
+
+          TopicSelectionPageObject.assertTopicSelectionPage();
+          TopicSelectionPageObject.selectTopicByName('General VA benefits');
+          TopicSelectionPageObject.unselectTopicByTestId(
+            'topic-checkbox-general-va-benefits',
+          );
+          TopicSelectionPageObject.clickContinue();
+
+          TopicSelectionPageObject.assertValidationError(
+            'Please choose a topic for your appointment.',
+          );
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_topics_unselectedAfterSelection');
+        });
+      });
+
+      describe('when the user selects a valid topic after triggering a validation error', () => {
+        it('should clear the validation error and proceed to review', () => {
+          mockTopicsApi();
+
+          DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
+          cy.wait('@vass:get:topics');
+
+          TopicSelectionPageObject.assertTopicSelectionPage();
+          TopicSelectionPageObject.submitWithoutSelection();
+          TopicSelectionPageObject.assertValidationError(
+            'Please choose a topic for your appointment.',
+          );
+
+          TopicSelectionPageObject.selectTopicAndContinue(
+            'General VA benefits',
+          );
+
+          ReviewPageObject.assertReviewPage();
+          cy.injectAxeThenAxeCheck();
+          saveScreenshot('vass_error_topics_validationClearsAfterSelection');
+        });
       });
     });
   });

--- a/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
+++ b/src/applications/vass/tests/e2e/happy-path.cypress.spec.js
@@ -84,8 +84,8 @@ describe('VASS Schedule Appointment', () => {
       DateTimeSelectionPageObject.selectFirstAvailableDateTimeAndContinue();
 
       cy.wait('@vass:get:topics');
-      cy.injectAxeThenAxeCheck();
       TopicSelectionPageObject.assertTopicSelectionPage();
+      cy.injectAxeThenAxeCheck();
       saveScreenshot('vass_schedule_topicSelection');
       TopicSelectionPageObject.selectTopicAndContinue('General VA benefits');
 
@@ -171,9 +171,10 @@ describe('VASS Schedule Appointment', () => {
       DateTimeSelectionPageObject.clickContinue();
 
       cy.wait('@vass:get:topics');
-      cy.injectAxeThenAxeCheck();
       TopicSelectionPageObject.assertTopicSelectionPage();
+      cy.injectAxeThenAxeCheck();
       TopicSelectionPageObject.selectTopicAndContinue(topic);
+      cy.injectAxeThenAxeCheck();
 
       ReviewPageObject.assertReviewPage();
       cy.injectAxeThenAxeCheck();
@@ -244,13 +245,16 @@ describe('VASS Schedule Appointment', () => {
       // Change topic: go back, unselect first and select second
       ReviewPageObject.clickEditTopic();
       TopicSelectionPageObject.assertTopicSelectionPage();
+      cy.injectAxeThenAxeCheck();
       TopicSelectionPageObject.unselectTopicByTestId(
         'topic-checkbox-general-va-benefits',
       );
+      cy.injectAxeThenAxeCheck();
       saveScreenshot('vass_schedule_topicSelection_changingTopic');
       TopicSelectionPageObject.selectTopicAndContinue(secondTopic);
 
       ReviewPageObject.assertReviewPage();
+      cy.injectAxeThenAxeCheck();
       ReviewPageObject.assertTopicDescription(secondTopic);
       saveScreenshot('vass_schedule_review_afterTopicChange');
       ReviewPageObject.clickConfirmAppointment();
@@ -355,18 +359,18 @@ describe('VASS Schedule Appointment', () => {
       VerifyPageObject.fillAndSubmitForm();
 
       cy.wait('@vass:post:request-otp');
-      cy.injectAxeThenAxeCheck();
       EnterOTPPageObject.assertEnterOTPPage({ cancellationFlow: true });
+      cy.injectAxeThenAxeCheck();
       EnterOTPPageObject.assertSuccessAlertContainsEmail('s****@email.com');
       saveScreenshot('vass_cancel_enterOTP_cancellationLink');
       EnterOTPPageObject.fillAndSubmitOTP();
 
       cy.wait('@vass:get:appointment-details');
 
-      cy.injectAxeThenAxeCheck();
       CancelAppointmentPageObject.assertCancelAppointmentPage({
         agentName: 'Agent Smith',
       });
+      cy.injectAxeThenAxeCheck();
       saveScreenshot('vass_cancel_cancelAppointmentPage_fromLink');
 
       CancelAppointmentPageObject.clickYesCancelAppointment();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
  - [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

  ### :warning: TeamSites :warning:
  Did you change site-wide styles, platform utilities or other infrastructure?
  - [x] No

  ## Summary

  - **What changed:** Added client-side UI validation E2E tests for the Date/Time Selection and
  Topic Selection pages in the VASS scheduling flow. Restructured existing error path tests under
  `API Errors` and `UI Errors` describe blocks for better organization. Fixed accessibility check
  (`cy.injectAxeThenAxeCheck()`) ordering in happy path tests so they run after page assertions
  confirm the correct page has loaded.
  - **Why:** Error path tests previously only covered API-level errors (500, 503, 403, etc.) but
  had no coverage for form validation scenarios like submitting without selecting a date/time or
  topic. Accessibility checks were also running before page assertions in several happy path steps,
   which could produce unreliable results.
  - **Solution:** Added new `UI Errors` describe blocks with tests covering empty submissions,
  partial selections, select-then-unselect flows, and validation-error-clearing scenarios for both
  the Date/Time Selection and Topic Selection pages. Moved existing API error tests under `API
  Errors` describe blocks. Reordered `cy.injectAxeThenAxeCheck()` calls to run after
  `assert*Page()` calls in the happy path.
  - **Team:** <!-- TODO: Add your team name --> VASS / Solid Start team owns this code.

  ## Related issue(s)

  - department-of-veterans-affairs/va.gov-team#136273

  ## Testing done

  - **Previous behavior:** Error path E2E tests only covered server-side API errors (invalid
  credentials, rate limiting, server errors, service unavailable). No tests existed for client-side
   form validation on the Date/Time Selection or Topic Selection pages. Happy path accessibility
  checks sometimes ran before the target page was confirmed loaded.
  - **Steps to verify:**
    1. Run the VASS E2E error path tests: `yarn cy:run --spec
  src/applications/vass/tests/e2e/error-path.cypress.spec.js`
    2. Run the VASS E2E happy path tests: `yarn cy:run --spec
  src/applications/vass/tests/e2e/happy-path.cypress.spec.js`
    3. Verify the following new test cases pass under **Appointment Availability Errors > UI
  Errors**:
       - Submitting without selecting any date/time shows validation error
       - Selecting a date but no time slot shows validation error
       - Selecting a valid date/time after triggering validation clears the error and proceeds
    4. Verify the following new test cases pass under **Topics Errors > UI Errors**:
       - Submitting without selecting any topic shows validation error
       - Selecting then unselecting all topics shows validation error
       - Selecting a valid topic after triggering validation clears the error and proceeds
    5. Confirm all existing API error tests still pass (now nested under `API Errors` blocks)
    6. Confirm happy path tests pass with corrected accessibility check ordering
  - **Tests updated:**
    - `error-path.cypress.spec.js` - 6 new UI validation test cases added, existing tests
  reorganized
    - `happy-path.cypress.spec.js` - reordered `cy.injectAxeThenAxeCheck()` calls, added missing
  accessibility checks

  ## Screenshots

  N/A - no UI changes. These are E2E test file modifications only.

  ## What areas of the site does it impact?

  Changes are scoped entirely to VASS E2E test files under `src/applications/vass/tests/e2e/`. No
  application code, shared platform code, or other applications are affected.

  ## Acceptance criteria

  ### Quality Assurance & Testing

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging,
  hardcoded, or specs
  - [ ] Linting warnings have been addressed
  - [ ] Documentation has been updated ([link to documentation](#) *if necessary)
  - [ ] Screenshot of the developed feature is added
  - [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-c
  ycle/prepare-for-an-accessibility-staging-review) has been performed

  ### Error Handling

  - [ ] Browser console contains no warnings or errors.
  - [ ] Events are being sent to the appropriate logging solution
  - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

  ### Authentication

  - [ ] Did you login to a local build and verify all authenticated routes work as expected with a
  test user

  ## Requested Feedback

  Reviewers: please verify the new page object methods (`submitWithoutSelection`,
  `assertValidationError`, `selectFirstAvailableDate`, `selectTopicByName`,
  `unselectTopicByTestId`) are used consistently and that the test reorganization under `API
  Errors` / `UI Errors` groupings is clear and maintainable.