### PR TITLE
corrected conditional in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1173,7 +1173,7 @@ jobs:
       # ----------------
 
       - name: Notify Slack about Unit test failures
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         env:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The Slack notification for unit test failures had an inverted condition that caused it to trigger on non-main branches while claiming tests failed on main. This resulted in false positive notifications showing "Unit tests in vets-website have failed on the main branch" when tests actually failed on feature/PR branches.

- Changed condition in continuous-integration.yml from github.ref != 'refs/heads/main' to github.ref == 'refs/heads/main'
- Slack notifications will now only be sent when unit tests actually fail on the main branch
- Eliminates false positive notifications from feature branch failures

## Related issue(s)

- _[Notification pileup can be found in the `qas-notifications` channel of the OCTO Slack workspace](https://dsva.slack.com/archives/C026PD47Z19)._
