### PR TITLE
Added Cerner Check to OH Portal Requirements

### DIFF
--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -127,7 +127,8 @@ export const checkPortalRequirements = ({
   userAttributes,
   provisioned,
 }) => {
-  const { vaPatient = false } = userAttributes?.vaProfile || {};
+  const { isCernerPatient = false, vaPatient = false } =
+    userAttributes?.vaProfile || {};
   const {
     userFacilityReadyForInfoAlert = false,
     userAtPretransitionedOhFacility = false,
@@ -137,8 +138,12 @@ export const checkPortalRequirements = ({
     isPortalNoticeInterstitialEnabled && provisioned && vaPatient;
 
   return {
-    needsPortalNotice: redirectElligible && userFacilityReadyForInfoAlert,
-    needsMyHealth: redirectElligible && !userAtPretransitionedOhFacility,
+    needsPortalNotice:
+      redirectElligible && isCernerPatient && userFacilityReadyForInfoAlert,
+    needsMyHealth:
+      redirectElligible &&
+      ((isCernerPatient && !userAtPretransitionedOhFacility) ||
+        !isCernerPatient),
   };
 };
 

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -353,6 +353,7 @@ describe('AuthApp', () => {
                   verified: true,
                 },
                 vaProfile: {
+                  isCernerPatient: true,
                   vaPatient: true,
                   facilities: [
                     {
@@ -418,6 +419,7 @@ describe('AuthApp', () => {
                   verified: true,
                 },
                 vaProfile: {
+                  isCernerPatient: true,
                   vaPatient: true,
                   facilities: [
                     {

--- a/src/applications/auth/tests/checkPortalRequirements.unit.spec.jsx
+++ b/src/applications/auth/tests/checkPortalRequirements.unit.spec.jsx
@@ -3,11 +3,13 @@ import { checkPortalRequirements } from '../helpers';
 
 describe('checkPortalRequirements', () => {
   const buildUserAttributes = ({
+    isCernerPatient = true,
     vaPatient = true,
     userFacilityReadyForInfoAlert = false,
     userAtPretransitionedOhFacility = false,
   } = {}) => ({
     vaProfile: {
+      isCernerPatient,
       vaPatient,
       ohMigrationInfo: {
         userFacilityReadyForInfoAlert,
@@ -17,11 +19,12 @@ describe('checkPortalRequirements', () => {
   });
 
   describe('needsPortalNotice', () => {
-    it('returns true when provisioned, vaPatient, and userFacilityReadyForInfoAlert', () => {
+    it('returns true when provisioned, vaPatient, isCernerPatient, and userFacilityReadyForInfoAlert', () => {
       const result = checkPortalRequirements({
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userFacilityReadyForInfoAlert: true,
         }),
@@ -34,6 +37,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: true,
         provisioned: false,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userFacilityReadyForInfoAlert: true,
         }),
@@ -46,7 +50,21 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: false,
+          userFacilityReadyForInfoAlert: true,
+        }),
+      });
+      expect(result.needsPortalNotice).to.be.false;
+    });
+
+    it('returns false when not isCernerPatient', () => {
+      const result = checkPortalRequirements({
+        isPortalNoticeInterstitialEnabled: true,
+        provisioned: true,
+        userAttributes: buildUserAttributes({
+          isCernerPatient: false,
+          vaPatient: true,
           userFacilityReadyForInfoAlert: true,
         }),
       });
@@ -58,6 +76,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userFacilityReadyForInfoAlert: false,
         }),
@@ -70,6 +89,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: false,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userFacilityReadyForInfoAlert: true,
         }),
@@ -79,13 +99,27 @@ describe('checkPortalRequirements', () => {
   });
 
   describe('needsMyHealth', () => {
-    it('returns true when toggle enabled, provisioned, vaPatient, and not at pretransitioned OH facility', () => {
+    it('returns true when toggle enabled, provisioned, vaPatient, isCernerPatient, and not at pretransitioned OH facility', () => {
       const result = checkPortalRequirements({
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userAtPretransitionedOhFacility: false,
+        }),
+      });
+      expect(result.needsMyHealth).to.be.true;
+    });
+
+    it('returns true when user is not a Cerner patient', () => {
+      const result = checkPortalRequirements({
+        isPortalNoticeInterstitialEnabled: true,
+        provisioned: true,
+        userAttributes: buildUserAttributes({
+          isCernerPatient: false,
+          vaPatient: true,
+          userAtPretransitionedOhFacility: true,
         }),
       });
       expect(result.needsMyHealth).to.be.true;
@@ -96,6 +130,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userAtPretransitionedOhFacility: true,
         }),
@@ -108,6 +143,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: false,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userAtPretransitionedOhFacility: false,
         }),
@@ -120,6 +156,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: true,
         provisioned: false,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: true,
           userAtPretransitionedOhFacility: false,
         }),
@@ -132,6 +169,7 @@ describe('checkPortalRequirements', () => {
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
         userAttributes: buildUserAttributes({
+          isCernerPatient: true,
           vaPatient: false,
           userAtPretransitionedOhFacility: false,
         }),
@@ -155,7 +193,9 @@ describe('checkPortalRequirements', () => {
       const result = checkPortalRequirements({
         isPortalNoticeInterstitialEnabled: true,
         provisioned: true,
-        userAttributes: { vaProfile: { vaPatient: true } },
+        userAttributes: {
+          vaProfile: { isCernerPatient: true, vaPatient: true },
+        },
       });
       expect(result.needsPortalNotice).to.be.false;
       expect(result.needsMyHealth).to.be.true;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added a Cerner check to the `checkPortalRequirements` helper for `AuthApp.jsx`.

## Related issue(s)
- [Identity Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/1181)
- [MHV Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/136470)


## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running:
  - `yarn test:unit src/applications/auth/tests/AuthApp.unit.spec.jsx`
  - `yarn test:unit src/applications/auth/tests/checkPortalRequirements.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `AuthApp.jsx`, its `helpers.js`, and the related tests.

## Acceptance criteria
- [x] Cerner patients are accounted for when checking for OH portal requirements