### PR TITLE
use new download_pdf get route

### DIFF
--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-identification-info.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-identification-info.unit.spec.jsx
@@ -85,14 +85,12 @@ describe('Claimant Identification Info Page', () => {
 
       // Check SSN schema
       expect(fieldSchema.properties.ssn).to.have.property('type', 'string');
-      expect(fieldSchema.properties.ssn).to.have.property('pattern');
 
       // Check VA file number schema
       expect(fieldSchema.properties.vaFileNumber).to.have.property(
         'type',
         'string',
       );
-      expect(fieldSchema.properties.vaFileNumber).to.have.property('pattern');
     });
   });
 

--- a/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-identification-info.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-identification-info.unit.spec.jsx
@@ -109,14 +109,12 @@ describe('Veteran Identification Info Page', () => {
 
       // Check SSN schema
       expect(fieldSchema.properties.ssn).to.have.property('type', 'string');
-      expect(fieldSchema.properties.ssn).to.have.property('pattern');
 
       // Check VA file number schema
       expect(fieldSchema.properties.vaFileNumber).to.have.property(
         'type',
         'string',
       );
-      expect(fieldSchema.properties.vaFileNumber).to.have.property('pattern');
     });
   });
 

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/constants/constants.js
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/constants/constants.js
@@ -78,4 +78,6 @@ export const TIME_LOST_UNITS = {
 export const API_ENDPOINTS = {
   csrfCheck: '/csrf_token',
   downloadPdf: '/form214192/download_pdf',
+  downloadPdfByGuid: guid =>
+    `/form214192/download_pdf/${encodeURIComponent(guid)}`,
 };

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/confirmation-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/confirmation-page.jsx
@@ -50,7 +50,7 @@ export const ConfirmationPage = ({ route }) => {
     [submissionGuid],
   );
 
-  const downloadGuid = submissionGuid || persistedGuid || confirmationNumber;
+  const downloadGuid = submissionGuid || persistedGuid;
   const ConfirmationHowToContact = () => (
     <>
       <p>
@@ -97,7 +97,7 @@ export const ConfirmationPage = ({ route }) => {
           If you’d like a PDF copy of your completed form, you can download it.{' '}
         </p>
         <DownloadFormPDF
-          confirmationNumber={downloadGuid}
+          downloadGuid={downloadGuid}
           formData={transformedData}
         />
       </div>

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/confirmation-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/confirmation-page.jsx
@@ -3,7 +3,7 @@
  * @description Confirmation page displayed after successful form submission
  */
 
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { formatDateLong } from 'platform/utilities/date';
@@ -23,6 +23,7 @@ import DownloadFormPDF from './download-form-pdf';
  * @returns {React.ReactElement} Confirmation page view
  */
 export const ConfirmationPage = ({ route }) => {
+  const GUID_STORAGE_KEY = 'form214192_download_guid';
   const form = useSelector(state => state.form || {});
   const submission = form?.submission || {};
   const { formConfig } = route || {};
@@ -30,7 +31,26 @@ export const ConfirmationPage = ({ route }) => {
 
   const submitDate = submission?.timestamp || '';
   const formattedSubmitDate = submitDate ? formatDateLong(submitDate) : '';
-  const confirmationNumber = submission?.response?.confirmationNumber || '';
+  const confirmationNumber =
+    submission?.response?.attributes?.confirmationNumber ||
+    submission?.response?.confirmationNumber ||
+    '';
+  const submissionGuid = submission?.response?.attributes?.guid || '';
+
+  const persistedGuid = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return window.sessionStorage.getItem(GUID_STORAGE_KEY) || '';
+  }, []);
+
+  useEffect(
+    () => {
+      if (typeof window === 'undefined' || !submissionGuid) return;
+      window.sessionStorage.setItem(GUID_STORAGE_KEY, submissionGuid);
+    },
+    [submissionGuid],
+  );
+
+  const downloadGuid = submissionGuid || persistedGuid || confirmationNumber;
   const ConfirmationHowToContact = () => (
     <>
       <p>
@@ -76,7 +96,10 @@ export const ConfirmationPage = ({ route }) => {
         <p>
           If you’d like a PDF copy of your completed form, you can download it.{' '}
         </p>
-        <DownloadFormPDF formData={transformedData} />
+        <DownloadFormPDF
+          confirmationNumber={downloadGuid}
+          formData={transformedData}
+        />
       </div>
       <div data-dd-privacy="mask" data-dd-action-name="confirmation summary">
         <ConfirmationView.ChapterSectionCollection />

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.jsx
@@ -6,7 +6,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import { API_ENDPOINTS } from '../../constants/constants';
 import { ensureValidCSRFToken } from '../../utils/actions/ensure-valid-csrf-token';
 
-const DownloadFormPDF = ({ formData }) => {
+const DownloadFormPDF = ({ confirmationNumber, formData }) => {
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
@@ -31,13 +31,35 @@ const DownloadFormPDF = ({ formData }) => {
 
       try {
         await ensureValidCSRFToken('fetchPdf');
-        const response = await apiRequest(API_ENDPOINTS.downloadPdf, {
-          method: 'POST',
-          body: formData,
-          headers: { 'Content-Type': 'application/json' },
-        });
 
-        if (!response.ok) {
+        const fetchPdfByPost = () =>
+          apiRequest(API_ENDPOINTS.downloadPdf, {
+            method: 'POST',
+            body: formData,
+            headers: { 'Content-Type': 'application/json' },
+          });
+
+        let response;
+        if (confirmationNumber) {
+          try {
+            response = await apiRequest(
+              API_ENDPOINTS.downloadPdfByGuid(confirmationNumber),
+              {
+                method: 'GET',
+              },
+            );
+
+            if (!response?.ok) {
+              throw new Error('GET PDF download failed');
+            }
+          } catch (error) {
+            response = await fetchPdfByPost();
+          }
+        } else {
+          response = await fetchPdfByPost();
+        }
+
+        if (!response?.ok) {
           throw new Error();
         }
 
@@ -53,7 +75,7 @@ const DownloadFormPDF = ({ formData }) => {
         setLoading(false);
       }
     },
-    [formData, handlePdfDownload],
+    [confirmationNumber, formData, handlePdfDownload],
   );
 
   // apply focus to the error alert if we have errors set
@@ -93,6 +115,7 @@ const DownloadFormPDF = ({ formData }) => {
 };
 
 DownloadFormPDF.propTypes = {
+  confirmationNumber: PropTypes.string,
   formData: PropTypes.string,
 };
 

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.jsx
@@ -6,7 +6,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import { API_ENDPOINTS } from '../../constants/constants';
 import { ensureValidCSRFToken } from '../../utils/actions/ensure-valid-csrf-token';
 
-const DownloadFormPDF = ({ confirmationNumber, formData }) => {
+const DownloadFormPDF = ({ downloadGuid, formData }) => {
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
@@ -40,10 +40,10 @@ const DownloadFormPDF = ({ confirmationNumber, formData }) => {
           });
 
         let response;
-        if (confirmationNumber) {
+        if (downloadGuid) {
           try {
             response = await apiRequest(
-              API_ENDPOINTS.downloadPdfByGuid(confirmationNumber),
+              API_ENDPOINTS.downloadPdfByGuid(downloadGuid),
               {
                 method: 'GET',
               },
@@ -75,7 +75,7 @@ const DownloadFormPDF = ({ confirmationNumber, formData }) => {
         setLoading(false);
       }
     },
-    [confirmationNumber, formData, handlePdfDownload],
+    [downloadGuid, formData, handlePdfDownload],
   );
 
   // apply focus to the error alert if we have errors set
@@ -115,7 +115,7 @@ const DownloadFormPDF = ({ confirmationNumber, formData }) => {
 };
 
 DownloadFormPDF.propTypes = {
-  confirmationNumber: PropTypes.string,
+  downloadGuid: PropTypes.string,
   formData: PropTypes.string,
 };
 

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.unit.spec.jsx
@@ -101,7 +101,7 @@ describe('DownloadFormPDF', () => {
   describe('Initial Rendering', () => {
     it('should render download link', () => {
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -116,7 +116,7 @@ describe('DownloadFormPDF', () => {
 
     it('should not show loading indicator initially', () => {
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const loadingIndicator = container.querySelector('va-loading-indicator');
@@ -125,7 +125,7 @@ describe('DownloadFormPDF', () => {
 
     it('should not show error message initially', () => {
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const errorAlert = container.querySelector('.form-download-error');
@@ -143,7 +143,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -163,7 +163,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -222,7 +222,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.onSecondCall().resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData={formData} />,
+        <DownloadFormPDF downloadGuid="abc-123" formData={formData} />,
       );
 
       const link = container.querySelector('va-link');
@@ -253,7 +253,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -276,7 +276,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -298,7 +298,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -318,7 +318,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -339,7 +339,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.rejects(new Error('Network error'));
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -364,7 +364,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -380,7 +380,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.rejects(new Error('Network error'));
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -399,7 +399,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.rejects(new Error('Network error'));
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');

--- a/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.unit.spec.jsx
@@ -21,6 +21,8 @@ describe('DownloadFormPDF', () => {
   let removeChildStub;
   let mockLink;
 
+  const renderComponent = ui => render(ui);
+
   beforeEach(() => {
     // Mock DOM element
     mockLink = {
@@ -98,7 +100,9 @@ describe('DownloadFormPDF', () => {
 
   describe('Initial Rendering', () => {
     it('should render download link', () => {
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       expect(link).to.exist;
@@ -111,14 +115,18 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should not show loading indicator initially', () => {
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const loadingIndicator = container.querySelector('va-loading-indicator');
       expect(loadingIndicator).to.not.exist;
     });
 
     it('should not show error message initially', () => {
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const errorAlert = container.querySelector('.form-download-error');
       expect(errorAlert).to.not.exist;
@@ -134,7 +142,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -145,6 +155,31 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should make API request with correct parameters', async () => {
+      const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+      const mockResponse = {
+        ok: true,
+        blob: sinon.stub().resolves(mockBlob),
+      };
+      apiRequestStub.resolves(mockResponse);
+
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
+
+      const link = container.querySelector('va-link');
+      link.click();
+
+      await waitFor(() => {
+        expect(apiRequestStub.called).to.be.true;
+        const callArgs = apiRequestStub.firstCall.args;
+        expect(callArgs[0]).to.equal('/form214192/download_pdf/abc-123');
+        expect(callArgs[1]).to.deep.include({
+          method: 'GET',
+        });
+      });
+    });
+
+    it('should use legacy POST endpoint when confirmation number is missing', async () => {
       const formData = '{"data":"test"}';
       const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
       const mockResponse = {
@@ -153,19 +188,59 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData={formData} />);
+      const { container } = renderComponent(
+        <DownloadFormPDF formData={formData} />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
 
       await waitFor(() => {
-        expect(apiRequestStub.called).to.be.true;
-        const callArgs = apiRequestStub.firstCall.args;
-        expect(callArgs[1]).to.deep.include({
-          method: 'POST',
-          body: formData,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        expect(apiRequestStub.calledOnce).to.be.true;
+      });
+
+      const callArgs = apiRequestStub.firstCall.args;
+      expect(callArgs[0]).to.equal('/form214192/download_pdf');
+      expect(callArgs[1]).to.deep.include({
+        method: 'POST',
+        body: formData,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    it('should fall back to POST endpoint when GET endpoint fails', async () => {
+      const formData = '{"data":"fallback"}';
+      const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+      const mockResponse = {
+        ok: true,
+        blob: sinon.stub().resolves(mockBlob),
+      };
+
+      apiRequestStub
+        .onFirstCall()
+        .resolves({ ok: false, blob: sinon.stub().resolves(mockBlob) });
+      apiRequestStub.onSecondCall().resolves(mockResponse);
+
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData={formData} />,
+      );
+
+      const link = container.querySelector('va-link');
+      link.click();
+
+      await waitFor(() => {
+        expect(apiRequestStub.callCount).to.equal(2);
+      });
+
+      const firstCallArgs = apiRequestStub.firstCall.args;
+      const secondCallArgs = apiRequestStub.secondCall.args;
+      expect(firstCallArgs[0]).to.equal('/form214192/download_pdf/abc-123');
+      expect(firstCallArgs[1]).to.deep.include({ method: 'GET' });
+      expect(secondCallArgs[0]).to.equal('/form214192/download_pdf');
+      expect(secondCallArgs[1]).to.deep.include({
+        method: 'POST',
+        body: formData,
+        headers: { 'Content-Type': 'application/json' },
       });
     });
 
@@ -177,7 +252,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -198,7 +275,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -218,7 +297,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -236,7 +317,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -255,7 +338,9 @@ describe('DownloadFormPDF', () => {
     it('should show error message when API request fails', async () => {
       apiRequestStub.rejects(new Error('Network error'));
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -278,7 +363,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -292,7 +379,9 @@ describe('DownloadFormPDF', () => {
     it('should record failure event on error', async () => {
       apiRequestStub.rejects(new Error('Network error'));
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -309,7 +398,9 @@ describe('DownloadFormPDF', () => {
     it('should attempt to focus error element when error occurs', async () => {
       apiRequestStub.rejects(new Error('Network error'));
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.jsx
@@ -43,7 +43,7 @@ export const ConfirmationPage = ({ route }) => {
     [submissionGuid],
   );
 
-  const downloadGuid = submissionGuid || persistedGuid || confirmationNumber;
+  const downloadGuid = submissionGuid || persistedGuid;
 
   const submissionAlertContent = (
     <p>
@@ -76,7 +76,7 @@ export const ConfirmationPage = ({ route }) => {
           If you’d like a PDF copy of your completed form, you can download it.{' '}
         </p>
         <DownloadFormPDF
-          confirmationNumber={downloadGuid}
+          downloadGuid={downloadGuid}
           formData={transformedData}
           veteranName={veteranName}
         />

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { formatDateLong } from 'platform/utilities/date';
@@ -14,6 +14,7 @@ import DownloadFormPDF from './download-form-pdf';
  * @returns {React.ReactElement} Confirmation page component
  */
 export const ConfirmationPage = ({ route }) => {
+  const GUID_STORAGE_KEY = 'form21p530a_download_guid';
   const form = useSelector(state => state.form || {});
   const submission = form?.submission || {};
   const { data = {} } = form;
@@ -23,7 +24,26 @@ export const ConfirmationPage = ({ route }) => {
 
   const submitDate = submission?.timestamp || '';
   const formattedSubmitDate = submitDate ? formatDateLong(submitDate) : '';
-  const confirmationNumber = submission?.response?.confirmationNumber || '';
+  const confirmationNumber =
+    submission?.response?.attributes?.confirmationNumber ||
+    submission?.response?.confirmationNumber ||
+    '';
+  const submissionGuid = submission?.response?.attributes?.guid || '';
+
+  const persistedGuid = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return window.sessionStorage.getItem(GUID_STORAGE_KEY) || '';
+  }, []);
+
+  useEffect(
+    () => {
+      if (typeof window === 'undefined' || !submissionGuid) return;
+      window.sessionStorage.setItem(GUID_STORAGE_KEY, submissionGuid);
+    },
+    [submissionGuid],
+  );
+
+  const downloadGuid = submissionGuid || persistedGuid || confirmationNumber;
 
   const submissionAlertContent = (
     <p>
@@ -55,7 +75,11 @@ export const ConfirmationPage = ({ route }) => {
         <p>
           If you’d like a PDF copy of your completed form, you can download it.{' '}
         </p>
-        <DownloadFormPDF formData={transformedData} veteranName={veteranName} />
+        <DownloadFormPDF
+          confirmationNumber={downloadGuid}
+          formData={transformedData}
+          veteranName={veteranName}
+        />
       </div>
       <div data-dd-privacy="mask" data-dd-action-name="confirmation summary">
         <ConfirmationView.ChapterSectionCollection />

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.jsx
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/browser';
 import { API_ENDPOINTS } from '../../constants/constants';
 import { ensureValidCSRFToken } from '../../utils/actions/ensure-valid-csrf-token';
 
-const DownloadFormPDF = ({ formData, veteranName }) => {
+const DownloadFormPDF = ({ confirmationNumber, formData, veteranName }) => {
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
@@ -43,13 +43,35 @@ const DownloadFormPDF = ({ formData, veteranName }) => {
 
       try {
         await ensureValidCSRFToken('fetchPdf');
-        const response = await apiRequest(API_ENDPOINTS.downloadPdf, {
-          method: 'POST',
-          body: formData,
-          headers: { 'Content-Type': 'application/json' },
-        });
 
-        if (!response.ok) {
+        const fetchPdfByPost = () =>
+          apiRequest(API_ENDPOINTS.downloadPdf, {
+            method: 'POST',
+            body: formData,
+            headers: { 'Content-Type': 'application/json' },
+          });
+
+        let response;
+        if (confirmationNumber) {
+          try {
+            response = await apiRequest(
+              API_ENDPOINTS.downloadPdfByGuid(confirmationNumber),
+              {
+                method: 'GET',
+              },
+            );
+
+            if (!response?.ok) {
+              throw new Error('GET PDF download failed');
+            }
+          } catch (error) {
+            response = await fetchPdfByPost();
+          }
+        } else {
+          response = await fetchPdfByPost();
+        }
+
+        if (!response?.ok) {
           throw new Error();
         }
 
@@ -69,7 +91,7 @@ const DownloadFormPDF = ({ formData, veteranName }) => {
         setLoading(false);
       }
     },
-    [formData, handlePdfDownload],
+    [confirmationNumber, formData, handlePdfDownload],
   );
 
   // apply focus to the error alert if we have errors set
@@ -109,6 +131,7 @@ const DownloadFormPDF = ({ formData, veteranName }) => {
 };
 
 DownloadFormPDF.propTypes = {
+  confirmationNumber: PropTypes.string,
   formData: PropTypes.string,
   veteranName: PropTypes.shape({
     first: PropTypes.string,

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.jsx
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/browser';
 import { API_ENDPOINTS } from '../../constants/constants';
 import { ensureValidCSRFToken } from '../../utils/actions/ensure-valid-csrf-token';
 
-const DownloadFormPDF = ({ confirmationNumber, formData, veteranName }) => {
+const DownloadFormPDF = ({ downloadGuid, formData, veteranName }) => {
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
@@ -52,10 +52,10 @@ const DownloadFormPDF = ({ confirmationNumber, formData, veteranName }) => {
           });
 
         let response;
-        if (confirmationNumber) {
+        if (downloadGuid) {
           try {
             response = await apiRequest(
-              API_ENDPOINTS.downloadPdfByGuid(confirmationNumber),
+              API_ENDPOINTS.downloadPdfByGuid(downloadGuid),
               {
                 method: 'GET',
               },
@@ -91,7 +91,7 @@ const DownloadFormPDF = ({ confirmationNumber, formData, veteranName }) => {
         setLoading(false);
       }
     },
-    [confirmationNumber, formData, handlePdfDownload],
+    [downloadGuid, formData, handlePdfDownload],
   );
 
   // apply focus to the error alert if we have errors set
@@ -131,7 +131,7 @@ const DownloadFormPDF = ({ confirmationNumber, formData, veteranName }) => {
 };
 
 DownloadFormPDF.propTypes = {
-  confirmationNumber: PropTypes.string,
+  downloadGuid: PropTypes.string,
   formData: PropTypes.string,
   veteranName: PropTypes.shape({
     first: PropTypes.string,

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.unit.spec.jsx
@@ -23,6 +23,8 @@ describe('DownloadFormPDF', () => {
   let removeChildStub;
   let mockLink;
 
+  const renderComponent = ui => render(ui);
+
   beforeEach(() => {
     // Mock DOM element
     mockLink = {
@@ -113,8 +115,9 @@ describe('DownloadFormPDF', () => {
 
   describe('Initial Rendering', () => {
     it('should render download link', () => {
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -131,8 +134,9 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should not show loading indicator initially', () => {
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -143,8 +147,9 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should not show error message initially', () => {
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -158,7 +163,13 @@ describe('DownloadFormPDF', () => {
   describe('Name Formatting', () => {
     it('should use provided veteran name', () => {
       const veteranName = { first: 'Jane', last: 'Smith' };
-      render(<DownloadFormPDF formData="{}" veteranName={veteranName} />);
+      renderComponent(
+        <DownloadFormPDF
+          confirmationNumber="abc-123"
+          formData="{}"
+          veteranName={veteranName}
+        />,
+      );
 
       // Name is used internally; we verify through download behavior in later tests
       // Check that no 'a' element was created (no download triggered)
@@ -166,15 +177,21 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should use default name when veteranName is undefined', () => {
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       expect(link).to.exist;
     });
 
     it('should use default values when veteranName properties are missing', () => {
-      const { container } = render(
-        <DownloadFormPDF formData="{}" veteranName={{}} />,
+      const { container } = renderComponent(
+        <DownloadFormPDF
+          confirmationNumber="abc-123"
+          formData="{}"
+          veteranName={{}}
+        />,
       );
 
       const link = container.querySelector('va-link');
@@ -182,8 +199,12 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should use default first name when only last name provided', () => {
-      const { container } = render(
-        <DownloadFormPDF formData="{}" veteranName={{ last: 'Doe' }} />,
+      const { container } = renderComponent(
+        <DownloadFormPDF
+          confirmationNumber="abc-123"
+          formData="{}"
+          veteranName={{ last: 'Doe' }}
+        />,
       );
 
       const link = container.querySelector('va-link');
@@ -191,8 +212,12 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should use default last name when only first name provided', () => {
-      const { container } = render(
-        <DownloadFormPDF formData="{}" veteranName={{ first: 'John' }} />,
+      const { container } = renderComponent(
+        <DownloadFormPDF
+          confirmationNumber="abc-123"
+          formData="{}"
+          veteranName={{ first: 'John' }}
+        />,
       );
 
       const link = container.querySelector('va-link');
@@ -209,8 +234,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -225,7 +251,6 @@ describe('DownloadFormPDF', () => {
     });
 
     it('should make API request with correct parameters', async () => {
-      const formData = '{"veteran":"data"}';
       const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
       const mockResponse = {
         ok: true,
@@ -233,9 +258,10 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
-          formData={formData}
+          confirmationNumber="abc-123"
+          formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
       );
@@ -246,11 +272,82 @@ describe('DownloadFormPDF', () => {
       await waitFor(() => {
         expect(apiRequestStub.called).to.be.true;
         const callArgs = apiRequestStub.firstCall.args;
+        expect(callArgs[0]).to.equal('/form21p530a/download_pdf/abc-123');
         expect(callArgs[1]).to.deep.include({
-          method: 'POST',
-          body: formData,
-          headers: { 'Content-Type': 'application/json' },
+          method: 'GET',
         });
+      });
+    });
+
+    it('should use legacy POST endpoint when confirmation number is missing', async () => {
+      const formData = '{"veteran":"data"}';
+      const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+      const mockResponse = {
+        ok: true,
+        blob: sinon.stub().resolves(mockBlob),
+      };
+      apiRequestStub.resolves(mockResponse);
+
+      const { container } = renderComponent(
+        <DownloadFormPDF
+          formData={formData}
+          veteranName={{ first: 'John', last: 'Doe' }}
+        />,
+      );
+
+      const link = container.querySelector('va-link');
+      link.click();
+
+      await waitFor(() => {
+        expect(apiRequestStub.calledOnce).to.be.true;
+      });
+
+      const callArgs = apiRequestStub.firstCall.args;
+      expect(callArgs[0]).to.equal('/form21p530a/download_pdf');
+      expect(callArgs[1]).to.deep.include({
+        method: 'POST',
+        body: formData,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    it('should fall back to POST endpoint when GET endpoint fails', async () => {
+      const formData = '{"veteran":"fallback"}';
+      const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+      const mockResponse = {
+        ok: true,
+        blob: sinon.stub().resolves(mockBlob),
+      };
+
+      apiRequestStub
+        .onFirstCall()
+        .resolves({ ok: false, blob: sinon.stub().resolves(mockBlob) });
+      apiRequestStub.onSecondCall().resolves(mockResponse);
+
+      const { container } = renderComponent(
+        <DownloadFormPDF
+          confirmationNumber="abc-123"
+          formData={formData}
+          veteranName={{ first: 'John', last: 'Doe' }}
+        />,
+      );
+
+      const link = container.querySelector('va-link');
+      link.click();
+
+      await waitFor(() => {
+        expect(apiRequestStub.callCount).to.equal(2);
+      });
+
+      const firstCallArgs = apiRequestStub.firstCall.args;
+      const secondCallArgs = apiRequestStub.secondCall.args;
+      expect(firstCallArgs[0]).to.equal('/form21p530a/download_pdf/abc-123');
+      expect(firstCallArgs[1]).to.deep.include({ method: 'GET' });
+      expect(secondCallArgs[0]).to.equal('/form21p530a/download_pdf');
+      expect(secondCallArgs[1]).to.deep.include({
+        method: 'POST',
+        body: formData,
+        headers: { 'Content-Type': 'application/json' },
       });
     });
 
@@ -262,8 +359,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -288,7 +386,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(<DownloadFormPDF formData="{}" />);
+      const { container } = renderComponent(
+        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+      );
 
       const link = container.querySelector('va-link');
       link.click();
@@ -306,8 +406,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -331,8 +432,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -354,8 +456,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -378,8 +481,9 @@ describe('DownloadFormPDF', () => {
     it('should show error message when API request fails', async () => {
       apiRequestStub.rejects(new Error('Network error'));
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -406,8 +510,9 @@ describe('DownloadFormPDF', () => {
       };
       apiRequestStub.resolves(mockResponse);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -425,8 +530,9 @@ describe('DownloadFormPDF', () => {
     it('should record failure event on error', async () => {
       apiRequestStub.rejects(new Error('Network error'));
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -448,8 +554,9 @@ describe('DownloadFormPDF', () => {
       const error = new Error('Network error');
       apiRequestStub.rejects(error);
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -469,8 +576,9 @@ describe('DownloadFormPDF', () => {
     it('should attempt to focus error element when error occurs', async () => {
       apiRequestStub.rejects(new Error('Network error'));
 
-      const { container } = render(
+      const { container } = renderComponent(
         <DownloadFormPDF
+          confirmationNumber="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.unit.spec.jsx
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.unit.spec.jsx
@@ -117,7 +117,7 @@ describe('DownloadFormPDF', () => {
     it('should render download link', () => {
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -136,7 +136,7 @@ describe('DownloadFormPDF', () => {
     it('should not show loading indicator initially', () => {
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -149,7 +149,7 @@ describe('DownloadFormPDF', () => {
     it('should not show error message initially', () => {
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -165,7 +165,7 @@ describe('DownloadFormPDF', () => {
       const veteranName = { first: 'Jane', last: 'Smith' };
       renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={veteranName}
         />,
@@ -178,7 +178,7 @@ describe('DownloadFormPDF', () => {
 
     it('should use default name when veteranName is undefined', () => {
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -188,7 +188,7 @@ describe('DownloadFormPDF', () => {
     it('should use default values when veteranName properties are missing', () => {
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{}}
         />,
@@ -201,7 +201,7 @@ describe('DownloadFormPDF', () => {
     it('should use default first name when only last name provided', () => {
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ last: 'Doe' }}
         />,
@@ -214,7 +214,7 @@ describe('DownloadFormPDF', () => {
     it('should use default last name when only first name provided', () => {
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John' }}
         />,
@@ -236,7 +236,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -260,7 +260,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -326,7 +326,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData={formData}
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -361,7 +361,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -387,7 +387,7 @@ describe('DownloadFormPDF', () => {
       apiRequestStub.resolves(mockResponse);
 
       const { container } = renderComponent(
-        <DownloadFormPDF confirmationNumber="abc-123" formData="{}" />,
+        <DownloadFormPDF downloadGuid="abc-123" formData="{}" />,
       );
 
       const link = container.querySelector('va-link');
@@ -408,7 +408,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -434,7 +434,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -458,7 +458,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -483,7 +483,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -512,7 +512,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -532,7 +532,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -556,7 +556,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,
@@ -578,7 +578,7 @@ describe('DownloadFormPDF', () => {
 
       const { container } = renderComponent(
         <DownloadFormPDF
-          confirmationNumber="abc-123"
+          downloadGuid="abc-123"
           formData="{}"
           veteranName={{ first: 'John', last: 'Doe' }}
         />,

--- a/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/constants/constants.js
+++ b/src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/constants/constants.js
@@ -19,4 +19,6 @@ export const TRACKING_PREFIX = '21p-530a-interment-allowance-';
 export const API_ENDPOINTS = {
   csrfCheck: '/csrf_token',
   downloadPdf: '/form21p530a/download_pdf',
+  downloadPdfByGuid: guid =>
+    `/form21p530a/download_pdf/${encodeURIComponent(guid)}`,
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added GET-by-guid PDF download flow on confirmation pages for both Bio Aquia forms in this PR scope.
- 21-4192 updates: constants, confirmation-page wiring, download component logic, and unit tests.
- 21P-530a updates: constants, confirmation-page wiring, download component logic, and unit tests.
- Added two 21-0779 test-only assertion updates to remove brittle `pattern` expectations against shared schema internals.
- Team: Benefits Intake Optimization (Aquia). Team owns maintenance for these form flows.
- No new frontend flipper introduced in this PR.

## Related issue(s)

- Backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/27699
- Original Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/136942

## Testing done

- Old behavior prior to this change:
  - Confirmation-page PDF download relied on the old POST route behavior and could be impacted by refresh/state loss scenarios.
- Steps run to verify changes:
  - Exercised updated confirmation/download component unit tests for 21-4192 and 21P-530a.
  - Verified two 21-0779 schema tests pass after removing brittle assertions.
- Commands/results:
  - `yarn test:unit src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.unit.spec.jsx src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.unit.spec.jsx` (pass)
  - `yarn test:unit src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/download-form-pdf.unit.spec.jsx src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/download-form-pdf.unit.spec.jsx src/applications/benefits-optimization-aquia/21-4192-employment-information/containers/confirmation-page/confirmation-page.unit.spec.jsx src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/components/confirmation-page/confirmation-page.unit.spec.jsx` (pass)
  - `yarn test:unit src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/claimant-identification-info.unit.spec.jsx src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/veteran-identification-info.unit.spec.jsx` (pass)
  - `npx eslint` on touched Bio Aquia frontend files (pass)
- Known gap:
  - End-to-end staging validation across independent frontend/backend deployment timing remains part of rollout validation.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A (request-path behavior change on download action) | N/A (same visible UI, updated download request behavior) |
| Desktop | N/A (request-path behavior change on download action) | N/A (same visible UI, updated download request behavior) |

## What areas of the site does it impact?

- `src/applications/benefits-optimization-aquia/21-4192-employment-information/**`
- `src/applications/benefits-optimization-aquia/21p-530a-interment-allowance/**`
- `src/applications/benefits-optimization-aquia/21-0779-nursing-home-information/pages/*identification-info.unit.spec.jsx` (test-only)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please focus review on:
- Download behavior parity between 21-4192 and 21P-530a confirmation pages.
- Rollout safety assumptions while backend and frontend deploy independently.
- Whether to keep 21-0779 brittle-test cleanup in this PR vs split.