### PR TITLE
(#134070) Remove SHA References on Evidence Types BDD Page

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -61,7 +61,9 @@ export const uiSchema = {
     'ui:title': '',
     'ui:description': BddEvidenceSubmitLater,
     'ui:options': {
-      hideIf: data => _.get('view:hasEvidence', data, true),
+      hideIf: data =>
+        _.get('view:hasEvidence', data, true) ||
+        data.disability526NewBddShaEnforcementWorkflowEnabled,
     },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -31,6 +31,14 @@ export const uiSchema = {
     'ui:options': {
       showFieldLabel: true,
       expandUnder: 'view:hasEvidence',
+      updateUiSchema: formData => {
+        if (formData.disability526NewBddShaEnforcementWorkflowEnabled) {
+          return {
+            'view:hasOtherEvidence': { 'ui:title': 'Other evidence' },
+          };
+        }
+        return {};
+      },
     },
     'ui:required': formData => get('view:hasEvidence', formData, false),
     'ui:validations': [

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -55,6 +55,7 @@ export const uiSchema = {
     'ui:description': evidenceTypeHelp,
     'ui:options': {
       expandUnder: 'view:hasEvidence',
+      hideIf: data => data.disability526NewBddShaEnforcementWorkflowEnabled,
     },
   },
   'view:evidenceSubmitLater': {

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
@@ -116,64 +116,117 @@ describe('evidenceTypes', () => {
     expect($('va-radio').error).to.be.null;
   });
 
-  it('should display alert when BDD SHA enabled and user selects "No, I will submit more information later" and disability526NewBddShaEnforcementWorkflowEnabled is false', () => {
-    const { queryByText, container } = render(
-      <DefaultDefinitionTester
-        data={{
-          disability526NewBddShaEnforcementWorkflowEnabled: false,
-        }}
-      />,
-    );
+  describe('BDD SHA Alert', () => {
+    it('should display when BDD SHA enabled and user selects "No, I will submit more information later" and disability526NewBddShaEnforcementWorkflowEnabled is false', () => {
+      const { queryByText, container } = render(
+        <DefaultDefinitionTester
+          data={{
+            disability526NewBddShaEnforcementWorkflowEnabled: false,
+          }}
+        />,
+      );
 
-    // Ensure mock data does not cause alert to display on initial render
-    expect(
-      queryByText(
-        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
-      ),
-    ).to.not.exist;
+      // Ensure mock data does not cause alert to display on initial render
+      expect(
+        queryByText(
+          'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+        ),
+      ).to.not.exist;
 
-    const page = getPageObject(container);
-    page.triggerNoSelection();
+      const page = getPageObject(container);
+      page.triggerNoSelection();
 
-    expect(
-      queryByText(
-        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
-      ),
-    ).to.exist;
+      expect(
+        queryByText(
+          'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+        ),
+      ).to.exist;
 
-    // Ensure alert goes away if user changes selection to "Yes"
-    page.triggerYesSelection();
+      // Ensure alert goes away if user changes selection to "Yes"
+      page.triggerYesSelection();
 
-    expect(
-      queryByText(
-        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
-      ),
-    ).to.not.exist;
+      expect(
+        queryByText(
+          'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+        ),
+      ).to.not.exist;
+    });
+
+    it('should not display when BDD SHA enabled and user selects "No, I will submit more information later" but disability526NewBddShaEnforcementWorkflowEnabled is true', () => {
+      const { queryByText, container } = render(
+        <DefaultDefinitionTester
+          data={{
+            disability526NewBddShaEnforcementWorkflowEnabled: true,
+          }}
+        />,
+      );
+
+      // Ensure mock data does not cause alert to display on initial render
+      expect(
+        queryByText(
+          'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+        ),
+      ).to.not.exist;
+
+      const page = getPageObject(container);
+      page.triggerNoSelection(container);
+
+      expect(
+        queryByText(
+          'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+        ),
+      ).to.not.exist;
+    });
   });
 
-  it('should not display alert when BDD SHA enabled and user selects "No, I will submit more information later" but disability526NewBddShaEnforcementWorkflowEnabled is true', () => {
-    const { queryByText, container } = render(
-      <DefaultDefinitionTester
-        data={{
-          disability526NewBddShaEnforcementWorkflowEnabled: true,
-        }}
-      />,
-    );
+  describe('Evidence Type Help', () => {
+    it('should display if user selects "Yes" and disability526NewBddShaEnforcementWorkflowEnabled is false', () => {
+      const { queryByText, container } = render(
+        <DefaultDefinitionTester
+          data={{
+            disability526NewBddShaEnforcementWorkflowEnabled: false,
+          }}
+        />,
+      );
 
-    // Ensure mock data does not cause alert to display on initial render
-    expect(
-      queryByText(
-        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
-      ),
-    ).to.not.exist;
+      // Ensure mock data does not cause alert to display on initial render
+      expect(queryByText('Types of evidence')).to.not.exist;
 
-    const page = getPageObject(container);
-    page.triggerNoSelection(container);
+      const page = getPageObject(container);
 
-    expect(
-      queryByText(
-        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
-      ),
-    ).to.not.exist;
+      page.triggerYesSelection();
+
+      expect(queryByText('Types of evidence')).to.exist;
+
+      // It should disaappear if user changes selection to "No"
+      page.triggerNoSelection();
+
+      expect(queryByText('Types of evidence')).to.not.exist;
+    });
+
+    it('should not display if user selects "Yes" and disability526NewBddShaEnforcementWorkflowEnabled is true', () => {
+      const { queryByText, container } = render(
+        <DefaultDefinitionTester
+          data={{
+            disability526NewBddShaEnforcementWorkflowEnabled: true,
+          }}
+        />,
+      );
+
+      // Ensure mock data does not cause alert to display on initial render
+      expect(queryByText('Types of evidence')).to.not.exist;
+
+      const page = getPageObject(container);
+
+      page.triggerYesSelection();
+
+      // Additional info does not show because feature flag is enabled, even though user selected "Yes"
+      expect(queryByText('Types of evidence')).to.not.exist;
+
+      // It still should not appear if the user selects no.
+      page.triggerNoSelection();
+
+      expect(queryByText('Types of evidence')).to.not.exist;
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
@@ -22,6 +22,10 @@ function getPageObject(container) {
         detail: { value: 'N' },
       });
     },
+    getOtherEvidenceCheckbox: () =>
+      $$('va-checkbox', container).find(
+        el => el.getAttribute('data-key') === 'view:hasOtherEvidence',
+      ),
   };
 }
 
@@ -176,6 +180,42 @@ describe('evidenceTypes', () => {
           'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
         ),
       ).to.not.exist;
+    });
+  });
+
+  describe('Other Evidence Label', () => {
+    it('should display full SHA label when disability526NewBddShaEnforcementWorkflowEnabled is false', () => {
+      const { container } = render(
+        <DefaultDefinitionTester
+          data={{
+            'view:hasEvidence': true,
+            disability526NewBddShaEnforcementWorkflowEnabled: false,
+          }}
+        />,
+      );
+
+      const page = getPageObject(container);
+      const checkbox = page.getOtherEvidenceCheckbox();
+      expect(checkbox).to.exist;
+      expect(checkbox.getAttribute('label')).to.equal(
+        'Required Separation Health Assessment - Part A Self-Assessment or other documents like your DD Form 214, supporting (lay) statements, or other evidence',
+      );
+    });
+
+    it('should display "Other evidence" label when disability526NewBddShaEnforcementWorkflowEnabled is true', () => {
+      const { container } = render(
+        <DefaultDefinitionTester
+          data={{
+            'view:hasEvidence': true,
+            disability526NewBddShaEnforcementWorkflowEnabled: true,
+          }}
+        />,
+      );
+
+      const page = getPageObject(container);
+      const checkbox = page.getOtherEvidenceCheckbox();
+      expect(checkbox).to.exist;
+      expect(checkbox.getAttribute('label')).to.equal('Other evidence');
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
@@ -4,13 +4,26 @@ import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { render } from '@testing-library/react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
 import {
   $,
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import formConfig from '../../config/form';
+
+function getPageObject(container) {
+  return {
+    triggerYesSelection: () => {
+      $('va-radio', container).__events.vaValueChange({
+        detail: { value: 'Y' },
+      });
+    },
+    triggerNoSelection: () => {
+      $('va-radio', container).__events.vaValueChange({
+        detail: { value: 'N' },
+      });
+    },
+  };
+}
 
 describe('evidenceTypes', () => {
   const {
@@ -18,31 +31,38 @@ describe('evidenceTypes', () => {
     uiSchema,
   } = formConfig.chapters.supportingEvidence.pages.evidenceTypesBDD;
 
-  it('should render', () => {
-    render(
+  /**
+   * Utility for reducing the noise in tests and highlighting only the important signals of the test.
+   *
+   * @param {*} props - Overrides to the default value of DefinitionTester. Primarily used to pass the data prop.
+   * @returns {JSX.Element} The rendered DefinitionTester component.
+   */
+  const DefaultDefinitionTester = props => {
+    return (
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
-        formData={{}}
-      />,
+        {...props}
+      />
     );
+  };
+
+  it('should render', () => {
+    render(<DefaultDefinitionTester />);
 
     expect($$('va-radio-option').length).to.equal(2);
   });
 
   it('should submit when no evidence selected', () => {
     const onSubmit = sinon.spy();
+
     const { getByText } = render(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
+      <DefaultDefinitionTester
         data={{
           'view:hasEvidence': false,
         }}
-        formData={{}}
         onSubmit={onSubmit}
       />,
     );
@@ -77,18 +97,15 @@ describe('evidenceTypes', () => {
 
   it('should submit with all required info', () => {
     const onSubmit = sinon.spy();
+
     const { getByText } = render(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
+      <DefaultDefinitionTester
         data={{
           'view:hasEvidence': true,
           'view:selectableEvidenceTypes': {
             'view:hasPrivateMedicalRecords': true,
           },
         }}
-        formData={{}}
         onSubmit={onSubmit}
       />,
     );
@@ -99,31 +116,64 @@ describe('evidenceTypes', () => {
     expect($('va-radio').error).to.be.null;
   });
 
-  it('should display alert when BDD SHA enabled and user selects no, submit info later', () => {
-    const fakeStore = createStore(() => ({
-      featureToggles: {},
-    }));
-
-    const { getByText, container } = render(
-      <Provider store={fakeStore}>
-        <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
-          schema={schema}
-          uiSchema={uiSchema}
-          data={{}}
-          formData={{}}
-        />
-      </Provider>,
+  it('should display alert when BDD SHA enabled and user selects "No, I will submit more information later" and disability526NewBddShaEnforcementWorkflowEnabled is false', () => {
+    const { queryByText, container } = render(
+      <DefaultDefinitionTester
+        data={{
+          disability526NewBddShaEnforcementWorkflowEnabled: false,
+        }}
+      />,
     );
 
-    $('va-radio', container).__events.vaValueChange({
-      detail: { value: 'N' },
-    });
+    // Ensure mock data does not cause alert to display on initial render
+    expect(
+      queryByText(
+        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+      ),
+    ).to.not.exist;
+
+    const page = getPageObject(container);
+    page.triggerNoSelection();
 
     expect(
-      getByText(
+      queryByText(
         'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
       ),
     ).to.exist;
+
+    // Ensure alert goes away if user changes selection to "Yes"
+    page.triggerYesSelection();
+
+    expect(
+      queryByText(
+        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+      ),
+    ).to.not.exist;
+  });
+
+  it('should not display alert when BDD SHA enabled and user selects "No, I will submit more information later" but disability526NewBddShaEnforcementWorkflowEnabled is true', () => {
+    const { queryByText, container } = render(
+      <DefaultDefinitionTester
+        data={{
+          disability526NewBddShaEnforcementWorkflowEnabled: true,
+        }}
+      />,
+    );
+
+    // Ensure mock data does not cause alert to display on initial render
+    expect(
+      queryByText(
+        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+      ),
+    ).to.not.exist;
+
+    const page = getPageObject(container);
+    page.triggerNoSelection(container);
+
+    expect(
+      queryByText(
+        'Submit your Separation Health Assessment - Part A Self-Assessment as soon as you can',
+      ),
+    ).to.not.exist;
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_

* Removes items that are no longer needed when the disability526NewBddShaEnforcementWorkflowEnabled flag is enabled because that flag adds a new page where these items are captured.
  * Removes the SHA warning when the enforcement toggle is enabled. 
  * Hide the additional evidence help info when the enforcement toggle is enabled. 
  * Changes the label of the Other Evidence to remove the reference to the SHA.

- _(If bug, how to reproduce)_
N/A

- _(What is the solution, why is this the solution)_
Utilizing hideIf which is normal for the forms system.

- _(Which team do you work for, does your team own the maintenance of this component?)_
DBC - Team 5

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
Using `disability526NewBddShaEnforcementWorkflowEnabled` for the flipper, which will be enabled once all the BDD SHA work has been completed and gone through staging review. Aiming for mid-April. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#134070

## Testing done

* Enter form as qualifying for BDD (Have a RAD date 180-90 days from current date)
* Navigate to Supporting Evidence Chapter
* Navigate to /supporting-evidence/evidence-types-bdd page
* Manipulate yes and no

Expected Behavior: No SHA alert is found and no additional information is found.


- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### With Yes Selected

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_evidence-types-bdd(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/e82ed79d-0a4a-480d-b911-5022f27c00f7" />   | <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_mental-health-form-0781_events(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/931a9910-50bf-4942-8a0f-c74b98afc499" /> |
| Desktop |  <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_evidence-types-bdd (1)" src="https://github.com/user-attachments/assets/d8b62cdf-b2b4-44d8-9ed6-d3dea4114c29" />   | <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_mental-health-form-0781_events" src="https://github.com/user-attachments/assets/758d410b-c9be-4032-b58f-c2856625f7eb" />  |

### With No Selected

|         | Before | After |
| ------- | ------ | ----- |
| Mobile |  <img  alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_evidence-types-bdd(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/227ff132-2239-41e7-aa29-4d20a90571f3" />  |  <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_evidence-types-bdd(iPhone 12 Pro) (3)" src="https://github.com/user-attachments/assets/c62226cf-eb54-4c26-affb-bdd82d131635" />  |
| Desktop |  <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_evidence-types-bdd (2)" src="https://github.com/user-attachments/assets/6491cfd5-46e6-45fa-977d-8d1a691e0ee9" /> |  <img alt="localhost_3001_disability_file-disability-claim-form-21-526ez_supporting-evidence_evidence-types-bdd (3)" src="https://github.com/user-attachments/assets/5aab0283-25be-4f56-8645-d6bcc26630ca" />   |


## What areas of the site does it impact?


*(Describe what parts of the site are impacted **if** code touched other areas)*

This change only impacts Form 526.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

No specific feedback requested.
