### PR TITLE
Prefill match

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -857,13 +857,18 @@ export function hideFormTitle(formConfig, pathName, formData) {
     return false;
 
   const formPages = createFormPageList(formConfig);
-  let pageList = createPageList(formConfig, formPages);
+  const fullPageList = createPageList(formConfig, formPages);
+  let pageList = fullPageList;
   try {
-    pageList = getActiveExpandedPages(pageList, formData);
+    pageList = getActiveExpandedPages(fullPageList, formData);
   } catch {
     // If we can't get active expanded pages, just use the default pageList
   }
-  const page = pageList.find(p => p.path === pathName);
+  // Check active pages first, then fall back to full list for pages with
+  // depends: () => false (e.g. edit contact info pages)
+  const page =
+    pageList.find(p => p.path === pathName) ||
+    fullPageList.find(p => p.path === pathName);
 
   if (pathName === '/confirmation') {
     return !!(formConfig.hideFormTitleConfirmation === undefined

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/ContactInfo.jsx
@@ -642,7 +642,7 @@ export const ContactInfoBase = ({
     <>
       {contentBeforeButtons}
       <FormNavButtons
-        goBack={!isMinimalHeader && handlers.onGoBack}
+        goBack={isMinimalHeader ? null : handlers.onGoBack}
         goForward={handlers.onGoForward}
       />
       {contentAfterButtons}

--- a/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/EditContactInfo.jsx
+++ b/src/platform/forms-system/src/js/patterns/prefill/ContactInfo/EditContactInfo.jsx
@@ -31,10 +31,13 @@ export const BuildPageBase = ({
   ...rest
 }) => {
   const dispatch = useDispatch();
-  const Heading = editContactInfoHeadingLevel || 'h3';
+  const isMinimalHeader = isMinimalHeaderPath();
+  const Header = isMinimalHeader ? 'h1' : editContactInfoHeadingLevel || 'h3';
+  const headerClass = isMinimalHeader
+    ? 'vads-u-font-size--h2'
+    : 'vads-u-font-size--h3';
   const headerRef = useRef(null);
   const contactInfoFormAppConfig = useContactInfoFormAppConfig();
-  const isMinimalHeader = isMinimalHeaderPath();
 
   const modalState = useSelector(state => state?.vapService.modal);
   const prevModalState = usePrevious(modalState);
@@ -117,9 +120,9 @@ export const BuildPageBase = ({
               </p>
             </va-alert>
           )}
-          <Heading ref={headerRef} className="vads-u-font-size--h3">
+          <Header ref={headerRef} className={headerClass}>
             {title}
-          </Heading>
+          </Header>
           <ProfileInformationFieldController
             forceEditView
             fieldName={FIELD_NAMES[field]}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR removes the form title from the Contact Info edit/add pages by [updating hideFormTitle](https://github.com/department-of-veterans-affairs/vets-website/pull/43178/changes#diff-2b3179654c0878c00db5dfe58b5ab2a41a9422c11f515fa558634ccfd53dcc73L851-R871) to include those edit pages, whereas before this they were being filtered out by `getActiveExpandedPages`.

It also [changes the EditContactInfo.jsx Header](https://github.com/department-of-veterans-affairs/vets-website/pull/43178/changes#diff-4d1308a118b4a908b47bbee50d95b07972040a31833c400d3e284a1ccb05e3b4R34-R38) to be an h1 (replacing the form title's header level).

Lastly it fixes a console warning that was appearing in the browser:
```
Warning: Failed prop type: Invalid prop `goBack` of type `boolean` supplied to `FormNavButtons`, expected `function`
```
by [changing the conditional](https://github.com/department-of-veterans-affairs/vets-website/pull/43178/changes#diff-5ea5c068b04a5dd188b0a819972ff3de79e0be1d1631d0f4c317358c678e00acL645) inside the FormNavButtons goBack prop.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5815

## Testing done

Manual testing
Full suite unit tests
Full suite e2e tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|<img width="826" height="758" alt="image" src="https://github.com/user-attachments/assets/2268b056-4020-409e-b85f-cd4095105f0a" />|<img width="834" height="754" alt="image" src="https://github.com/user-attachments/assets/009ff622-7fb2-4ed1-bc4c-0c8ade899cd6" />|

## What areas of the site does it impact?

- Prefill pattern
- `hideFormTitle` function in `/platform/forms-system/src/js/helpers.js`
- Update/cancel buttons in `/platform/user/profile/vap-svc/components`

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
