### PR TITLE
Add cross-date validation for termination and last-payment pages

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-last-payment.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-last-payment.js
@@ -11,6 +11,8 @@ import {
   radioUI,
   radioSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { convertToDateField } from 'platform/forms-system/src/js/validation';
+import { dateFieldToDate } from 'platform/utilities/date';
 import { MemorableDateUI } from '../components/memorable-date-ui';
 
 // Constants for required fields
@@ -26,6 +28,45 @@ const LUMP_SUM_REQUIRED_FIELDS = [
   'datePaid',
 ];
 
+const isValidDateObject = date =>
+  date instanceof Date && !Number.isNaN(date.getTime());
+
+const toDate = value => {
+  if (!value) {
+    return null;
+  }
+
+  return dateFieldToDate(convertToDateField(value));
+};
+
+const validateLastPaymentDates = (errors, fieldData, fullData) => {
+  const beginningDate = toDate(fullData?.employmentDates?.beginningDate);
+  if (!isValidDateObject(beginningDate)) {
+    return;
+  }
+
+  const dateOfLastPayment = toDate(fieldData?.dateOfLastPayment);
+  if (
+    isValidDateObject(dateOfLastPayment) &&
+    dateOfLastPayment < beginningDate
+  ) {
+    errors.dateOfLastPayment.addError(
+      "Date of last payment can't be before beginning date of employment",
+    );
+  }
+
+  if (fieldData?.lumpSumPayment !== 'yes') {
+    return;
+  }
+
+  const lumpSumDatePaid = toDate(fieldData?.datePaid);
+  if (isValidDateObject(lumpSumDatePaid) && lumpSumDatePaid < beginningDate) {
+    errors.datePaid.addError(
+      "Date of lump sum payment can't be before beginning date of employment",
+    );
+  }
+};
+
 /**
  * uiSchema for Employment Last Payment page
  * Collects information about the last payment received
@@ -33,6 +74,7 @@ const LUMP_SUM_REQUIRED_FIELDS = [
 export const employmentLastPaymentUiSchema = {
   'ui:title': 'Last payment',
   employmentLastPayment: {
+    'ui:validations': [validateLastPaymentDates],
     dateOfLastPayment: MemorableDateUI({
       title: 'Date of last payment',
       dataDogHidden: true,

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-last-payment.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-last-payment.unit.spec.jsx
@@ -12,6 +12,87 @@ import {
 } from './employment-last-payment';
 
 describe('Employment Last Payment Page', () => {
+  describe('date relationship validations', () => {
+    const getValidation = () =>
+      employmentLastPaymentUiSchema.employmentLastPayment['ui:validations'][0];
+
+    const buildErrors = () => {
+      const messages = {
+        dateOfLastPayment: [],
+        datePaid: [],
+      };
+
+      const errors = {
+        dateOfLastPayment: {
+          addError: message => {
+            messages.dateOfLastPayment.push(message || '');
+          },
+        },
+        datePaid: {
+          addError: message => {
+            messages.datePaid.push(message || '');
+          },
+        },
+      };
+
+      return { errors, messages };
+    };
+
+    it('should add error when date of last payment is before beginning date of employment', () => {
+      const validation = getValidation();
+      const { errors, messages } = buildErrors();
+
+      validation(
+        errors,
+        { dateOfLastPayment: '2020-01-01', lumpSumPayment: 'no' },
+        { employmentDates: { beginningDate: '2020-01-02' } },
+      );
+
+      expect(messages.dateOfLastPayment).to.deep.equal([
+        "Date of last payment can't be before beginning date of employment",
+      ]);
+      expect(messages.datePaid).to.have.lengthOf(0);
+    });
+
+    it('should add error when lump sum date is before beginning date of employment', () => {
+      const validation = getValidation();
+      const { errors, messages } = buildErrors();
+
+      validation(
+        errors,
+        {
+          dateOfLastPayment: '2020-01-03',
+          lumpSumPayment: 'yes',
+          datePaid: '2020-01-01',
+        },
+        { employmentDates: { beginningDate: '2020-01-02' } },
+      );
+
+      expect(messages.dateOfLastPayment).to.have.lengthOf(0);
+      expect(messages.datePaid).to.deep.equal([
+        "Date of lump sum payment can't be before beginning date of employment",
+      ]);
+    });
+
+    it('should not add errors when date relationships are valid', () => {
+      const validation = getValidation();
+      const { errors, messages } = buildErrors();
+
+      validation(
+        errors,
+        {
+          dateOfLastPayment: '2020-01-03',
+          lumpSumPayment: 'yes',
+          datePaid: '2020-01-04',
+        },
+        { employmentDates: { beginningDate: '2020-01-02' } },
+      );
+
+      expect(messages.dateOfLastPayment).to.have.lengthOf(0);
+      expect(messages.datePaid).to.have.lengthOf(0);
+    });
+  });
+
   describe('updateSchema conditional required fields', () => {
     const { updateSchema } = employmentLastPaymentUiSchema['ui:options'];
     const baseSchema = employmentLastPaymentSchema;

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.js
@@ -8,7 +8,40 @@ import {
   textareaUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { convertToDateField } from 'platform/forms-system/src/js/validation';
+import { dateFieldToDate } from 'platform/utilities/date';
 import { MemorableDateUI } from '../components/memorable-date-ui';
+
+const isValidDateObject = date =>
+  date instanceof Date && !Number.isNaN(date.getTime());
+
+const toDate = value => {
+  if (!value) {
+    return null;
+  }
+
+  return dateFieldToDate(convertToDateField(value));
+};
+
+const validateDateLastWorked = (errors, fieldData, fullData) => {
+  const dateLastWorked = toDate(fieldData?.dateLastWorked);
+  if (!isValidDateObject(dateLastWorked)) {
+    return;
+  }
+
+  const beginningDate = toDate(fullData?.employmentDates?.beginningDate);
+  const endingDate = toDate(fullData?.employmentDates?.endingDate);
+
+  if (isValidDateObject(beginningDate) && dateLastWorked < beginningDate) {
+    errors.dateLastWorked.addError(
+      "Date last worked can't be before beginning date of employment",
+    );
+  } else if (isValidDateObject(endingDate) && dateLastWorked > endingDate) {
+    errors.dateLastWorked.addError(
+      "Date last worked can't be after ending date of employment",
+    );
+  }
+};
 
 /**
  * uiSchema for Employment Termination page
@@ -17,6 +50,7 @@ import { MemorableDateUI } from '../components/memorable-date-ui';
 export const employmentTerminationUiSchema = {
   'ui:title': 'Termination of employment',
   employmentTermination: {
+    'ui:validations': [validateDateLastWorked],
     terminationReason: textareaUI({
       title: 'Reason for termination of employment',
       hint:

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/pages/employment-termination.unit.spec.jsx
@@ -1,0 +1,79 @@
+/**
+ * @module tests/pages/employment-termination.unit.spec
+ * @description Unit tests for Employment Termination page date validation logic
+ * VA Form 21-4192 - Request for Employment Information
+ */
+
+import { expect } from 'chai';
+import { employmentTerminationUiSchema } from './employment-termination';
+
+describe('Employment Termination Page', () => {
+  const getValidation = () =>
+    employmentTerminationUiSchema.employmentTermination['ui:validations'][0];
+
+  const buildErrors = () => {
+    const messages = [];
+    const errors = {
+      dateLastWorked: {
+        addError: message => {
+          messages.push(message || '');
+        },
+      },
+    };
+
+    return { errors, messages };
+  };
+
+  it('should add error when date last worked is before beginning date of employment', () => {
+    const validation = getValidation();
+    const { errors, messages } = buildErrors();
+
+    validation(
+      errors,
+      { dateLastWorked: '2020-01-01' },
+      { employmentDates: { beginningDate: '2020-01-02' } },
+    );
+
+    expect(messages).to.deep.equal([
+      "Date last worked can't be before beginning date of employment",
+    ]);
+  });
+
+  it('should add error when date last worked is after ending date of employment', () => {
+    const validation = getValidation();
+    const { errors, messages } = buildErrors();
+
+    validation(
+      errors,
+      { dateLastWorked: '2020-01-03' },
+      {
+        employmentDates: {
+          beginningDate: '2020-01-01',
+          endingDate: '2020-01-02',
+        },
+      },
+    );
+
+    expect(messages).to.deep.equal([
+      "Date last worked can't be after ending date of employment",
+    ]);
+  });
+
+  it('should not add error when date last worked is within beginning and ending dates', () => {
+    const validation = getValidation();
+    const { errors, messages } = buildErrors();
+
+    validation(
+      errors,
+      { dateLastWorked: '2020-01-02' },
+      {
+        employmentDates: {
+          beginningDate: '2020-01-01',
+          endingDate: '2020-01-03',
+        },
+      },
+    );
+
+    expect(messages).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds cross-date validation logic to the employment information pages in VA Form 21-4192 (Request for Employment Information). The changes ensure that employment-related dates maintain logical relationships and fall within valid date ranges.

**Changes made:**
- Added validation to the "Termination of employment" page to verify that the "Date last worked" falls within the employment date range (not before the beginning date and not after the ending date)
- Added validation to the "Last payment" page to verify that the "Date of last payment" and lump-sum "Date paid" are not before the employment beginning date
- Implemented date conversion utilities to handle different date formats and ensure type-safe date comparisons
- Added comprehensive unit test coverage for all validation scenarios, including valid and invalid date relationships

**Why this approach:**
These validations improve data quality by preventing users from entering logically inconsistent dates. By validating at the form level before submission, we catch errors early and provide immediate feedback to veterans, reducing form abandonment and rework at the backend. The validation uses the existing `ui:validations` pattern in the form schema, ensuring consistency with other validation approaches in the platform.

**Team information:**
Benefits Optimization Team

## Related issue(s)

- VA.gov-team issue: department-of-veterans-affairs/va.gov-team#136355

## Testing done

**Old behavior:**
Previously, the employment information pages accepted any date values without validating their logical relationships to other employment dates. A veteran could enter a "Date last worked" before their employment start date or after their employment end date, or payment dates before employment began, leading to data validation errors on the backend.

**Testing steps:**
1. Navigate to VA Form 21-4192
2. Complete the employment dates section with:
   - Beginning date: 2020-01-01
   - Ending date: 2020-01-31
3. Test the termination page:
   - Enter "Date last worked" as 2019-12-31 (before beginning date) - should display error: "Date last worked can't be before beginning date of employment"
   - Enter "Date last worked" as 2020-02-01 (after ending date) - should display error: "Date last worked can't be after ending date of employment"
   - Enter "Date last worked" as 2020-01-15 (valid) - should not display error
4. Test the last payment page:
   - Enter "Date of last payment" as 2019-12-31 (before beginning date) - should display error: "Date of last payment can't be before beginning date of employment"
   - Enter "Date of last payment" as 2020-01-15 (valid) - should not display error
   - With lump-sum payment selected, enter "Date paid" as 2019-12-31 - should display error: "Date of lump sum payment can't be before beginning date of employment"
   - With lump-sum payment selected, enter "Date paid" as 2020-01-20 (valid) - should not display error

**Tests completed:**
- Unit tests added to `employment-termination.unit.spec.jsx` with 3 test cases covering:
  - Error when date last worked is before employment beginning date
  - Error when date last worked is after employment ending date
  - No error when date last worked falls within valid range
- Unit tests added to `employment-last-payment.unit.spec.jsx` with 3 test cases covering:
  - Error when date of last payment is before employment beginning date
  - Error when lump-sum date paid is before employment beginning date
  - No error when dates fall within valid ranges
- All unit tests passing

## Screenshots

Not applicable - this is a backend validation change with no UI modifications.

## What areas of the site does it impact?

This change impacts the VA Form 21-4192 (Request for Employment Information) application in the Benefits Optimization - Aquia module. The validation is isolated to the employment information collection pages and does not affect other parts of the form or site.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) *if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

The validation logic uses helper functions (`toDate` and `isValidDateObject`) to safely convert and validate date values from different input formats. The approach ensures that invalid or missing dates gracefully skip validation rather than causing errors. Reviewers should verify that the error messages are clear and user-friendly for veterans encountering date validation failures.
